### PR TITLE
Resolves #73: Produce artifacts with shaded protobuf and guava dependencies

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -45,6 +45,9 @@
       <module name="fdb-extensions_integrationTest" target="1.8" />
       <module name="fdb-extensions_main" target="1.8" />
       <module name="fdb-extensions_test" target="1.8" />
+      <module name="fdb-record-layer-core-shaded_integrationTest" target="1.8" />
+      <module name="fdb-record-layer-core-shaded_main" target="1.8" />
+      <module name="fdb-record-layer-core-shaded_test" target="1.8" />
       <module name="fdb-record-layer-core_integrationTest" target="1.8" />
       <module name="fdb-record-layer-core_main" target="1.8" />
       <module name="fdb-record-layer-core_test" target="1.8" />

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         classpath 'org.jboss.tattletale:tattletale:1.2.0.Beta2'
         classpath 'de.undercouch:gradle-download-task:3.1.1'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.0'
-        classpath "com.github.jengelman.gradle.plugins:shadow:2.0.0"
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
         //classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.4'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
@@ -194,6 +194,22 @@ subprojects {
         }
     }
 
+    def protoMajorVersion
+    if (System.getenv('PROTO_VERSION') != null) {
+        protoMajorVersion = System.getenv('PROTO_VERSION')
+    } else {
+        protoMajorVersion = '2'
+    }
+    ext {
+        if (protoMajorVersion != "2") {
+            coreProjectName = "fdb-record-layer-core-pb${protoMajorVersion}"
+            shadedProjectName = "fdb-record-layer-core-pb${protoMajorVersion}-shaded"
+        } else {
+            coreProjectName = "fdb-record-layer-core"
+            shadedProjectName = "fdb-record-layer-core-shaded"
+        }
+    }
+
     publishing {
         publications {
             library(MavenPublication) {
@@ -219,6 +235,7 @@ subprojects {
                 override = !isReleaseBuild
                 publish = publishBuild
             }
+            bintrayPublish.enabled = true
         } else {
             bintrayPublish.enabled = false
         }

--- a/build.py
+++ b/build.py
@@ -140,7 +140,9 @@ def build(release=False, proto2=False, proto3=False, publish=False):
 
     if proto3:
         # Make with protobuf 3.
-        success = run_gradle(3, 'build', 'destructiveTest', ':fdb-record-layer-core-pb3:bintrayUpload', '-PcoreNotStrict',
+        success = run_gradle(3, 'build', 'destructiveTest', '-PcoreNotStrict',
+                                ':fdb-record-layer-core-pb3:bintrayUpload',
+                                ':fdb-record-layer-core-pb3-shaded:bintrayUpload',
                                 '-PreleaseBuild={0}'.format('true' if release else 'false'),
                                 '-PpublishBuild={0}'.format('true' if publish else 'false'))
         if not success:

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -1,0 +1,78 @@
+/*
+ * fdb-record-layer-core-shaded.gradle
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
+def coreProject = ":${ext.coreProjectName}"
+
+dependencies {
+  compile project(coreProject)
+}
+
+shadowJar {
+    classifier = null
+    relocate 'com.google', 'com.apple.foundationdb.record.shaded.com.google'
+    dependencies {
+        include(dependency(coreProject))
+        include(dependency('com.google.guava:guava'))
+        include(dependency('com.google.protobuf:protobuf-java'))
+    }
+}
+
+build.dependsOn {
+    shadowJar
+}
+
+publishing {
+    publications {
+        shadow(MavenPublication) { publication ->
+            from project.shadow.component(publication)
+            publication.pom { pom ->
+                pom.withXml { xml ->
+                    // Remove any existing dependencies sections
+                    def childNodes = xml.asNode().children()
+                    def dependenciesNodes = new ArrayList<groovy.util.Node>()
+                    childNodes.forEach { childNode ->
+                        if (childNode.name().equals('dependencies')) {
+                            dependenciesNodes.add(childNode)
+                        }
+                    }
+                    dependenciesNodes.forEach {
+                        xml.asNode().remove(it)
+                    }
+                    // Add a section containing all non-shaded dependencies
+                    def dependenciesNode = xml.asNode().appendNode('dependencies')
+                    project(coreProject).configurations.compile.getDependencies().forEach {
+                        if (!it.name.equals('guava') && !it.name.equals('protobuf-java')) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                            dependencyNode.appendNode('scope', 'compile')
+                        }
+                    }
+                }
+            }
+        }
+    }
+    bintray {
+        publications = ["shadow"]
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ rootProject.name='fdb-record-layer'
 
 include 'fdb-extensions'
 include 'fdb-record-layer-core'
+include 'fdb-record-layer-core-shaded'
 
 
 // It's confusing to have dozens of files called build.gradle scattered around the project
@@ -43,9 +44,13 @@ rootProject.children.each { project ->
 // https://docs.gradle.org/4.8/userguide/publishing_maven.html#publishing_maven:deferred_configuration
 enableFeaturePreview('STABLE_PUBLISHING')
 
+def protoMajorVersion
 if ( System.getenv('PROTO_VERSION') != null) {
-    def protoMajorVersion = System.getenv('PROTO_VERSION')
-    if (protoMajorVersion != "2") {
-        project(':fdb-record-layer-core').name = "fdb-record-layer-core-pb${protoMajorVersion}"
-    }
+    protoMajorVersion = System.getenv('PROTO_VERSION')
+} else {
+    protoMajorVersion = '2'
+}
+if (protoMajorVersion != "2") {
+    project(':fdb-record-layer-core').name = "fdb-record-layer-core-pb${protoMajorVersion}"
+    project(':fdb-record-layer-core-shaded').name = "fdb-record-layer-core-pb${protoMajorVersion}-shaded"
 }


### PR DESCRIPTION
This adds a new subproject whose sole purpose in life is to produce the shaded artifacts. It takes the core project as a dependency, and then it produces a shadow jar containing that dependency, guava, and protobuf-java. The core project is kept in its namespace; the two others are now under the `com.apple.foundationdb.record.shaded` package.

Left as an excercise to the reader is how to produce output from protoc whose generated message are in our shaded package path rather than in the standard package. I believe that @coufo might be able to add information on how to do that. Once we know that, I think we should also add to our docs (1) that this shaded package exists and what it is good for and (2) how to make your protoc output conform with this package. I haven't actually tested that all of that works soup to nuts, but with that extra information, I should be able to. But I wanted to get this PR out to show others what the shading is going to look like.