### PR TITLE
Resolves #144: Full Text: Index option for disabling writing position lists

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/metadata/Index.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/metadata/Index.java
@@ -79,6 +79,7 @@ public class Index {
     public static final String TEXT_TOKENIZER_NAME_OPTION = "textTokenizerName";
     public static final String TEXT_TOKENIZER_VERSION_OPTION = "textTokenizerVersion";
     public static final String TEXT_ADD_AGGRESSIVE_CONFLICT_RANGES_OPTION = "textAddAggressiveConflictRanges";
+    public static final String TEXT_OMIT_POSITIONS_OPTION = "textOmitPositions";
     public static final String RANK_NLEVELS = "rankNLevels";
 
     /**


### PR DESCRIPTION
This writes the empty list instead if the option is written. This means that the on-disk format is the same whether the option is enabled or not (there's just extra information if this option is not enabled), so a user can switch this option on and off on live data sets. There is some weirdness related to queries, but I think it's about as little weirdness as one could hope for when one uses this option.