### PR TITLE
Fixes #227: The OnlineIndexerTest::closeWhileBuilding test sometimes hangs

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBase.java
@@ -281,7 +281,12 @@ public class OnlineIndexerBase<M extends Message> implements AutoCloseable {
                             }
                         }
                     }
-                }).thenCompose(Function.identity()), runner.getExecutor());
+                }).thenCompose(Function.identity()), runner.getExecutor())
+                .whenComplete((vignore, e) -> {
+                    if (e != null) {
+                        ret.completeExceptionally(runner.getDatabase().mapAsyncToSyncException(e));
+                    }
+                });
 
         return ret;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -84,6 +84,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -144,6 +145,7 @@ public class OnlineIndexerTest {
     public void setUp() {
         if (fdb == null) {
             fdb = FDBDatabaseFactory.instance().getDatabase();
+            fdb.setAsyncToSyncTimeout(5, TimeUnit.MINUTES);
         }
         if (subspace == null) {
             subspace = DirectoryLayer.getDefault().createOrOpen(fdb.database(), Arrays.asList("record-test", "unit", "oib")).join();
@@ -2206,7 +2208,7 @@ public class OnlineIndexerTest {
             recordStore.clearAndMarkIndexWriteOnly(index).join();
             context.commit();
         }
-        
+
         final FDBStoreTimer timer = new FDBStoreTimer();
         final CompletableFuture<Void> future;
         try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()


### PR DESCRIPTION
There was an instance where we return a future and update it within a whileTrue loop. If the runner was closed at the right time, then it could be the case that the whileTrue loop itself ended in an exceptional state. That error was swallowed and the returned future was never completed. This adds a check to that whileTrue statement to catch such an error and propagates it to the returned future.

This also adds a 5 minute timeout to operations in the OnlineIndexerTest so that errors like this eventually cause timeouts rather than things infinitely hanging.

Also, this first push runs the failing test 300 times to verify the error is gone. (In my experience, this usually reproduced after around 150 repetitions.) Once that passes, I will re-push with a version that doesn't repeat it that many times for build speediness.