### PR TITLE
Resolves #58: Apply stability annotations to fdb-extensions subproject

### DIFF
--- a/fdb-extensions/src/com/apple/foundationdb/async/AsyncPeekIterator.java
+++ b/fdb-extensions/src/com/apple/foundationdb/async/AsyncPeekIterator.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.async;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import java.util.NoSuchElementException;
 
@@ -39,6 +41,7 @@ import java.util.NoSuchElementException;
  *
  * @param <T> type of elements returned by the scan
  */
+@API(API.Status.STABLE)
 public interface AsyncPeekIterator<T> extends AsyncIterator<T> {
     /**
      * Get the next item of the scan without advancing it.

--- a/fdb-extensions/src/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.async;
 
+import com.apple.foundationdb.API;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import javax.annotation.Nonnull;
@@ -47,6 +48,7 @@ import static com.apple.foundationdb.async.AsyncUtil.whileTrue;
 /**
  * More helpers in the spirit of {@link AsyncUtil}.
  */
+@API(API.Status.UNSTABLE)
 public class MoreAsyncUtil {
 
     private static ScheduledThreadPoolExecutor scheduledThreadPoolExecutor
@@ -778,6 +780,7 @@ public class MoreAsyncUtil {
      * @param future the future to check for normal completion
      * @return whether the future has completed without exception
      */
+    @API(API.Status.MAINTAINED)
     public static boolean isCompletedNormally(@Nonnull CompletableFuture<?> future) {
         return future.isDone() && !future.isCompletedExceptionally();
     }
@@ -793,6 +796,7 @@ public class MoreAsyncUtil {
      * @param unit the time unit of the delay parameter
      * @return a {@link CompletableFuture} that will fire after the given delay
      */
+    @API(API.Status.MAINTAINED)
     @Nonnull
     public static CompletableFuture<Void> delayedFuture(long delay, @Nonnull TimeUnit unit) {
         if (delay <= 0) {
@@ -807,18 +811,14 @@ public class MoreAsyncUtil {
      * Close the given iterator, or at least cancel it.
      * @param iterator iterator to close
      */
-    public static void closeIterator(AsyncIterator<?> iterator) {
+    @API(API.Status.MAINTAINED)
+    public static void closeIterator(@Nonnull AsyncIterator<?> iterator) {
         if (iterator instanceof CloseableAsyncIterator) {
             ((CloseableAsyncIterator<?>)iterator).close();
         } else {
             iterator.cancel();
         }
     }
-
-    /**
-     * This is a static class, and should not be instantiated.
-     **/
-    private MoreAsyncUtil() {}
 
     /**
      * A {@code Boolean} function that is always true.
@@ -832,4 +832,9 @@ public class MoreAsyncUtil {
             return true;
         }
     }
+
+    /**
+     * This is a static class, and should not be instantiated.
+     **/
+    private MoreAsyncUtil() {}
 }

--- a/fdb-extensions/src/com/apple/foundationdb/async/RangeSet.java
+++ b/fdb-extensions/src/com/apple/foundationdb/async/RangeSet.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.async;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.ReadTransaction;
@@ -47,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * append only set that can be used to keep track of the progress that that job is making.
  * </p>
  */
+@API(API.Status.MAINTAINED)
 public class RangeSet {
     @Nonnull private Subspace subspace;
     @Nonnull private static final byte[] FIRST_KEY = new byte[]{(byte)0x00};

--- a/fdb-extensions/src/com/apple/foundationdb/async/RankedSet.java
+++ b/fdb-extensions/src/com/apple/foundationdb/async/RankedSet.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.async;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.KeySelector;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.MutationType;
@@ -55,8 +56,8 @@ import static com.apple.foundationdb.async.AsyncUtil.READY_FALSE;
  * its rank.
  * </p>
  */
-public class RankedSet
-{
+@API(API.Status.MAINTAINED)
+public class RankedSet {
     private static final int LEVEL_FAN_POW = 4;
     private static final int[] LEVEL_FAN_VALUES; // 2^(l * FAN) - 1 per level
     public static final int MAX_LEVELS = Integer.SIZE / LEVEL_FAN_POW;

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedMap.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedMap.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.KeySelector;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.MutationType;
@@ -97,6 +98,7 @@ import javax.annotation.Nullable;
  * @param <K> type of keys in the map
  * @param <V> type of values in the map
  */
+@API(API.Status.EXPERIMENTAL)
 public class BunchedMap<K,V> {
     private static final int MAX_VALUE_SIZE = 10_000; // The actual max value size is 100_000, but let's stay clear of that
     private static final byte[] ZERO_ARRAY = new byte[]{0x00};

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapException.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapException.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.util.LoggableException;
 import javax.annotation.Nonnull;
 
@@ -34,6 +35,7 @@ import javax.annotation.Nonnull;
  * @see BunchedSerializationException
  */
 @SuppressWarnings("serial")
+@API(API.Status.EXPERIMENTAL)
 public class BunchedMapException extends LoggableException {
     public BunchedMapException(@Nonnull String message) {
         super(message);

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapIterator.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapIterator.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.async.AsyncPeekIterator;
@@ -45,6 +46,7 @@ import java.util.concurrent.CompletableFuture;
  * @param <K> type of keys in the map
  * @param <V> type of values in the map
  */
+@API(API.Status.EXPERIMENTAL)
 public class BunchedMapIterator<K,V> implements AsyncPeekIterator<Map.Entry<K,V>> {
     @Nonnull private final AsyncPeekIterator<KeyValue> underlying;
     @Nonnull private final Subspace subspace;

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapMultiIterator.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapMultiIterator.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.async.AsyncPeekIterator;
@@ -50,6 +51,7 @@ import java.util.concurrent.CompletableFuture;
  * @param <V> type of values in the maps
  * @param <T> type of tags associated with each subspace
  */
+@API(API.Status.EXPERIMENTAL)
 public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<BunchedMapScanEntry<K,V,T>> {
     @Nonnull private final AsyncPeekIterator<KeyValue> underlying;
     @Nonnull private final ReadTransaction tr;

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapScanEntry.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedMapScanEntry.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.subspace.Subspace;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -37,6 +38,7 @@ import javax.annotation.Nullable;
  * @param <V> type of values in the bunched map
  * @param <T> type of the tag associated with each subspace
  */
+@API(API.Status.EXPERIMENTAL)
 public class BunchedMapScanEntry<K,V,T> {
     @Nonnull private final Subspace subspace;
     @Nullable private final T subspaceTag;

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedSerializationException.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedSerializationException.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 
 import javax.annotation.Nonnull;
@@ -32,6 +33,7 @@ import java.util.Arrays;
  * with the exception such as what inputs into the serializer caused the exception
  * to be thrown.
  */
+@API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("serial")
 public class BunchedSerializationException extends BunchedMapException {
     @Nullable

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedSerializer.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedSerializer.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,6 +35,7 @@ import javax.annotation.Nonnull;
  * @param <K> type of the keys in the {@link BunchedMap}
  * @param <V> type of the values in the {@link BunchedMap}
  */
+@API(API.Status.EXPERIMENTAL)
 public interface BunchedSerializer<K,V> {
 
     /**

--- a/fdb-extensions/src/com/apple/foundationdb/map/BunchedTupleSerializer.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/BunchedTupleSerializer.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import java.util.AbstractMap;
@@ -37,6 +38,7 @@ import javax.annotation.Nonnull;
  * space inefficient when serializing an entry as the {@link Tuple} encoding is
  * designed to preserve order, which is unnecessary for values.
  */
+@API(API.Status.EXPERIMENTAL)
 public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
     @Nonnull
     static final byte[] PREFIX = new byte[]{0x10};

--- a/fdb-extensions/src/com/apple/foundationdb/map/SubspaceSplitter.java
+++ b/fdb-extensions/src/com/apple/foundationdb/map/SubspaceSplitter.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.map;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.subspace.Subspace;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
  *
  * @param <T> type of tag returned by the subspace splitter
  */
+@API(API.Status.EXPERIMENTAL)
 public interface SubspaceSplitter<T> {
     /**
      * Determine a {@link Subspace} that the given key is contained

--- a/fdb-extensions/src/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.tuple;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -28,6 +30,7 @@ import java.util.List;
 /**
  * Helper methods in the spirit of {@link ByteArrayUtil}.
  */
+@API(API.Status.UNSTABLE)
 public class ByteArrayUtil2 {
 
     private static final byte EQUALS_CHARACTER = (byte)'=';
@@ -54,6 +57,7 @@ public class ByteArrayUtil2 {
         return new String(hex);
     }
 
+    @API(API.Status.MAINTAINED)
     @Nullable
     public static String loggable(@Nullable byte[] bytes) {
         if (bytes == null) {
@@ -78,6 +82,7 @@ public class ByteArrayUtil2 {
         }
     }
 
+    @API(API.Status.MAINTAINED)
     @Nullable
     public static byte[] unprint(@Nullable String loggedBytes) {
         if (loggedBytes == null) {
@@ -119,5 +124,8 @@ public class ByteArrayUtil2 {
             }
         }
         return true;
+    }
+
+    private ByteArrayUtil2() {
     }
 }

--- a/fdb-extensions/src/com/apple/foundationdb/tuple/TupleHelpers.java
+++ b/fdb-extensions/src/com/apple/foundationdb/tuple/TupleHelpers.java
@@ -20,22 +20,29 @@
 
 package com.apple.foundationdb.tuple;
 
+import com.apple.foundationdb.API;
+
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
  * Helper methods for working with {@link Tuple}s.
  */
+@API(API.Status.UNSTABLE)
 public class TupleHelpers {
 
+    @Nonnull
     public static final Tuple EMPTY = Tuple.from();
 
-    public static Tuple set(Tuple src, int index, Object value) {
+    @Nonnull
+    public static Tuple set(@Nonnull Tuple src, int index, Object value) {
         final List<Object> items = src.getItems();
         items.set(index, value);
         return Tuple.fromList(items);
     }
 
-    public static Tuple subTuple(Tuple src, int start, int end) {
+    @Nonnull
+    public static Tuple subTuple(@Nonnull Tuple src, int start, int end) {
         final List<Object> items = src.getItems();
         return Tuple.fromList(items.subList(start, end));
     }
@@ -51,7 +58,8 @@ public class TupleHelpers {
      *         a value less than {@code 0} if {@code t1} would sort before {@code t2}
      *         a value greater than {@code 0} if {@code t1} would sort after {@code t2}
      */
-    public static int compare(Tuple t1, Tuple t2) {
+    @API(API.Status.MAINTAINED)
+    public static int compare(@Nonnull Tuple t1, @Nonnull Tuple t2) {
         final int t1Len = t1.size();
         final int t2Len = t2.size();
         final int len = Math.min(t1Len, t2Len);
@@ -63,5 +71,8 @@ public class TupleHelpers {
             }
         }
         return t1Len - t2Len;
+    }
+
+    private TupleHelpers() {
     }
 }

--- a/fdb-extensions/src/com/apple/foundationdb/util/LogMessageKeys.java
+++ b/fdb-extensions/src/com/apple/foundationdb/util/LogMessageKeys.java
@@ -20,12 +20,15 @@
 
 package com.apple.foundationdb.util;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 
 /**
  * Common {@link LoggableException} keys logged by the FoundationDB extensions library.
  * In general, we try to consolidate all of the keys for this library, so that it's easy to check for collisions, ensure consistency, etc.
  */
+@API(API.Status.UNSTABLE)
 public enum LogMessageKeys {
     SUBSPACE("subspace");
 

--- a/fdb-extensions/src/com/apple/foundationdb/util/LoggableException.java
+++ b/fdb-extensions/src/com/apple/foundationdb/util/LoggableException.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.util;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -31,6 +33,7 @@ import java.util.Map;
  * be logged in a way that better supports searching later.
  */
 @SuppressWarnings("serial")
+@API(API.Status.MAINTAINED)
 public class LoggableException extends RuntimeException {
     private static final Object[] EMPTY_LOG_INFO = new Object[0];
     @Nullable private Map<String, Object> logInfo;


### PR DESCRIPTION
I went with `UNSTABLE` for most things, as this subproject tends not to see a lot of changes, but we tend to treat it more as a utility API than as something we want as part of our public API, but some things could be useful for others, I guess, but they will probably change without a lot of notice. A few of the more common ones got marked as `MAINTAINED`. The `RangeSet` and `RankSet` data structures are kind of designed to be usable outside this project, so I went with `MAINTAINED` for those, though maybe they should be `STABLE`.

All of the `BunchedMap` classes I just marked as `EXPERIMENTAL` because they were added along with the full-text things, which I guess will also be `EXPERIMENTAL`. We should probably upgrade them when we are more confident in that solution.