### PR TITLE
Resolves #151: KeySpacePath no longer carries around a context

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/KeyRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/KeyRange.java
@@ -1,0 +1,113 @@
+/*
+ * KeyRange.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.API;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A range within a subspace specified by two byte value endpoints.
+ */
+@API(API.Status.MAINTAINED)
+public class KeyRange {
+    @Nonnull
+    private final byte[] lowKey;
+    @Nonnull
+    private final EndpointType lowEndpoint;
+    @Nonnull
+    private final byte[] highKey;
+    @Nonnull
+    private final EndpointType highEndpoint;
+
+    /**
+     * Creates a key range.
+     *
+     * @param lowKey the starting key in the range. Note that a direct reference to this key is retained, so
+     *    care must be taken not to modify its contents
+     * @param lowEndpoint how the low endpoint is to be treated
+     * @param highKey the ending key in the range. Note that a direct reference to this key is retained, so
+     *    care must be taken not to modify its contents
+     * @param highEndpoint how the high endpoint is to be treated
+     */
+    @SpotBugsSuppressWarnings("EI_EXPOSE_REP2")
+    public KeyRange(@Nonnull byte[] lowKey, @Nonnull EndpointType lowEndpoint,
+                    @Nonnull byte[] highKey, @Nonnull EndpointType highEndpoint) {
+        this.lowKey = lowKey;
+        this.lowEndpoint = lowEndpoint;
+        this.highKey = highKey;
+        this.highEndpoint = highEndpoint;
+    }
+
+    /**
+     * Creates a key range.
+     *
+     * @param lowKey the starting key of the range, inclusive
+     * @param highKey the ending key of the range, exclusive
+     */
+    public KeyRange(@Nonnull byte[] lowKey, @Nonnull byte[] highKey) {
+        this(lowKey, EndpointType.RANGE_INCLUSIVE, highKey, EndpointType.RANGE_EXCLUSIVE);
+    }
+
+    /**
+     * Returns the lower boundary of the range to be scanned. How this starting key is to be interpreted
+     * in relation to a scan (e.g., inclusive or exclusive) is determined by the low endpoint value
+     * ({@link #getLowEndpoint()}.  The value returned by this method should be treated as immutable and
+     * must not be modified by the caller.
+     *
+     * @return the low key of the range to be scanned
+     */
+    @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
+    @Nonnull
+    public byte[] getLowKey() {
+        return lowKey;
+    }
+
+    /**
+     * @return how the lower boundary key of the range is to be interpreted by the scan (e.g. inclusive or exclusive)
+     */
+    @Nonnull
+    public EndpointType getLowEndpoint() {
+        return lowEndpoint;
+    }
+
+    /**
+     * Returns the upper boundary of the range to be scanned. How this key is to be interpreted
+     * in relation to a scan (e.g., inclusive or exclusive) is determined by the high endpoint value
+     * ({@link #getHighEndpoint()}.  The value returned by this method should be treated as immutable and
+     * must not be modified by the caller.
+     *
+     * @return the high key of the range to be scanned
+     */
+    @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
+    @Nonnull
+    public byte[] getHighKey() {
+        return highKey;
+    }
+
+    /**
+     * @return how the upper boundary key of the range is to be interpreted by the scan (e.g. inclusive or exclusive)
+     */
+    @Nonnull
+    public EndpointType getHighEndpoint() {
+        return highEndpoint;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
@@ -80,7 +80,7 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
     }
 
     public FDBMetaDataStore(@Nonnull FDBRecordContext context, @Nonnull KeySpacePath path) {
-        this(context, new Subspace(path.toTuple()), null);
+        this(context, new Subspace(path.toTuple(context)), null);
     }
 
     // All keys in subspace are taken by SplitHelper.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -2000,7 +2000,7 @@ public abstract class FDBRecordStoreBase<M extends Message> extends FDBStoreBase
     }
 
     public static void deleteStore(FDBRecordContext context, KeySpacePath path) {
-        final Subspace subspace = new Subspace(path.toTuple());
+        final Subspace subspace = new Subspace(path.toTuple(context));
         deleteStore(context, subspace);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.CursorStreamingMode;
 import com.apple.foundationdb.record.EndpointType;
+import com.apple.foundationdb.record.KeyRange;
 import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.SpotBugsSuppressWarnings;
@@ -280,6 +281,12 @@ public class KeyValueCursor implements BaseCursor<KeyValue> {
 
         public Builder setScanProperties(@Nonnull ScanProperties scanProperties) {
             this.scanProperties = scanProperties;
+            return this;
+        }
+
+        public Builder setRange(@Nonnull KeyRange range) {
+            setLow(range.getLowKey(), range.getLowEndpoint());
+            setHigh(range.getHighKey(), range.getHighEndpoint());
             return this;
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderByKeySpacePath.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderByKeySpacePath.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath
 import com.apple.foundationdb.subspace.Subspace;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -35,10 +36,13 @@ import java.util.concurrent.CompletableFuture;
 @API(API.Status.MAINTAINED)
 public class SubspaceProviderByKeySpacePath implements SubspaceProvider {
     @Nonnull
-    private KeySpacePath keySpacePath;
+    private final KeySpacePath keySpacePath;
 
     @Nonnull
-    private FDBRecordContext context;
+    private final FDBRecordContext context;
+
+    @Nullable
+    private CompletableFuture<Subspace> subspaceFuture;
 
     SubspaceProviderByKeySpacePath(@Nonnull KeySpacePath keySpacePath, @Nonnull FDBRecordContext context) {
         this.keySpacePath = keySpacePath;
@@ -54,7 +58,10 @@ public class SubspaceProviderByKeySpacePath implements SubspaceProvider {
     @Nonnull
     @Override
     public CompletableFuture<Subspace> getSubspaceAsync() {
-        return keySpacePath.toSubspaceAsync();
+        if (subspaceFuture == null) {
+            subspaceFuture = keySpacePath.toSubspaceAsync(context);
+        }
+        return subspaceFuture;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
@@ -51,11 +51,11 @@ import java.util.function.Function;
  * <p>When creating a path through a directory layer directory, you may either specify the string name that
  * you wish to place in the directory, like so:
  * <pre>
- *     keySpace.path("library").add("book_title", "Twenty Thousand Leagues Under the Sea").toTuple();
+ *     keySpace.path("library").add("book_title", "Twenty Thousand Leagues Under the Sea").toTuple(context);
  * </pre>
  * or you may retrieve it by directory layer value:
  * <pre>
- *     keySpace.path("library").add(443L).toTuple();
+ *     keySpace.path("library").add(443L).toTuple(context);
  * </pre>
  * Retrieving by directory layer value will result in an exception if the value provided is either not a valid
  * directory layer value, or it is not the value that corresponds to the constant name for this directory.
@@ -167,7 +167,7 @@ public class DirectoryLayerDirectory extends KeySpaceDirectory {
     @Override
     @Nonnull
     @SuppressWarnings("squid:S1604") // need annotation so no lambda
-    protected CompletableFuture<PathValue> toTupleValueAsync(@Nonnull FDBRecordContext context, @Nullable Object value) {
+    protected CompletableFuture<PathValue> toTupleValueAsyncImpl(@Nonnull FDBRecordContext context, @Nullable Object value) {
         // We allow someone to explicitly pass the value of a directory layer entry, however if
         // this directory is hard-wired to a specific value, then the value passed in is compared
         // with the directory layer to ensure it is valid.
@@ -253,8 +253,8 @@ public class DirectoryLayerDirectory extends KeySpaceDirectory {
                                                 : TupleHelpers.subTuple(key, childKeyIndex, key.size());
 
                         // Make sure that the path is constructed with the text-name from the directory layer.
-                        KeySpacePath myPath = KeySpacePathImpl.newPath(parent, this, context, directoryString,
-                                CompletableFuture.completedFuture(toPathValue(directoryResolverResult)), remainder);
+                        KeySpacePath myPath = KeySpacePathImpl.newPath(parent, this, context, directoryString, true,
+                                toPathValue(directoryResolverResult), remainder);
 
                         // We are finished if there are no more subdirectories or no more tuple to consume
                         if (!canHaveChild) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.ValueRange;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 
@@ -35,9 +36,9 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * A <code>KeySpacePath</code> represents a discrete path through a directory tree defined by a <code>KeySpace</code>.
- * A <code>KeySpacePath</code> is started via {@link KeySpace#path(FDBRecordContext, String)},
+ * A <code>KeySpacePath</code> is started via {@link KeySpace#path(String)},
  * and a specific path may be traced down through the directory structure via successive calls to
- * {@link #add(String, Object)}. Once a desired path has been fully constructed, {@link #toTuple()} is used
+ * {@link #add(String, Object)}. Once a desired path has been fully constructed, {@link #toTuple(FDBRecordContext)} is used
  * to turn the resulting path into a <code>Tuple</code> to represent the FDB row key.
  */
 @API(API.Status.MAINTAINED)
@@ -63,19 +64,34 @@ public interface KeySpacePath {
      * can be encompassed in a single transaction, so this method provides a mechanism by which the path can
      * be reconstructed with a new transaction between continuations.
      *
+     * <p>This method has been deprecated. Paths should no longer be started with {@link KeySpace#path(FDBRecordContext, String, Object)},
+     * and therefore should no longer need the ability to create a copy with a different context. Instead you should
+     * be starting your paths with {@link KeySpace#path(String, Object)} and then only employ a
+     * <code>FDBRecordContext</code> when the path is resolved with {@link #toTuple(FDBRecordContext)}
+     *
      * @param newContext the new record context to use
      * @return a copy of this <code>KeySpacePath</code> containing a new transaction context. Note that the
      *   information contained in this path will still be based upon the transaction state at the time at which
      *   it was originally created; only new operations on the returned path will utilize the new transaction
      *   context
+     * @deprecated use {@link KeySpace#path(String, Object)} instead
      */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
     @Nonnull
     KeySpacePath copyWithNewContext(@Nonnull FDBRecordContext newContext);
 
     /**
      * Returns the {@link FDBRecordContext} this path was created with.
      * @return {@link FDBRecordContext} this path was created with
+     *
+     * @throws IllegalStateException if the path was not original started with a context
+     *
+     * @deprecated paths should no longer be constructed with a <code>FDBRecordContext</code>, instead all operations
+     *   that require a context in order to resolve a tuple or subspace should pass the context in at that point
      */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
     @Nonnull
     FDBRecordContext getContext();
 
@@ -140,50 +156,170 @@ public interface KeySpacePath {
     Object getValue();
 
     /**
-     * Get the value that will be stored for the directory at the specific path element.
-     * @return a future that completes with the resolved form of the path value
-     * @see #getValue
+     * Retrieve the value that is to be stored for this directory entry.  For example, if the directory associated
+     * with this entry is a <code>DirectoryLayerDirectory</code> the value returned will be the number assigned
+     * by the directory layer for this path entry's value.
+     *
+     * @param context the context in which to resolve the value
+     * @return future that will resolve to value to be store for this path element.  Note that if the path
+     *   was produced via {@link KeySpace#pathFromKeyAsync(FDBRecordContext, Tuple)} or {@link #listAsync(FDBRecordContext, String, byte[], ScanProperties)},
+     *   then the future that is returned will have already been completed (i.e it is safe to retrieve the
+     *   value without blocking)
      */
     @Nonnull
-    CompletableFuture<Object> getResolvedValue();
+    CompletableFuture<PathValue> resolveAsync(@Nonnull FDBRecordContext context);
 
     /**
-     * Get the metadata stored for the directory entry at the specific path element.
-     * @return a future that completes with the metadata associated with the path element
+     * If this path was created via a call to <code>pathFromKey</code> or <code>listAsync</code> (or their blocking
+     * variants), this method may be used to determine what the underlying value was physically stored in the key.
+     *
+     * @return the value that was stored for the path element
+     * @throws IllegalStateException if this path element was not produced from one of the above method calls
      */
     @Nonnull
-    CompletableFuture<byte[]> getResolvedPathMetadata();
+    PathValue getStoredValue();
 
     /**
-     * Converts this path into a tuple, during this process the value that was provided for the directory, or
-     * was resolved by the directory implementation, is validated to ensure that it is a valid type for the
-     * directory.
-     * @return the tuple form of this path
-     * @throws com.apple.foundationdb.record.RecordCoreArgumentException If the value generated for a position in the path is not valid for
-     *   that particular position.
+     * @return true if it is legal to call {@link #getStoredValue()}.
      */
-    @Nonnull
-    Tuple toTuple();
-
-    @Nonnull
-    CompletableFuture<Tuple> toTupleAsync();
+    boolean hasStoredValue();
 
     /**
-     * Converts the tuple produced for this path to a subspace.
-     * @return a future that completes with the subspace for this path
+     * Returns a future representing the value that is to be stored for this position in the path when
+     * the path value has been resolved by the directory.
+     *
+     * @return the value that will be stored for this path entry
+     * @deprecated use {@link #resolveAsync(FDBRecordContext)} instead
      */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
     @Nonnull
-    default CompletableFuture<Subspace> toSubspaceAsync() {
-        return toTupleAsync().thenApply(Subspace::new);
+    default CompletableFuture<Object> getResolvedValue() {
+        return resolveAsync(getContext()).thenApply(PathValue::getResolvedValue);
     }
 
     /**
-     * Synchronous form of {@link #toSubspaceAsync()}.
-     * @return the subspace for this path
+     * Returns the meta-data (if any) that is stored for this directory value.
+     * @return a future that will complete to the meta-data for the stored directory value or null if there is no
+     *   meta-data associated with the value
+     * @deprecated use {@link #resolveAsync(FDBRecordContext)} instead
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default CompletableFuture<byte[]> getResolvedPathMetadata() {
+        return resolveAsync(getContext()).thenApply(PathValue::getMetadata);
+    }
+
+    /**
+     * Converts this path into a tuple. During this process the value that was provided for the directory, or
+     * was resolved by the directory implementation, is validated to ensure that it is a valid type for the
+     * directory.
+     *
+     * @return the tuple form of this path
+     * @deprecated use {@link #toTuple(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default Tuple toTuple() {
+        return toTuple(getContext());
+    }
+
+    /**
+     * Converts this path into a tuple. During this process the value that was provided for the directory, or
+     * was resolved by the directory implementation, is validated to ensure that it is a valid type for the
+     * directory.
+     *
+     * @param context the context in which to resolve the path
+     * @return the tuple form of this path
+     * @throws com.apple.foundationdb.record.RecordCoreArgumentException if the value generated for a position in the path is not valid for
+     *   that particular position
      */
     @Nonnull
+    default Tuple toTuple(@Nonnull FDBRecordContext context) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_PATH_RESOLVE, toTupleAsync(context));
+    }
+
+    /**
+     * Converts this path into a tuple. During this process the value that was provided for the directory, or
+     * was resolved by the directory implementation, is validated to ensure that it is a valid type for the
+     * directory.
+     *
+     * @return a future that will complete to the tuple representation of this path
+     * @deprecated use {@link #toTupleAsync(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default CompletableFuture<Tuple> toTupleAsync() {
+        return toTupleAsync(getContext());
+    }
+
+    /**
+     * Converts this path into a tuple. During this process the value that was provided for the directory, or
+     * was resolved by the directory implementation, is validated to ensure that it is a valid type for the
+     * directory.
+     *
+     * @param context the context in which the path is to be resolved
+     * @return a future that will complete to the tuple representation of this path
+     */
+    @Nonnull
+    CompletableFuture<Tuple> toTupleAsync(@Nonnull FDBRecordContext context);
+
+    /**
+     * Converts the tuple produced for this path to a subspace.
+     *
+     * @return The subspace from the resolved path.
+     * @deprecated use {@link #toSubspace(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
     default Subspace toSubspace() {
-        return new Subspace(toTuple());
+        return toSubspace(getContext());
+    }
+
+    /**
+     * Converts the tuple produced for this path to a subspace.
+     *
+     * @param context the context in which to resolve the path
+     * @return The subspace from the resolved path.
+     */
+    default Subspace toSubspace(FDBRecordContext context) {
+        return new Subspace(toTuple(context));
+    }
+
+    /**
+     * Converts the tuple produced for this path to a subspace.
+     *
+     * @param context the context in which to resolve the path
+     * @return a future that completes with the subspace for this path
+     */
+    @Nonnull
+    default CompletableFuture<Subspace> toSubspaceAsync(@Nonnull FDBRecordContext context) {
+        return toTupleAsync(context).thenApply(Subspace::new);
+    }
+
+    /**
+     * Converts the tuple produced for this path to a subspace.
+     *
+     * @return a future that completes with the subspace for this path
+     * @deprecated use {@link #toSubspaceAsync(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default CompletableFuture<Subspace> toSubspaceAsync() {
+        return toTupleAsync(getContext()).thenApply(Subspace::new);
     }
 
     /**
@@ -195,46 +331,101 @@ public interface KeySpacePath {
     List<KeySpacePath> flatten();
 
     /**
-     * Get whether data exists for this path.
+     * Check whether data exists for this path.
+     * @return a future that evaluates to {@code true} if data exists for this path
+     * @deprecated use {@link #hasDataAsync(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default CompletableFuture<Boolean> hasDataAsync() {
+        return hasDataAsync(getContext());
+    }
+
+    /**
+     * Check whether data exists for this path.
+     *
+     * @param context the context in which the path is resolved and a scan is performed looking for data
      * @return a future that evaluates to {@code true} if data exists for this path
      */
     @Nonnull
-    CompletableFuture<Boolean> hasDataAsync();
+    CompletableFuture<Boolean> hasDataAsync(FDBRecordContext context);
 
     /**
      * Synchronous version of {@link #hasDataAsync()}.
+     *
+     * @return {@code true} if data exists for this path
+     * @deprecated use {@link #hasData(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    default boolean hasData() {
+        return hasData(getContext());
+    }
+
+    /**
+     * Synchronous version of {@link #hasDataAsync(FDBRecordContext)}.
+     *
+     * @param context the context in which the path is resolved and a scan is performed looking for data
      * @return {@code true} if data exists for this path
      */
-    boolean hasData();
+    default boolean hasData(@Nonnull FDBRecordContext context) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_SCAN, hasDataAsync(context));
+    }
 
     /**
      * Delete all data from this path. Use with care.
+     *
+     * @return a future that will delete all data underneath of this path
+     * @deprecated use {@link #deleteAllDataAsync(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default CompletableFuture<Void> deleteAllDataAsync() {
+        return deleteAllDataAsync(getContext());
+    }
+
+    /**
+     * Delete all data from this path. Use with care.
+     *
+     * @param context the context in which the path is resolved and the delete operation takes place
      * @return a future that will delete all data underneath of this path
      */
     @Nonnull
-    CompletableFuture<Void> deleteAllDataAsync();
+    CompletableFuture<Void> deleteAllDataAsync(@Nonnull FDBRecordContext context);
 
     /**
      * Synchronous version of {@link #deleteAllDataAsync()}.
+     *
+     * @deprecated use {@link #deleteAllData(FDBRecordContext)} instead
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
      */
-    void deleteAllData();
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    default void deleteAllData() {
+        deleteAllData(getContext());
+    }
+
+    /**
+     * Synchronous version of {@link #deleteAllDataAsync(FDBRecordContext)}.
+     *
+     * @param context the context in which the path is resolved and the delete operation takes place
+     */
+    default void deleteAllData(@Nonnull FDBRecordContext context) {
+        context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_CLEAR, deleteAllDataAsync(context));
+    }
 
     /**
      * For a given subdirectory from this path element, return a list of paths for all available keys in the FDB
-     * keyspace for that directory. For example, given the tree:
-     * <pre>
-     * root
-     *   +- node
-     *       +- leaf
-     * </pre>
-     * Performing a <code>listAsync</code> from a given <code>node</code>, will result in a list of paths, one for
-     * each <code>leaf</code> that is available within the <code>node</code>'s scope.
-     *
-     * <p>The listing is performed by reading the first key of the data type (and possibly constant value) for the
-     * subdirectory and, if a key is found, skipping to the next available value after the first one that was found,
-     * and so one, each time resulting in an additional <code>KeySpacePath</code> that is returned.  In each case,
-     * the returned <code>KeySpacePath</code> may contain a remainder (see {@link #getRemainder()}) of the portion
-     * of the key tuple that was read.
+     * keyspace for that directory.
      *
      * @param subdirName the name of the subdirectory that is to be listed
      * @param continuation an optional continuation from a previous list attempt
@@ -243,11 +434,43 @@ public interface KeySpacePath {
      * @throws NoSuchDirectoryException if the subdirectory name provided does not exist
      * @throws com.apple.foundationdb.record.RecordCoreException if a key found during the listing process did not correspond to
      *    the directory tree
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     * @deprecated use {@link #listAsync(FDBRecordContext, String, byte[], ScanProperties)} instead
      */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
     @Nonnull
     default RecordCursor<KeySpacePath> listAsync(@Nonnull String subdirName, @Nullable byte[] continuation,
+                                         @Nonnull ScanProperties scanProperties) {
+        return listAsync(getContext(), subdirName, null, continuation, scanProperties);
+    }
+
+    /**
+     * For a given subdirectory from this path element, return a list of paths for all available keys in the FDB
+     * keyspace for that directory.
+     *
+     * @param subdirName the name of the subdirectory that is to be listed
+     * @param range the range of the subdirectory values to be listed. All will be listed if it is <code>null</code>.
+     *     If the directory is restricted to a specific constant value, it has to be <code>null</code>
+     * @param continuation an optional continuation from a previous list attempt
+     * @param scanProperties details for how the scan should be performed
+     * @return a list of fully qualified paths for each value contained within this directory
+     * @throws NoSuchDirectoryException if the subdirectory name provided does not exist
+     * @throws com.apple.foundationdb.record.RecordCoreException if a key found during the listing process did not correspond to
+     *    the directory tree
+     * @throws IllegalStateException if the path was started without a context (e.g. it was started with
+     *   {@link KeySpace#path(String, Object)})
+     * @deprecated use {@link #listAsync(FDBRecordContext, String, ValueRange, byte[], ScanProperties)} instead
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default RecordCursor<KeySpacePath> listAsync(@Nonnull String subdirName, 
+                                                 @Nullable ValueRange<?> range,
+                                                 @Nullable byte[] continuation,
                                                  @Nonnull ScanProperties scanProperties) {
-        return listAsync(subdirName, null, continuation, scanProperties);
+        return listAsync(getContext(), subdirName, range, continuation, scanProperties);
     }
 
     /**
@@ -267,6 +490,40 @@ public interface KeySpacePath {
      * the returned <code>KeySpacePath</code> may contain a remainder (see {@link #getRemainder()}) of the portion
      * of the key tuple that was read.
      *
+     * @param context the transaction in which to perform the listing
+     * @param subdirName the name of the subdirectory that is to be listed
+     * @param continuation an optional continuation from a previous list attempt
+     * @param scanProperties details for how the scan should be performed
+     * @return a list of fully qualified paths for each value contained within this directory
+     * @throws NoSuchDirectoryException if the subdirectory name provided does not exist
+     * @throws com.apple.foundationdb.record.RecordCoreException if a key found during the listing process did not correspond to
+     *    the directory tree
+     */
+    @Nonnull
+    default RecordCursor<KeySpacePath> listAsync(@Nonnull FDBRecordContext context,
+                                                 @Nonnull String subdirName, @Nullable byte[] continuation,
+                                                 @Nonnull ScanProperties scanProperties) {
+        return listAsync(context, subdirName, null, continuation, scanProperties);
+    }
+
+    /**
+     * For a given subdirectory from this path element, return a list of paths for all available keys in the FDB
+     * keyspace for that directory. For example, given the tree:
+     * <pre>
+     * root
+     *   +- node
+     *       +- leaf
+     * </pre>
+     * Performing a <code>listAsync</code> from a given <code>node</code>, will result in a list of paths, one for
+     * each <code>leaf</code> that is available within the <code>node</code>'s scope.
+     *
+     * <p>The listing is performed by reading the first key of the data type (and possibly constant value) for the
+     * subdirectory and, if a key is found, skipping to the next available value after the first one that was found,
+     * and so one, each time resulting in an additional <code>KeySpacePath</code> that is returned.  In each case,
+     * the returned <code>KeySpacePath</code> may contain a remainder (see {@link #getRemainder()}) of the portion
+     * of the key tuple that was read.
+     *
+     * @param context the transaction in which to perform the listing
      * @param subdirName the name of the subdirectory that is to be listed
      * @param range the range of the subdirectory values to be listed. All will be listed if it is <code>null</code>.
      *     If the directory is restricted to a specific constant value, it has to be <code>null</code>
@@ -278,25 +535,84 @@ public interface KeySpacePath {
      *    the directory tree
      */
     @Nonnull
-    RecordCursor<KeySpacePath> listAsync(@Nonnull String subdirName, @Nullable ValueRange<Object> range,
-                                         @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties);
+    RecordCursor<KeySpacePath> listAsync(@Nonnull FDBRecordContext context, 
+                                         @Nonnull String subdirName, 
+                                         @Nullable ValueRange<?> range,
+                                         @Nullable byte[] continuation,
+                                         @Nonnull ScanProperties scanProperties);
 
     /**
      * Synchronous version of <code>listAsync</code>.
+     *
+     * @param subdirName the name of the subdirectory that is to be listed
+     * @param scanProperties details for how the scan should be performed
+     * @return a list of fully qualified paths for each value contained within this directory
+     * @deprecated use {@link #list(FDBRecordContext, String, ScanProperties)} instead
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default List<KeySpacePath> list(@Nonnull String subdirName, @Nonnull ScanProperties scanProperties) {
+        return list(getContext(), subdirName, scanProperties);
+    }
+
+    /**
+     * Synchronous version of <code>listAsync</code>.
+     *
+     * @param context the transaction in which to perform the listing
      * @param subdirName the name of the subdirectory that is to be listed
      * @param scanProperties details for how the scan should be performed
      * @return a list of fully qualified paths for each value contained within this directory
      */
     @Nonnull
-    List<KeySpacePath> list(@Nonnull String subdirName, @Nonnull ScanProperties scanProperties);
+    default List<KeySpacePath> list(@Nonnull FDBRecordContext context, @Nonnull String subdirName,
+                                    @Nonnull ScanProperties scanProperties) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_LIST, listAsync(context, subdirName, null, scanProperties).asList());
+    }
+
+    /**
+     * Synchronous version of <code>listAsync</code>.
+     *
+     * @param context the transaction in which to perform the listing
+     * @param subdirName the name of the subdirectory that is to be listed
+     * @param range the range of the subdirectory values to be listed. All will be listed if it is <code>null</code>.
+     *     If the directory is restricted to a specific constant value, it has to be <code>null</code>
+     * @param continuation an optional continuation from a previous list attempt
+     * @param scanProperties details for how the scan should be performed
+     * @return a list of fully qualified paths for each value contained within this directory
+     */
+    @Nonnull
+    default List<KeySpacePath> list(@Nonnull FDBRecordContext context, @Nonnull String subdirName,
+                                    @Nullable ValueRange<?> range,
+                                    @Nullable byte[] continuation,
+                                    @Nonnull ScanProperties scanProperties) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_LIST, listAsync(context, subdirName, range, continuation, scanProperties).asList());
+    }
 
     /**
      * Synchronous version of <code>listAsync</code> that performs a forward, serializable scan.
+     *
+     * @param subdirName the name of the subdirectory that is to be listed
+     * @return a list of fully qualified paths for each value contained within this directory
+     *
+     * @deprecated use {@link #list(FDBRecordContext, String, ScanProperties)} instead
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
+    @Nonnull
+    default List<KeySpacePath> list(@Nonnull String subdirName) {
+        return list(getContext(), subdirName, ScanProperties.FORWARD_SCAN);
+    }
+
+    /**
+     * Synchronous version of <code>listAsync</code> that performs a forward, serializable scan.
+     *
+     * @param context the transaction in which to perform the listing
      * @param subdirName the name of the subdirectory that is to be listed
      * @return a list of fully qualified paths for each value contained within this directory
      */
     @Nonnull
-    default List<KeySpacePath> list(@Nonnull String subdirName) {
-        return list(subdirName, ScanProperties.FORWARD_SCAN);
+    default List<KeySpacePath> list(@Nonnull FDBRecordContext context, @Nonnull String subdirName) {
+        return list(context, subdirName, ScanProperties.FORWARD_SCAN);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
@@ -94,12 +94,14 @@ public class KeySpacePathWrapper implements KeySpacePath {
         this.inner = inner;
     }
 
+    @Deprecated
     @Nonnull
     @Override
     public KeySpacePath copyWithNewContext(@Nonnull FDBRecordContext newContext) {
         return inner.copyWithNewContext(newContext);
     }
 
+    @Deprecated
     @Nonnull
     @Override
     public FDBRecordContext getContext() {
@@ -147,28 +149,26 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.getValue();
     }
 
-    @Override
-    @Nonnull
-    public CompletableFuture<Object> getResolvedValue() {
-        return inner.getResolvedValue();
-    }
-
     @Nonnull
     @Override
-    public CompletableFuture<byte[]> getResolvedPathMetadata() {
-        return inner.getResolvedPathMetadata();
+    public PathValue getStoredValue() {
+        return inner.getStoredValue();
     }
 
     @Override
-    @Nonnull
-    public Tuple toTuple() {
-        return inner.toTuple();
+    public boolean hasStoredValue() {
+        return inner.hasStoredValue();
     }
 
     @Override
     @Nonnull
-    public CompletableFuture<Tuple> toTupleAsync() {
-        return inner.toTupleAsync();
+    public CompletableFuture<PathValue> resolveAsync(@Nonnull FDBRecordContext context) {
+        return inner.resolveAsync(context);
+    }
+
+    @Nonnull
+    public CompletableFuture<Tuple> toTupleAsync(@Nonnull FDBRecordContext context) {
+        return inner.toTupleAsync(context);
     }
 
     @Override
@@ -179,39 +179,24 @@ public class KeySpacePathWrapper implements KeySpacePath {
 
     @Nonnull
     @Override
-    public CompletableFuture<Boolean> hasDataAsync() {
-        return inner.hasDataAsync();
-    }
-
-    @Override
-    public boolean hasData() {
-        return inner.hasData();
+    public CompletableFuture<Boolean> hasDataAsync(@Nonnull FDBRecordContext context) {
+        return inner.hasDataAsync(context);
     }
 
     @Nonnull
     @Override
-    public CompletableFuture<Void> deleteAllDataAsync() {
-        return inner.deleteAllDataAsync();
-    }
-
-    @Override
-    public void deleteAllData() {
-        inner.deleteAllData();
+    public CompletableFuture<Void> deleteAllDataAsync(@Nonnull FDBRecordContext context) {
+        return inner.deleteAllDataAsync(context);
     }
 
     @Nonnull
     @Override
-    public List<KeySpacePath> list(@Nonnull String subdirName, ScanProperties scanProperties ) {
-        return inner.list(subdirName, scanProperties);
-    }
-
-    @Nonnull
-    @Override
-    public RecordCursor<KeySpacePath> listAsync(@Nonnull String subdirName,
-                                                @Nullable ValueRange<Object> range,
+    public RecordCursor<KeySpacePath> listAsync(@Nonnull FDBRecordContext context,
+                                                @Nonnull String subdirName,
+                                                @Nullable ValueRange<?> range,
                                                 @Nullable byte[] continuation,
                                                 @Nonnull ScanProperties scanProperties) {
-        return inner.listAsync(subdirName, range, continuation, scanProperties);
+        return inner.listAsync(context, subdirName, range, continuation, scanProperties);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/PathValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/PathValue.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 
@@ -31,21 +30,21 @@ import java.util.Arrays;
  * of it (e.g. {@link DirectoryLayerDirectory}.
  */
 class PathValue {
-    @Nonnull
+    @Nullable
     private Object resolvedValue;
     @Nullable
     private byte[] metadata;
 
-    PathValue(@Nonnull Object resolvedValue) {
+    PathValue(@Nullable Object resolvedValue) {
         this(resolvedValue, null);
     }
 
-    PathValue(@Nonnull Object resolvedValue, @Nullable byte[] metadata) {
+    PathValue(@Nullable Object resolvedValue, @Nullable byte[] metadata) {
         this.resolvedValue = resolvedValue;
         this.metadata = metadata == null ? null : Arrays.copyOf(metadata, metadata.length);
     }
 
-    @Nonnull
+    @Nullable
     public Object getResolvedValue() {
         return resolvedValue;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayer.java
@@ -176,8 +176,8 @@ public class StringInterningLayer {
 
     private HighContentionAllocator getHca(@Nonnull FDBRecordContext context) {
         return isRootLevel ?
-                HighContentionAllocator.forRoot(context.ensureActive(), counterSubspace, reverseMappingSubspace) :
-                new HighContentionAllocator(context.ensureActive(), counterSubspace, reverseMappingSubspace);
+                HighContentionAllocator.forRoot(context, counterSubspace, reverseMappingSubspace) :
+                new HighContentionAllocator(context, counterSubspace, reverseMappingSubspace);
     }
 
     private byte[] serializeValue(@Nonnull ResolverResult allocated) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -71,6 +71,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -436,6 +437,13 @@ public class RecordCursorTest {
             ++i;
         }
         assertEquals(6, i);
+    }
+
+    @Test
+    public void lazyCursorExceptionTest() {
+        LazyCursor<Integer> cursor = new LazyCursor<>(
+                CompletableFuture.supplyAsync( () -> { throw new IllegalArgumentException("Uh oh"); }));
+        assertThrows(RecordCoreException.class, () -> cursor.hasNext());
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
@@ -149,7 +149,7 @@ public class FDBDatabaseRunnerTest {
 
             runner.run(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
                         .build();
                 store.deleteRecord(Tuple.from(1066L));
                 return null;
@@ -157,7 +157,7 @@ public class FDBDatabaseRunnerTest {
 
             FDBStoredRecord<Message> retrieved2 = runner.run(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
                         .build();
                 return store.loadRecord(Tuple.from(1066L));
             });
@@ -286,14 +286,14 @@ public class FDBDatabaseRunnerTest {
         try (FDBDatabaseRunner runner = database.newRunner()) {
             runner.runAsync(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
                         .build();
                 return store.deleteRecordAsync(Tuple.from(1066L));
             }).join();
 
             FDBStoredRecord<Message> retrieved2 = runner.runAsync(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
                         .build();
                 return store.loadRecordAsync(Tuple.from(1066L));
             }).join();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -191,7 +191,7 @@ public class FDBDatabaseTest {
 
         database.run(context -> {
             FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                    .setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH_OBJECTS))
+                    .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
                     .build();
             store.deleteAllRecords();
             store.saveRecord(simpleRecord);
@@ -204,7 +204,7 @@ public class FDBDatabaseTest {
         // Tests to make sure the database operations are run and committed.
         TestRecords1Proto.MySimpleRecord retrieved = database.run(context -> {
             FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                    .setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH_OBJECTS))
+                    .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
                     .build();
             TestRecords1Proto.MySimpleRecord.Builder builder = TestRecords1Proto.MySimpleRecord.newBuilder();
             FDBStoredRecord<Message> rec = store.loadRecord(Tuple.from(recordNumber));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
@@ -60,7 +60,7 @@ public class FDBMetaDataStoreTest {
     FDBMetaDataStore metaDataStore;
 
     public void openMetaDataStore(FDBRecordContext context) {
-        metaDataStore = new FDBMetaDataStore(context, TestKeySpace.getKeyspacePath(context, "record-test", "unit", "metadataStore"));
+        metaDataStore = new FDBMetaDataStore(context, TestKeySpace.getKeyspacePath("record-test", "unit", "metadataStore"));
         metaDataStore.setDependencies(new Descriptors.FileDescriptor[] {
                 RecordMetaDataOptionsProto.getDescriptor()
         });

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
@@ -179,7 +179,7 @@ public class FDBRecordStorePerformanceTest {
         while (n < databaseParameters.recordCount) {
             try (FDBRecordContext context = fdb.openContext()) {
                 FDBRecordStore recordStore = FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(metaData)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(context, databaseParameters.path))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(databaseParameters.path))
                         .uncheckedOpen();
                 if (n == 0) {
                     recordStore.validateMetaData();
@@ -241,7 +241,7 @@ public class FDBRecordStorePerformanceTest {
                     context.ensureActive().options().setReadYourWritesDisable();
                 }
                 FDBRecordStore store = FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(metaData)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(context, databaseParameters.path))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(databaseParameters.path))
                         .setPipelineSizer(parameters)
                         .uncheckedOpen();
                 for (int j = 0; j < parameters.repeatCount; j++) {
@@ -298,7 +298,7 @@ public class FDBRecordStorePerformanceTest {
                 context.ensureActive().options().setReadYourWritesDisable();
             }
             return FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(metaData)
-                    .setKeySpacePath(TestKeySpace.getKeyspacePath(context, databaseParameters.path))
+                    .setKeySpacePath(TestKeySpace.getKeyspacePath(databaseParameters.path))
                     .setPipelineSizer(parameters)
                     .uncheckedOpenAsync().thenCompose(store -> {
                         long startTime = System.nanoTime();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -1686,9 +1686,9 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         Subspace expectedSubspace;
         Subspace metaDataSubspace;
         try (FDBRecordContext context = fdb.openContext()) {
-            metaDataPath = TestKeySpace.getKeyspacePath(context, metaDataPathObjects);
-            expectedSubspace = new Subspace(path.toTuple());
-            metaDataSubspace = new Subspace(metaDataPath.toTuple());
+            metaDataPath = TestKeySpace.getKeyspacePath(metaDataPathObjects);
+            expectedSubspace = path.toSubspace(context);
+            metaDataSubspace = metaDataPath.toSubspace(context);
             context.ensureActive().clear(Range.startsWith(metaDataSubspace.pack()));
             context.commit();
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -68,7 +68,7 @@ public abstract class FDBRecordStoreTestBase {
     protected boolean useRewritePlanner = false;
     protected QueryPlanner planner;
     protected FDBEvaluationContext<Message> evaluationContext;
-    protected KeySpacePath path;
+    protected final KeySpacePath path = TestKeySpace.getKeyspacePath(PATH_OBJECTS);
 
     /**
      * Meta data setup hook, used for testing.
@@ -98,8 +98,7 @@ public abstract class FDBRecordStoreTestBase {
     public void clearAndInitialize() {
         getFDB();
         fdb.run(timer, null, context -> {
-            setKeySpacePath(context);
-            Subspace subspace = new Subspace(path.toTuple());
+            Subspace subspace = path.toSubspace(context);
             FDBRecordStore.deleteStore(context, subspace);
             return null;
         });
@@ -107,10 +106,6 @@ public abstract class FDBRecordStoreTestBase {
 
     public void getFDB() {
         fdb = FDBDatabaseFactory.instance().getDatabase();
-    }
-
-    private void setKeySpacePath(FDBRecordContext context) {
-        path = TestKeySpace.getKeyspacePath(context, PATH_OBJECTS);
     }
 
     protected void createOrOpenRecordStore(FDBRecordContext context, RecordMetaData metaData) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -654,7 +654,7 @@ public class FDBReverseDirectoryCacheTest {
         KeySpace keySpace = new KeySpace(new KeySpaceDirectory(name, KeySpaceDirectory.KeyType.STRING, name));
         FDBRecordContext context = fdb.openContext();
         KeySpacePath path = keySpace.pathFromKey(context, Tuple.from(name));
-        return new ScopedDirectoryLayer(path);
+        return new ScopedDirectoryLayer(context, path);
     }
 
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStoreTest.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
-import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +59,7 @@ public class FDBTypedRecordStoreTest {
     public void setup() {
         fdb = FDBDatabaseFactory.instance().getDatabase();
         try (FDBRecordContext context = fdb.openContext()) {
-            FDBRecordStore.deleteStore(context, TestKeySpace.getKeyspacePath(context, "record-test", "unit", "typedtest"));
+            FDBRecordStore.deleteStore(context, TestKeySpace.getKeyspacePath("record-test", "unit", "typedtest"));
             context.commit();
         }
     }
@@ -68,7 +67,7 @@ public class FDBTypedRecordStoreTest {
     public void openTypedRecordStore(FDBRecordContext context) throws Exception {
         recordStore = BUILDER.copyBuilder()
                 .setContext(context)
-                .setSubspace(new Subspace(TestKeySpace.getKeyspacePath(context, "record-test", "unit", "typedtest").toTuple()))
+                .setKeySpacePath(TestKeySpace.getKeyspacePath("record-test", "unit", "typedtest"))
                 .createOrOpen();
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -61,9 +61,9 @@ public class KeyValueCursorTest {
     public void runBefore() {
         fdb = FDBDatabaseFactory.instance().getDatabase();
         subspace = fdb.run(context -> {
-            KeySpacePath path = TestKeySpace.getKeyspacePath(context, "record-test", "unit", "keyvaluecursor");
+            KeySpacePath path = TestKeySpace.getKeyspacePath("record-test", "unit", "keyvaluecursor");
             FDBRecordStore.deleteStore(context, path);
-            return new Subspace(path.toTuple());
+            return path.toSubspace(context);
         });
 
         // Populate with data.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
@@ -50,7 +50,7 @@ public class OneOfTest {
     public void setup() {
         fdb = FDBDatabaseFactory.instance().getDatabase();
         try (FDBRecordContext context = fdb.openContext()) {
-            FDBRecordStore.deleteStore(context, TestKeySpace.getKeyspacePath(context, PATH));
+            FDBRecordStore.deleteStore(context, TestKeySpace.getKeyspacePath(PATH));
             context.commit();
         }
     }
@@ -70,7 +70,7 @@ public class OneOfTest {
                 .setMetaDataProvider(metaData());
 
         try (FDBRecordContext context = fdb.openContext()) {
-            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH)).create();
+            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(PATH)).create();
             TestRecordsOneOfProto.MySimpleRecord.Builder recBuilder = TestRecordsOneOfProto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
             recBuilder.setStrValueIndexed("abc");
@@ -78,7 +78,7 @@ public class OneOfTest {
             context.commit();
         }
         try (FDBRecordContext context = fdb.openContext()) {
-            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH)).open();
+            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(PATH)).open();
             FDBStoredRecord<Message> rec1 = recordStore.loadRecord(Tuple.from(1L));
             assertNotNull(rec1);
             TestRecordsOneOfProto.MySimpleRecord.Builder myrec1 = TestRecordsOneOfProto.MySimpleRecord.newBuilder();
@@ -95,7 +95,7 @@ public class OneOfTest {
                 .setSerializer(new MessageBuilderRecordSerializer(TestRecordsOneOfProto.RecordTypeUnion::newBuilder));
 
         try (FDBRecordContext context = fdb.openContext()) {
-            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH)).create();
+            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(PATH)).create();
             TestRecordsOneOfProto.MySimpleRecord.Builder recBuilder = TestRecordsOneOfProto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
             recBuilder.setStrValueIndexed("abc");
@@ -103,7 +103,7 @@ public class OneOfTest {
             context.commit();
         }
         try (FDBRecordContext context = fdb.openContext()) {
-            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH)).open();
+            final FDBRecordStore recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(PATH)).open();
             FDBStoredRecord<Message> rec1 = recordStore.loadRecord(Tuple.from(1L));
             assertNotNull(rec1);
             TestRecordsOneOfProto.MySimpleRecord myrec1 = (TestRecordsOneOfProto.MySimpleRecord)rec1.getRecord();
@@ -126,7 +126,7 @@ public class OneOfTest {
                         .setMetaDataProvider(metaData());
 
         try (FDBRecordContext context = fdb.openContext()) {
-            final FDBTypedRecordStore<TestRecordsOneOfProto.MySimpleRecord> recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH)).create();
+            final FDBTypedRecordStore<TestRecordsOneOfProto.MySimpleRecord> recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(PATH)).create();
             TestRecordsOneOfProto.MySimpleRecord.Builder recBuilder = TestRecordsOneOfProto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
             recBuilder.setStrValueIndexed("abc");
@@ -134,7 +134,7 @@ public class OneOfTest {
             context.commit();
         }
         try (FDBRecordContext context = fdb.openContext()) {
-            final FDBTypedRecordStore<TestRecordsOneOfProto.MySimpleRecord> recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(context, PATH)).open();
+            final FDBTypedRecordStore<TestRecordsOneOfProto.MySimpleRecord> recordStore = storeBuilder.setContext(context).setKeySpacePath(TestKeySpace.getKeyspacePath(PATH)).open();
             FDBStoredRecord<TestRecordsOneOfProto.MySimpleRecord> rec1 = recordStore.loadRecord(Tuple.from(1L));
             assertNotNull(rec1);
             TestRecordsOneOfProto.MySimpleRecord myrec1 = rec1.getRecord();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
@@ -114,7 +114,9 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
 
     @BeforeEach
     public void setSubspace() {
-        subspace = path.toSubspace();
+        try (FDBRecordContext context = openContext()) {
+            subspace = path.toSubspace(context);
+        }
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TestKeySpace.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TestKeySpace.java
@@ -53,11 +53,11 @@ public class TestKeySpace {
      * A method that roughly approximates mapPathKeys, designed only for use in test suite setup. The provided path
      * must be valid in the test keys space.
      */
-    public static KeySpacePath getKeyspacePath(FDBRecordContext context, Object... pathElements) {
+    public static KeySpacePath getKeyspacePath(Object... pathElements) {
         if (pathElements.length <= 0) {
             fail("must call this method with at least one path element");
         }
-        KeySpacePath path = keySpace.path(context, (String) pathElements[0]);
+        KeySpacePath path = keySpace.path((String) pathElements[0]);
         for (int i = 1; i < pathElements.length; i++) {
             path = path.add((String) pathElements[i]);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
@@ -121,7 +121,7 @@ public class VersionIndexTest {
             fdb = FDBDatabaseFactory.instance().getDatabase();
         }
         if (subspace == null) {
-            subspace = fdb.run(context -> new Subspace(TestKeySpace.getKeyspacePath(context, "record-test", "unit", "indexTest", "version").toTuple()));
+            subspace = fdb.run(context -> TestKeySpace.getKeyspacePath("record-test", "unit", "indexTest", "version").toSubspace(context));
         }
         fdb.run(context -> {
             FDBRecordStore.deleteStore(context, subspace);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerToInterningLayerReplicaTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerToInterningLayerReplicaTest.java
@@ -31,8 +31,8 @@ public class DirectoryLayerToInterningLayerReplicaTest extends ResolverMappingRe
     @BeforeEach
     public void setup() {
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedDirectoryLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedDirectoryLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
@@ -76,9 +76,9 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     @Test
     public void testWriteCompatibilityScoped() {
         try (FDBRecordContext context = database.openContext()) {
-            KeySpacePath path = keySpace.path(context, "path").add("to").add("dirLayer");
-            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(path);
-            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(path);
+            KeySpacePath path = keySpace.path("path").add("to").add("dirLayer");
+            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(context, path);
+            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
 
             testReadCompatible(backwardsCompatible, scopedDirectoryLayer);
         }
@@ -87,9 +87,9 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     @Test
     public void testReadCompatibilityScoped() {
         try (FDBRecordContext context = database.openContext()) {
-            KeySpacePath path = keySpace.path(context, "path").add("to").add("dirLayer");
-            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(path);
-            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(path);
+            KeySpacePath path = keySpace.path("path").add("to").add("dirLayer");
+            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(context, path);
+            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
 
             testReadCompatible(scopedDirectoryLayer, backwardsCompatible);
         }
@@ -177,9 +177,9 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     public void testExtendedInParallelWithScopedDirectoryLayer() {
         KeySpacePath path;
         try (FDBRecordContext context = database.openContext()) {
-            path = keySpace.path(context, "path").add("to").add("dirLayer");
-            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(path);
-            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(path);
+            path = keySpace.path("path").add("to").add("dirLayer");
+            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
+            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(context, path);
             testParallelAllocation(false, database, extendedDirectoryLayer, scopedDirectoryLayer);
         }
     }
@@ -188,9 +188,9 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     public void testScopedDirectoryLayerInParallelWithExtended() {
         KeySpacePath path;
         try (FDBRecordContext context = database.openContext()) {
-            path = keySpace.path(context, "path").add("to").add("dirLayer");
-            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(path);
-            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(path);
+            path = keySpace.path("path").add("to").add("dirLayer");
+            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
+            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(context, path);
             testParallelAllocation(false, database, extendedDirectoryLayer, scopedDirectoryLayer);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToExtendedDirectoryLayerReplicaTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToExtendedDirectoryLayerReplicaTest.java
@@ -33,8 +33,8 @@ public class InterningLayerToExtendedDirectoryLayerReplicaTest extends ResolverM
     @BeforeEach
     public void setup() {
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ExtendedDirectoryLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ExtendedDirectoryLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
         seedWithMetadata = true;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToInterningLayerReplicaTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToInterningLayerReplicaTest.java
@@ -31,8 +31,8 @@ public class InterningLayerToInterningLayerReplicaTest extends ResolverMappingRe
     @BeforeEach
     public void setup() {
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
         seedWithMetadata = true;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
@@ -69,9 +69,9 @@ public class ResolverMappingDigestTest {
         factory.setDirectoryCacheSize(100);
         database = factory.getDatabase();
         // wipe test keyspace
+        KeySpacePath basePath = keySpace.path("test-path");
         database.run(context -> {
-            KeySpacePath basePath = keySpace.path(context, "test-path");
-            basePath.deleteAllData();
+            basePath.deleteAllData(context);
             return null;
         });
     }
@@ -81,8 +81,8 @@ public class ResolverMappingDigestTest {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedDirectoryLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedDirectoryLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
 
         testComputeDigest(primary, replica, false);
@@ -93,8 +93,8 @@ public class ResolverMappingDigestTest {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
 
         testComputeDigest(primary, replica, false);
@@ -105,8 +105,8 @@ public class ResolverMappingDigestTest {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
 
         byte[] metadata = Tuple.from("some-metadata").pack();
@@ -118,8 +118,8 @@ public class ResolverMappingDigestTest {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ExtendedDirectoryLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ExtendedDirectoryLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
 
         testComputeDigest(primary, replica, false);
@@ -130,8 +130,8 @@ public class ResolverMappingDigestTest {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(keySpace.path(context, "test-path").add("to").add("primary"));
-            replica = new ExtendedDirectoryLayer(keySpace.path(context, "test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
+            replica = new ExtendedDirectoryLayer(context, keySpace.path("test-path").add("to").add("replica"));
         }
 
         testComputeDigest(primary, replica, true);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
@@ -77,10 +77,10 @@ public abstract class ResolverMappingReplicatorTest {
         factory.setDirectoryCacheSize(100);
         database = factory.getDatabase();
         database.clearCaches();
+        KeySpacePath basePath = keySpace.path("test-path");
         // wipe test keyspace
         database.run(context -> {
-            KeySpacePath basePath = keySpace.path(context, "test-path");
-            context.ensureActive().clear(Range.startsWith(basePath.toTuple().pack()));
+            context.ensureActive().clear(Range.startsWith(basePath.toTuple(context).pack()));
             return null;
         });
     }
@@ -240,9 +240,9 @@ public abstract class ResolverMappingReplicatorTest {
         ResolverMappingReplicator replicator = new ResolverMappingReplicator(primary, 10);
         FDBDatabase differentDB = new FDBDatabase(FDBDatabaseFactory.instance(), null);
 
+        KeySpacePath path = keySpace.path("test-path").add("to").add("replica");
         try (FDBRecordContext context = differentDB.openContext()) {
-            KeySpacePath path = keySpace.path(context, "test-path").add("to").add("replica");
-            LocatableResolver resolverInDifferentDB = new ScopedInterningLayer(path);
+            LocatableResolver resolverInDifferentDB = new ScopedInterningLayer(context, path);
             replicator.copyTo(resolverInDifferentDB);
             fail("should throw IllegalArgumentException");
         } catch (IllegalArgumentException ex) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
@@ -131,12 +131,12 @@ public class ScopedDirectoryLayerTest extends LocatableResolverTest {
         FDBRecordContext context = database.openContext();
         KeySpacePath path = keySpace.pathFromKey(context, Tuple.from("path", "to", "dirLayer"));
 
-        LocatableResolver resolver = scopedDirectoryGenerator.apply(path);
+        LocatableResolver resolver = scopedDirectoryGenerator.apply(context, path);
         Long value = resolver.resolve(context.getTimer(), "foo").join();
 
         DirectoryLayer directoryLayer = new DirectoryLayer(
-                new Subspace(Bytes.concat(path.toTuple().pack(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())),
-                new Subspace(path.toTuple()));
+                new Subspace(Bytes.concat(path.toTuple(context).pack(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())),
+                path.toSubspace(context));
         context = database.openContext();
         validate(context, resolver, directoryLayer, "foo", value);
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -150,9 +150,9 @@ public class LeaderboardIndexTest {
         public abstract void addIndex(RecordMetaDataBuilder metaDataBuilder);
 
         public void openRecordStore(FDBRecordContext context, boolean clearFirst) {
-            final KeySpacePath path = TestKeySpace.getKeyspacePath(context, "record-test", "unit", "indexTest", "leaderboard");
+            final KeySpacePath path = TestKeySpace.getKeyspacePath("record-test", "unit", "indexTest", "leaderboard");
             if (clearFirst) {
-                context.ensureActive().clear(path.toTuple().range());
+                path.deleteAllData(context);
             }
 
             recordStore = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context).setKeySpacePath(path).build();


### PR DESCRIPTION
This turned out to touch a lot of things. I'll enumerate the changes here:

* The methods to start a path out of a KeySpace no longer take a context,
  the original methods that required a context are still available, but
  are marked deprecated.
* The methods that required the context (e.g. toTuple(), toSubspace(), list(),
  etc.) now explicitly take a context rather than using the one provided by
  the Path.  The old methods are deprecated but still supported.
* If you try to use a deprecated method, like toTuple(), on a path created
  with the new API (i.e. without a context), it will throw an IllegalStateException.
* All of the places that was using the old API was updated to use the new one.

One side note about the change. With the old mechanism, a path that had been
turned into a tuple effectively cached the results of resolving the path values
so it was moderately cheap to repeatedly as a path for a tuple.  This is no
longer the case, so clients updating to the new API should be aware of this
difference.