### PR TITLE
Fixes #167: Figure out whether .idea/encodings.xml belongs in source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ atlassian-ide-plugin.xml
 .idea/libraries/*
 .idea/modules/**
 .idea/modules.xml
+.idea/encodings.xml
 
 # Eclipse specific files/directories
 .classpath

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
-</project>


### PR DESCRIPTION
It does not, but was accidentally pulled into 8cb416538d0eb050a8b8764c177c6269e53ad5ec.