### PR TITLE
Resolves #25: Support covered queries with text index scans

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordMetaData;
-import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
@@ -34,18 +33,26 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+import com.apple.foundationdb.record.query.plan.temp.SingleExpressionRef;
+import com.google.common.collect.Iterators;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Iterator;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A query plan that reconstructs records from the entries in a covering index.
  */
-public class RecordQueryCoveringIndexPlan extends RecordQueryIndexPlan {
+public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
 
+    @Nonnull
+    private final ExpressionRef<RecordQueryPlanWithIndex> indexPlan;
     @Nonnull
     private final String recordTypeName;
     @Nonnull
@@ -53,14 +60,14 @@ public class RecordQueryCoveringIndexPlan extends RecordQueryIndexPlan {
 
     public RecordQueryCoveringIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse,
                                         @Nonnull final String recordTypeName, @Nonnull IndexKeyValueToPartialRecord toRecord) {
-        super(indexName, scanType, comparisons, reverse);
-        this.recordTypeName = recordTypeName;
-        this.toRecord = toRecord;
+        this(new RecordQueryIndexPlan(indexName, scanType, comparisons, reverse), recordTypeName, toRecord);
     }
 
-    public RecordQueryCoveringIndexPlan(@Nonnull RecordQueryIndexPlan plan,
+    public RecordQueryCoveringIndexPlan(@Nonnull RecordQueryPlanWithIndex plan,
                                         @Nonnull final String recordTypeName, @Nonnull IndexKeyValueToPartialRecord toRecord) {
-        this(plan.indexName, plan.scanType, plan.comparisons, plan.reverse, recordTypeName, toRecord);
+        this.indexPlan = SingleExpressionRef.of(plan);
+        this.recordTypeName = recordTypeName;
+        this.toRecord = toRecord;
     }
 
     @Nonnull
@@ -72,23 +79,53 @@ public class RecordQueryCoveringIndexPlan extends RecordQueryIndexPlan {
         final FDBRecordStoreBase<M> store = context.getStore();
         final RecordMetaData metaData = store.getRecordMetaData();
         final RecordType recordType = metaData.getRecordType(recordTypeName);
-        final Index index = metaData.getIndex(indexName);
-        final TupleRange range = comparisons.toTupleRange(context);
+        final Index index = metaData.getIndex(getIndexName());
         final Descriptors.Descriptor recordDescriptor = recordType.getDescriptor();
-        final boolean hasPrimaryKey = scanType != IndexScanType.BY_GROUP;
-        return store.scanIndex(index, scanType, range, continuation,
-                executeProperties.asScanProperties(reverse))
-                .map(indexEntry ->
-                        store.coveredIndexQueriedRecord(index, indexEntry, recordType, (M) toRecord.toRecord(recordDescriptor, indexEntry), hasPrimaryKey));
+        boolean hasPrimaryKey = getScanType() != IndexScanType.BY_GROUP;
+        return indexPlan.get().executeEntries(context, continuation, executeProperties)
+                .map(indexEntry -> store.coveredIndexQueriedRecord(index, indexEntry, recordType, (M) toRecord.toRecord(recordDescriptor, indexEntry), hasPrimaryKey));
+    }
+
+    @Nonnull
+    public String getIndexName() {
+        return indexPlan.get().getIndexName();
+    }
+
+    @Nonnull
+    public IndexScanType getScanType() {
+        return indexPlan.get().getScanType();
+    }
+
+    @Override
+    public boolean isReverse() {
+        return getChild().isReverse();
+    }
+
+    @Override
+    public boolean hasRecordScan() {
+        return false;
+    }
+
+    @Override
+    public boolean hasFullRecordScan() {
+        return false;
+    }
+
+    @Override
+    public boolean hasIndexScan(@Nonnull String indexName) {
+        return getChild().hasIndexScan(indexName);
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getUsedIndexes() {
+        return getChild().getUsedIndexes();
     }
 
     @Nonnull
     @Override
     public String toString() {
-        StringBuilder str = new StringBuilder("CoveringIndex(");
-        appendScanDetails(str);
-        str.append(")");
-        return str.toString();
+        return "CoveringIndex(" + indexPlan + " -> " + toRecord + ")";
     }
 
     @Override
@@ -109,13 +146,7 @@ public class RecordQueryCoveringIndexPlan extends RecordQueryIndexPlan {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), recordTypeName, toRecord);
-    }
-
-    @Override
-    protected void appendScanDetails(StringBuilder str) {
-        super.appendScanDetails(str);
-        str.append(" -> ").append(toRecord);
+        return Objects.hash(indexPlan.hashCode(), recordTypeName, toRecord);
     }
 
     @Override
@@ -123,4 +154,24 @@ public class RecordQueryCoveringIndexPlan extends RecordQueryIndexPlan {
         timer.increment(FDBStoreTimer.Counts.PLAN_COVERING_INDEX);
     }
 
+    @Override
+    public int getComplexity() {
+        return getChild().getComplexity();
+    }
+
+    @Override
+    public RecordQueryPlan getChild() {
+        return indexPlan.get();
+    }
+
+    @Override
+    public int planHash() {
+        return getChild().planHash();
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
+        return Iterators.singletonIterator(indexPlan);
+    }
 }

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -21,12 +21,13 @@
 package com.apple.foundationdb.record.query.plan.plans;
 
 import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBEvaluationContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
@@ -63,13 +64,11 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBEvaluationContext<M> context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
+    public <M extends Message> RecordCursor<IndexEntry> executeEntries(@Nonnull FDBEvaluationContext<M> context, @Nullable byte[] continuation, @Nonnull ExecuteProperties executeProperties) {
         final TupleRange range = comparisons.toTupleRange(context);
         final FDBRecordStoreBase<M> store = context.getStore();
-        return store.scanIndexRecords(indexName, scanType, range, continuation, executeProperties.asScanProperties(reverse))
-                .map(store::queriedRecord);
+        final RecordMetaData metaData = store.getRecordMetaData();
+        return store.scanIndex(metaData.getIndex(indexName), scanType, range, continuation, executeProperties.asScanProperties(reverse));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
@@ -22,14 +22,11 @@ package com.apple.foundationdb.record.query.plan.plans;
 
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBEvaluationContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.IndexOrphanBehavior;
 import com.apple.foundationdb.record.query.plan.planning.TextScan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
@@ -64,16 +61,20 @@ public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex {
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBEvaluationContext<M> context, @Nullable byte[] continuation, @Nonnull ExecuteProperties executeProperties) {
-        final FDBRecordStoreBase<M> store = context.getStore();
-        final Index index = store.getRecordMetaData().getIndex(indexName);
-        RecordCursor<IndexEntry> entryCursor = textScan.scan(context, continuation, executeProperties.asScanProperties(reverse));
-        return store.fetchIndexRecords(index, entryCursor, IndexOrphanBehavior.ERROR).map(FDBQueriedRecord::indexed);
+    public <M extends Message> RecordCursor<IndexEntry> executeEntries(@Nonnull FDBEvaluationContext<M> context, @Nullable byte[] continuation, @Nonnull ExecuteProperties executeProperties) {
+        return textScan.scan(context, continuation, executeProperties.asScanProperties(reverse));
     }
 
     @Nonnull
+    @Override
     public String getIndexName() {
         return indexName;
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanType getScanType() {
+        return IndexScanType.BY_TEXT_TOKEN;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
@@ -78,7 +78,7 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setRequiredResults(Arrays.asList(Key.Expressions.field("num_value_unique")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(allOf(indexName("MySimpleRecord$num_value_unique"), bounds(hasTupleString("([990],>")))));
+        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), bounds(hasTupleString("([990],>"))))));
         assertEquals(-158312359, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -112,7 +112,7 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setRequiredResults(Arrays.asList(Key.Expressions.field("num_value_3_indexed")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(unbounded()))));
+        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(unbounded())))));
         assertEquals(413789395, plan.planHash());
     }
 
@@ -194,7 +194,7 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                         Key.Expressions.field("num_value_2")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(allOf(indexName("multi_index"), bounds(hasTupleString("([990],>")))));
+        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("multi_index"), bounds(hasTupleString("([990],>"))))));
         assertEquals(291429560, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -240,7 +240,7 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                         Key.Expressions.field("num_value_2")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(allOf(indexName("multi_index_value"), bounds(hasTupleString("([990],>")))));
+        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("multi_index_value"), bounds(hasTupleString("([990],>"))))));
         assertEquals(-782505942, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -284,7 +284,7 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setRequiredResults(Arrays.asList(Key.Expressions.field("header").nest("path")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(allOf(indexName("MyRecord$str_value"), bounds(hasTupleString("[[lion],[lion]]")))));
+        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("MyRecord$str_value"), bounds(hasTupleString("[[lion],[lion]]"))))));
         assertEquals(-629018945, plan.planHash());
     }
 
@@ -320,7 +320,7 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setRequiredResults(Arrays.asList(Key.Expressions.field("header").nest("rec_no")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(allOf(indexName("MyRecord$str_value"), bounds(hasTupleString("[[lion],[lion]]")))));
+        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("MyRecord$str_value"), bounds(hasTupleString("[[lion],[lion]]"))))));
         assertEquals(-629018945, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -580,7 +580,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
                         .setFilter(Query.field("fint64").greaterThan(0L))
                         .setRequiredResults(Stream.of("uuid", "fint64").map(Key.Expressions::field).collect(Collectors.toList()))
                         .build());
-                assertThat(coveringPlan, PlanMatchers.coveringIndexScan(PlanMatchers.indexName("MyFieldsRecord$fint64")));
+                assertThat(coveringPlan, PlanMatchers.coveringIndexScan(PlanMatchers.indexScan(PlanMatchers.indexName("MyFieldsRecord$fint64"))));
                 final List<Pair<UUID, Long>> results = recordStore.executeQuery(coveringPlan).map(rec -> {
                     final TestRecordsTupleFieldsProto.MyFieldsRecord myrec = TestRecordsTupleFieldsProto.MyFieldsRecord.newBuilder().mergeFrom(rec.getRecord()).build();
                     return Pair.of(TupleFieldsHelper.fromProto(myrec.getUuid()), TupleFieldsHelper.fromProto(myrec.getFint64()));

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/CoveringIndexMatcher.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/CoveringIndexMatcher.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.match;
 
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -33,22 +34,22 @@ import javax.annotation.Nonnull;
  */
 public class CoveringIndexMatcher extends TypeSafeMatcher<RecordQueryPlan> {
     @Nonnull
-    private final Matcher<? super RecordQueryCoveringIndexPlan> planMatcher;
+    private final Matcher<? super RecordQueryPlanWithIndex> childMatcher;
 
-    public CoveringIndexMatcher(@Nonnull Matcher<? super RecordQueryCoveringIndexPlan> planMatcher) {
-        this.planMatcher = planMatcher;
+    public CoveringIndexMatcher(@Nonnull Matcher<? super RecordQueryPlanWithIndex> childMatcher) {
+        this.childMatcher = childMatcher;
     }
 
     @Override
     public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
         return plan instanceof RecordQueryCoveringIndexPlan &&
-                planMatcher.matches(plan);
+                childMatcher.matches(((RecordQueryCoveringIndexPlan)plan).getChild());
     }
 
     @Override
     public void describeTo(Description description) {
         description.appendText("CoveringIndex(");
-        planMatcher.describeTo(description);
+        childMatcher.describeTo(description);
         description.appendText(")");
     }
 }

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/IndexMatcher.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/IndexMatcher.java
@@ -106,7 +106,7 @@ public class IndexMatcher extends TypeSafeMatcher<RecordQueryPlan> {
     /**
      * Match the index plan's {@link IndexScanType}.
      */
-    public static class ScanTypeMatcher extends TypeSafeMatcher<RecordQueryIndexPlan> {
+    public static class ScanTypeMatcher extends TypeSafeMatcher<RecordQueryPlanWithIndex> {
         @Nonnull
         private final Matcher<IndexScanType> scanTypeMatcher;
 
@@ -115,7 +115,7 @@ public class IndexMatcher extends TypeSafeMatcher<RecordQueryPlan> {
         }
 
         @Override
-        public boolean matchesSafely(@Nonnull RecordQueryIndexPlan plan) {
+        public boolean matchesSafely(@Nonnull RecordQueryPlanWithIndex plan) {
             return scanTypeMatcher.matches(plan.getScanType());
         }
 

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithComparisons;
@@ -82,11 +81,11 @@ public class PlanMatchers {
         return indexName(equalTo(indexName));
     }
 
-    public static Matcher<RecordQueryIndexPlan> indexScanType(@Nonnull Matcher<IndexScanType> scanTypeMatcher) {
+    public static Matcher<RecordQueryPlanWithIndex> indexScanType(@Nonnull Matcher<IndexScanType> scanTypeMatcher) {
         return new IndexMatcher.ScanTypeMatcher(scanTypeMatcher);
     }
 
-    public static Matcher<RecordQueryIndexPlan> indexScanType(@Nonnull IndexScanType scanType) {
+    public static Matcher<RecordQueryPlanWithIndex> indexScanType(@Nonnull IndexScanType scanType) {
         return new IndexMatcher.ScanTypeMatcher(equalTo(scanType));
     }
 
@@ -106,8 +105,8 @@ public class PlanMatchers {
         return new ScanComparisonsEmptyMatcher();
     }
 
-    public static Matcher<RecordQueryPlan> coveringIndexScan(@Nonnull Matcher<? super RecordQueryCoveringIndexPlan> planMatcher) {
-        return new CoveringIndexMatcher(planMatcher);
+    public static Matcher<RecordQueryPlan> coveringIndexScan(@Nonnull Matcher<? super RecordQueryPlan> childMatcher) {
+        return new CoveringIndexMatcher(childMatcher);
     }
 
     public static Matcher<RecordQueryPlan> filter(@Nonnull Matcher<QueryComponent> filterMatcher,


### PR DESCRIPTION
This refactors the `RecordQueryCoveringIndexPlan` class so that it now has a child plan. That plan has to be able to produce a stream of index entries, and then the covering plan turns those streams of entries into partial records (as was done before this change). The reqular and text index scan plans have then been made to comply with this interface so that they can be used with the covering scan. In addition, to support using covering indexes with prefix queries, this also changes the logic to push down a covering query so that the covering operation is applied before applying the unordered primary key distinct filter.