### PR TITLE
Fixes #33: Release build fails because of re-publishing fdb-extensions

### DIFF
--- a/build.py
+++ b/build.py
@@ -140,7 +140,7 @@ def build(release=False, proto2=False, proto3=False, publish=False):
 
     if proto3:
         # Make with protobuf 3.
-        success = run_gradle(3, 'build', 'destructiveTest', 'bintrayUpload', '-PcoreNotStrict',
+        success = run_gradle(3, 'build', 'destructiveTest', ':fdb-record-layer-core-pb3:bintrayUpload', '-PcoreNotStrict',
                                 '-PreleaseBuild={0}'.format('true' if release else 'false'),
                                 '-PpublishBuild={0}'.format('true' if publish else 'false'))
         if not success:


### PR DESCRIPTION
The problem was that it was uploading both the fdb-extensions and the fdb-record-layer-core jars in the release build. It should now upload fdb-extensions and fdb-record-layer-core in the proto2 build and then fdb-record-layer-core in the proto3 build.

The fix won't get picked up by the CI server until this is merged, but I've tested this locally by publishing a proto3 build (version 2.0.1.0, off of the same commit that gave us version 2.0.1.0 for the proto2 build as well as the fdb-extensions build).