### PR TITLE
Resolves #139: Add support for building and running on Java 11

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/metadata/package-info.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/metadata/package-info.java
@@ -26,14 +26,24 @@
  * <p>
  * All operations on records are mediated by a {@link com.apple.foundationdb.record.RecordMetaData}.
  * It describes the format of persistent records, their fields and secondary indexes.
+ * There is a rough correspondence between the terminology used within the Record Layer
+ * and those used by relational databases:
  * </p>
  *
- * <table border="1" summary="relational correspondences">
+ * <table border="1">
+ * <caption>relational correspondences</caption>
  * <tr><th>Record Layer</th><th>Relational</th></tr>
- * <tr><th>meta-data</th><th>schema</th></tr>
- * <tr><th>record type</th><th>table</th></tr>
- * <tr><th>field</th><th>column</th></tr>
+ * <tr><td>meta-data</td><td>schema</td></tr>
+ * <tr><td>record type</td><td>table</td></tr>
+ * <tr><td>field</td><td>column</td></tr>
  * </table>
+ *
+ * <p>
+ * Note that this correspondence is not exact. In particular, note that a record type and a
+ * table differ in that records of various types are included within the same extent. There are
+ * more details about the differences between tables and record types within the
+ * <a href="https://github.com/FoundationDB/fdb-record-layer/blob/master/docs/FAQ.md#are-record-types-tables">Record Layer FAQ</a>.
+ * </p>
  *
  * <p>
  * The core of the meta-data is a Protobuf {@link com.google.protobuf.Descriptors.FileDescriptor}.

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
@@ -52,7 +52,7 @@ public class TracedTransaction implements Transaction {
         this.transaction = transaction;
     }
 
-    @SuppressWarnings({"NoFinalizer", "squid:ObjectFinalizeOverridenCheck"})
+    @SuppressWarnings({"NoFinalizer", "squid:ObjectFinalizeOverridenCheck", "deprecation"})
     @Override
     protected void finalize() {
         if (transaction != null) {

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexBuilderTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexBuilderTest.java
@@ -1330,7 +1330,7 @@ public class OnlineIndexBuilderTest {
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());
         Set<Integer> usedKeys = new HashSet<>();
-        List<Integer> primaryKeys = IntStream.generate(() -> r.nextInt(100)).filter(usedKeys::add).limit(50).mapToObj(Integer::new).collect(Collectors.toList());
+        List<Integer> primaryKeys = IntStream.generate(() -> r.nextInt(100)).filter(usedKeys::add).limit(50).boxed().collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = primaryKeys.stream().map(recNo ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(recNo).setNumValue2(r.nextInt(20) + 20).build()
         ).collect(Collectors.toList());
@@ -1345,7 +1345,7 @@ public class OnlineIndexBuilderTest {
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());
         Set<Integer> usedKeys = new HashSet<>();
-        List<Integer> primaryKeys = IntStream.generate(() -> r.nextInt(100)).filter(usedKeys::add).limit(50).mapToObj(Integer::new).collect(Collectors.toList());
+        List<Integer> primaryKeys = IntStream.generate(() -> r.nextInt(100)).filter(usedKeys::add).limit(50).boxed().collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = primaryKeys.stream().map(recNo ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(recNo).setNumValue2(r.nextInt(20) + 20).build()
         ).collect(Collectors.toList());
@@ -1442,7 +1442,7 @@ public class OnlineIndexBuilderTest {
         ).limit(100).collect(Collectors.toList());
         openSimpleMetaData(metaDataBuilder -> metaDataBuilder.setStoreRecordVersions(false));
         Set<Integer> usedKeys = new HashSet<>();
-        List<Integer> primaryKeys = IntStream.generate(() -> r.nextInt(100)).filter(usedKeys::add).limit(50).mapToObj(Integer::new).collect(Collectors.toList());
+        List<Integer> primaryKeys = IntStream.generate(() -> r.nextInt(100)).filter(usedKeys::add).limit(50).boxed().collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = primaryKeys.stream().map(recNo ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(recNo).setNumValue2(r.nextInt(20) + 20).build()
         ).collect(Collectors.toList());

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ log4jVersion=2.4.1
 guavaVersion=19.0
 autoServiceVersion=1.0-rc4
 junitVersion=5.1.0
-jacocoVersion=0.7.7.201606060606
+jacocoVersion=0.8.2
 
 protobufSrcDir=proto
 protobufOutDir=protogen


### PR DESCRIPTION
As suspected, because we aren't doing anything too fancy, the things that needed changing were:

1. Remove a reference to a "summary" flag that was removed in HTML5 which is the Javadoc format for Java 11.
1. `Integer::new` was deprecated, so a few references to that were removed.
1. Finalizers were deprecated. We're using one to detect if a transaction hasn't been manually closed, so I didn't want to remove it, but this suppresses the warning to band-aid over that for now.
1. Update the JaCoCo version to one that supports Java 11.

This does *not* turn our build JDK to 11, and it certainly doesn't change the source or target versions. At some point, we should update our build image to 11 but continue producing Java 8 binary versions (so that Java 8 users can still use it).