### PR TITLE
Resolves #89: Expressions for use with maps

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.metadata.expressions.LiteralKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.RecordTypeKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
@@ -157,6 +158,68 @@ public class Key {
                 exprs.add(field(field));
             }
             return new ThenKeyExpression(exprs);
+        }
+
+        /** The name of the key field in Protobuf {@code map} messages. */
+        @Nonnull
+        public static final String MAP_KEY_FIELD = "key";
+        /** The name of the value field in Protobuf {@code map} messages. */
+        @Nonnull
+        public static final String MAP_VALUE_FIELD = "value";
+
+        /**
+         * Index key and value from a {@code map}.
+         *
+         * A map can be an actual Protobuf 3 {@code map} field or, 
+         * in Protobuf 2, a {@code repeated} message field with fields named {@code key} and {@code value}.
+         * @param name name of the map field
+         * @return a new expression which evaluates to the key and value pairs of the given {@code map} field.
+         */
+        @Nonnull
+        public static NestingKeyExpression mapKeyValues(@Nonnull String name) {
+            return field(name, KeyExpression.FanType.FanOut).nest(concatenateFields(MAP_KEY_FIELD, MAP_VALUE_FIELD));
+        }
+
+        /**
+         * Index key from a {@code map}.
+         *
+         * A map can be an actual Protobuf 3 {@code map} field or, 
+         * in Protobuf 2, a {@code repeated} message field with fields named {@code key} and {@code value}.
+         * @param name name of the map field
+         * @return a new expression which evaluates to the values of the given {@code map} field.
+         */
+        @Nonnull
+        public static NestingKeyExpression mapKeys(@Nonnull String name) {
+            return field(name, KeyExpression.FanType.FanOut).nest(field(MAP_KEY_FIELD));
+        }
+
+        /**
+         * Index value from a {@code map}.
+         *
+         * A map can be an actual Protobuf 3 {@code map} field or, 
+         * in Protobuf 2, a {@code repeated} message field with fields named {@code key} and {@code value}.
+         * @param name name of the map field
+         * @return a new expression which evaluates to the values of the given {@code map} field.
+         */
+        @Nonnull
+        public static NestingKeyExpression mapValues(@Nonnull String name) {
+            return field(name, KeyExpression.FanType.FanOut).nest(field(MAP_VALUE_FIELD));
+        }
+
+        /**
+         * Index value and key from a {@code map}.
+         *
+         * Like {@link #mapKeyValues}, but with the key and value field order reversed. This allows queries
+         * such as equality on the value and inequality on the key or equality on the value ordered by the key.
+         *
+         * A map can be an actual Protobuf 3 {@code map} field or, 
+         * in Protobuf 2, a {@code repeated} message field with fields named {@code key} and {@code value}.
+         * @param name name of the map field
+         * @return a new expression which evaluates to the value and key pairs of the given {@code map} field.
+         */
+        @Nonnull
+        public static NestingKeyExpression mapValueKeys(@Nonnull String name) {
+            return field(name, KeyExpression.FanType.FanOut).nest(concatenateFields(MAP_VALUE_FIELD, MAP_KEY_FIELD));
         }
 
         /**

--- a/fdb-record-layer-core/src/test/java-proto2/com/apple/foundationdb/record/provider/foundationdb/MapsTest.java
+++ b/fdb-record-layer-core/src/test/java-proto2/com/apple/foundationdb/record/provider/foundationdb/MapsTest.java
@@ -1,0 +1,120 @@
+/*
+ * MapsTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.TestRecordsMapsProto;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.match.PlanMatchers;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.protobuf.Message;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test substitutes for {@code map} fields.
+ *
+ * These nested messages are compatible with actual Protobuf 3 map fields both on disk and when used with indexes and queries.
+ */
+@Tag(Tags.RequiresFDB)
+public class MapsTest extends FDBRecordStoreTestBase {
+
+    @Test
+    public void simple() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context);
+
+            TestRecordsMapsProto.StringToString.Builder recBuilder = TestRecordsMapsProto.StringToString.newBuilder();
+            recBuilder.setRecNo(1);
+            //recBuilder.putMapValue("hello", "world");
+            recBuilder.addMapValueBuilder().setKey("hello").setValue("world");
+            recordStore.saveRecord(recBuilder.build());
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context);
+            FDBStoredRecord<Message> rec1 = recordStore.loadRecord(Tuple.from(1L));
+            assertNotNull(rec1);
+            TestRecordsMapsProto.StringToString.Builder myrec1 = TestRecordsMapsProto.StringToString.newBuilder();
+            myrec1.mergeFrom(rec1.getRecord());
+            assertEquals("world",
+                    //myrec1.getMapValueOrThrow("hello"));
+                    myrec1.getMapValueList().stream().filter(e -> e.getKey().equals("hello")).map(TestRecordsMapsProto.StringToString.MapEntry::getValue)
+                            .findFirst().orElseThrow(() -> new RuntimeException("not found")));
+            commit(context);
+        }
+    }
+
+    @Test
+    public void indexed() throws Exception {
+        final RecordMetaDataHook hook = md -> {
+            md.addIndex("StringToInt", "mapKeyValue", Key.Expressions.mapKeyValues("map_value"));
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context, hook);
+
+            TestRecordsMapsProto.StringToInt.Builder recBuilder = TestRecordsMapsProto.StringToInt.newBuilder();
+            recBuilder.setRecNo(1);
+            //recBuilder.putMapValue("num", 1);
+            recBuilder.addMapValueBuilder().setKey("num").setValue(1);
+            //recBuilder.putMapValue("other", 2);
+            recBuilder.addMapValueBuilder().setKey("other").setValue(2);
+            recordStore.saveRecord(recBuilder.build());
+
+            recBuilder.setRecNo(2);
+            recBuilder.clearMapValue();
+            //recBuilder.putMapValue("num", 2);
+            recBuilder.addMapValueBuilder().setKey("num").setValue(2);
+            recordStore.saveRecord(recBuilder.build());
+            commit(context);
+        }
+
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("StringToInt")
+                .setFilter(Query.field("map_value").mapMatches(k -> k.equalsValue("num"), v -> v.greaterThan(1)))
+                .build();
+
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context, hook);
+            RecordQueryPlan plan = planner.plan(query);
+            List<Tuple> results = recordStore.executeQuery(plan).map(FDBQueriedRecord::getPrimaryKey).asList().join();
+            assertEquals(Collections.singletonList(Tuple.from(2)), results);
+            MatcherAssert.assertThat(plan, PlanMatchers.primaryKeyDistinct(PlanMatchers.indexScan(Matchers.allOf(
+                    indexName("mapKeyValue"),
+                    PlanMatchers.bounds(PlanMatchers.hasTupleString("([num, 1],[num]]"))))));
+            commit(context);
+        }
+    }
+
+}

--- a/fdb-record-layer-core/src/test/java-proto3/com/apple/foundationdb/record/provider/foundationdb/MapsTest.java
+++ b/fdb-record-layer-core/src/test/java-proto3/com/apple/foundationdb/record/provider/foundationdb/MapsTest.java
@@ -1,0 +1,115 @@
+/*
+ * MapsTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.TestRecordsMapsProto;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.match.PlanMatchers;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.protobuf.Message;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test {@code map} fields.
+ *
+ * Maps are just a surface phenomenon in the generated code; the underlying representation is still a repeated message with
+ * {@code key} and {@code value} fields.
+ */
+@Tag(Tags.RequiresFDB)
+public class MapsTest extends FDBRecordStoreTestBase {
+
+    @Test
+    public void simple() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context);
+
+            TestRecordsMapsProto.StringToString.Builder recBuilder = TestRecordsMapsProto.StringToString.newBuilder();
+            recBuilder.setRecNo(1);
+            recBuilder.putMapValue("hello", "world");
+            recordStore.saveRecord(recBuilder.build());
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context);
+            FDBStoredRecord<Message> rec1 = recordStore.loadRecord(Tuple.from(1L));
+            assertNotNull(rec1);
+            TestRecordsMapsProto.StringToString.Builder myrec1 = TestRecordsMapsProto.StringToString.newBuilder();
+            myrec1.mergeFrom(rec1.getRecord());
+            assertEquals("world",
+                    myrec1.getMapValueOrThrow("hello"));
+            commit(context);
+        }
+    }
+
+    @Test
+    public void indexed() throws Exception {
+        final RecordMetaDataHook hook = md -> {
+            md.addIndex("StringToInt", "mapKeyValue", Key.Expressions.mapKeyValues("map_value"));
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context, hook);
+
+            TestRecordsMapsProto.StringToInt.Builder recBuilder = TestRecordsMapsProto.StringToInt.newBuilder();
+            recBuilder.setRecNo(1);
+            recBuilder.putMapValue("num", 1);
+            recBuilder.putMapValue("other", 2);
+            recordStore.saveRecord(recBuilder.build());
+
+            recBuilder.setRecNo(2);
+            recBuilder.clearMapValue();
+            recBuilder.putMapValue("num", 2);
+            recordStore.saveRecord(recBuilder.build());
+            commit(context);
+        }
+
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("StringToInt")
+                .setFilter(Query.field("map_value").mapMatches(k -> k.equalsValue("num"), v -> v.greaterThan(1)))
+                .build();
+
+        try (FDBRecordContext context = openContext()) {
+            openAnyRecordStore(TestRecordsMapsProto.getDescriptor(), context, hook);
+            RecordQueryPlan plan = planner.plan(query);
+            List<Tuple> results = recordStore.executeQuery(plan).map(FDBQueriedRecord::getPrimaryKey).asList().join();
+            assertEquals(Collections.singletonList(Tuple.from(2)), results);
+            MatcherAssert.assertThat(plan, PlanMatchers.primaryKeyDistinct(PlanMatchers.indexScan(Matchers.allOf(
+                    indexName("mapKeyValue"),
+                    PlanMatchers.bounds(PlanMatchers.hasTupleString("([num, 1],[num]]"))))));
+            commit(context);
+        }
+    }
+
+}

--- a/fdb-record-layer-core/src/test/proto2/test_records_maps.proto
+++ b/fdb-record-layer-core/src/test/proto2/test_records_maps.proto
@@ -1,0 +1,50 @@
+/*
+ * test_records_maps.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.testMaps;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecordsMapsProto";
+
+import "record_metadata_options.proto";
+
+message StringToString {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  message MapEntry {
+    optional string key = 1;
+    optional string value = 2;
+  }
+  repeated MapEntry map_value = 2;
+}
+
+message StringToInt {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  message MapEntry {
+    optional string key = 1;
+    optional int32 value = 2;
+  }
+  repeated MapEntry map_value = 2;
+}
+
+message RecordTypeUnion {
+  optional StringToString _StringToString = 1;
+  optional StringToInt _StringToInt = 2;
+}

--- a/fdb-record-layer-core/src/test/proto3/test_records_maps.proto
+++ b/fdb-record-layer-core/src/test/proto3/test_records_maps.proto
@@ -1,0 +1,42 @@
+/*
+ * test_records_maps.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.testMaps;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecordsMapsProto";
+
+import "record_metadata_options.proto";
+
+message StringToString {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  map<string, string> map_value = 2;
+}
+
+message StringToInt {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  map<string, int32> map_value = 2;
+}
+
+message RecordTypeUnion {
+  optional StringToString _StringToString = 1;
+  optional StringToInt _StringToInt = 2;
+}


### PR DESCRIPTION
These new methods are just shortcuts for existing expressions, so no planner support is required for them to work. They are compatible with anything that conforms to the [language guide](https://developers.google.com/protocol-buffers/docs/proto3#maps), namely a repeated message field with key and value fields. So they work with Protobuf 2 (as does the on-disk format).

The directories for the new proto-version-specific tests are just placeholders, pending #219.