### PR TITLE
Change API status annotation to allow a simpler annotation.

### DIFF
--- a/fdb-extensions/src/com/apple/foundationdb/API.java
+++ b/fdb-extensions/src/com/apple/foundationdb/API.java
@@ -48,7 +48,7 @@ public @interface API {
      * Return the {@link Status} of the API element.
      * @return the current stability status of the annotated element
      */
-    Status stability();
+    Status value();
 
     /**
      * An enum of possible API stability statuses. Each use of the {@code API} annotation must declare its status as


### PR DESCRIPTION
Change the `status()` method to `value()` so that our annotations look like: `@API(INTERNAL)` instead of `@API(stability = INTERNAL)`.