### PR TITLE
Fixes #117: Full Text: Queries on maps when combined with other filters throw an error when planned

### DIFF
--- a/fdb-record-layer-core/proto/test/test_records_text.proto
+++ b/fdb-record-layer-core/proto/test/test_records_text.proto
@@ -46,6 +46,7 @@ message MapDocument {
         optional string value = 2;
     }
     repeated Entry entry = 2;
+    optional int64 group = 3;
 }
 
 message MultiDocument {


### PR DESCRIPTION
The fix was to make the QueryToKeyMatcher more recursive and have it no longer try and guess which path it needs based on a string representation of how the path from the root to the leaf element would look. This allows it to handle nested ands, etc. Depending on what kinds of queries and expressions it gets, it might be less efficient in some cases if it needs to do a lot of recursing.