### PR TITLE
Resolves #66: Adds @API to com.apple.foundationdb.record

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/AsyncLoadingCache.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/AsyncLoadingCache.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -34,6 +35,7 @@ import java.util.function.Supplier;
  * @param <K> key type for the cache
  * @param <V> value type for the cache
  */
+@API(API.Status.UNSTABLE)
 public class AsyncLoadingCache<K, V> {
     @Nonnull
     private final Cache<K, CompletableFuture<V>> cache;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/Bindings.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/Bindings.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -31,6 +33,7 @@ import java.util.Map;
  * A binding map can also have a parent from which values are taken if they are absent in the child.
  * </p>
  */
+@API(API.Status.MAINTAINED)
 public class Bindings {
 
     /**

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/CursorStreamingMode.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/CursorStreamingMode.java
@@ -20,11 +20,14 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 /**
  * The streaming mode to use when opening {@link RecordCursor}s.
  *
  * @see ScanProperties#getCursorStreamingMode
  */
+@API(API.Status.EXPERIMENTAL)
 public enum CursorStreamingMode {
     /** The client will process records one-at-a-time. */
     ITERATOR,

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/EndpointType.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/EndpointType.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -30,6 +32,7 @@ import javax.annotation.Nonnull;
  * There is also a special type for the range of values where a string element of a {@code Tuple} begins with a given string.
  * </p>
  */
+@API(API.Status.MAINTAINED)
 public enum EndpointType {
     TREE_START,
     TREE_END,

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/EvaluationContext.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/EvaluationContext.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.concurrent.Executor;
@@ -33,6 +35,7 @@ import java.util.concurrent.ForkJoinPool;
  * @see com.apple.foundationdb.record.query.expressions.QueryComponent#eval
  * @see com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan#execute
  */
+@API(API.Status.MAINTAINED)
 public abstract class EvaluationContext {
     @Nonnull
     private final Bindings bindings;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/EvaluationContextBuilder.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/EvaluationContextBuilder.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -29,6 +31,7 @@ import javax.annotation.Nullable;
  * context.childBuilder().setBinding("x", x).build()
  * </code></pre>
  */
+@API(API.Status.MAINTAINED)
 public class EvaluationContextBuilder {
     @Nonnull
     protected final EvaluationContext original;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/ExecuteProperties.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/ExecuteProperties.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.ReadTransaction;
 
 import javax.annotation.Nonnull;
@@ -36,6 +37,7 @@ import java.util.List;
  * <li>limit on number of key-value pairs scanned</li>
  * </ul>
  */
+@API(API.Status.MAINTAINED)
 public class ExecuteProperties {
     /**
      * A constant representing that no time limit is set.

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/ExecuteState.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/ExecuteState.java
@@ -21,6 +21,8 @@
 package com.apple.foundationdb.record;
 
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -31,6 +33,7 @@ import javax.annotation.Nullable;
  * In general, the state object should be constructed by as part of a "root" <code>ExecuteProperties</code> rather than
  * directly by the client.
  */
+@API(API.Status.MAINTAINED)
 public class ExecuteState {
     /**
      * An empty execute state with no record scan limit.

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/FunctionNames.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/FunctionNames.java
@@ -20,9 +20,12 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 /**
  * Names of core-supported query functions.
  */
+@API(API.Status.MAINTAINED)
 public class FunctionNames {
 
     /* Aggregate functions */

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/IndexEntry.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/IndexEntry.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin;
 import com.apple.foundationdb.tuple.Tuple;
@@ -33,6 +34,7 @@ import javax.annotation.Nullable;
  * Further, if the key and value were produced by applying an index key expression to a record, this will carry
  * around additional information about the nulls contained in the expression.
  */
+@API(API.Status.MAINTAINED)
 public class IndexEntry {
     private static final NullStandin[] NO_NULLS = new NullStandin[0];
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/IndexScanType.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/IndexScanType.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import java.util.Objects;
 
 /**
@@ -30,6 +32,7 @@ import java.util.Objects;
  *
  * @see com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer#scan
  */
+@API(API.Status.MAINTAINED)
 public class IndexScanType implements PlanHashable {
     private final String name;
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/IndexState.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/IndexState.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -27,6 +29,7 @@ import javax.annotation.Nonnull;
  * These states might differ between record stores that have
  * otherwise identical meta-data.
  */
+@API(API.Status.MAINTAINED)
 public enum IndexState {
     /**
      * This is the default state for an index. It is

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/IsolationLevel.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/IsolationLevel.java
@@ -20,13 +20,20 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 /**
  * The isolation level for reads from the database.
  *
  * @see ExecuteProperties#getIsolationLevel
  */
+@API(API.Status.MAINTAINED)
 public enum IsolationLevel {
+
+    @API(API.Status.STABLE)
     SNAPSHOT(true),
+
+    @API(API.Status.STABLE)
     SERIALIZABLE(false)
     ;
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/MutableRecordStoreState.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/MutableRecordStoreState.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
@@ -32,6 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Such modifications are only allowed between {@link #beginWrite} and {@link #endWrite} and will conflict with
  * {@link #beginRead} ... {@link #endRead}.
  */
+@API(API.Status.INTERNAL)
 public class MutableRecordStoreState extends RecordStoreState {
 
     private static final long READ_MASK = 0xFFFF0000;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/PipelineOperation.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/PipelineOperation.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 /**
  * Kind of asynchronous pipelined operation being performed.
  *
@@ -28,6 +30,7 @@ package com.apple.foundationdb.record;
  * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.PipelineSizer
  * @see RecordCursor#mapPipelined
  */
+@API(API.Status.MAINTAINED)
 public class PipelineOperation {
     private final String name;
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/PlanHashable.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/PlanHashable.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -27,6 +29,7 @@ import java.util.Arrays;
 /**
  * A more stable version of {@link Object#hashCode}.
  */
+@API(API.Status.UNSTABLE)
 public interface PlanHashable {
     /**
      * Return a hash similar to <code>hashCode</code>, but with the additional guarantee that is is stable across JVMs.

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreArgumentException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreArgumentException.java
@@ -20,11 +20,14 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 
 /**
  * Functional equivalent of <code>IllegalArgumentException</code>.
  */
+@API(API.Status.STABLE)
 public class RecordCoreArgumentException extends RecordCoreException {
     private static final long serialVersionUID = 1;
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreException.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.util.LoggableException;
 
 import javax.annotation.Nonnull;
@@ -28,6 +29,7 @@ import javax.annotation.Nullable;
 /**
  * An exception thrown by the core of the Record Layer.
  */
+@API(API.Status.STABLE)
 @SuppressWarnings("serial")
 public class RecordCoreException extends LoggableException {
     public RecordCoreException(@Nonnull String msg, @Nullable Object ... keyValues) {

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreInterruptedException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreInterruptedException.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -28,6 +30,7 @@ import javax.annotation.Nonnull;
  * NOTE: When catching an {@code InterruptedException} and rethrowing as this wrapping exception, Java best practice
  * is to call {@code Thread.currentThread().interrupt()} so that the interrupt is not lost.
  */
+@API(API.Status.STABLE)
 public class RecordCoreInterruptedException extends RecordCoreException {
     private static final long serialVersionUID = 1;
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreRetriableTransactionException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreRetriableTransactionException.java
@@ -20,12 +20,15 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
  * An exception from transaction processing that ought to be retried.
  */
+@API(API.Status.STABLE)
 @SuppressWarnings("serial")
 public class RecordCoreRetriableTransactionException extends RecordCoreStorageException {
     public RecordCoreRetriableTransactionException(@Nonnull String msg) {

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreStorageException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCoreStorageException.java
@@ -20,12 +20,15 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
  * Exceptions due to problems with the state of or connection to a particular record store.
  */
+@API(API.Status.STABLE)
 @SuppressWarnings("serial")
 public class RecordCoreStorageException extends RecordCoreException {
     public RecordCoreStorageException(@Nonnull String msg) {

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCursor.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.cursors.EmptyCursor;
@@ -81,6 +82,7 @@ import java.util.function.Function;
  *
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.STABLE)
 public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
     /**
      * Asynchronously check whether there are more records available from the cursor.

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCursorVisitor.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordCursorVisitor.java
@@ -20,11 +20,14 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 /**
  * A hierarchical visitor for record cursor trees designed mostly to allow tests to gather information without adding
  * invasive query methods to the {@link RecordCursor} interface.
  * Note that the "ordering" of children of each <code>RecordCursor</code> is determined by individual implementors.
  */
+@API(API.Status.EXPERIMENTAL)
 public interface RecordCursorVisitor {
     /**
      * Called on nodes in the record cursor tree in visit pre-order of the depth-first traversal of the tree.

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordFunction.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordFunction.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.google.protobuf.Descriptors;
 
 import javax.annotation.Nonnull;
@@ -28,6 +29,7 @@ import javax.annotation.Nonnull;
  * A function to be applied to a record as part of query execution.
  * @param <T> the result type of the function
  */
+@API(API.Status.STABLE)
 public abstract class RecordFunction<T> implements PlanHashable {
 
     @Nonnull

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordIndexUniquenessViolation.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordIndexUniquenessViolation.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.tuple.Tuple;
@@ -35,6 +36,7 @@ import javax.annotation.Nullable;
  * {@code commit} <em>will not</em> complete successfully, whether it was thrown earlier or from {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext#commit}
  * itself.
  */
+@API(API.Status.STABLE)
 @SuppressWarnings({"serial", "squid:S1948", "squid:MaximumInheritanceDepth"})
 public class RecordIndexUniquenessViolation extends RecordCoreException {
     @Nonnull private Index index;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordMetaData.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordMetaData.java
@@ -247,6 +247,7 @@ public class RecordMetaData implements RecordMetaDataProvider {
     }
 
     @Nullable
+    @API(API.Status.DEPRECATED)
     public KeyExpression getRecordCountKey() {
         return recordCountKey;
     }

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordMetaDataBuilder.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordMetaDataBuilder.java
@@ -604,6 +604,7 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
      */
     @Nullable
     @Deprecated
+    @API(API.Status.DEPRECATED)
     public KeyExpression getRecordCountKey() {
         return recordCountKey;
     }
@@ -615,6 +616,7 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
      * @deprecated use {@code COUNT} type indexes instead
      */
     @Deprecated
+    @API(API.Status.DEPRECATED)
     public void setRecordCountKey(KeyExpression recordCountKey) {
         if (!Objects.equals(this.recordCountKey, recordCountKey)) {
             version += 1;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordScanLimiter.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordScanLimiter.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -28,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @see ExecuteState#getRecordScanLimiter
  */
+@API(API.Status.MAINTAINED)
 public class RecordScanLimiter {
     private final int originalLimit;
     private final AtomicInteger allowedRecordScansRemaining;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordStoreState.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordStoreState.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.google.common.collect.ImmutableMap;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
  * it is not serialized with the rest of the metadata and must be retrieved
  * from the store.
  */
+@API(API.Status.MAINTAINED)
 public class RecordStoreState {
     /**
      * Empty <code>RecordStoreState</code>. This is the state of an empty

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/ScanLimitReachedException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/ScanLimitReachedException.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.cursors.CursorLimitManager;
 
 import javax.annotation.Nonnull;
@@ -30,6 +31,7 @@ import javax.annotation.Nonnull;
  * @see ExecuteProperties.Builder#setFailOnScanLimitReached(boolean)
  * @see CursorLimitManager#tryRecordScan()
  */
+@API(API.Status.STABLE)
 @SuppressWarnings("serial")
 public class ScanLimitReachedException extends RecordCoreException {
     public ScanLimitReachedException(@Nonnull String msg) {

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/ScanProperties.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/ScanProperties.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import java.util.function.Function;
 
@@ -28,6 +30,7 @@ import java.util.function.Function;
  * Among these properties is an {@link ExecuteProperties}, which holds the properties that pertain to an entire
  * execution.
  */
+@API(API.Status.MAINTAINED)
 public class ScanProperties {
     public static final ScanProperties FORWARD_SCAN = new ScanProperties(ExecuteProperties.newBuilder()
             .setReturnedRowLimit(Integer.MAX_VALUE)

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/SpotBugsSuppressWarnings.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/SpotBugsSuppressWarnings.java
@@ -20,11 +20,14 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
+
 /**
  * Suppress warnings from FindBugs / SpotBugs tools.
  *
  * Avoids introducing another transitive dependency.
  */
+@API(API.Status.STABLE)
 public @interface SpotBugsSuppressWarnings {
     String[] value();
     String justification() default "";

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/TimeScanLimiter.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/TimeScanLimiter.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see com.apple.foundationdb.record.cursors.CursorLimitManager
  */
+@API(API.Status.MAINTAINED)
 public class TimeScanLimiter {
     private static final Logger LOGGER = LoggerFactory.getLogger(TimeScanLimiter.class);
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/TupleRange.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/TupleRange.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.subspace.Subspace;
@@ -34,6 +35,7 @@ import java.util.Arrays;
 /**
  * A range within a subspace specified by two {@link Tuple} endpoints.
  */
+@API(API.Status.MAINTAINED)
 public class TupleRange {
     public static final TupleRange ALL = new TupleRange(null, null, EndpointType.TREE_START, EndpointType.TREE_END);
     @Nullable

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/logging/CompletionExceptionLogHelper.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/logging/CompletionExceptionLogHelper.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.logging;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -34,6 +36,7 @@ import java.util.concurrent.ExecutionException;
  * in an appropriate subclass of {@link com.apple.foundationdb.record.RecordCoreException}, so that
  * is returned, after remembering the original exception as a suppressed exception.
  */
+@API(API.Status.MAINTAINED)
 public class CompletionExceptionLogHelper {
 
     private static boolean addSuppressed = true;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.logging;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -33,6 +35,7 @@ import java.util.TreeMap;
  *
  * A {@code KeyValueLogMessage} has an associated set of key-value pairs, which are output after the static portion of the message in {@code key=value} form.
  */
+@API(API.Status.MAINTAINED)
 public class KeyValueLogMessage {
     private final long timestamp;
     private final String staticMessage;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -20,12 +20,15 @@
 
 package com.apple.foundationdb.record.logging;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 
 /**
  * Common {@link KeyValueLogMessage} keys logged by the Record Layer core.
  * In general, we try to consolidate all of the keys here, so that it's easy to check for collisions, ensure consistency, etc.
  */
+@API(API.Status.UNSTABLE)
 public enum LogMessageKeys {
     // general keys
     TITLE("ttl"),


### PR DESCRIPTION
Apply stability annotations to com.apple.foundationdb.record (excluding subpackages, including logging)