### PR TITLE
Resolves #196: Add a method on FDBRecordStore to check if a record exists

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -224,6 +224,8 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_LOAD_RECORD_VERSION("wait for load record version"),
         /** Wait for saving a record. */
         WAIT_SAVE_RECORD("wait for save record"),
+        /** Wait to check if a record exists. */
+        WAIT_RECORD_EXISTS("wait to check if a record exists"),
         /** Wait for deleting a record. */
         WAIT_DELETE_RECORD("wait for delete record"),
         /** Wait for resolving directory layer entries. */


### PR DESCRIPTION
The method is called `recordExists`, and there are blocking and asynchronous variants. There are also variants that take an `IsolationLevel` and variants that don't. (By default, it reads at `SERIALIZABLE` isolation level.) At present, this method just runs `loadRawRecordAsync` in the background and then returns a result (without serializing the record or adding it to the `preloadCache`, though records will still be loaded into the read-your-writes cache). Future work could make use of a future (but unimplemented) FoundationDB client API that allowed the user to ask if a key existed without returning the values (to save network traffic).

This also resolves #194 as it makes the `loadRawRecordAsync` function private, so now `FDBRawRecord` and `loadRawRecordAsync` have sensible visibility restrictions when paired together. In my mind, the most sensible reasons for an external user to want to use `loadRawRecordAsync` is to either (1) get the side-effects of loading the record into the cache (which can be done by calling `preloadRecordAsync`) or (2) check if the record is present or not by comparing to `null` (which can now be done by calling the new method). So, I think it's safe to remove. In principle, to make things backwards compatible, we could instead label it as `INTERNAL`.