### PR TITLE
Fixes #106: New database does not receive current datacenter id

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -353,6 +353,7 @@ public class FDBDatabaseFactory {
             database.setDirectoryCacheSize(getDirectoryCacheSize());
             database.setTrackLastSeenVersion(getTrackLastSeenVersion());
             database.setResolverStateRefreshTimeMillis(getStateRefreshTimeMillis());
+            database.setDatacenterId(getDatacenterId());
             databases.put(clusterFile, database);
         }
         return database;


### PR DESCRIPTION
Make this like all the rest of the options already there.

Since there isn't a way to read it back out, there isn't an obvious test to add.