### PR TITLE
Fixes #119: Add strict compatibility mode for prefersIndexToScan

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/QueryPlanner.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/QueryPlanner.java
@@ -31,6 +31,29 @@ import javax.annotation.Nonnull;
  */
 public interface QueryPlanner {
     /**
+     * Preference between index scan and record scan.
+     * @see #setIndexScanPreference
+     */
+    enum IndexScanPreference {
+        /**
+         * Prefer a full scan over an index scan.
+         * A full scan does not have to separately fetch the record, but may return records of types that just
+         * need to be skipped.
+         */
+        PREFER_SCAN,
+        /**
+         * Prefer index scan over full scan.
+         * An index scan always fetches the record separately but is less vulnerable to the addition of records
+         * of unrelated record types.
+         */
+        PREFER_INDEX,
+        /**
+         * Prefer a scan using an index for <em>exactly</em> the primary key.
+         */
+        PREFER_PRIMARY_KEY_INDEX
+    }
+
+    /**
      * Create a plan to get the results of the provided query.
      *
      * @param query a query for records on this planner's metadata
@@ -47,7 +70,7 @@ public interface QueryPlanner {
      * Scanning without an index is more efficient, but will have to skip over unrelated record types.
      * For that reason, it is safer to use an index, except when there is only one record type.
      * If the meta-data has more than one record type but the record store does not, this can be overridden.
-     * @param preferIndexToScan whether to prefer index scan over record scan
+     * @param indexScanPreference whether to prefer index scan over record scan
      */
-    void setPreferIndexToScan(boolean preferIndexToScan);
+    void setIndexScanPreference(@Nonnull IndexScanPreference indexScanPreference);
 }

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -110,7 +110,8 @@ public class RecordQueryPlanner implements QueryPlanner {
     private final PlannableIndexTypes indexTypes;
 
     private boolean primaryKeyHasRecordTypePrefix;
-    private boolean preferIndexToScan;
+    @Nonnull
+    private IndexScanPreference indexScanPreference;
 
     public RecordQueryPlanner(@Nonnull RecordMetaData metaData, @Nonnull RecordStoreState recordStoreState) {
         this(metaData, recordStoreState, null);
@@ -141,7 +142,8 @@ public class RecordQueryPlanner implements QueryPlanner {
 
         primaryKeyHasRecordTypePrefix = metaData.primaryKeyHasRecordTypePrefix();
         // If we are going to need type filters on Scan, index is safer without knowing any cardinalities.
-        preferIndexToScan = metaData.getRecordTypes().size() > 1 && !primaryKeyHasRecordTypePrefix;
+        indexScanPreference = metaData.getRecordTypes().size() > 1 && !primaryKeyHasRecordTypePrefix ?
+                              IndexScanPreference.PREFER_INDEX : IndexScanPreference.PREFER_SCAN;
     }
 
     /**
@@ -149,8 +151,9 @@ public class RecordQueryPlanner implements QueryPlanner {
      * satisfy any additional conditions.
      * @return whether to prefer index scan over record scan
      */
-    public boolean prefersIndexToScan() {
-        return preferIndexToScan;
+    @Nonnull
+    public IndexScanPreference getIndexScanPreference() {
+        return indexScanPreference;
     }
 
     /**
@@ -159,11 +162,11 @@ public class RecordQueryPlanner implements QueryPlanner {
      * Scanning without an index is more efficient, but will have to skip over unrelated record types.
      * For that reason, it is safer to use an index, except when there is only one record type.
      * If the meta-data has more than one record type but the record store does not, this can be overridden.
-     * @param preferIndexToScan whether to prefer index scan over record scan
+     * @param indexScanPreference whether to prefer index scan over record scan
      */
     @Override
-    public void setPreferIndexToScan(boolean preferIndexToScan) {
-        this.preferIndexToScan = preferIndexToScan;
+    public void setIndexScanPreference(@Nonnull IndexScanPreference indexScanPreference) {
+        this.indexScanPreference = indexScanPreference;
     }
 
     /**
@@ -273,13 +276,27 @@ public class RecordQueryPlanner implements QueryPlanner {
             if (index2 == null) {
                 return 0;
             } else {
-                return prefersIndexToScan() ? -1 : +1;
+                return preferIndexToScan(planContext, index2) ? -1 : +1;
             }
         } else if (index2 == null) {
-            return prefersIndexToScan() ? +1 : -1;
+            return preferIndexToScan(planContext, index1) ? +1 : -1;
         } else {
             // Better for fewer stored columns.
             return Integer.compare(indexSizeOverhead(planContext, index2), indexSizeOverhead(planContext, index1));
+        }
+    }
+
+    // Compatible behavior with older code: prefer an index on *just* the primary key.
+    private boolean preferIndexToScan(PlanContext planContext, @Nonnull Index index) {
+        switch (getIndexScanPreference()) {
+            case PREFER_INDEX:
+                return true;
+            case PREFER_SCAN:
+                return false;
+            case PREFER_PRIMARY_KEY_INDEX:
+                return index.getRootExpression().equals(planContext.commonPrimaryKey);
+            default:
+                throw new RecordCoreException("Unknown indexScanPreference: " + indexScanPreference);
         }
     }
 

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/temp/RewritePlanner.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/temp/RewritePlanner.java
@@ -90,7 +90,7 @@ public class RewritePlanner implements QueryPlanner {
     }
 
     @Override
-    public void setPreferIndexToScan(boolean preferIndexToScan) {
+    public void setIndexScanPreference(@Nonnull IndexScanPreference indexScanPreference) {
         // nothing to do here, yet
     }
 

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
@@ -45,6 +45,7 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryRecordFunction;
+import com.apple.foundationdb.record.query.plan.QueryPlanner;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
@@ -906,7 +907,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
                         Query.rank(Key.Expressions.field("score").groupBy(Key.Expressions.field("header").nest(Key.Expressions.field("group"))))
                                 .lessThan(2L)))
                 .build();
-        planner.setPreferIndexToScan(false);
+        planner.setIndexScanPreference(QueryPlanner.IndexScanPreference.PREFER_SCAN);
         RecordQueryPlan plan = planner.plan(query);
         assertEquals("Scan(([buffaloes, 100],[buffaloes]]) | [HeaderRankedRecord]" +
                         " | score LESS_THAN $__rank_0 WHERE __rank_0 = score_by_nested_id.score_for_rank_else_skip(buffaloes, 2)",

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.QueryPlanner;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
@@ -260,7 +261,7 @@ public class FDBAndQueryToIntersectionTest extends FDBRecordStoreQueryTestBase {
                         Query.field("str_value_indexed").equalsValue("even"),
                         Query.field("num_value_3_indexed").equalsValue(3)))
                 .build();
-        planner.setPreferIndexToScan(false);
+        planner.setIndexScanPreference(QueryPlanner.IndexScanPreference.PREFER_SCAN);
         RecordQueryPlan plan = planner.plan(query);
         // Would get Intersection didn't have identical continuations if it did
         assertThat("Should not use grouped index", plan, hasNoDescendant(indexScan(indexName("grouped_index"))));

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreIndexScanPreferenceTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreIndexScanPreferenceTest.java
@@ -1,0 +1,106 @@
+/*
+ * FDBRecordStoreIndexScanPreferenceTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.query;
+
+import com.apple.foundationdb.record.TestNoIndexesProto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.plan.QueryPlanner;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.typeFilter;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.unbounded;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+
+/**
+ * Tests of {@link QueryPlanner.IndexScanPreference}
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBRecordStoreIndexScanPreferenceTest extends FDBRecordStoreQueryTestBase {
+
+    @Test
+    public void noIndexes() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestNoIndexesProto.getDescriptor(), context);
+        }
+
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .build();
+
+        for (QueryPlanner.IndexScanPreference indexScanPreference : QueryPlanner.IndexScanPreference.values()) {
+            planner.setIndexScanPreference(indexScanPreference);
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, scan(bounds(unbounded())));
+        }
+    }
+
+    @Test
+    public void regularIndexes() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+        }
+
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .build();
+
+        for (QueryPlanner.IndexScanPreference indexScanPreference : QueryPlanner.IndexScanPreference.values()) {
+            planner.setIndexScanPreference(indexScanPreference);
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, indexScanPreference == QueryPlanner.IndexScanPreference.PREFER_INDEX ?
+                             indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(unbounded()))) :
+                             typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))));
+        }
+    }
+
+    @Test
+    public void primaryKeyIndex() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, md -> {
+                md.addIndex(md.getRecordType("MySimpleRecord"), new Index("pkey", "rec_no"));
+            });
+        }
+
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .build();
+
+        for (QueryPlanner.IndexScanPreference indexScanPreference : QueryPlanner.IndexScanPreference.values()) {
+            planner.setIndexScanPreference(indexScanPreference);
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, indexScanPreference == QueryPlanner.IndexScanPreference.PREFER_SCAN ?
+                             typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))) :
+                             indexScan(allOf(indexName("pkey"), bounds(unbounded()))));
+        }
+    }
+
+}


### PR DESCRIPTION
Coincidentally, this also resolves the tricky naming convention of the old boolean methods.