### PR TITLE
Resolves #148: Add a union cursor that doesn't care about ordering

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -357,6 +357,8 @@ public class FDBStoreTimer extends StoreTimer {
         PLAN_TYPE_FILTER("number of type filter plans", false),
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan}. */
         PLAN_UNION("number of union plans", false),
+        /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan}. */
+        PLAN_UNORDERED_UNION("number of unordered union plans", false),
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan}. */
         PLAN_DISTINCT("number of unordered distinct plans", false),
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan}. */

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorBase.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorBase.java
@@ -268,6 +268,16 @@ abstract class IntersectionCursorBase<T, U> implements RecordCursor<U> {
         return nextFuture;
     }
 
+    /**
+     * Given a list of cursor states, return a value based on the states of
+     * an appropriate type. This will only be called when all of the cursor states
+     * already all match, so this does not need to check for an intersection. The result
+     * of this method then determines the value that the cursor actually omits having
+     * found a match.
+     *
+     * @param cursorStates a list of cursor states with all cursors already having found a match
+     * @return the result to return given an intersection
+     */
     abstract U getNextResult(@Nonnull List<CursorState<T>> cursorStates);
 
     @Nullable
@@ -417,6 +427,7 @@ abstract class IntersectionCursorBase<T, U> implements RecordCursor<U> {
         }
     }
 
+    @Nonnull
     protected static <T> List<CursorState<T>> createCursorStates(@Nonnull Function<byte[], RecordCursor<T>> left, @Nonnull Function<byte[], RecordCursor<T>> right,
                                                                  @Nullable byte[] continuation) {
         final RecordCursorProto.IntersectionContinuation parsed;
@@ -436,6 +447,7 @@ abstract class IntersectionCursorBase<T, U> implements RecordCursor<U> {
         return cursorStates;
     }
 
+    @Nonnull
     protected static <T> List<CursorState<T>> createCursorStates(@Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions, @Nullable byte[] continuation) {
         if (cursorFunctions.size() < 2) {
             throw new RecordCoreArgumentException("not enough child cursors provided to IntersectionCursor")

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
@@ -21,175 +21,38 @@
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
 import com.apple.foundationdb.record.RecordCoreArgumentException;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.RecordCursorProto;
-import com.apple.foundationdb.record.RecordCursorVisitor;
-import com.apple.foundationdb.record.cursors.IllegalContinuationAccessChecker;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
-import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBEvaluationContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.tuple.ByteArrayUtil2;
-import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 /**
  * A cursor that implements a union of all the records from a set of cursors all of whom are ordered compatibly.
  * @param <T> the type of elements returned by the cursor
  */
-public class UnionCursor<T> implements RecordCursor<T> {
-    @Nonnull
-    private final Function<? super T, ? extends List<Object>> comparisonKeyFunction;
+public class UnionCursor<T> extends UnionCursorBase<T> {
     private final boolean reverse;
-    @Nonnull
-    private final List<CursorState<T>> cursorStates;
-    @Nullable
-    private final FDBStoreTimer timer;
-
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
-
-    @Nonnull
-    private static final Set<StoreTimer.Event> duringEvents = Collections.singleton(FDBStoreTimer.Events.QUERY_UNION);
-    @Nonnull
-    private static final Set<StoreTimer.Count> uniqueCounts = Collections.singleton(FDBStoreTimer.Counts.QUERY_UNION_PLAN_UNIQUES);
-    @Nonnull
-    private static final Set<StoreTimer.Count> duplicateCounts =
-            ImmutableSet.of(FDBStoreTimer.Counts.QUERY_UNION_PLAN_DUPLICATES, FDBStoreTimer.Counts.QUERY_DISCARDED);
-
-    private static class CursorState<T> {
-        private static final RecordCursorProto.UnionContinuation.CursorState EXHAUSTED_PROTO = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
-                .setExhausted(true)
-                .build();
-
-        @Nonnull
-        private final RecordCursor<T> cursor;
-        @Nullable
-        private CompletableFuture<Void> onHasNextFuture;
-        private boolean hasNext;
-        @Nullable
-        private T element;
-        private List<Object> key;
-        @Nullable
-        private byte[] continuationBefore;
-        @Nullable
-        private byte[] continuationAfter;
-        @Nullable
-        private byte[] continuation;
-
-        public CursorState(@Nonnull RecordCursor<T> cursor, @Nullable byte[] continuationStart) {
-            this.cursor = cursor;
-            this.continuation = continuationStart;
-            this.continuationAfter = continuationStart;
-        }
-
-        @Nonnull
-        public CompletableFuture<Void> getOnHasNextFuture() {
-            if (onHasNextFuture == null) {
-                onHasNextFuture = cursor.onHasNext().thenAccept(cursorHasNext -> this.hasNext = cursorHasNext);
-            }
-            return onHasNextFuture;
-        }
-
-        public void ready(@Nonnull Function<? super T, ? extends List<Object>> keyFunction) {
-            if (element == null && hasNext) {
-                continuationBefore = continuationAfter;
-                element = cursor.next();
-                continuationAfter = cursor.getContinuation();
-                key = keyFunction.apply(element);
-            }
-        }
-
-        public void consume() {
-            onHasNextFuture = null;
-            element = null;
-            continuation = continuationAfter;
-        }
-
-        public boolean isExhausted() {
-            return !hasNext && cursor.getNoNextReason().isSourceExhausted();
-        }
-
-        @Nonnull
-        public RecordCursorProto.UnionContinuation.CursorState getContinuationProto() {
-            if (continuation != null) {
-                return RecordCursorProto.UnionContinuation.CursorState.newBuilder()
-                        .setContinuation(ByteString.copyFrom(continuation))
-                        .build();
-            } else if (isExhausted()) {
-                return EXHAUSTED_PROTO;
-            } else {
-                return RecordCursorProto.UnionContinuation.CursorState.getDefaultInstance();
-            }
-        }
-
-        @Nonnull
-        public static <T> CursorState<T> exhausted() {
-            return new CursorState<>(RecordCursor.empty(), null);
-        }
-
-        @Nonnull
-        public static <T> CursorState<T> fromProto(
-                @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
-                @Nonnull RecordCursorProto.UnionContinuation.CursorStateOrBuilder proto) {
-            if (proto.getExhausted()) {
-                return exhausted();
-            } else {
-                byte[] continuation = proto.hasContinuation() ? proto.getContinuation().toByteArray() : null;
-                RecordCursor<T> cursor = cursorFunction.apply(continuation);
-                return new CursorState<>(cursor, continuation);
-            }
-        }
-
-        @Nonnull
-        public static <T> CursorState<T> from(
-                @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
-                boolean exhausted, @Nullable byte[] continuation) {
-            if (exhausted) {
-                return exhausted();
-            } else {
-                return new CursorState<>(cursorFunction.apply(continuation), continuation);
-            }
-        }
-    }
 
     private UnionCursor(@Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
                         boolean reverse, @Nonnull List<CursorState<T>> cursorStates,
                         @Nullable FDBStoreTimer timer) {
-        this.comparisonKeyFunction = comparisonKeyFunction;
+        super(comparisonKeyFunction, cursorStates, timer);
         this.reverse = reverse;
-        this.cursorStates = cursorStates;
-        this.timer = timer;
     }
 
     @Nonnull
     @Override
-    public CompletableFuture<Boolean> onHasNext() {
-        mayGetContinuation = false;
-        CompletableFuture<?>[] futures = new CompletableFuture<?>[cursorStates.size()];
-        int i = 0;
-        for (CursorState<T> cursorState : cursorStates) {
-            futures[i] = cursorState.getOnHasNextFuture();
-            i++;
-        }
-        return CompletableFuture.allOf(futures).thenApply(vignore -> {
+    CompletableFuture<Boolean> getIfAnyHaveNext(@Nonnull List<CursorState<T>> cursorStates) {
+        return whenAll(cursorStates).thenApply(vignore -> {
             cursorStates.forEach(cursorState -> {
                 if (!cursorState.hasNext) { // continuation is valid immediately
                     cursorState.continuation = cursorState.cursor.getContinuation();
@@ -200,22 +63,19 @@ public class UnionCursor<T> implements RecordCursor<T> {
                 if (!cursorState.hasNext && cursorState.cursor.getNoNextReason().isLimitReached()) { // continuation is valid immediately
                     // If any side stopped due to limit reached, need to stop completely,
                     // since might otherwise duplicate ones after that, if other side still available.
-                    mayGetContinuation = true;
                     return false;
-                } else {
-                    if (cursorState.hasNext) {
-                        anyHasNext = true;
-                    }
+                } else if (cursorState.hasNext) {
+                    anyHasNext = true;
                 }
             }
-            mayGetContinuation = !anyHasNext;
             return anyHasNext;
         });
     }
 
-    private void mergeStates(@Nonnull List<CursorState<T>> minStates, @Nonnull List<CursorState<T>> otherStates) {
+    @Override
+    void chooseStates(@Nonnull List<CursorState<T>> allStates, @Nonnull List<CursorState<T>> chosenStates, @Nonnull List<CursorState<T>> otherStates) {
         List<Object> nextKey = null;
-        for (CursorState<T> cursorState : cursorStates) {
+        for (CursorState<T> cursorState : allStates) {
             if (cursorState.element == null) {
                 cursorState.continuation = null;
             } else {
@@ -230,181 +90,16 @@ public class UnionCursor<T> implements RecordCursor<T> {
                 }
                 if (compare < 0) {
                     // We have a new next key. Reset the book-keeping information.
-                    otherStates.addAll(minStates);
-                    minStates.clear();
+                    otherStates.addAll(chosenStates);
+                    chosenStates.clear();
                     nextKey = cursorState.key;
                 }
                 if (compare <= 0) {
-                    minStates.add(cursorState);
+                    chosenStates.add(cursorState);
                 } else {
                     otherStates.add(cursorState);
                 }
             }
-        }
-        if (timer != null) {
-            if (minStates.size() == 1) {
-                timer.increment(uniqueCounts);
-            } else {
-                // The number of duplicates is the number of minimum states
-                // for this value except for the first one (hence the "- 1").
-                timer.increment(duplicateCounts, minStates.size() - 1);
-            }
-        }
-    }
-
-    @Nonnull
-    @Override
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        mayGetContinuation = true;
-        for (CursorState<T> cursorState : cursorStates) {
-            cursorState.ready(comparisonKeyFunction);
-        }
-        final long startTime = System.nanoTime();
-        List<CursorState<T>> minStates = new ArrayList<>(cursorStates.size());
-        List<CursorState<T>> otherStates = new ArrayList<>(cursorStates.size());
-        mergeStates(minStates, otherStates);
-        if (minStates.isEmpty()) {
-            throw new RecordCoreException("union with additional items had no next states");
-        }
-        final T result = minStates.get(0).element;
-        if (result == null) {
-            throw new RecordCoreException("minimum element had null result");
-        }
-        // Advance each minimum state.
-        minStates.forEach(CursorState::consume);
-        for (CursorState<T> cursorState : otherStates) {
-            cursorState.continuation = cursorState.continuationBefore;
-        }
-        if (timer != null) {
-            timer.record(duringEvents, System.nanoTime() - startTime);
-        }
-        return result;
-    }
-
-    @Nullable
-    @Override
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        boolean allNull = cursorStates.stream().allMatch(cursorState -> cursorState.continuation == null);
-        if (allNull) {
-            return null;
-        }
-        final RecordCursorProto.UnionContinuation.Builder builder = RecordCursorProto.UnionContinuation.newBuilder();
-        final Iterator<CursorState<T>> cursorStateIterator = cursorStates.iterator();
-        // The first two continuations are special (essentially for compatibility reasons)
-        final CursorState<T> firstCursorState = cursorStateIterator.next();
-        if (firstCursorState.continuation != null) {
-            builder.setFirstContinuation(ByteString.copyFrom(firstCursorState.continuation));
-        } else if (firstCursorState.isExhausted()) {
-            builder.setFirstExhausted(true);
-        }
-        final CursorState<T> secondCursorSatate = cursorStateIterator.next();
-        if (secondCursorSatate.continuation != null) {
-            builder.setSecondContinuation(ByteString.copyFrom(secondCursorSatate.continuation));
-        } else if (secondCursorSatate.isExhausted()) {
-            builder.setSecondExhausted(true);
-        }
-        // The rest of the cursor states get written as elements in a repeated message field
-        while (cursorStateIterator.hasNext()) {
-            builder.addOtherChildState(cursorStateIterator.next().getContinuationProto());
-        }
-        return builder.build().toByteArray();
-    }
-
-    @Override
-    public NoNextReason getNoNextReason() {
-        return mergeNoNextReasons();
-    }
-
-    /**
-     * Merges all of the cursors and whether they have stopped and returns the "strongest" reason for the result to stop.
-     * It will return an out-of-band reason if any of the children stopped for an out-of-band reason, and it will
-     * only return {@link NoNextReason#SOURCE_EXHAUSTED SOURCE_EXHAUSTED} if all of the cursors are exhausted.
-     * @return the strongest reason for stopping
-     */
-    private NoNextReason mergeNoNextReasons() {
-        if (cursorStates.stream().allMatch(cursorState -> cursorState.hasNext)) {
-            throw new RecordCoreException("mergeNoNextReason should not be called when all children have next");
-        }
-        NoNextReason reason = null;
-        for (CursorState<T> cursorState : cursorStates) {
-            if (!cursorState.hasNext) {
-                // Combine the current reason so far with this child's reason.
-                // In particular, choose the child reason if it is at least as strong
-                // as the current one. This guarantees that it will choose an
-                // out of band reason if there is one and will only return
-                // SOURCE_EXHAUSTED if every child ended with SOURCE_EXHAUSTED.
-                NoNextReason childReason = cursorState.cursor.getNoNextReason();
-                if (reason == null || childReason.isOutOfBand() || reason.isSourceExhausted()) {
-                    reason = childReason;
-                }
-            }
-        }
-        return reason;
-    }
-
-    @Override
-    public void close() {
-        cursorStates.forEach(cursorState -> cursorState.cursor.close());
-    }
-
-    @Nonnull
-    @Override
-    public Executor getExecutor() {
-        return cursorStates.get(0).cursor.getExecutor();
-    }
-
-    @Override
-    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
-        if (visitor.visitEnter(this)) {
-            for (CursorState<T> cursorState : cursorStates) {
-                if (!cursorState.cursor.accept(visitor)) {
-                    break;
-                }
-            }
-        }
-        return visitor.visitLeave(this);
-    }
-
-    @Nonnull
-    private static RecordCursorProto.UnionContinuation parseContinuation(@Nonnull byte[] continuation) {
-        try {
-            return RecordCursorProto.UnionContinuation.parseFrom(continuation);
-        } catch (InvalidProtocolBufferException ex) {
-            throw new RecordCoreException("invalid continuation", ex)
-                    .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(continuation));
-        }
-    }
-
-    private static <T> void addFirstTwoCursorStates(
-            @Nullable RecordCursorProto.UnionContinuation parsed,
-            @Nonnull Function<byte[], RecordCursor<T>> first,
-            @Nonnull Function<byte[], RecordCursor<T>> second,
-            @Nonnull List<CursorState<T>> destination) {
-        if (parsed != null) {
-            byte[] firstContinuation = null;
-            boolean firstExhausted = false;
-            if (parsed.hasFirstContinuation()) {
-                firstContinuation = parsed.getFirstContinuation().toByteArray();
-            } else {
-                firstExhausted = parsed.getFirstExhausted();
-            }
-            destination.add(CursorState.from(first, firstExhausted, firstContinuation));
-
-            byte[] secondContinuation = null;
-            boolean secondExhausted = false;
-            if (parsed.hasSecondContinuation()) {
-                secondContinuation = parsed.getSecondContinuation().toByteArray();
-            } else {
-                secondExhausted = parsed.getSecondExhausted();
-            }
-            destination.add(CursorState.from(second, secondExhausted, secondContinuation));
-        } else {
-            destination.add(CursorState.from(first, false, null));
-            destination.add(CursorState.from(second, false, null));
         }
     }
 
@@ -460,20 +155,7 @@ public class UnionCursor<T> implements RecordCursor<T> {
             @Nonnull Function<byte[], RecordCursor<T>> right,
             @Nullable byte[] continuation,
             @Nullable FDBStoreTimer timer) {
-        final List<CursorState<T>> cursorStates = new ArrayList<>(2);
-        final RecordCursorProto.UnionContinuation parsed;
-        if (continuation != null) {
-            parsed = parseContinuation(continuation);
-            if (parsed.getOtherChildStateCount() != 0) {
-                throw new RecordCoreArgumentException("invalid continuation (extraneous child state information present)")
-                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(continuation))
-                        .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, 0)
-                        .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, parsed.getOtherChildStateCount());
-            }
-        } else {
-            parsed = null;
-        }
-        addFirstTwoCursorStates(parsed, left, right, cursorStates);
+        final List<CursorState<T>> cursorStates = createCursorStates(left, right, continuation);
         return new UnionCursor<>(comparisonKeyFunction, reverse, cursorStates, timer);
     }
 
@@ -547,25 +229,7 @@ public class UnionCursor<T> implements RecordCursor<T> {
             throw new RecordCoreArgumentException("not enough child cursors provided to UnionCursor")
                     .addLogInfo(LogMessageKeys.CHILD_COUNT, cursorFunctions.size());
         }
-        final List<CursorState<T>> cursorStates = new ArrayList<>(cursorFunctions.size());
-        if (continuation != null) {
-            final RecordCursorProto.UnionContinuation parsed = parseContinuation(continuation);
-            if (cursorFunctions.size() != parsed.getOtherChildStateCount() + 2) {
-                throw new RecordCoreArgumentException("invalid continuation (expected continuation count does not match read)")
-                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(continuation))
-                        .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, cursorFunctions.size() - 2)
-                        .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, parsed.getOtherChildStateCount());
-            }
-            addFirstTwoCursorStates(parsed, cursorFunctions.get(0), cursorFunctions.get(1), cursorStates);
-            Iterator<RecordCursorProto.UnionContinuation.CursorState> protoStateIterator = parsed.getOtherChildStateList().iterator();
-            for (Function<byte[], RecordCursor<T>> cursorFunction : cursorFunctions.subList(2, cursorFunctions.size())) {
-                cursorStates.add(CursorState.fromProto(cursorFunction, protoStateIterator.next()));
-            }
-        } else {
-            for (Function<byte[], RecordCursor<T>> cursorFunction : cursorFunctions) {
-                cursorStates.add(CursorState.from(cursorFunction, false, null));
-            }
-        }
+        final List<CursorState<T>> cursorStates = createCursorStates(cursorFunctions, continuation);
         return new UnionCursor<>(comparisonKeyFunction, reverse, cursorStates, timer);
     }
 }

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
@@ -1,0 +1,512 @@
+/*
+ * UnionCursorBase.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorProto;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.cursors.EmptyCursor;
+import com.apple.foundationdb.record.cursors.IllegalContinuationAccessChecker;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+/**
+ * Common implementation code for performing a union shared between
+ * the different intersection cursors. In particular, this base cursor
+ * is agnostic to the type of result it returns to the users
+ *
+ * @param <T> the type of elements returned by each child cursor
+ */
+@API(API.Status.INTERNAL)
+abstract class UnionCursorBase<T> implements RecordCursor<T> {
+    @Nonnull
+    private final Function<? super T, ? extends List<Object>> comparisonKeyFunction;
+    @Nonnull
+    private final List<CursorState<T>> cursorStates;
+    @Nonnull
+    private final Executor executor;
+    @Nullable
+    private final FDBStoreTimer timer;
+
+    @Nonnull
+    private static final Set<StoreTimer.Event> duringEvents = Collections.singleton(FDBStoreTimer.Events.QUERY_UNION);
+    @Nonnull
+    private static final Set<StoreTimer.Count> uniqueCounts = Collections.singleton(FDBStoreTimer.Counts.QUERY_UNION_PLAN_UNIQUES);
+    @Nonnull
+    private static final Set<StoreTimer.Count> duplicateCounts =
+            ImmutableSet.of(FDBStoreTimer.Counts.QUERY_UNION_PLAN_DUPLICATES, FDBStoreTimer.Counts.QUERY_DISCARDED);
+
+    // for detecting incorrect cursor usage
+    protected boolean mayGetContinuation = false;
+
+    protected static class CursorState<T> {
+        private static final RecordCursorProto.UnionContinuation.CursorState EXHAUSTED_PROTO = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
+                .setExhausted(true)
+                .build();
+
+        @Nonnull
+        protected final RecordCursor<T> cursor;
+        @Nullable
+        private CompletableFuture<Void> onHasNextFuture;
+        protected boolean hasNext;
+        @Nullable
+        protected T element;
+        protected List<Object> key;
+        @Nullable
+        private byte[] continuationBefore;
+        @Nullable
+        private byte[] continuationAfter;
+        @Nullable
+        protected byte[] continuation;
+        private boolean exhausted;
+
+        @SpotBugsSuppressWarnings(value = {"EI_EXPOSE_REP2"}, justification = "copying byte arrays is expensive")
+        public CursorState(@Nonnull RecordCursor<T> cursor, @Nullable byte[] continuationStart) {
+            this.cursor = cursor;
+            this.continuation = continuationStart;
+            this.continuationAfter = continuationStart;
+        }
+
+        @Nonnull
+        public CompletableFuture<Void> getOnHasNextFuture() {
+            if (exhausted) {
+                return AsyncUtil.DONE;
+            } else if (onHasNextFuture == null) {
+                onHasNextFuture = cursor.onHasNext().thenAccept(cursorHasNext -> {
+                    this.hasNext = cursorHasNext;
+                    if (!cursorHasNext && cursor.getNoNextReason().isSourceExhausted()) {
+                        continuationBefore = continuationAfter;
+                        continuation = cursor.getContinuation();
+                        continuationAfter = continuation;
+                        exhausted = true;
+                    }
+                });
+            }
+            return onHasNextFuture;
+        }
+
+        public void ready(@Nonnull Function<? super T, ? extends List<Object>> keyFunction) {
+            if (element == null && hasNext) {
+                continuationBefore = continuationAfter;
+                element = cursor.next();
+                continuationAfter = cursor.getContinuation();
+                key = keyFunction.apply(element);
+            }
+        }
+
+        public void consume() {
+            onHasNextFuture = null;
+            element = null;
+            hasNext = false;
+            continuation = continuationAfter;
+            if (continuation == null) {
+                // Some cursors, if they know they are at the end, wil return null for
+                // their continuation *before* returning "false" from "hasNext" to signal
+                // that they are done. Take that into account now if possible.
+                exhausted = true;
+            }
+        }
+
+        public boolean isExhausted() {
+            return exhausted;
+        }
+
+        @Nonnull
+        public RecordCursorProto.UnionContinuation.CursorState getContinuationProto() {
+            if (continuation != null) {
+                return RecordCursorProto.UnionContinuation.CursorState.newBuilder()
+                        .setContinuation(ByteString.copyFrom(continuation))
+                        .build();
+            } else if (isExhausted()) {
+                return EXHAUSTED_PROTO;
+            } else {
+                return RecordCursorProto.UnionContinuation.CursorState.getDefaultInstance();
+            }
+        }
+
+        @Nonnull
+        public static <T> CursorState<T> exhausted() {
+            return new CursorState<>(RecordCursor.empty(), null);
+        }
+
+        @Nonnull
+        public static <T> CursorState<T> fromProto(
+                @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
+                @Nonnull RecordCursorProto.UnionContinuation.CursorStateOrBuilder proto) {
+            if (proto.getExhausted()) {
+                return exhausted();
+            } else {
+                byte[] continuation = proto.hasContinuation() ? proto.getContinuation().toByteArray() : null;
+                RecordCursor<T> cursor = cursorFunction.apply(continuation);
+                return new CursorState<>(cursor, continuation);
+            }
+        }
+
+        @Nonnull
+        public static <T> CursorState<T> from(
+                @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
+                boolean exhausted, @Nullable byte[] continuation) {
+            if (exhausted) {
+                return exhausted();
+            } else {
+                return new CursorState<>(cursorFunction.apply(continuation), continuation);
+            }
+        }
+    }
+
+    private static <T> CompletableFuture<?>[] getOnHasNextFutures(@Nonnull List<CursorState<T>> cursorStates) {
+        CompletableFuture<?>[] futures = new CompletableFuture<?>[cursorStates.size()];
+        int i = 0;
+        for (CursorState<T> cursorState : cursorStates) {
+            futures[i] = cursorState.getOnHasNextFuture();
+            i++;
+        }
+        return futures;
+    }
+
+    // This returns a "wildcard" to handle the fact that the signature of AsyncUtil.DONE is
+    // CompletableFuture<Void> whereas CompletableFuture.anyOf returns a CompletableFuture<Object>.
+    // The caller always ignores the result anyway and just uses this as a signal, so it's not
+    // a big loss.
+    @SuppressWarnings("squid:S1452")
+    @Nonnull
+    protected static <T> CompletableFuture<?> whenAny(@Nonnull List<CursorState<T>> cursorStates) {
+        List<CursorState<T>> nonExhausted = new ArrayList<>(cursorStates.size());
+        for (CursorState<T> cursorState : cursorStates) {
+            if (!cursorState.isExhausted()) {
+                if (cursorState.getOnHasNextFuture().isDone()) {
+                    // Short-circuit and return immediately if we find a state that is already done.
+                    return AsyncUtil.DONE;
+                } else {
+                    nonExhausted.add(cursorState);
+                }
+            }
+        }
+        if (nonExhausted.isEmpty()) {
+            // Everything is exhausted. Can return immediately.
+            return AsyncUtil.DONE;
+        } else {
+            return CompletableFuture.anyOf(getOnHasNextFutures(nonExhausted));
+        }
+    }
+
+    @Nonnull
+    protected static <T> CompletableFuture<Void> whenAll(@Nonnull List<CursorState<T>> cursorStates) {
+        return CompletableFuture.allOf(getOnHasNextFutures(cursorStates));
+    }
+
+    protected UnionCursorBase(@Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
+                              @Nonnull List<CursorState<T>> cursorStates,
+                              @Nullable FDBStoreTimer timer) {
+        this.comparisonKeyFunction = comparisonKeyFunction;
+        this.cursorStates = cursorStates;
+        this.timer = timer;
+
+        // Choose the executor from the first non-empty cursor. The executors for empty cursors are just
+        // the default one, whereas non-empty cursors may have an executor set by the user.
+        Executor cursorExecutor = null;
+        for (CursorState<T> cursorState : cursorStates) {
+            if (!(cursorState.cursor instanceof EmptyCursor)) {
+                cursorExecutor = cursorState.cursor.getExecutor();
+                break;
+            }
+        }
+        this.executor = cursorExecutor != null ? cursorExecutor : cursorStates.get(0).cursor.getExecutor();
+    }
+
+    /**
+     * Determine if there is a next element to be returned by looking at the
+     * current cursor states.
+     *
+     * @param cursorStates the list of states of all child cursors
+     */
+    @Nonnull
+    abstract CompletableFuture<Boolean> getIfAnyHaveNext(@Nonnull List<CursorState<T>> cursorStates);
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Boolean> onHasNext() {
+        mayGetContinuation = false;
+        return getIfAnyHaveNext(cursorStates).thenApply(doesHaveNext -> {
+            mayGetContinuation = !doesHaveNext;
+            return doesHaveNext;
+        });
+    }
+
+    /**
+     * Choose which states should be returned by the union cursor as the next element. If this
+     * method adds more than one state to the <code>chosenStates</code> list, then all results
+     * from those cursors should be considered equivalent, and every cursor in that list
+     * of states will be consumed when the {@link #next()} method of this cursor is called. If the
+     * extender wishes to combine all duplicates for a given step in some way, they can control how the elements
+     * are combined by overriding the {@link #getNextResult(List)} method.
+     *
+     * @param allStates all states of all children of this cursor
+     * @param chosenStates the list to populate with states to choose as part of the union
+     * @param otherStates the list to populate with all other states
+     */
+    abstract void chooseStates(@Nonnull List<CursorState<T>> allStates, @Nonnull List<CursorState<T>> chosenStates,
+                               @Nonnull List<CursorState<T>> otherStates);
+
+    /**
+     * Get the result from the list of chosen states. These states have all been identified
+     * as equivalent from the point of view of the union, so only one element should be
+     * returned from all of them. Implementations may choose to combine the results
+     * from the various child results if that is useful.
+     *
+     * @param chosenStates the states that contain the next value to return
+     * @return the result to return from this cursor given these elements appear in the union
+     */
+    T getNextResult(@Nonnull List<CursorState<T>> chosenStates) {
+        return chosenStates.get(0).element;
+    }
+
+    @Nonnull
+    @Override
+    public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        mayGetContinuation = true;
+        for (CursorState<T> cursorState : cursorStates) {
+            cursorState.ready(comparisonKeyFunction);
+        }
+        final long startTime = System.nanoTime();
+        List<CursorState<T>> chosenStates = new ArrayList<>(cursorStates.size());
+        List<CursorState<T>> otherStates = new ArrayList<>(cursorStates.size());
+        chooseStates(cursorStates, chosenStates, otherStates);
+        if (chosenStates.isEmpty()) {
+            throw new RecordCoreException("union with additional items had no next states");
+        }
+        if (timer != null) {
+            if (chosenStates.size() == 1) {
+                timer.increment(uniqueCounts);
+            } else {
+                // The number of duplicates is the number of minimum states
+                // for this value except for the first one (hence the "- 1").
+                timer.increment(duplicateCounts, chosenStates.size() - 1);
+            }
+        }
+        final T result = getNextResult(chosenStates);
+        if (result == null) {
+            throw new RecordCoreException("minimum element had null result");
+        }
+        // Advance each returned state.
+        chosenStates.forEach(CursorState::consume);
+        if (timer != null) {
+            timer.record(duringEvents, System.nanoTime() - startTime);
+        }
+        return result;
+    }
+
+    @Nullable
+    @Override
+    public byte[] getContinuation() {
+        IllegalContinuationAccessChecker.check(mayGetContinuation);
+        boolean allExhausted = cursorStates.stream().allMatch(CursorState::isExhausted);
+        if (allExhausted) {
+            return null;
+        }
+        final RecordCursorProto.UnionContinuation.Builder builder = RecordCursorProto.UnionContinuation.newBuilder();
+        final Iterator<CursorState<T>> cursorStateIterator = cursorStates.iterator();
+        // The first two continuations are special (essentially for compatibility reasons)
+        final CursorState<T> firstCursorState = cursorStateIterator.next();
+        if (firstCursorState.isExhausted()) {
+            builder.setFirstExhausted(true);
+        } else if (firstCursorState.continuation != null) {
+            builder.setFirstContinuation(ByteString.copyFrom(firstCursorState.continuation));
+        }
+        final CursorState<T> secondCursorState = cursorStateIterator.next();
+        if (secondCursorState.isExhausted()) {
+            builder.setSecondExhausted(true);
+        } else if (secondCursorState.continuation != null) {
+            builder.setSecondContinuation(ByteString.copyFrom(secondCursorState.continuation));
+        }
+        // The rest of the cursor states get written as elements in a repeated message field
+        while (cursorStateIterator.hasNext()) {
+            builder.addOtherChildState(cursorStateIterator.next().getContinuationProto());
+        }
+        return builder.build().toByteArray();
+    }
+
+    @Override
+    public NoNextReason getNoNextReason() {
+        return mergeNoNextReasons();
+    }
+
+    /**
+     * Merges all of the cursors and whether they have stopped and returns the "strongest" reason for the result to stop.
+     * It will return an out-of-band reason if any of the children stopped for an out-of-band reason, and it will
+     * only return {@link NoNextReason#SOURCE_EXHAUSTED SOURCE_EXHAUSTED} if all of the cursors are exhausted.
+     * @return the strongest reason for stopping
+     */
+    private NoNextReason mergeNoNextReasons() {
+        if (cursorStates.stream().allMatch(cursorState -> cursorState.hasNext)) {
+            throw new RecordCoreException("mergeNoNextReason should not be called when all children have next");
+        }
+        NoNextReason reason = null;
+        for (CursorState<T> cursorState : cursorStates) {
+            if (!cursorState.getOnHasNextFuture().isDone()) {
+                continue;
+            }
+            if (!cursorState.hasNext) {
+                // Combine the current reason so far with this child's reason.
+                // In particular, choose the child reason if it is at least as strong
+                // as the current one. This guarantees that it will choose an
+                // out of band reason if there is one and will only return
+                // SOURCE_EXHAUSTED if every child ended with SOURCE_EXHAUSTED.
+                NoNextReason childReason = cursorState.cursor.getNoNextReason();
+                if (reason == null || childReason.isOutOfBand() || reason.isSourceExhausted()) {
+                    reason = childReason;
+                }
+            }
+        }
+        return reason;
+    }
+
+    @Override
+    public void close() {
+        cursorStates.forEach(cursorState -> cursorState.cursor.close());
+    }
+
+    @Nonnull
+    @Override
+    public Executor getExecutor() {
+        return executor;
+    }
+
+    @Override
+    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+        if (visitor.visitEnter(this)) {
+            for (CursorState<T> cursorState : cursorStates) {
+                if (!cursorState.cursor.accept(visitor)) {
+                    break;
+                }
+            }
+        }
+        return visitor.visitLeave(this);
+    }
+
+    @Nonnull
+    private static RecordCursorProto.UnionContinuation parseContinuation(@Nonnull byte[] continuation) {
+        try {
+            return RecordCursorProto.UnionContinuation.parseFrom(continuation);
+        } catch (InvalidProtocolBufferException ex) {
+            throw new RecordCoreException("invalid continuation", ex)
+                    .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(continuation));
+        }
+    }
+
+    private static <T> void addFirstTwoCursorStates(
+            @Nullable RecordCursorProto.UnionContinuation parsed,
+            @Nonnull Function<byte[], RecordCursor<T>> first,
+            @Nonnull Function<byte[], RecordCursor<T>> second,
+            @Nonnull List<CursorState<T>> destination) {
+        if (parsed != null) {
+            byte[] firstContinuation = null;
+            boolean firstExhausted = false;
+            if (parsed.hasFirstContinuation()) {
+                firstContinuation = parsed.getFirstContinuation().toByteArray();
+            } else {
+                firstExhausted = parsed.getFirstExhausted();
+            }
+            destination.add(CursorState.from(first, firstExhausted, firstContinuation));
+
+            byte[] secondContinuation = null;
+            boolean secondExhausted = false;
+            if (parsed.hasSecondContinuation()) {
+                secondContinuation = parsed.getSecondContinuation().toByteArray();
+            } else {
+                secondExhausted = parsed.getSecondExhausted();
+            }
+            destination.add(CursorState.from(second, secondExhausted, secondContinuation));
+        } else {
+            destination.add(CursorState.from(first, false, null));
+            destination.add(CursorState.from(second, false, null));
+        }
+    }
+
+    @Nonnull
+    protected static <T> List<CursorState<T>> createCursorStates(@Nonnull Function<byte[], RecordCursor<T>> left, @Nonnull Function<byte[], RecordCursor<T>> right,
+                                                                 @Nullable byte[] continuation) {
+        final List<CursorState<T>> cursorStates = new ArrayList<>(2);
+        final RecordCursorProto.UnionContinuation parsed;
+        if (continuation != null) {
+            parsed = parseContinuation(continuation);
+            if (parsed.getOtherChildStateCount() != 0) {
+                throw new RecordCoreArgumentException("invalid continuation (extraneous child state information present)")
+                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(continuation))
+                        .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, 0)
+                        .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, parsed.getOtherChildStateCount());
+            }
+        } else {
+            parsed = null;
+        }
+        addFirstTwoCursorStates(parsed, left, right, cursorStates);
+        return cursorStates;
+    }
+
+    @Nonnull
+    protected static <T> List<CursorState<T>> createCursorStates(@Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions, @Nullable byte[] continuation) {
+        final List<CursorState<T>> cursorStates = new ArrayList<>(cursorFunctions.size());
+        if (continuation != null) {
+            final RecordCursorProto.UnionContinuation parsed = parseContinuation(continuation);
+            if (cursorFunctions.size() != parsed.getOtherChildStateCount() + 2) {
+                throw new RecordCoreArgumentException("invalid continuation (expected continuation count does not match read)")
+                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(continuation))
+                        .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, cursorFunctions.size() - 2)
+                        .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, parsed.getOtherChildStateCount());
+            }
+            addFirstTwoCursorStates(parsed, cursorFunctions.get(0), cursorFunctions.get(1), cursorStates);
+            Iterator<RecordCursorProto.UnionContinuation.CursorState> protoStateIterator = parsed.getOtherChildStateList().iterator();
+            for (Function<byte[], RecordCursor<T>> cursorFunction : cursorFunctions.subList(2, cursorFunctions.size())) {
+                cursorStates.add(CursorState.fromProto(cursorFunction, protoStateIterator.next()));
+            }
+        } else {
+            for (Function<byte[], RecordCursor<T>> cursorFunction : cursorFunctions) {
+                cursorStates.add(CursorState.from(cursorFunction, false, null));
+            }
+        }
+        return cursorStates;
+    }
+}

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
@@ -1,0 +1,128 @@
+/*
+ * UnorderedUnionCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+/**
+ * A cursor that returns the results of two or more cursors that may return
+ * elements in any order. This cursor makes no guarantees as to the order of
+ * elements it returns, and it may return the same element more than once
+ * as it does not make any attempt to de-duplicate elements that appear in multiple
+ * of its source cursors. It attempts to return elements from its children
+ * "as they come", which means that it might be the case that identical cursors
+ * of this type may return results in two different orders even if all of its
+ * child cursors all return the same results if different children happen to
+ * be faster in (due to, for example, non-determinism in the network).
+ *
+ * @param <T> the type of elements returned by the cursor
+ */
+public class UnorderedUnionCursor<T> extends UnionCursorBase<T> {
+
+    protected UnorderedUnionCursor(@Nonnull List<CursorState<T>> cursorStates,
+                                   @Nullable FDBStoreTimer timer) {
+        super(ignore -> Collections.emptyList(), cursorStates, timer);
+    }
+
+    @Nonnull
+    @Override
+    CompletableFuture<Boolean> getIfAnyHaveNext(@Nonnull List<CursorState<T>> cursorStates) {
+        AtomicBoolean unionHasNext = new AtomicBoolean(false);
+        return AsyncUtil.whileTrue(() -> whenAny(cursorStates).thenApply(vignore -> {
+            boolean anyHasNext = false;
+            boolean anyLimitReached = false;
+            boolean allExhausted = true;
+            for (CursorState<T> cursorState : cursorStates) {
+                if (!cursorState.getOnHasNextFuture().isDone()) {
+                    allExhausted = false;
+                    continue;
+                }
+                if (!cursorState.hasNext) {
+                    // Continuation is valid immediately.
+                    cursorState.continuation = cursorState.cursor.getContinuation();
+                    if (cursorState.cursor.getNoNextReason().isLimitReached()) {
+                        anyLimitReached = true;
+                        allExhausted = false;
+                    }
+                } else {
+                    // Found a cursor with an element.
+                    anyHasNext = true;
+                    allExhausted = false;
+                }
+            }
+            // If any cursor has reached a limit, stop the union cursor.
+            if (anyLimitReached) {
+                return false;
+            }
+            // If any cursor has another element, return that there is another element
+            // for the union. If no element was found, it was because the child
+            // cursor that became ready was exhausted and the cursor needs to
+            // keep looking for another (so this loops again).
+            if (anyHasNext) {
+                unionHasNext.set(true);
+            }
+            return !allExhausted && !anyHasNext;
+        }), getExecutor()).thenApply(vignore -> unionHasNext.get());
+    }
+
+    @Override
+    void chooseStates(@Nonnull List<CursorState<T>> allStates, @Nonnull List<CursorState<T>> chosenStates, @Nonnull List<CursorState<T>> otherStates) {
+        boolean found = false;
+        for (CursorState<T> cursorState : allStates) {
+            if (found || cursorState.isExhausted() || !cursorState.getOnHasNextFuture().isDone() || cursorState.element == null) {
+                otherStates.add(cursorState);
+            } else if (cursorState.getOnHasNextFuture().isDone()) {
+                chosenStates.add(cursorState);
+                found = true;
+            }
+        }
+    }
+
+    /**
+     * Create a union cursor from two or more cursors. Unlike the other {@link UnionCursor}, this does
+     * not require that the child cursors return values in any particular order. The trade-off, however,
+     * is that this cursor will not attempt to remove any duplicates from its children. It will return
+     * results from its children as they become available.
+     *
+     * @param cursorFunctions a list of functions to produce {@link RecordCursor}s from a continuation
+     * @param continuation any continuation from a previous scan
+     * @param timer the timer used to instrument events
+     * @param <T> the type of elements returned by this cursor
+     * @return a cursor containing any records from any child cursor
+     */
+    @Nonnull
+    public static <T> UnorderedUnionCursor<T> create(
+            @Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
+            @Nullable byte[] continuation,
+            @Nullable FDBStoreTimer timer) {
+        return new UnorderedUnionCursor<>(createCursorStates(cursorFunctions, continuation), timer);
+    }
+}

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
@@ -125,8 +125,9 @@ public class PlanOrderingKey {
                     // plus the text column itself.
                     prefixSize = groupingSize + suffixSize + 1;
                 } else {
-                    // Can only using the grouping columns as the text index itself uses an inequality comparison
-                    prefixSize = groupingSize;
+                    // The inequality text comparisons do not really allow for combining results as they are ordered
+                    // by the token that the prefix scan just so happened to hit.
+                    return null;
                 }
             } else {
                 // Some unknown index plan. Maybe this should throw an error?

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.query.plan.plans;
 
-import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
@@ -40,36 +39,25 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A query plan that executes by taking the union of records from two or more compatibly-sorted child plans.
  * To work, each child cursor must order its children the same way according to the comparison key.
  */
-public class RecordQueryUnionPlan implements RecordQueryPlanWithChildren {
+public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
     public static final Logger LOGGER = LoggerFactory.getLogger(RecordQueryUnionPlan.class);
 
-    private static final String UNION = "∪";    // U+222A
-    /* The current implementations of equals() and hashCode() treat RecordQueryUnionPlan as if it were isomorphic under
-     * a reordering of its children. In particular, all of the tests assume that a RecordQueryUnionPlan with its children
-     * reordered is identical. This is accurate in the current implementation (except that the continuation might no longer
-     * be valid); if this ever changes, equals() and hashCode() must be updated.
-     */
-    @Nonnull
-    private final List<ExpressionRef<RecordQueryPlan>> children;
+    private static final StoreTimer.Count PLAN_COUNT = FDBStoreTimer.Counts.PLAN_UNION;
+
     @Nonnull
     private final ExpressionRef<KeyExpression> comparisonKey;
     @Nonnull
     private final List<ExpressionRef<? extends PlannerExpression>> expressionChildren;
     private final boolean showComparisonKey;
-    private final boolean reverse;
 
     public RecordQueryUnionPlan(@Nonnull RecordQueryPlan left, @Nonnull RecordQueryPlan right,
                                 @Nonnull KeyExpression comparisonKey, boolean reverse, boolean showComparisonKey) {
@@ -78,86 +66,26 @@ public class RecordQueryUnionPlan implements RecordQueryPlanWithChildren {
 
     public RecordQueryUnionPlan(@Nonnull List<RecordQueryPlan> children,
                                 @Nonnull KeyExpression comparisonKey, boolean reverse, boolean showComparisonKey) {
-        final ImmutableList.Builder<ExpressionRef<RecordQueryPlan>> childrenBuilder = ImmutableList.builder();
+        super(children, reverse);
         final ImmutableList.Builder<ExpressionRef<? extends PlannerExpression>> expressionChildrenBuilder = ImmutableList.builder();
-        for (RecordQueryPlan child : children) {
-            ExpressionRef<RecordQueryPlan> childRef = SingleExpressionRef.of(child);
-            childrenBuilder.add(childRef);
-            expressionChildrenBuilder.add(childRef);
-        }
-        this.children = childrenBuilder.build();
+        expressionChildrenBuilder.addAll(super.getPlannerExpressionChildren());
         this.comparisonKey = SingleExpressionRef.of(comparisonKey);
         this.expressionChildren = expressionChildrenBuilder.add(this.comparisonKey).build();
         this.showComparisonKey = showComparisonKey;
-        this.reverse = reverse;
     }
+
 
     @Nonnull
     @Override
-    @SuppressWarnings("squid:S2095") // SonarQube doesn't realize that the union cursor is wrapped and returned
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBEvaluationContext<M> context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
-        final ExecuteProperties childExecuteProperties;
-        // Can pass the limit down to all sides, since that is the most we'll take total.
-        if (executeProperties.getSkip() > 0) {
-            childExecuteProperties = executeProperties.clearSkipAndAdjustLimit();
-        } else {
-            childExecuteProperties = executeProperties;
-        }
-
-        return UnionCursor.create(context, getComparisonKey(), reverse,
-                getChildStream()
-                        .map(childPlan -> (Function<byte[], RecordCursor<FDBQueriedRecord<M>>>)
-                                ((byte[] childContinuation) -> childPlan.execute(context, childContinuation, childExecuteProperties)))
-                        .collect(Collectors.toList()),
-                continuation).skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
-    }
-
-    @Override
-    public boolean isReverse() {
-        return reverse;
-    }
-
-    @Override
-    public boolean hasRecordScan() {
-        return getChildStream().anyMatch(RecordQueryPlan::hasRecordScan);
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getChildStream().anyMatch(RecordQueryPlan::hasFullRecordScan);
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getChildStream().anyMatch(child -> child.hasIndexScan(indexName));
-    }
-
-    @Nonnull
-    private Stream<RecordQueryPlan> getChildStream() {
-        return children.stream().map(ExpressionRef::get);
-    }
-
-    @Override
-    @Nonnull
-    public List<RecordQueryPlan> getChildren() {
-        return getChildStream().collect(Collectors.toList());
+    <M extends Message> RecordCursor<FDBQueriedRecord<M>> createUnionCursor(@Nonnull FDBEvaluationContext<M> context,
+                                                                            @Nonnull List<Function<byte[], RecordCursor<FDBQueriedRecord<M>>>> childCursorFunctions,
+                                                                            @Nullable byte[] continuation) {
+        return UnionCursor.create(context, getComparisonKey(), isReverse(), childCursorFunctions, continuation);
     }
 
     @Nonnull
     public KeyExpression getComparisonKey() {
         return comparisonKey.get();
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        HashSet<String> usedIndexes = new HashSet<>();
-        for (ExpressionRef<RecordQueryPlan> child : children) {
-            usedIndexes.addAll(child.get().getUsedIndexes());
-        }
-        return usedIndexes;
     }
 
     @Nonnull
@@ -175,47 +103,28 @@ public class RecordQueryUnionPlan implements RecordQueryPlanWithChildren {
             return false;
         }
         RecordQueryUnionPlan that = (RecordQueryUnionPlan) o;
-        return reverse == that.reverse &&
-                Objects.equals(Sets.newHashSet(getChildren()), Sets.newHashSet(that.getChildren())) &&  // isomorphic under re-ordering of children
-                Objects.equals(getComparisonKey(), that.getComparisonKey());
+        return super.equals(o) && Objects.equals(getComparisonKey(), that.getComparisonKey());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(Sets.newHashSet(getChildren()), getComparisonKey(), reverse); // isomorphic under re-ordering of children
+        return Objects.hash(Sets.newHashSet(getChildren()), getComparisonKey(), isReverse()); // isomorphic under re-ordering of children
     }
 
     @Override
     public int planHash() {
-        return PlanHashable.planHash(getChildren()) + getComparisonKey().planHash() + (reverse ? 1 : 0);
+        return PlanHashable.planHash(getChildren()) + getComparisonKey().planHash() + (isReverse() ? 1 : 0);
     }
 
     @Nonnull
     @Override
-    public String toString() {
-        return String.join(" " + UNION + (showComparisonKey ? getComparisonKey().toString() : "") + " ",
-                getChildStream().map(RecordQueryPlan::toString).collect(Collectors.toList()));
+    String getDelimiter() {
+        return " " + UNION + (showComparisonKey ? getComparisonKey().toString() : "") + " ";
     }
 
+    @Nonnull
     @Override
-    public void logPlanStructure(StoreTimer timer) {
-        timer.increment(FDBStoreTimer.Counts.PLAN_UNION);
-        for (ExpressionRef<RecordQueryPlan> child : children) {
-            child.get().logPlanStructure(timer);
-        }
-    }
-
-    @Override
-    public int getComplexity() {
-        int complexity = 1;
-        for (ExpressionRef<RecordQueryPlan> child : children) {
-            complexity += child.get().getComplexity();
-        }
-        return complexity;
-    }
-
-    @Override
-    public int getRelationalChildCount() {
-        return children.size();
+    StoreTimer.Count getPlanCount() {
+        return PLAN_COUNT;
     }
 }

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -1,0 +1,206 @@
+/*
+ * RecordQueryUnionPlanBase.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBEvaluationContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+import com.apple.foundationdb.record.query.plan.temp.SingleExpressionRef;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.google.protobuf.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@API(API.Status.INTERNAL)
+abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChildren {
+    public static final Logger LOGGER = LoggerFactory.getLogger(RecordQueryUnionPlanBase.class);
+
+    protected static final String UNION = "∪";    // U+222A
+    /* The current implementations of equals() and hashCode() treat RecordQueryUnionPlan as if it were isomorphic under
+     * a reordering of its children. In particular, all of the tests assume that a RecordQueryUnionPlan with its children
+     * reordered is identical. This is accurate in the current implementation (except that the continuation might no longer
+     * be valid); if this ever changes, equals() and hashCode() must be updated.
+     */
+    @Nonnull
+    private final List<ExpressionRef<RecordQueryPlan>> children;
+    private final boolean reverse;
+
+    public RecordQueryUnionPlanBase(@Nonnull RecordQueryPlan left, @Nonnull RecordQueryPlan right, boolean reverse) {
+        this(ImmutableList.of(left, right), reverse);
+    }
+
+    public RecordQueryUnionPlanBase(@Nonnull List<RecordQueryPlan> children, boolean reverse) {
+        final ImmutableList.Builder<ExpressionRef<RecordQueryPlan>> childrenBuilder = ImmutableList.builder();
+        for (RecordQueryPlan child : children) {
+            ExpressionRef<RecordQueryPlan> childRef = SingleExpressionRef.of(child);
+            childrenBuilder.add(childRef);
+        }
+        this.children = childrenBuilder.build();
+        this.reverse = reverse;
+    }
+
+    @Nonnull
+    abstract <M extends Message> RecordCursor<FDBQueriedRecord<M>> createUnionCursor(@Nonnull FDBEvaluationContext<M> context,
+                                                                                     @Nonnull List<Function<byte[], RecordCursor<FDBQueriedRecord<M>>>> childCursorFunctions,
+                                                                                     @Nullable byte[] continuation);
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("squid:S2095") // SonarQube doesn't realize that the union cursor is wrapped and returned
+    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBEvaluationContext<M> context,
+                                                                         @Nullable byte[] continuation,
+                                                                         @Nonnull ExecuteProperties executeProperties) {
+        final ExecuteProperties childExecuteProperties;
+        // Can pass the limit down to all sides, since that is the most we'll take total.
+        if (executeProperties.getSkip() > 0) {
+            childExecuteProperties = executeProperties.clearSkipAndAdjustLimit();
+        } else {
+            childExecuteProperties = executeProperties;
+        }
+        final List<Function<byte[], RecordCursor<FDBQueriedRecord<M>>>> childCursorFunctions = getChildStream()
+                .map(childPlan -> (Function<byte[], RecordCursor<FDBQueriedRecord<M>>>)
+                        ((byte[] childContinuation) -> childPlan.execute(context, childContinuation, childExecuteProperties)))
+                .collect(Collectors.toList());
+        return createUnionCursor(context, childCursorFunctions, continuation).skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
+    }
+
+    @Override
+    public boolean isReverse() {
+        return reverse;
+    }
+
+    @Override
+    public boolean hasRecordScan() {
+        return getChildStream().anyMatch(RecordQueryPlan::hasRecordScan);
+    }
+
+    @Override
+    public boolean hasFullRecordScan() {
+        return getChildStream().anyMatch(RecordQueryPlan::hasFullRecordScan);
+    }
+
+    @Override
+    public boolean hasIndexScan(@Nonnull String indexName) {
+        return getChildStream().anyMatch(child -> child.hasIndexScan(indexName));
+    }
+
+    @Nonnull
+    private Stream<RecordQueryPlan> getChildStream() {
+        return children.stream().map(ExpressionRef::get);
+    }
+
+    @Override
+    @Nonnull
+    public List<RecordQueryPlan> getChildren() {
+        return getChildStream().collect(Collectors.toList());
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getUsedIndexes() {
+        HashSet<String> usedIndexes = new HashSet<>();
+        for (ExpressionRef<RecordQueryPlan> child : children) {
+            usedIndexes.addAll(child.get().getUsedIndexes());
+        }
+        return usedIndexes;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
+        return children.iterator();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RecordQueryUnionPlanBase that = (RecordQueryUnionPlanBase) o;
+        return reverse == that.reverse &&
+               Objects.equals(Sets.newHashSet(getChildren()), Sets.newHashSet(that.getChildren()));  // isomorphic under re-ordering of children
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Sets.newHashSet(getChildren()), reverse); // isomorphic under re-ordering of children
+    }
+
+    @Override
+    public int planHash() {
+        return PlanHashable.planHash(getChildren()) + (reverse ? 1 : 0);
+    }
+
+    @Nonnull
+    abstract String getDelimiter();
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return String.join(getDelimiter(), getChildStream().map(RecordQueryPlan::toString).collect(Collectors.toList()));
+    }
+
+    @Nonnull
+    abstract StoreTimer.Count getPlanCount();
+
+    @Override
+    public void logPlanStructure(StoreTimer timer) {
+        timer.increment(getPlanCount());
+        for (ExpressionRef<RecordQueryPlan> child : children) {
+            child.get().logPlanStructure(timer);
+        }
+    }
+
+    @Override
+    public int getComplexity() {
+        int complexity = 1;
+        for (ExpressionRef<RecordQueryPlan> child : children) {
+            complexity += child.get().getComplexity();
+        }
+        return complexity;
+    }
+
+    @Override
+    public int getRelationalChildCount() {
+        return children.size();
+    }
+}

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedUnionPlan.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedUnionPlan.java
@@ -1,0 +1,77 @@
+/*
+ * RecordQueryUnorderedUnionPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBEvaluationContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.cursors.UnorderedUnionCursor;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A query plan that returns results from two-or-more cursors as they as ready. Unlike the {@link RecordQueryUnionPlan},
+ * there are no ordering restrictions placed on the child plans (i.e., the children are free to return results
+ * in any order). However, this plan also makes no effort to remove duplicates from its children, and it also
+ * makes no guarantees as to what order it will return results.
+ */
+public class RecordQueryUnorderedUnionPlan extends RecordQueryUnionPlanBase {
+
+    public RecordQueryUnorderedUnionPlan(@Nonnull RecordQueryPlan left, @Nonnull RecordQueryPlan right, boolean reverse) {
+        super(left, right, reverse);
+    }
+
+    public RecordQueryUnorderedUnionPlan(@Nonnull List<RecordQueryPlan> children, boolean reverse) {
+        super(children, reverse);
+    }
+
+    @Nonnull
+    @Override
+    <M extends Message> RecordCursor<FDBQueriedRecord<M>> createUnionCursor(@Nonnull FDBEvaluationContext<M> context,
+                                                                            @Nonnull List<Function<byte[], RecordCursor<FDBQueriedRecord<M>>>> childCursorFunctions,
+                                                                            @Nullable byte[] continuation) {
+        return UnorderedUnionCursor.create(childCursorFunctions, continuation, context.getTimer());
+    }
+
+    @Nonnull
+    @Override
+    String getDelimiter() {
+        return " " + UNION + " ";
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return "Unordered(" + super.toString() + ")";
+    }
+
+    @Nonnull
+    @Override
+    StoreTimer.Count getPlanCount() {
+        return FDBStoreTimer.Counts.PLAN_UNORDERED_UNION;
+    }
+}

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/cursors/FirableCursor.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/cursors/FirableCursor.java
@@ -1,0 +1,141 @@
+/*
+ * FirableCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.cursors;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * A cursor that wraps another cursor, but it returns an element only after the user calls the
+ * "fire" command. This is useful for controlling the order in which cursors return results,
+ * which can be used to simulate different scenarios deterministically.
+ *
+ * @param <T> the type of element returned by this cursor
+ */
+@API(API.Status.INTERNAL)
+public class FirableCursor<T> implements RecordCursor<T> {
+    @Nonnull
+    private final RecordCursor<T> underlying;
+    private byte[] continuation;
+    private boolean mayGetContinuation;
+    @Nullable
+    private CompletableFuture<Boolean> onHasNextFuture;
+    @Nonnull
+    private CompletableFuture<Void> fireSignal;
+    private volatile boolean fireWhenReady;
+
+    public FirableCursor(@Nonnull RecordCursor<T> underlying) {
+        this.underlying = underlying;
+        this.fireSignal = new CompletableFuture<>();
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Boolean> onHasNext() {
+        if (onHasNextFuture == null) {
+            mayGetContinuation = false;
+            onHasNextFuture = fireSignal.thenCompose(vignore -> underlying.onHasNext().thenApply(cursorHasNext -> {
+                this.mayGetContinuation = !cursorHasNext;
+                if (!cursorHasNext) {
+                    this.continuation = underlying.getContinuation();
+                }
+                return cursorHasNext;
+            }));
+        }
+        return onHasNextFuture;
+    }
+
+    @Nullable
+    @Override
+    public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        final T elem = underlying.next();
+        continuation = underlying.getContinuation();
+        onHasNextFuture = null;
+        mayGetContinuation = true;
+        synchronized (this) {
+            if (!fireWhenReady) {
+                fireSignal = new CompletableFuture<>();
+            }
+        }
+        return elem;
+    }
+
+    /**
+     * Allow a single element to be emitted by the cursor.
+     */
+    public void fire() {
+        fireSignal.complete(null);
+    }
+
+    /**
+     * Allow the cursor to start emitting its child cursors elements
+     * as they come.
+     */
+    public void fireAll() {
+        fire();
+        synchronized (this) {
+            fireWhenReady = true;
+            fireSignal = AsyncUtil.DONE;
+        }
+    }
+
+    @Nullable
+    @Override
+    public byte[] getContinuation() {
+        IllegalContinuationAccessChecker.check(mayGetContinuation);
+        return continuation;
+    }
+
+    @Override
+    public NoNextReason getNoNextReason() {
+        return underlying.getNoNextReason();
+    }
+
+    @Override
+    public void close() {
+        underlying.close();
+    }
+
+    @Nonnull
+    @Override
+    public Executor getExecutor() {
+        return underlying.getExecutor();
+    }
+
+    @Override
+    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+        if (visitor.visitEnter(this)) {
+            underlying.accept(visitor);
+        }
+        return visitor.visitLeave(this);
+    }
+}

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
@@ -1,0 +1,213 @@
+/*
+ * UnorderedUnionCursorTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorTest;
+import com.apple.foundationdb.record.cursors.FirableCursor;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for the {@link UnorderedUnionCursor} class. This cursor is somewhat unique in that it
+ * makes almost no guarantees about the order in which things come in.
+ */
+@Tag(Tags.RequiresFDB)
+public class UnorderedUnionCursorTest {
+
+    @Nonnull
+    private <T> List<Function<byte[], RecordCursor<T>>> functionsFromLists(@Nonnull List<List<T>> lists) {
+        return lists.stream()
+                .map(list -> (Function<byte[], RecordCursor<T>>)((byte[] continuation) -> RecordCursor.fromList(list, continuation)))
+                .collect(Collectors.toList());
+    }
+
+    @Nonnull
+    private <T> List<Function<byte[], RecordCursor<T>>> functionsFromCursors(@Nonnull List<? extends RecordCursor<T>> cursors) {
+        return cursors.stream()
+                .map(cursor -> (Function<byte[], RecordCursor<T>>)((byte[] ignore) -> cursor))
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void basicUnion() throws ExecutionException, InterruptedException {
+        final List<List<Integer>> elems = Arrays.asList(
+                Arrays.asList(0, 100, 200),
+                Arrays.asList(401, 201, 1),
+                Arrays.asList(2, 302, 102)
+        );
+        final UnorderedUnionCursor<Integer> cursor = UnorderedUnionCursor.create(functionsFromLists(elems), null, null);
+        List<Integer> results = cursor.asList().get();
+        assertEquals(elems.stream().mapToInt(List::size).sum(), results.size());
+        // Verify that each list is returned within the cursor in the same order as it appears in the source list.
+        for (List<Integer> childCursorList : elems) {
+            int pos = 0;
+            for (Integer result : results) {
+                if (pos < childCursorList.size() && result.equals(childCursorList.get(pos))) {
+                    pos++;
+                }
+            }
+            assertEquals(childCursorList.size(), pos);
+        }
+        assertThat(cursor.hasNext(), is(false));
+        assertThat(cursor.getNoNextReason().isSourceExhausted(), is(true));
+    }
+
+    @Test
+    public void roundRobin() {
+        final List<Integer> expectedResults = Arrays.asList(0, 401, 2, 100, 201, 302, 200, 1, 102);
+        final List<FirableCursor<Integer>> cursors = Arrays.asList(
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(0, 100, 200))),
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(401, 201, 1))),
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(2, 302, 102)))
+        );
+        final UnorderedUnionCursor<Integer> cursor = UnorderedUnionCursor.create(functionsFromCursors(cursors), null, null);
+        Iterator<Integer> expectedIterator = expectedResults.iterator();
+        int currentCursor = 0;
+        while (expectedIterator.hasNext()) {
+            cursors.get(currentCursor).fire();
+            int nextValue = cursor.next();
+            assertEquals((int)expectedIterator.next(), nextValue);
+            currentCursor = (currentCursor + 1) % cursors.size();
+        }
+        cursors.forEach(FirableCursor::fireAll);
+        assertThat(cursor.hasNext(), is(false));
+        assertThat(cursor.getNoNextReason().isSourceExhausted(), is(true));
+    }
+
+    @Test
+    public void concat() {
+        final int childCursorSize = 3;
+        final List<Integer> expectedResults = Arrays.asList(0, 100, 200, 401, 201, 1, 2, 302, 102);
+        final List<FirableCursor<Integer>> cursors = Arrays.asList(
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(0, 100, 200))),
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(401, 201, 1))),
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(2, 302, 102)))
+        );
+        final UnorderedUnionCursor<Integer> cursor = UnorderedUnionCursor.create(functionsFromCursors(cursors), null, null);
+        Iterator<Integer> expectedIterator = expectedResults.iterator();
+        for (FirableCursor<Integer> childCursor : cursors) {
+            childCursor.fireAll();
+            for (int i = 0; i < childCursorSize; i++) {
+                assertEquals((int)expectedIterator.next(), (int)cursor.next());
+            }
+            assertThat(childCursor.hasNext(), is(false));
+        }
+        assertThat(cursor.hasNext(), is(false));
+        assertThat(cursor.getNoNextReason().isSourceExhausted(), is(true));
+    }
+
+    @Test
+    public void innerLimitReasons() throws ExecutionException, InterruptedException {
+        // One hits limit ; one has not yet returned anything
+        List<FirableCursor<Integer>> cursors = Arrays.asList(
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(0, 1)).limitRowsTo(1)),
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(3, 4)))
+        );
+        UnorderedUnionCursor<Integer> cursor = UnorderedUnionCursor.create(functionsFromCursors(cursors), null, null);
+        cursors.get(0).fireAll();
+        assertEquals(Collections.singletonList(0), cursor.asList().get());
+        assertThat(cursor.hasNext(), is(false));
+        assertEquals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, cursor.getNoNextReason());
+
+        // One hits limit ; one has fired exactly once
+        cursors = Arrays.asList(
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(0, 1)).limitRowsTo(1)),
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(3, 4)))
+        );
+        cursor = UnorderedUnionCursor.create(functionsFromCursors(cursors), null, null);
+        cursors.get(1).fire();
+        assertEquals(3, (int)cursor.next());
+        cursors.get(0).fireAll();
+        assertEquals(0, (int)cursor.next());
+        assertThat(cursor.hasNext(), is(false));
+        assertEquals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, cursor.getNoNextReason());
+
+        // One hits limit ; one is exhausted
+        cursors = Arrays.asList(
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(0, 1)).limitRowsTo(1)),
+                new FirableCursor<>(RecordCursor.fromList(Collections.singletonList(3)))
+        );
+        cursor = UnorderedUnionCursor.create(functionsFromCursors(cursors), null, null);
+        cursors.get(1).fire();
+        assertEquals(3, (int)cursor.next());
+        cursors.get(0).fireAll();
+        cursors.get(1).fireAll();
+        assertEquals(0, (int)cursor.next());
+        assertThat(cursor.hasNext(), is(false));
+        assertEquals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, cursor.getNoNextReason());
+
+        // One hits return limit ; one hits scan limit exhausted
+        cursors = Arrays.asList(
+                new FirableCursor<>(RecordCursor.fromList(Arrays.asList(0, 1)).limitRowsTo(1)),
+                new FirableCursor<>(new RecordCursorTest.FakeOutOfBandCursor<>(RecordCursor.fromList(Arrays.asList(3, 4)), 1))
+        );
+        cursor = UnorderedUnionCursor.create(functionsFromCursors(cursors), null, null);
+        cursors.get(1).fire();
+        assertEquals(3, (int)cursor.next());
+        cursors.get(0).fireAll();
+        assertEquals(0, (int)cursor.next());
+        cursors.get(1).fireAll();
+        assertThat(cursor.hasNext(), is(false));
+        assertEquals(RecordCursor.NoNextReason.TIME_LIMIT_REACHED, cursor.getNoNextReason());
+    }
+
+    @ValueSource(ints = {1, 3, 5})
+    @ParameterizedTest(name = "basicContinuation() [limit = {0}]")
+    public void basicContinuation(int limit) {
+        final List<List<Integer>> elems = Arrays.asList(
+                Arrays.asList(0, 3, 5),
+                Arrays.asList(6, 4, 1),
+                Arrays.asList(2, 8, 7)
+        );
+        byte[] continuation = null;
+        boolean done = false;
+        List<Integer> results = new ArrayList<>();
+        while (!done) {
+            RecordCursor<Integer> cursor = UnorderedUnionCursor.create(functionsFromLists(elems), continuation, null).limitRowsTo(limit);
+            while (cursor.hasNext()) {
+                results.add(cursor.next());
+            }
+            continuation = cursor.getContinuation();
+            done = cursor.getNoNextReason().isSourceExhausted();
+        }
+        assertEquals(elems.stream().mapToInt(List::size).sum(), results.size());
+        assertEquals(elems.stream().flatMap(List::stream).collect(Collectors.toSet()), new HashSet<>(results));
+    }
+}

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
@@ -139,6 +139,15 @@ public class PlanMatchers {
         return new UnionMatcher(childMatchers, comparisonKeyMatcher); // order of child arguments does not matter
     }
 
+    public static Matcher<RecordQueryPlan> unorderedUnion(@Nonnull Matcher<RecordQueryPlan> oneMatcher,
+                                                          @Nonnull Matcher<RecordQueryPlan> otherMatcher) {
+        return new UnorderedUnionMatcher(Arrays.asList(oneMatcher, otherMatcher)); // order of arguments does not matter
+    }
+
+    public static Matcher<RecordQueryPlan> unorderedUnion(@Nonnull List<Matcher<RecordQueryPlan>> childMatchers) {
+        return new UnorderedUnionMatcher(childMatchers); // order of child arguments does not matter
+    }
+
     public static Matcher<RecordQueryPlan> intersection(@Nonnull Matcher<RecordQueryPlan> oneMatcher,
                                                         @Nonnull Matcher<RecordQueryPlan> otherMatcher) {
         return new IntersectionMatcher(Arrays.asList(oneMatcher, otherMatcher)); // order of arguments does not matter

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/UnorderedUnionMatcher.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/query/plan/match/UnorderedUnionMatcher.java
@@ -1,0 +1,52 @@
+/*
+ * UnorderedUnionMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.match;
+
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+/**
+ * The unordered union matcher requires two or more child matchers which must match the children of an
+ * unordered union in some order.
+ */
+public class UnorderedUnionMatcher extends PlanMatcherWithChildren {
+
+    public UnorderedUnionMatcher(@Nonnull Collection<Matcher<RecordQueryPlan>> childMatchers) {
+        super(childMatchers);
+    }
+
+    @Override
+    public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
+        return plan instanceof RecordQueryUnorderedUnionPlan && super.matchesSafely(plan);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("UnorderedUnion(");
+        super.describeTo(description);
+        description.appendText(")");
+    }
+}


### PR DESCRIPTION
This adds the "UnorderedUnionCursor" as well as the "RecordQueryUnorderedUnionPlan" which makes use of the cursor. All "or" queries are first planned as if they might be compatibly ordered. If there is, then the old RecordQueryUnionPlan (in its duplicate-removing glory) is returned. Otherwise, the new union is returned.

I'd kind of like it if this had more tests. It tests out some of the basic functionality including making a few queries within our tests more efficient, but it could probably use something more thorough, though I'm not quite sure what.

This is (hopefully) a smaller PR than it appears. Much of the work is really refactoring the `UnionCursor` into a `UnionCursorBase`. There isn't a super principled reason for where the abstraction lies. It's something like "things I could generalize between the two cursors (like continuations) go into the base, things that I couldn't (like picking the next value) became abstract methods".