### PR TITLE
Fixes #177: fdb-record-layer-release job is failing

### DIFF
--- a/build.py
+++ b/build.py
@@ -154,6 +154,7 @@ def build(release=False, proto2=False, proto3=False, publish=False):
         if publish:
             success = run_gradle(3, ':fdb-record-layer-core-pb3:bintrayUpload',
                                     ':fdb-record-layer-core-pb3-shaded:bintrayUpload',
+                                    '-PcoreNotStrict',
                                     '-PreleaseBuild={0}'.format('true' if release else 'false'),
                                     '-PpublishBuild=true')
             if not success:


### PR DESCRIPTION
Prior to #78 (3384a8010f0057e6557207bbb70d946232c35751), there was a single command line to build and upload and it had `-PcoreNotStrict`. So add it to the second command line, too.