### PR TITLE
Resolves #114: Self-contained metadata proto

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -67,7 +67,7 @@ RecordMetaData metaData = RecordMetaData.build(TestRecords2Proto.getDescriptor()
 
 If you need more complicated secondary indexes or primary keys, the more verbose and powerful builder structure is required:
 ```java
-RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords3Proto.getDescriptor());
+RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords3Proto.getDescriptor());
 metaDataBuilder.getRecordType("MyHierarchicalRecord").setPrimaryKey(
         concatenateFields("parent_path", "child_name"));
 metaDataBuilder.addIndex(metaDataBuilder.getRecordType("RestaurantRecord"),

--- a/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
+++ b/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
@@ -253,7 +253,7 @@ public class Main {
 
         // To build richer primary keys or secondary indexes (than those definable in the protobuf
         // message types), you need to use the more verbose and powerful RecordMetaDataBuilder.
-        RecordMetaDataBuilder rmdBuilder = new RecordMetaDataBuilder(SampleProto.getDescriptor());
+        RecordMetaDataBuilder rmdBuilder = RecordMetaData.newBuilder().setRecords(SampleProto.getDescriptor());
 
         // Order customers by last name, then first name, then their ID if otherwise equal.
         // NOTE: This operation is dangerous if you have existing data! Existing records are *not*

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
@@ -215,7 +215,10 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
 
     @Nonnull
     protected RecordMetaData buildMetaData(RecordMetaDataProto.MetaData metaDataProto) {
-        return new RecordMetaDataBuilder(metaDataProto, dependencies, false).getRecordMetaData();
+        RecordMetaDataBuilder builder = RecordMetaData.newBuilder()
+                .addDependencies(dependencies)
+                .setRecords(metaDataProto);
+        return builder.getRecordMetaData();
     }
 
     public CompletableFuture<RecordMetaData> loadVersion(int version) {
@@ -232,7 +235,7 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * @return a future that completes when the save is done
      */
     public CompletableFuture<Void> saveAndSetCurrent(@Nonnull RecordMetaDataProto.MetaData metaDataProto) {
-        RecordMetaData validatedMetaData = new RecordMetaDataBuilder(metaDataProto, dependencies, false).getRecordMetaData();
+        RecordMetaData validatedMetaData = buildMetaData(metaDataProto);
         MetaDataValidator validator = new MetaDataValidator(validatedMetaData, IndexMaintainerRegistryImpl.instance());
         validator.validate();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.API;
-import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
 import com.apple.foundationdb.record.provider.common.TypedRecordSerializer;
@@ -74,7 +74,7 @@ public class FDBTypedRecordStore<M extends Message> extends FDBRecordStoreBase<M
                           @Nonnull Predicate<U> tester,
                           @Nonnull Function<U, M> getter,
                           @Nonnull BiConsumer<B, M> setter) {
-            metaDataProvider = new RecordMetaDataBuilder(fileDescriptor);
+            metaDataProvider = RecordMetaData.build(fileDescriptor);
             serializer = new TypedRecordSerializer<>(fieldDescriptor, builderSupplier, tester, getter, setter);
         }
 

--- a/fdb-record-layer-core/src/main/proto/record_metadata.proto
+++ b/fdb-record-layer-core/src/main/proto/record_metadata.proto
@@ -84,6 +84,7 @@ message MetaData {
   repeated FormerIndex former_indexes = 6;
   optional KeyExpression record_count_key = 7 [deprecated = true];
   optional bool store_record_versions = 8;
+  repeated google.protobuf.FileDescriptorProto dependencies = 9;
   extensions 1000 to 2000;
 }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataValidatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataValidatorTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.metadata;
 
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TestRecords4Proto;
@@ -42,7 +43,7 @@ public class MetaDataValidatorTest {
 
     @Test
     public void duplicateRecordTypeKey() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaData.getRecordType("MySimpleRecord").setPrimaryKey(Key.Expressions.concat(Key.Expressions.recordType(), Key.Expressions.field("rec_no")));
         metaData.getRecordType("MySimpleRecord").setRecordTypeKey("same");
         metaData.getRecordType("MyOtherRecord").setPrimaryKey(Key.Expressions.concat(Key.Expressions.recordType(), Key.Expressions.field("rec_no")));
@@ -52,14 +53,14 @@ public class MetaDataValidatorTest {
 
     @Test
     public void primaryKeyRepeated() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaData.getRecordType("MySimpleRecord").setPrimaryKey(Key.Expressions.field("repeater", KeyExpression.FanType.FanOut));
         assertThrows(MetaDataException.class, () -> validate(metaData));
     }
 
     @Test
     public void duplicateSubspaceKey() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaData.getIndex("MySimpleRecord$str_value_indexed").setSubspaceKey("same");
         metaData.getIndex("MySimpleRecord$num_value_3_indexed").setSubspaceKey("same");
         assertThrows(MetaDataException.class, () -> validate(metaData));
@@ -67,28 +68,28 @@ public class MetaDataValidatorTest {
 
     @Test
     public void badPrimaryKeyField() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaData.getRecordType("MySimpleRecord").setPrimaryKey(Key.Expressions.field("no_such_field"));
         assertThrows(KeyExpression.InvalidExpressionException.class, () -> validate(metaData));
     }
 
     @Test
     public void badPrimaryKeyType() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords4Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords4Proto.getDescriptor());
         metaData.getRecordType("RestaurantReviewer").setPrimaryKey(Key.Expressions.field("stats"));
         assertThrows(Query.InvalidExpressionException.class, () -> validate(metaData));
     }
 
     @Test
     public void badIndexField() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaData.addIndex("MySimpleRecord", "no_such_field");
         assertThrows(KeyExpression.InvalidExpressionException.class, () -> validate(metaData));
     }
 
     @Test
     public void badIndexType() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords4Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords4Proto.getDescriptor());
         metaData.addIndex("RestaurantReviewer", "stats");
         assertThrows(Query.InvalidExpressionException.class, () -> validate(metaData));
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/RecordMetaDataBuilderTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/RecordMetaDataBuilderTest.java
@@ -22,7 +22,10 @@ package com.apple.foundationdb.record.metadata;
 
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.RecordMetaDataProto;
+import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TestRecordsChained1Proto;
 import com.apple.foundationdb.record.TestRecordsUnsigned1Proto;
 import com.apple.foundationdb.record.TestRecordsUnsigned2Proto;
 import com.apple.foundationdb.record.TestRecordsUnsigned3Proto;
@@ -30,7 +33,12 @@ import com.apple.foundationdb.record.TestRecordsUnsigned4Proto;
 import com.apple.foundationdb.record.TestRecordsUnsigned5Proto;
 import com.apple.foundationdb.record.TestRecordsWithHeaderProto;
 import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
+import com.google.protobuf.Descriptors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nonnull;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
@@ -39,7 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -48,16 +58,27 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link RecordMetaDataBuilder}.
  */
 public class RecordMetaDataBuilderTest {
+    @SuppressWarnings("deprecation")
+    private RecordMetaDataBuilder createBuilder(@Nonnull Descriptors.FileDescriptor fileDescriptor,
+                                                boolean deprecatedWay) {
+        RecordMetaDataBuilder builder;
+        if (deprecatedWay) {
+            builder = new RecordMetaDataBuilder(fileDescriptor);
+        } else {
+            builder = RecordMetaData.newBuilder().setRecords(fileDescriptor);
+        }
+        return builder;
+    }
 
-    @Test
-    public void caching() throws Exception {
-        RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+    @EnumSource(TestHelpers.BooleanEnum.class)
+    @ParameterizedTest(name = "caching [deprecatedWay = {0}]")
+    public void caching(final TestHelpers.BooleanEnum deprecatedWay) throws Exception {
+        RecordMetaDataBuilder builder = createBuilder(TestRecords1Proto.getDescriptor(), deprecatedWay.toBoolean());
         RecordMetaData metaData1 = builder.getRecordMetaData();
         assertTrue(metaData1 == builder.getRecordMetaData());
         builder.addIndex("MySimpleRecord", "MySimpleRecord$PRIMARY", "rec_no");
         RecordMetaData metaData2 = builder.getRecordMetaData();
         assertFalse(metaData1 == metaData2);
-
     }
 
     @Test
@@ -68,22 +89,24 @@ public class RecordMetaDataBuilderTest {
         assertNull(index.getPrimaryKeyComponentPositions());
     }
 
-    @Test
-    public void primaryIndexDoesOverlapPrimaryKey() throws Exception {
-        RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+    @EnumSource(TestHelpers.BooleanEnum.class)
+    @ParameterizedTest(name = "caching [deprecatedWay = {0}]")
+    public void primaryIndexDoesOverlapPrimaryKey(final TestHelpers.BooleanEnum deprecatedWay) throws Exception {
+        RecordMetaDataBuilder builder = createBuilder(TestRecords1Proto.getDescriptor(), deprecatedWay.toBoolean());
         builder.addIndex("MySimpleRecord", "MySimpleRecord$PRIMARY", "rec_no");
         RecordMetaData metaData = builder.getRecordMetaData();
         Index index = metaData.getIndex("MySimpleRecord$PRIMARY");
         assertNotNull(index);
         assertNotNull(index.getPrimaryKeyComponentPositions());
-        assertArrayEquals(new int[] { 0 }, index.getPrimaryKeyComponentPositions());
+        assertArrayEquals(new int[] {0}, index.getPrimaryKeyComponentPositions());
     }
 
-    @Test
-    public void indexOnNestedPrimaryKey() throws Exception {
-        RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecordsWithHeaderProto.getDescriptor());
+    @EnumSource(TestHelpers.BooleanEnum.class)
+    @ParameterizedTest(name = "caching [deprecatedWay = {0}]")
+    public void indexOnNestedPrimaryKey(final TestHelpers.BooleanEnum deprecatedWay) throws Exception {
+        RecordMetaDataBuilder builder = createBuilder(TestRecordsWithHeaderProto.getDescriptor(), deprecatedWay.toBoolean());
         builder.getRecordType("MyRecord")
-            .setPrimaryKey(field("header").nest("rec_no"));
+                .setPrimaryKey(field("header").nest("rec_no"));
         builder.addIndex("MyRecord", new Index("MyRecord$PRIMARY",
                 field("header").nest("rec_no"),
                 IndexTypes.VALUE));
@@ -91,14 +114,15 @@ public class RecordMetaDataBuilderTest {
         Index index = metaData.getIndex("MyRecord$PRIMARY");
         assertNotNull(index);
         assertNotNull(index.getPrimaryKeyComponentPositions());
-        assertArrayEquals(new int[] { 0 }, index.getPrimaryKeyComponentPositions());
+        assertArrayEquals(new int[] {0}, index.getPrimaryKeyComponentPositions());
     }
 
-    @Test
-    public void indexOnPartialNestedPrimaryKey() throws Exception {
-        RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecordsWithHeaderProto.getDescriptor());
+    @EnumSource(TestHelpers.BooleanEnum.class)
+    @ParameterizedTest(name = "caching [deprecatedWay = {0}]")
+    public void indexOnPartialNestedPrimaryKey(final TestHelpers.BooleanEnum deprecatedWay) throws Exception {
+        RecordMetaDataBuilder builder = createBuilder(TestRecordsWithHeaderProto.getDescriptor(), deprecatedWay.toBoolean());
         builder.getRecordType("MyRecord")
-            .setPrimaryKey(field("header").nest(concatenateFields("path", "rec_no")));
+                .setPrimaryKey(field("header").nest(concatenateFields("path", "rec_no")));
         builder.addIndex("MyRecord", new Index("MyRecord$path_str",
                 concat(field("header").nest("path"),
                         field("str_value")),
@@ -107,37 +131,37 @@ public class RecordMetaDataBuilderTest {
         Index index = metaData.getIndex("MyRecord$path_str");
         assertNotNull(index);
         assertNotNull(index.getPrimaryKeyComponentPositions());
-        assertArrayEquals(new int[] { 0, -1 }, index.getPrimaryKeyComponentPositions());
+        assertArrayEquals(new int[] {0, -1}, index.getPrimaryKeyComponentPositions());
     }
 
     @Test
     public void unsignedFields() {
         try {
-            new RecordMetaDataBuilder(TestRecordsUnsigned1Proto.getDescriptor());
+            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned1Proto.getDescriptor());
             fail("Did not throw exception for TestRecordsUnsigned1Proto");
         } catch (MetaDataException e) {
             assertEquals("Field unsigned_rec_no in message com.apple.foundationdb.record.unsigned.SimpleUnsignedRecord has illegal unsigned type UINT64", e.getMessage());
         }
         try {
-            new RecordMetaDataBuilder(TestRecordsUnsigned2Proto.getDescriptor());
+            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned2Proto.getDescriptor());
             fail("Did not throw exception for TestRecordsUnsigned2Proto");
         } catch (MetaDataException e) {
             assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.NestedWithUnsigned has illegal unsigned type UINT32", e.getMessage());
         }
         try {
-            new RecordMetaDataBuilder(TestRecordsUnsigned3Proto.getDescriptor());
+            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned3Proto.getDescriptor());
             fail("Did not throw exception for TestRecordsUnsigned3Proto");
         } catch (MetaDataException e) {
             assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.Fixed32UnsignedRecord has illegal unsigned type FIXED32", e.getMessage());
         }
         try {
-            new RecordMetaDataBuilder(TestRecordsUnsigned4Proto.getDescriptor());
+            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned4Proto.getDescriptor());
             fail("Did not throw exception for TestRecordsUnsigned4Proto");
         } catch (MetaDataException e) {
             assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.Fixed64UnsignedRecord has illegal unsigned type FIXED64", e.getMessage());
         }
         try {
-            new RecordMetaDataBuilder(TestRecordsUnsigned5Proto.getDescriptor());
+            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned5Proto.getDescriptor());
             fail("Did not throw exception for TestRecordsUnsigned5Proto");
         } catch (MetaDataException e) {
             assertEquals("Field unsigned_rec_no in message com.apple.foundationdb.record.unsigned.SimpleUnsignedRecord has illegal unsigned type UINT64", e.getMessage());
@@ -146,9 +170,62 @@ public class RecordMetaDataBuilderTest {
 
     @Test
     public void versionInPrimaryKey() {
-        RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         RecordTypeBuilder simpleRecordTypeBuilder = builder.getRecordType("MySimpleRecord");
         assertThrows(MetaDataException.class, () ->
                 simpleRecordTypeBuilder.setPrimaryKey(Key.Expressions.concat(Key.Expressions.field("rec_no"), VersionKeyExpression.VERSION)));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void selfContainedMetaData() {
+        // Using the deprecated constructor to ensure that the output of the new builder equals the old one.
+        RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecordsChained1Proto.getDescriptor());
+        RecordMetaDataProto.MetaData metaData = builder.getRecordMetaData().toProto();
+
+        // Rebuild from proto and file descriptor
+        RecordMetaData recordMetaData = RecordMetaData.build(metaData);
+        MetaDataProtoTest.verifyEquals(builder.getRecordMetaData(), recordMetaData);
+        MetaDataProtoTest.verifyEquals(recordMetaData, RecordMetaData.build(TestRecordsChained1Proto.getDescriptor()));
+
+        // Basic setRecords
+        RecordMetaDataBuilder builder2 = RecordMetaData.newBuilder().setRecords(metaData);
+        MetaDataProtoTest.verifyEquals(recordMetaData, builder2.getRecordMetaData());
+
+        // Override a dependency
+        RecordMetaDataBuilder builder3 = RecordMetaData.newBuilder()
+                .addDependency(TestRecords1Proto.getDescriptor())
+                .setRecords(builder2.getRecordMetaData().toProto());
+        MetaDataProtoTest.verifyEquals(recordMetaData, builder3.getRecordMetaData());
+
+        // Exclude dependencies
+        Descriptors.FileDescriptor[] dependencies = new Descriptors.FileDescriptor[] {
+                TestRecords1Proto.getDescriptor()
+        };
+
+        Throwable t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(recordMetaData.toProto(dependencies)));
+        assertEquals("Dependency test_records_1.proto not found", t.getMessage());
+        RecordMetaDataBuilder builder4 = RecordMetaData.newBuilder()
+                .addDependencies(dependencies)
+                .setRecords(recordMetaData.toProto(dependencies));
+        MetaDataProtoTest.verifyEquals(recordMetaData, builder4.getRecordMetaData());
+        Descriptors.FileDescriptor dep4 = builder4.getRecordMetaData().getRecordsDescriptor().getDependencies().get(1);
+        assertEquals(dep4.getName(), TestRecords1Proto.getDescriptor().getName());
+        assertSame(dep4, dependencies[0]);
+        Descriptors.FileDescriptor dep2 = builder2.getRecordMetaData().getRecordsDescriptor().getDependencies().get(1);
+        assertEquals(dep2.getName(), dep4.getName());
+        assertNotSame(dep2, dep4);
+
+        // Add and remove index
+        int version = builder.getVersion();
+        builder.addIndex("MySimpleRecord", "MySimpleRecord$testIndex", "rec_no");
+        assertEquals(builder.getVersion(), version + 1);
+        assertNotNull(builder.getRecordMetaData().getIndex("MySimpleRecord$testIndex"));
+        builder.removeIndex("MySimpleRecord$testIndex");
+        assertEquals(builder.getVersion(), version + 2);
+        t = assertThrows(MetaDataException.class, () ->
+                builder.getRecordMetaData().getIndex("MySimpleRecord$testIndex"));
+        assertEquals("Index MySimpleRecord$testIndex not defined", t.getMessage());
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
@@ -246,7 +246,7 @@ public class FDBMetaDataStoreTest {
 
     @Test
     public void withToProto() throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsParentChildRelationshipProto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsParentChildRelationshipProto.getDescriptor());
         metaDataBuilder.addIndex("MyChildRecord", "MyChildRecord$str_value", Key.Expressions.field("str_value"));
         metaDataBuilder.removeIndex("MyChildRecord$parent_rec_no");
         metaDataBuilder.addIndex("MyChildRecord", new Index("MyChildRecord$parent&str", Key.Expressions.concatenateFields("parent_rec_no", "str_value"), Index.EMPTY_VALUE, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -1656,7 +1656,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         };
 
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecordsIndexFilteringProto.getDescriptor());
+            RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecordsIndexFilteringProto.getDescriptor());
             if (hook != null) {
                 hook.apply(metaData);
             }
@@ -1738,7 +1738,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         };
 
         try (FDBRecordContext context = openContext()) {
-            final RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestNoIndexesProto.getDescriptor());
+            final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
             if (withCount) {
                 builder.addUniversalIndex(COUNT_INDEX);
             }
@@ -1757,7 +1757,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         newIndex.setSubspaceKey(2);
         final String recordType = "MySimpleRecord";
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestNoIndexesProto.getDescriptor());
+            RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
             if (withCount) {
                 builder.addUniversalIndex(COUNT_INDEX);
             }
@@ -1771,7 +1771,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         }
 
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestNoIndexesProto.getDescriptor());
+            RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
             if (withCount) {
                 builder.addUniversalIndex(COUNT_INDEX);
             }
@@ -1794,7 +1794,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
     @Test
     public void testChangeIndexDefinitionWriteOnly() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            final RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestNoIndexesProto.getDescriptor());
+            final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
             recordStore = FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(builder).setKeySpacePath(path).createOrOpen();
             recordStore.deleteAllRecords();
             // Save 200 records without any indexes.
@@ -1807,7 +1807,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         }
         try (FDBRecordContext context = openContext()) {
             // Add a new index named "index" on rec_no.
-            final RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestNoIndexesProto.getDescriptor());
+            final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
             final Index index = new Index("index", "rec_no");
             builder.addIndex("MySimpleRecord", index);
             recordStore = FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(builder).setKeySpacePath(path).createOrOpen();
@@ -1825,7 +1825,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         Index index = new Index("index", "num_value");
         try (FDBRecordContext context = openContext()) {
             // Change the definition of the "index" index to be on num_value instead.
-            final RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestNoIndexesProto.getDescriptor());
+            final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
             builder.setVersion(builder.getVersion() + 100);
             builder.addIndex("MySimpleRecord", index);
             recordStore = FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(builder).setKeySpacePath(path).createOrOpen();
@@ -1879,7 +1879,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             }
         };
 
-        final RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestNoIndexesProto.getDescriptor());
+        final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
         metaData.addUniversalIndex(COUNT_INDEX);
 
         final FDBRecordStore.Builder storeBuilder = FDBRecordStore.newBuilder()
@@ -2057,7 +2057,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
     @Test
     public void formerIndexes() throws Exception {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
         try (FDBRecordContext context = openContext()) {
             createRecordStore(context, metaData.getRecordMetaData());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
@@ -161,7 +161,7 @@ public class FDBRecordStorePerformanceTest {
         factory.setDirectoryCacheSize(databaseParameters.pathCache);
         fdb = factory.getDatabase();
 
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaDataBuilder.setSplitLongRecords(databaseParameters.splitRecords);
         if (databaseParameters.stringSize > 100) {
             metaDataBuilder.removeIndex("MySimpleRecord$str_value_indexed");

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -569,7 +569,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     @SuppressWarnings("deprecation")
     public void testUpdateRecordCounts() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            final RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecordsWithHeaderProto.getDescriptor());
+            final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecordsWithHeaderProto.getDescriptor());
             builder.getRecordType("MyRecord")
                     .setPrimaryKey(field("header").nest(concatenateFields("path", "num", "rec_no")));
             builder.setRecordCountKey(field("header").nest(concat(field("path"), field("num"))));
@@ -742,7 +742,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     @Test
     public void testDeleteWhereMissingIndex() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecordsWithHeaderProto.getDescriptor());
+            RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecordsWithHeaderProto.getDescriptor());
             builder.getRecordType("MyRecord")
                 .setPrimaryKey(field("header").nest(concatenateFields("rec_no", "path")));
             builder.addIndex("MyRecord", "MyRecord$str_value", concat(field("header").nest("path"),
@@ -757,7 +757,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     @Test
     public void testOverlappingPrimaryKey() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecordsWithHeaderProto.getDescriptor());
+            RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecordsWithHeaderProto.getDescriptor());
             builder.getRecordType("MyRecord")
                 .setPrimaryKey(field("header").nest(concatenateFields("path", "rec_no")));
             builder.addIndex("MyRecord", "MyRecord$path_str", concat(field("header").nest("path"),
@@ -1736,7 +1736,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         // Test open without a MetaDataStore
 
         try (FDBRecordContext context = fdb.openContext()) {
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
             FDBRecordStore recordStore = FDBRecordStore.newBuilder().setContext(context).setKeySpacePath(path)
                     .setMetaDataProvider(metaDataBuilder).createOrOpen();
@@ -1788,7 +1788,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
                         return null;
                     }).join();
 
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
             RecordMetaData origMetaData = metaDataBuilder.getRecordMetaData();
             final int version = origMetaData.getVersion();
 
@@ -1836,7 +1836,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         // Test uncheckedOpen without a MetaDataStore
 
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
             FDBRecordStore recordStore = FDBRecordStore.newBuilder().setContext(context).setKeySpacePath(path)
                     .setMetaDataProvider(metaDataBuilder).uncheckedOpen();
@@ -1886,7 +1886,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
                         return null;
                     }).join();
 
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
             RecordMetaData origMetaData = metaDataBuilder.getRecordMetaData();
             int version = origMetaData.getVersion();
 
@@ -2120,7 +2120,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             }
         };
 
-        final RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         try (FDBRecordContext context = openContext()) {
             recordStore = FDBRecordStore.newBuilder()
                 .setContext(context).setKeySpacePath(path).setMetaDataProvider(builder).setUserVersionChecker(userVersion1)
@@ -2177,7 +2177,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
     @Test
     public void testUserVersionDeterminesMetaData() throws Exception {
-        final RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         builder.setVersion(101);
         final RecordMetaData metaData1 = builder.getRecordMetaData();
         builder.setVersion(102);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -163,7 +163,7 @@ public abstract class FDBRecordStoreTestBase {
     }
 
     public void openSimpleRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook) throws Exception {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaData.addUniversalIndex(COUNT_INDEX);
         metaData.addUniversalIndex(COUNT_UPDATES_INDEX);
         if (hook != null) {
@@ -177,7 +177,7 @@ public abstract class FDBRecordStoreTestBase {
     }
 
     public void openRecordWithHeader(FDBRecordContext context, @Nullable RecordMetaDataHook hook) throws Exception {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecordsWithHeaderProto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecordsWithHeaderProto.getDescriptor());
         if (hook != null) {
             hook.apply(metaData);
         }
@@ -190,7 +190,7 @@ public abstract class FDBRecordStoreTestBase {
 
     @Nonnull
     protected FDBRecordStore openNewUnionRecordStore(FDBRecordContext context) {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsWithUnionProto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsWithUnionProto.getDescriptor());
         metaDataBuilder.addUniversalIndex(
                 new Index("versions", field("etag")));
         metaDataBuilder.addMultiTypeIndex(
@@ -214,7 +214,7 @@ public abstract class FDBRecordStoreTestBase {
     }
 
     public void openAnyRecordStore(Descriptors.FileDescriptor fileDescriptor, FDBRecordContext context, @Nullable RecordMetaDataHook hook) throws Exception {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(fileDescriptor);
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(fileDescriptor);
         if (hook != null) {
             hook.apply(metaData);
         }
@@ -222,7 +222,7 @@ public abstract class FDBRecordStoreTestBase {
     }
 
     public void openMultiRecordStore(FDBRecordContext context) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsMultiProto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsMultiProto.getDescriptor());
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addMultiTypeIndex(Arrays.asList(metaDataBuilder.getRecordType("MultiRecordOne"), metaDataBuilder.getRecordType("MultiRecordTwo")),
                 new Index("onetwo$element", field("element", FanType.FanOut)));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyIndexTest.java
@@ -25,12 +25,13 @@ import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
-import com.apple.foundationdb.record.UnstoredRecord;
 import com.apple.foundationdb.record.TestDataTypesProto;
 import com.apple.foundationdb.record.TestDataTypesProto.TypesRecord;
 import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.UnstoredRecord;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
@@ -128,7 +129,7 @@ public class FunctionKeyIndexTest extends FDBRecordStoreTestBase {
 
 
     protected void openRecordStore(FDBRecordContext context, Index ... indexes) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestDataTypesProto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestDataTypesProto.getDescriptor());
         RecordTypeBuilder scalarRecordType = metaDataBuilder.getRecordType("TypesRecord");
         for (Index index : indexes) {
             metaDataBuilder.addIndex(scalarRecordType, index);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyRecordTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyRecordTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecords8Proto;
@@ -69,7 +70,7 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.value;
 public class FunctionKeyRecordTest extends FDBRecordStoreTestBase {
 
     private void openRecordStore(@Nonnull FDBRecordContext context, @Nonnull RecordMetaDataHook hook) {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecords8Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords8Proto.getDescriptor());
         hook.apply(metaData);
         createRecordStore(context, metaData.getRecordMetaData());
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestRecordsOneOfProto;
 import com.apple.foundationdb.record.metadata.Key;
@@ -55,7 +56,7 @@ public class OneOfTest {
     }
 
     private RecordMetaDataBuilder metaData() {
-        final RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecordsOneOfProto.getDescriptor());
+        final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecordsOneOfProto.getDescriptor());
         final KeyExpression pkey = Key.Expressions.field("rec_no");
         metaData.getRecordType("MySimpleRecord").setPrimaryKey(pkey);
         metaData.getRecordType("MyOtherRecord").setPrimaryKey(pkey);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -166,7 +166,7 @@ public class OnlineIndexerTest {
     }
 
     private void openMetaData(@Nonnull Descriptors.FileDescriptor descriptor, @Nonnull RecordMetaDataHook hook) {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(descriptor);
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(descriptor);
         hook.apply(metaDataBuilder);
         metaData = metaDataBuilder.getRecordMetaData();
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordFunction;
 import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecordsRankProto;
@@ -97,7 +98,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
     }
 
     protected void openRecordStore(FDBRecordContext context, FDBRecordStoreTest.RecordMetaDataHook hook) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsRankProto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsRankProto.getDescriptor());
         metaDataBuilder.addIndex("BasicRankedRecord",
                 new Index("rank_by_gender", Key.Expressions.field("score").groupBy(Key.Expressions.field("gender")),
                         IndexTypes.RANK));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -76,7 +76,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
 
     @Test
     public void testExplicitKeys() throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         final RecordTypeBuilder t1 = metaDataBuilder.getRecordType("MySimpleRecord");
         final RecordTypeBuilder t2 = metaDataBuilder.getRecordType("MyOtherRecord");
         final KeyExpression pkey = concat(recordType(), field("rec_no"));
@@ -87,15 +87,14 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
         assertEquals("t1", metaData.getRecordType("MySimpleRecord").getExplicitRecordTypeKey());
         assertNull(metaData.getRecordType("MyOtherRecord").getExplicitRecordTypeKey());
 
-        metaDataBuilder = new RecordMetaDataBuilder(metaData.toProto(), false);
-        metaData = metaDataBuilder.getRecordMetaData();
+        metaData = RecordMetaData.build(metaData.toProto());
         assertEquals("t1", metaData.getRecordType("MySimpleRecord").getExplicitRecordTypeKey());
         assertNull(metaData.getRecordType("MyOtherRecord").getExplicitRecordTypeKey());
     }
 
     @Test
     public void testIllegalKey() throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         final RecordTypeBuilder t1 = metaDataBuilder.getRecordType("MySimpleRecord");
         assertThrows(MetaDataException.class, () -> {
             t1.setRecordTypeKey(this);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
@@ -230,7 +230,7 @@ public class VersionIndexTest {
     };
 
     private FDBRecordContext openContext(@Nullable RecordMetaDataHook hook) {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         hook.apply(metaDataBuilder);
 
         FDBRecordContext context = fdb.openContext();
@@ -1272,7 +1272,7 @@ public class VersionIndexTest {
         for (KeyExpression expression : expressions) {
             assertThrows(KeyExpression.InvalidExpressionException.class, () -> {
                 Index index = new Index("test_index", expression, IndexTypes.VERSION);
-                RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+                RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
                 metaDataBuilder.addIndex("MySimpleRecord", index);
                 RecordMetaData metaData = metaDataBuilder.getRecordMetaData();
                 MetaDataValidator validator = new MetaDataValidator(metaData, IndexMaintainerRegistryImpl.instance());
@@ -1283,7 +1283,7 @@ public class VersionIndexTest {
 
         assertThrows(MetaDataException.class, () -> {
             Index index = new Index("test_index", VersionKeyExpression.VERSION, EmptyKeyExpression.EMPTY, IndexTypes.VERSION, IndexOptions.UNIQUE_OPTIONS);
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords1Proto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
             metaDataBuilder.addIndex("MySimpleRecord", index);
             RecordMetaData metaData = metaDataBuilder.getRecordMetaData();
             MetaDataValidator validator = new MetaDataValidator(metaData, IndexMaintainerRegistryImpl.instance());
@@ -1292,7 +1292,7 @@ public class VersionIndexTest {
 
         assertThrows(MetaDataException.class, () -> {
             Index index = new Index("global_version", VersionKeyExpression.VERSION, IndexTypes.VERSION);
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords2Proto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords2Proto.getDescriptor());
             metaDataBuilder.addUniversalIndex(index);
             RecordMetaData metaData = metaDataBuilder.getRecordMetaData();
             MetaDataValidator validator = new MetaDataValidator(metaData, IndexMaintainerRegistryImpl.instance());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -218,7 +218,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     protected void openRecordStore(FDBRecordContext context, RecordMetaDataHook hook) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsTextProto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
         metaDataBuilder.getRecordType(COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
         hook.apply(metaDataBuilder);
         createRecordStore(context, metaDataBuilder.getRecordMetaData());
@@ -2320,7 +2320,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
 
     @Nonnull
     public static Stream<Arguments> indexArguments() {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsTextProto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
         Index simpleIndex = metaDataBuilder.getIndex(SIMPLE_DEFAULT_NAME);
         return Stream.of(simpleIndex, SIMPLE_TEXT_FILTERING, SIMPLE_TEXT_PREFIX, SIMPLE_TEXT_SUFFIXES)
                 .map(Arguments::of);
@@ -2467,7 +2467,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     @Nonnull
     private <T extends Exception> T invalidateIndex(@Nonnull Class<T> clazz, @Nonnull String recordType, @Nonnull Index index) {
         return assertThrows(clazz, () -> {
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsTextProto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
             metaDataBuilder.addIndex(recordType, index);
             RecordMetaData metaData = metaDataBuilder.getRecordMetaData();
             MetaDataValidator validator = new MetaDataValidator(metaData, IndexMaintainerRegistryImpl.instance());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -122,7 +122,7 @@ public class LeaderboardIndexTest {
         }
 
         public void buildMetaData(Consumer<RecordMetaDataBuilder> metaDataHook) {
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsLeaderboardProto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsLeaderboardProto.getDescriptor());
             metaDataHook.accept(metaDataBuilder);
             metaData = metaDataBuilder.getRecordMetaData();
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords3Proto;
@@ -276,7 +277,7 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     @Test
     public void nestedAndOnNestedMap() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecordsNestedMapProto.getDescriptor());
+            RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsNestedMapProto.getDescriptor());
             metaDataBuilder.addIndex("OuterRecord", "key_index", concat(
                     field("other_id"),
                     field("map").nest(field("entry", KeyExpression.FanType.FanOut).nest("key"))));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -81,18 +81,18 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     protected static RecordMetaData proto2MetaData() {
-        return new RecordMetaDataBuilder(TestRecordsNulls2Proto.getDescriptor()).getRecordMetaData();
+        return RecordMetaData.newBuilder().setRecords(TestRecordsNulls2Proto.getDescriptor()).getRecordMetaData();
     }
 
     protected static RecordMetaData proto3MetaData() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecordsNulls3Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecordsNulls3Proto.getDescriptor());
         metaData.addIndex("MyNullRecord", "int_value");
         metaData.addIndex("MyNullRecord", "string_value");
         return metaData.getRecordMetaData();
     }
 
     protected static RecordMetaData proto3ScalarNotNullMetaData() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecordsNulls3Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecordsNulls3Proto.getDescriptor());
         metaData.addIndex("MyNullRecord", "MyNullRecord$int_value", Key.Expressions.field("int_value", KeyExpression.FanType.None,
                 Key.Evaluated.NullStandin.NOT_NULL));
         metaData.addIndex("MyNullRecord", "MyNullRecord$string_value", Key.Expressions.field("string_value", KeyExpression.FanType.None,
@@ -101,7 +101,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     protected static RecordMetaData proto3NestedMetaData() {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecordsNulls3Proto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecordsNulls3Proto.getDescriptor());
         metaData.addIndex("MyNullRecord", "MyNullRecord$int_value", Key.Expressions.field("nullable_int_value")
                 .nest(Key.Expressions.field("value", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NOT_NULL)));
         metaData.addIndex("MyNullRecord", "MyNullRecord$string_value", Key.Expressions.field("nullable_string_value")
@@ -484,7 +484,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     protected static RecordMetaData tupleFieldsMetaData() {
-        return new RecordMetaDataBuilder(TestRecordsTupleFieldsProto.getDescriptor()).getRecordMetaData();
+        return RecordMetaData.build(TestRecordsTupleFieldsProto.getDescriptor());
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb.query;
 
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords1Proto;
@@ -140,7 +141,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
     }
 
     protected void openHierarchicalRecordStore(FDBRecordContext context) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords3Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords3Proto.getDescriptor());
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.getRecordType("MyHierarchicalRecord").setPrimaryKey(
                 concatenateFields("parent_path", "child_name"));
@@ -152,7 +153,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
     }
 
     protected void openNestedRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords4Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords4Proto.getDescriptor());
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addIndex("RestaurantRecord", "review_rating", field("reviews", FanType.FanOut).nest("rating"));
         metaDataBuilder.addIndex("RestaurantRecord", "tag", field("tags", FanType.FanOut).nest(
@@ -201,7 +202,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
     }
 
     protected void openDoublyNestedRecordStore(FDBRecordContext context) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords5Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords5Proto.getDescriptor());
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addIndex("CalendarEvent", "alarm_start", field("alarmIndex").nest(
                 field("recurrence", FanType.FanOut).nest("start")));
@@ -211,7 +212,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
     }
 
     public void openConcatNestedRecordStore(FDBRecordContext context) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords5Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords5Proto.getDescriptor());
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addIndex("CalendarEvent", "versions", concat(field("alarmIndex").nest("version"),
                 field("eventIndex").nest("version")));
@@ -316,7 +317,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
     }
 
     protected void openEnumRecordStore(FDBRecordContext context, RecordMetaDataHook hook) throws Exception {
-        RecordMetaDataBuilder metaData = new RecordMetaDataBuilder(TestRecordsEnumProto.getDescriptor());
+        RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecordsEnumProto.getDescriptor());
         if (hook != null) {
             hook.apply(metaData);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords1Proto;
@@ -73,7 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag(Tags.RequiresFDB)
 public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     private void openDoublyRepeatedRecordStore(FDBRecordContext context) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords6Proto.getDescriptor());
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords6Proto.getDescriptor());
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addIndex("MyRepeatedRecord", "rep_strings", concat(field("s1", FanType.Concatenate), field("s2", FanType.Concatenate)));
         metaDataBuilder.addIndex("MyRepeatedRecord", "s1$concat", field("s1", FanType.Concatenate));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
@@ -585,7 +585,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
     @Test
     public void sortNested() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            RecordMetaDataBuilder builder = new RecordMetaDataBuilder(TestRecordsWithHeaderProto.getDescriptor());
+            RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecordsWithHeaderProto.getDescriptor());
             builder.getRecordType("MyRecord")
                     .setPrimaryKey(field("header").nest(concatenateFields("path", "rec_no")));
             builder.addIndex("MyRecord", "MyRecord$header_num", concat(field("header").nest("num"),

--- a/fdb-record-layer-core/src/test/proto/test_records_chained_1.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_chained_1.proto
@@ -1,0 +1,35 @@
+/*
+ * test_records_import.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.chained1;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecordsChained1Proto";
+
+import "record_metadata_options.proto";
+import "test_records_1.proto";
+import "test_records_chained_2.proto";
+
+message RecordTypeUnion {
+  option (com.apple.foundationdb.record.record).usage = UNION;
+  optional com.apple.foundationdb.record.test1.MySimpleRecord _MySimpleRecord = 1;
+  optional com.apple.foundationdb.record.chained2.MyChainedRecord2 _MyChainedRecord2 = 2;
+}

--- a/fdb-record-layer-core/src/test/proto/test_records_chained_2.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_chained_2.proto
@@ -1,0 +1,41 @@
+/*
+ * test_records_import.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.chained2;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecordsChained2Proto";
+
+import "record_metadata_options.proto";
+import "test_records_1.proto";
+import "test_records_2.proto";
+
+message MyChainedRecord2 {
+  required int64 rec_no = 1 [(field).primary_key = true];
+  optional int64 val = 2;
+  optional int32 indexed_val = 3 [(field).index = {}];
+}
+
+message RecordTypeUnion {
+  option (com.apple.foundationdb.record.record).usage = UNION;
+  optional MyChainedRecord2 _MyChainedRecord2 = 1;
+  optional com.apple.foundationdb.record.test2.MyLongRecord _MyLongRecord = 2;
+}


### PR DESCRIPTION
This change extends the serialized metadata proto to also include its dependencies. After this change, one can build record metadata from a a serialized proto without providing its list of dependencies. This change includes the following: 
 
* RecordMetaDataProto.MetaData message now has a repeated field for its dependencies. 
* RecordMetaData.toProto is now extended to fill the list of dependencies. 
* One can de-serialize the proto by passing a serialized proto and processExtentionsOptions=false to the following constructor: 
  public RecordMetaDataBuilder(@Nonnull RecordMetaDataProto.MetaData metaDataProto, boolean processExtensionOptions); 
* I opted for simplicity and decided to add all dependencies including record_metadata_options. Please me know if you have any objections. 
* Also a minor fallout from b4c9c7b was fixed. One of the calls to protoFieldOptions hadn't manage to receive processExtensionOptions from initRecordTypes. 
* Test selfContainedMetaData was added to exercise the change. The testing proto files are organized such that nested dependencies are covered. Please let me know if you have suggestions for further testing.

