### PR TITLE
Fixes #231: LeaderboardIndexTest::parallel sometimes fails with an uncaught exception

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -61,6 +61,8 @@ import com.apple.test.Tags;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.Message;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -89,8 +91,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LeaderboardIndexTest {
     FDBDatabase fdb;
     FDBStoreTimer metrics;
+    private static int oldMaxAttempts;
+    private static final int TEST_MAX_ATTEMPTS = 100;
+    private static long oldMaxDelay;
+    private static final long TEST_MAX_DELAY = 10L;
 
     private static final boolean TRACE = false;
+
+    @BeforeAll
+    public static void initializeRetryPolicy() {
+        oldMaxAttempts = FDBDatabaseFactory.instance().getMaxAttempts();
+        FDBDatabaseFactory.instance().setMaxAttempts(TEST_MAX_ATTEMPTS);
+        oldMaxDelay = FDBDatabaseFactory.instance().getMaxDelayMillis();
+        FDBDatabaseFactory.instance().setMaxDelayMillis(TEST_MAX_DELAY);
+    }
+
+    @AfterAll
+    public static void resetRetryPolicy() {
+        FDBDatabaseFactory.instance().setMaxAttempts(oldMaxAttempts);
+        FDBDatabaseFactory.instance().setMaxDelayMillis(oldMaxDelay);
+    }
 
     @BeforeEach
     public void getFDB() {


### PR DESCRIPTION
This exception was one that was being checked by the retry loop and caught again. It reproduced after about 10 runs of the test locally. This just increases the retry attempts (but decreases the max delay) and passed after about 100 local runs.

This is written assuming that the test wasn't trying to make sure that things completed within 10 attempts, which I don't think it was. By bumping the max attempts to 100, this should decrease the probability of a conflict becoming an uncaught exception, but I suppose it doesn't make it impossible.

This fixes #231.