### PR TITLE
Fixes #209: Don't swallow build errors in build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -129,7 +129,7 @@ def build(release=False, proto2=False, proto3=False, publish=False):
     if proto2:
         # Make with protobuf 2.
         success = run_gradle(2, 'clean', 'build', 'destructiveTest',
-                                '-PreleaseBuild={0}'.format('true' if release else 'false')),
+                                '-PreleaseBuild={0}'.format('true' if release else 'false'))
         if not success:
             return False
 


### PR DESCRIPTION
I kind of wish I had been able to combine this with #207, but alas.

The problem here is that we were essentially doing:

```python
   success = f(),
   if success:
       return False
   else:
       # Continue to next statement
````

If `f()` evaluated to `False`, then what it was doing--because of the sneaky comma--was returning the tuple `(False,)` and `bool( (False,) )` evaluates to `True`. The key is to remove the comma.