### PR TITLE
Some small fixes / cleanups:

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/MutableRecordStoreState.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/MutableRecordStoreState.java
@@ -130,8 +130,8 @@ public class MutableRecordStoreState extends RecordStoreState {
 
     @Nonnull
     @Override
-    public MutableRecordStoreState withWriteOnlyIndexes(@Nonnull final List<String> writeOnlyIndexeNames) {
-        return new MutableRecordStoreState(writeOnlyMap(writeOnlyIndexeNames));
+    public MutableRecordStoreState withWriteOnlyIndexes(@Nonnull final List<String> writeOnlyIndexNames) {
+        return new MutableRecordStoreState(writeOnlyMap(writeOnlyIndexNames));
     }
 
     // NOTE: Does not actually implement own equals. Is equal to immutable one, too.

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordMetaDataBuilder.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordMetaDataBuilder.java
@@ -441,21 +441,11 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
 
     @Nonnull
     public Descriptors.FieldDescriptor getUnionFieldForRecordType(@Nonnull RecordType recordType) {
-        final Descriptors.FieldDescriptor unionField = getUnionFieldForRecordType(recordType.getName());
+        final Descriptors.FieldDescriptor unionField = unionFields.get(recordType.getDescriptor());
         if (unionField == null) {
-            throw new MetaDataException("RecordType is not in the union");
+            throw new MetaDataException("Record type " + recordType.getName() + " is not in the union");
         }
         return unionField;
-    }
-
-    @Nullable
-    private Descriptors.FieldDescriptor getUnionFieldForRecordType(@Nonnull String recordType) {
-        for (Descriptors.FieldDescriptor field : unionDescriptor.getFields()) {
-            if (field.getMessageType().getFullName().equals(recordType)) {
-                return field;
-            }
-        }
-        return null;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordStoreState.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/RecordStoreState.java
@@ -273,19 +273,19 @@ public class RecordStoreState {
 
     /**
      * Create a new version of this RecordStoreState, but with additional WRITE_ONLY indexes.
-     * @param writeOnlyIndexeNames the indexes to be marked as WRITE_ONLY. If the index is already DISABLED, it will
+     * @param writeOnlyIndexNames the indexes to be marked as WRITE_ONLY. If the index is already DISABLED, it will
      * stay disabled, but will otherwise be set to WRITE_ONLY.
      * @return a new version of this RecordStoreState, but with additional WRITE_ONLY indexes.
      */
     @Nonnull
-    public RecordStoreState withWriteOnlyIndexes(@Nonnull final List<String> writeOnlyIndexeNames) {
-        return new RecordStoreState(writeOnlyMap(writeOnlyIndexeNames));
+    public RecordStoreState withWriteOnlyIndexes(@Nonnull final List<String> writeOnlyIndexNames) {
+        return new RecordStoreState(writeOnlyMap(writeOnlyIndexNames));
     }
 
     @Nonnull
-    protected Map<String, IndexState> writeOnlyMap(@Nonnull final List<String> writeOnlyIndexeNames) {
+    protected Map<String, IndexState> writeOnlyMap(@Nonnull final List<String> writeOnlyIndexNames) {
         Map<String, IndexState> map = new HashMap<>(getIndexStates());
-        writeOnlyIndexeNames.forEach(indexName ->
+        writeOnlyIndexNames.forEach(indexName ->
                 map.compute(indexName, (name, state) -> {
                     // state may be null (which implies READABLE)
                     if (state == IndexState.DISABLED) {

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBRecord.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBRecord.java
@@ -29,7 +29,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * A record that has just been saved to the store or retrieved from it in some way.
+ * A record associated with the corresponding meta-data.
+ *
+ * Adds information about the primary key and record type.
  * @param <M> type used to represent stored records
  */
 @API(API.Status.STABLE)

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -2281,10 +2281,7 @@ public abstract class FDBRecordStoreBase<M extends Message> extends FDBStoreBase
     /**
      * Loads the current state of the record store within the given subspace asynchronously.
      * This method is static so that one can load the record store state before instantiating
-     * the instance. In particular, because a complete {@link RecordMetaData} should include
-     * the current state, this method can be run first to get the state that should
-     * be fed into the {@link com.apple.foundationdb.record.RecordMetaDataBuilder}. This method is done for the user by the
-     * various static <code>open</code> methods.
+     * the instance. This method is called for the user by the various static <code>open</code> methods.
      * @param context the record context in which to retrieve the record store state
      * @param subspace the subspace of the record store
      * @param isolationLevel the isolation level to use when reading
@@ -3448,8 +3445,6 @@ public abstract class FDBRecordStoreBase<M extends Message> extends FDBStoreBase
      */
     @Nonnull
     public RecordQueryPlan planQuery(@Nonnull RecordQuery query) {
-        // NOTE: If this planner were cached, it would need to be keyed on recordStoreState, which can change
-        // even if meta-data never does.
         final RecordQueryPlanner planner = new RecordQueryPlanner(getRecordMetaData(), getRecordStoreState());
         return planner.plan(query);
     }

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 /**
  * A record stored in the database.
  *
- * To the raw Protobuf record, adds its primary key and record type.
+ * Adds information about storage sizes from saving or retrieving.
  * @param <M> type used to represent stored records
  * @see FDBRecordStoreBase#saveRecord
  * @see FDBRecordStoreBase#loadRecord
@@ -185,10 +185,10 @@ public class FDBStoredRecord<M extends Message> implements FDBRecord<M>, FDBStor
      */
     @Nonnull
     public FDBStoredRecord<M> withCommittedVersion(@Nullable byte[] committedVersion) {
-        if (!hasVersion() || recordVersion.isComplete()) {
+        if (recordVersion == null || recordVersion.isComplete()) {
             return this;
         }
-        return new FDBStoredRecord<>(primaryKey, recordType, record, keyCount, keySize, valueSize, split, versionedInline, recordVersion.withCommittedVersion(committedVersion));
+        return withVersion(recordVersion.withCommittedVersion(committedVersion));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -89,8 +89,8 @@ public abstract class IndexMaintainer<M extends Message> {
      * @return a future that is complete when the record update is done
      */
     @Nonnull
-    public abstract  CompletableFuture<Void> update(@Nullable FDBStoredRecord<M> oldRecord,
-                                                    @Nullable FDBStoredRecord<M> newRecord);
+    public abstract CompletableFuture<Void> update(@Nullable FDBStoredRecord<M> oldRecord,
+                                                   @Nullable FDBStoredRecord<M> newRecord);
 
     /**
      * Remove or add a uniqueness violation within the database. This is used to keep track of

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexBuilderBase.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexBuilderBase.java
@@ -548,9 +548,7 @@ public class OnlineIndexBuilderBase<M extends Message> implements AutoCloseable 
     // TupleRange version of above.
     @Nonnull
     private CompletableFuture<Tuple> buildRangeOnly(@Nonnull FDBRecordStoreBase<M> store, @Nonnull TupleRange range, boolean respectLimit) {
-        // Test whether the same up to store state by checking something that is pointer-copied but not normally
-        // otherwise shared.
-        if (store.getRecordMetaData().getRecordTypes() != recordStoreBuilder.getMetaDataProvider().getRecordMetaData().getRecordTypes()) {
+        if (store.getRecordMetaData() != recordStoreBuilder.getMetaDataProvider().getRecordMetaData()) {
             throw new MetaDataException("Store does not have the same metadata");
         }
         final IndexMaintainer<M> maintainer = store.getIndexMaintainer(index);

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -432,6 +432,12 @@ public class SplitHelper {
             valueSize += valueBytes.length;
         }
 
+        public void add(@Nonnull FDBStoredSizes sizes) {
+            keyCount += sizes.getKeyCount();
+            keySize += sizes.getKeySize();
+            valueSize += sizes.getValueSize();
+        }
+
         public void reset() {
             keyCount = 0;
             keySize = 0;


### PR DESCRIPTION
* A typo `IndexeNames` in several places, perhaps from renaming from `Indexes`.
* `RecordMetaDataBuilder.getUnionFieldForRecordType` is unnecessarily inconsistent with `RecordMetaData`'s method.
* Javadoc for `FDBRecord` and `FDBStoredRecord` don't make the difference clear.
* `FDBStoredRecord.withCommittedVersion` doesn't use `withVersion`.
* `IndexMaintainer.update` has an extra space.
* Several places are left-over from when the index state was an overlay on the meta-data. It is now a separate object. Mostly comments.
* `SplitHelper.sizeInfo` could use an add method that takes another `FDBStoredSizes`.