### PR TITLE
 Fixes #188: MetaDataValidator does not validate primary key expression

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/metadata/MetaDataValidator.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/metadata/MetaDataValidator.java
@@ -69,6 +69,7 @@ public class MetaDataValidator implements RecordMetaDataProvider {
     }
 
     protected void validatePrimaryKeyForRecordType(@Nonnull KeyExpression primaryKey, @Nonnull RecordType recordType) {
+        primaryKey.validate(recordType.getDescriptor());
         if (primaryKey.createsDuplicates()) {
             throw new MetaDataException("Primary key for " + recordType.getName() +
                                         " can generate more than one entry");

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/metadata/MetaDataValidatorTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/metadata/MetaDataValidatorTest.java
@@ -66,6 +66,20 @@ public class MetaDataValidatorTest {
     }
 
     @Test
+    public void badPrimaryKeyField() {
+        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        metaData.getRecordType("MySimpleRecord").setPrimaryKey(Key.Expressions.field("no_such_field"));
+        assertThrows(KeyExpression.InvalidExpressionException.class, () -> validate(metaData));
+    }
+
+    @Test
+    public void badPrimaryKeyType() {
+        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords4Proto.getDescriptor());
+        metaData.getRecordType("RestaurantReviewer").setPrimaryKey(Key.Expressions.field("stats"));
+        assertThrows(Query.InvalidExpressionException.class, () -> validate(metaData));
+    }
+
+    @Test
     public void badIndexField() {
         RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
         metaData.addIndex("MySimpleRecord", "no_such_field");


### PR DESCRIPTION
Also adds start of unit test for `MetaDataValidator`.