### PR TITLE
Resolves #63: Apply stability annotations to com.apple.foundationdb.record.provider.common

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/DynamicMessageRecordSerializer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/DynamicMessageRecordSerializer.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 /**
  * Serialize records using default Protobuf serialization using {@link DynamicMessage}.
  */
+@API(API.Status.UNSTABLE)
 public class DynamicMessageRecordSerializer implements RecordSerializer<Message> {
     private static final Logger LOGGER = LoggerFactory.getLogger(DynamicMessageRecordSerializer.class);
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializer.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.google.protobuf.Descriptors;
@@ -31,6 +32,7 @@ import java.util.function.Supplier;
 /**
  * Serialize records using default Protobuf serialization using supplied message builder for the union message type.
  */
+@API(API.Status.UNSTABLE)
 public class MessageBuilderRecordSerializer extends MessageBuilderRecordSerializerBase<Message, Message, Message.Builder> {
     public MessageBuilderRecordSerializer(@Nonnull Supplier<Message.Builder> builderSupplier) {
         super(builderSupplier);

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializerBase.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializerBase.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -40,6 +41,7 @@ import java.util.function.Supplier;
  * @param <B> generated Protobuf class for the union message's builder
  * @see DynamicMessageRecordSerializer
  */
+@API(API.Status.UNSTABLE)
 public abstract class MessageBuilderRecordSerializerBase<M extends Message, U extends Message, B extends Message.Builder> implements RecordSerializer<M> {
     @Nonnull
     private final Supplier<B> builderSupplier;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/RecordSerializationException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/RecordSerializationException.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreException;
 
 import javax.annotation.Nonnull;
@@ -28,6 +29,7 @@ import javax.annotation.Nullable;
 /**
  * Exception thrown when there is a problem serializing or deserializing a record.
  */
+@API(API.Status.MAINTAINED)
 @SuppressWarnings("serial")
 public class RecordSerializationException extends RecordCoreException {
     public RecordSerializationException(@Nonnull String msg, @Nullable Object ... keyValues) {

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorVisitor;
@@ -49,6 +50,7 @@ import java.util.stream.Stream;
  * If a context has a store timer, various operations will record timing information in it. It is up to the caller to provide the necessary integration
  * between this information and any system monitoring tools.
  */
+@API(API.Status.MAINTAINED)
 public class StoreTimer {
     static final Counter EMPTY_COUNTER = new Counter();
 
@@ -56,7 +58,7 @@ public class StoreTimer {
      * Confirm that there is no naming conflict among the event names that will be used.
      * @param events a stream of events to check for duplicates
      */
-    public static void checkEventNameUniqueness(Stream<Event> events) {
+    public static void checkEventNameUniqueness(@Nonnull Stream<Event> events) {
         final Set<String> seen = new HashSet<>();
         final Set<String> duplicates = events.map(Event::name).filter(n -> !seen.add(n)).collect(Collectors.toSet());
         if (!duplicates.isEmpty()) {
@@ -64,7 +66,8 @@ public class StoreTimer {
         }
     }
 
-    protected static Counter getCounter(Map<Event, Counter> counters, Event event, boolean create) {
+    @Nonnull
+    protected static Counter getCounter(@Nonnull Map<Event, Counter> counters, @Nonnull Event event, boolean create) {
         if (create) {
             return counters.computeIfAbsent(event, evignore -> new Counter());
         } else {
@@ -75,25 +78,25 @@ public class StoreTimer {
     /**
      * An identifier for occurrences that need to be timed.
      */
-    public static interface Event {
+    public interface Event {
         /**
          * Get the name of this event for machine processing.
          * @return the name
          */
-        public String name();
+        String name();
 
         /**
          * Get the title of this event for user displays.
          * @return the user-visible title
          */
-        public String title();
+        String title();
     }
 
     /**
      * {@link Event}s that are a significant part of a larger process.
      * The time in these events should be accounted for within another event and so should not be added to totals.
      */
-    public static interface DetailEvent extends Event {
+    public interface DetailEvent extends Event {
     }
 
     /**
@@ -101,19 +104,19 @@ public class StoreTimer {
      * The time for a {@code Wait} is the time actually waiting, which may be shorter than the time for the asynchronous
      * operation itself.
      */
-    public static interface Wait extends Event {
+    public interface Wait extends Event {
     }
 
     /**
      * {@link Event}s that only count occurrences or total size.
      * There is no meaningful time duration associated with these events.
      */
-    public static interface Count extends Event {
+    public interface Count extends Event {
         /**
          * Get whether the count value is actually a size in bytes.
          * @return {@code true} if the count value is actually a size in bytes
          */
-        public boolean isSize();
+        boolean isSize();
     }
 
     protected static class Counter {

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
@@ -74,6 +75,7 @@ import java.util.zip.Inflater;
  *
  * @param <M> type of {@link Message} that underlying records will use
  */
+@API(API.Status.UNSTABLE)
 public class TransformedRecordSerializer<M extends Message> implements RecordSerializer<M> {
     @VisibleForTesting
     protected static final int ENCODING_ENCRYPTED = 1;

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerJCE.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerJCE.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.google.protobuf.Message;
 
@@ -35,6 +36,7 @@ import java.security.SecureRandom;
  * An extension of {@link TransformedRecordSerializer} to use JCE to encrypt and decrypt records.
  * @param <M> type of {@link Message} that underlying records will use
  */
+@API(API.Status.UNSTABLE)
 public class TransformedRecordSerializerJCE<M extends Message> extends TransformedRecordSerializer<M> {
 
     // AES with 128 bits key

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/TypedRecordSerializer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/TypedRecordSerializer.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -41,6 +42,7 @@ import java.util.function.Supplier;
  * @param <U> generated Protobuf class for the union message
  * @param <B> generated Protobuf class for the union message's builder
  */
+@API(API.Status.UNSTABLE)
 public class TypedRecordSerializer<M extends Message, U extends Message, B extends Message.Builder>
         extends MessageBuilderRecordSerializerBase<M, U, B> {
     @Nonnull

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/DefaultTextTokenizer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/DefaultTextTokenizer.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.provider.common.text;
 
+import com.apple.foundationdb.API;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.text.BreakIterator;
@@ -38,6 +40,7 @@ import java.util.NoSuchElementException;
  * it handle languages like Chinese, Japanese, or Thai that do not generally use whitespace
  * to indicate word boundaries.
  */
+@API(API.Status.EXPERIMENTAL)
 public class DefaultTextTokenizer implements TextTokenizer {
     @Nonnull
     private static final DefaultTextTokenizer INSTANCE = new DefaultTextTokenizer();

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/DefaultTextTokenizerFactory.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/DefaultTextTokenizerFactory.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common.text;
 
+import com.apple.foundationdb.API;
 import com.google.auto.service.AutoService;
 
 import javax.annotation.Nonnull;
@@ -28,6 +29,7 @@ import javax.annotation.Nonnull;
  * Factory class for the {@link DefaultTextTokenizer}. That class is a singleton,
  * so it will return the already existing instance.
  */
+@API(API.Status.EXPERIMENTAL)
 @AutoService(TextTokenizerFactory.class)
 public class DefaultTextTokenizerFactory implements TextTokenizerFactory {
     /**

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizer.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common.text;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.MetaDataException;
@@ -56,6 +57,7 @@ import java.util.Map;
  * @see TextTokenizerRegistry
  * @see com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexMaintainer
  */
+@API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("squid:S1214") // constants in interfaces
 public interface TextTokenizer {
     /**

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizerFactory.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizerFactory.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common.text;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexMaintainer;
 
 import javax.annotation.Nonnull;
@@ -32,6 +33,7 @@ import javax.annotation.Nonnull;
  *
  * @see TextIndexMaintainer
  */
+@API(API.Status.EXPERIMENTAL)
 public interface TextTokenizerFactory {
     /**
      * Get the unique name for the text tokenizer. This is the name that should

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistry.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistry.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common.text;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.MetaDataException;
@@ -43,6 +44,7 @@ import java.util.Map;
  * for tokenizers that are built on the fly from configuration parameters, for example.
  * </p>
  */
+@API(API.Status.EXPERIMENTAL)
 public interface TextTokenizerRegistry {
     /**
      * Gets the tokenizer of the given name. If <code>name</code> is <code>null</code>,

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistryImpl.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistryImpl.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.common.text;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
@@ -44,6 +45,7 @@ import java.util.ServiceLoader;
  * additional tokenizers for that index by calling the {@link #register(TextTokenizerFactory) register}
  * method on the singleton instance of this class and supplying the additional tokenizer.
  */
+@API(API.Status.EXPERIMENTAL)
 public class TextTokenizerRegistryImpl implements TextTokenizerRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(TextTokenizerRegistryImpl.class);
     private static final TextTokenizerRegistryImpl INSTANCE = new TextTokenizerRegistryImpl();


### PR DESCRIPTION
The text things I all marked as experimental. The interface for record serializers I marked as "maintained", and then the implementations were all marked as unstable, the idea being that we are unlikely to change the outer interface for all of those classes but might change how some of the particular ones are initialized (etc.).