### PR TITLE
Give covering index back a readable plan.

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -125,7 +125,7 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
     @Nonnull
     @Override
     public String toString() {
-        return "CoveringIndex(" + indexPlan + " -> " + toRecord + ")";
+        return "Covering(" + indexPlan.get() + " -> " + toRecord + ")";
     }
 
     @Override


### PR DESCRIPTION
What was (before #25) `CoveringIndex(i, b -> f)` is now `Covering(Index(i, b) -> f)`.