### PR TITLE
Resolves #234: Most tests should use createOrOpen

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -108,7 +108,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         assertThrows(RecordIndexUniquenessViolation.class, () -> {
             try (FDBRecordContext context = openContext()) {
                 openSimpleRecordStore(context);
-                recordStore.deleteAllRecords();
 
                 recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(1)
@@ -137,8 +136,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         };
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
-
 
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
                     .setRecNo(1)
@@ -166,7 +163,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         };
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
                     .setRecNo(1)
@@ -192,7 +188,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertEquals(0L, recordStore.evaluateAggregateFunction(allTypes, total, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join().getLong(0));
             assertEquals(0L, recordStore.evaluateAggregateFunction(allTypes, subtotal, Key.Evaluated.scalar(1), IsolationLevel.SNAPSHOT).join().getLong(0));
@@ -238,7 +233,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1066L);
@@ -265,7 +259,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -352,7 +345,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertNull(recordStore.evaluateAggregateFunction(types, minOverall, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
             assertNull(recordStore.evaluateAggregateFunction(types, maxOverall, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
@@ -424,7 +416,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1066L);
@@ -458,7 +449,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertNull(recordStore.evaluateAggregateFunction(types, min, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
             assertNull(recordStore.evaluateAggregateFunction(types, max, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
@@ -499,7 +489,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertNull(recordStore.evaluateAggregateFunction(types, minOverall, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
             assertNull(recordStore.evaluateAggregateFunction(types, maxOverall, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
@@ -544,7 +533,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertNull(recordStore.evaluateAggregateFunction(types, min, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
             assertNull(recordStore.evaluateAggregateFunction(types, max, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
@@ -594,7 +582,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertNull(recordStore.evaluateAggregateFunction(types, min, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
             assertNull(recordStore.evaluateAggregateFunction(types, max, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
@@ -645,7 +632,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertNull(recordStore.evaluateAggregateFunction(types, minOverall, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
             assertNull(recordStore.evaluateAggregateFunction(types, maxOverall, Key.Evaluated.EMPTY, IsolationLevel.SNAPSHOT).join());
@@ -732,7 +718,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -784,7 +769,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -980,7 +964,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             recordStore.saveRecord(evenRec);
             fail("Added record with even value for terrible index");
         } catch (UnsupportedOperationException e) {
@@ -989,7 +972,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             recordStore.saveRecord(oddRec);
             recordStore.deleteRecord(Tuple.from(1776));
             fail("Removed record with odd value for terrible index");
@@ -999,7 +981,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             recordStore.saveRecord(oddRec);
             recordStore.saveRecord(oddRec2);
             fail("Updating record not caught.");
@@ -1023,7 +1004,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             recordStore.saveRecord(oddRec);
             fail("Added record with odd value for index key");
         } catch (UnsupportedOperationException e) {
@@ -1032,7 +1012,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             recordStore.saveRecord(evenRec);
             recordStore.deleteRecord(Tuple.from(1066));
             fail("Removed record with even value for index key");
@@ -1042,7 +1021,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             recordStore.saveRecord(evenRec);
             recordStore.saveRecord(evenRec2);
             fail("Updated record with bad values for index key");
@@ -1056,7 +1034,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         final String indexName = "MySimpleRecord$str_value_indexed";
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             assertThat(recordStore.isIndexWriteOnly(indexName), is(false));
             recordStore.markIndexWriteOnly(indexName).get();
             assertThat(recordStore.isIndexWriteOnly(indexName), is(true));
@@ -1064,7 +1042,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         }
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             Index index = recordStore.getRecordMetaData().getIndex(indexName);
             assertThat(recordStore.isIndexReadable(index), is(false));
             try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder().setRecordStore(recordStore).setIndex(index).build()) {
@@ -1092,7 +1070,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         }
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             Index index = recordStore.getRecordMetaData().getIndex(indexName);
             assertThat(recordStore.isIndexReadable(index), is(false));
             try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder().setRecordStore(recordStore).setIndex(index).build()) {
@@ -1581,7 +1559,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
     public void noMaintenanceFilteredOnIndex() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openAnyRecordStore(TestRecordsIndexFilteringProto.getDescriptor(), context);
-            recordStore.deleteAllRecords();
 
             TestRecordsIndexFilteringProto.MyBasicRecord recordA = TestRecordsIndexFilteringProto.MyBasicRecord.newBuilder()
                     .setRecNo(1001).setNumValue2(101).build();
@@ -1637,7 +1614,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
     public void noMaintenanceFilteredIndexOnCheckVersion() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openAnyRecordStore(TestRecordsIndexFilteringProto.getDescriptor(), context);
-            recordStore.deleteAllRecords();
 
             TestRecordsIndexFilteringProto.MyBasicRecord recordA = TestRecordsIndexFilteringProto.MyBasicRecord.newBuilder()
                     .setRecNo(1001).setNumValue2(101).build();
@@ -1744,7 +1720,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             }
             recordStore = FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(builder).setKeySpacePath(path)
                     .setUserVersionChecker(alwaysEnabled).createOrOpen();
-            recordStore.deleteAllRecords();
             assertTrue(recordStore.getRecordStoreState().isReadable(COUNT_INDEX.getName()));
             TestNoIndexesProto.MySimpleRecord recordA = TestNoIndexesProto.MySimpleRecord.newBuilder()
                     .setNumValue(3).setStrValue("boo").build();
@@ -1796,7 +1771,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             final RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
             recordStore = FDBRecordStore.newBuilder().setContext(context).setMetaDataProvider(builder).setKeySpacePath(path).createOrOpen();
-            recordStore.deleteAllRecords();
             // Save 200 records without any indexes.
             for (int i = 0; i < 200; i++) {
                 TestNoIndexesProto.MySimpleRecord record = TestNoIndexesProto.MySimpleRecord.newBuilder()
@@ -1887,7 +1861,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             recordStore = storeBuilder.setContext(context).setKeySpacePath(path).create(); // builds count index
-            recordStore.deleteAllRecords();
             assertTrue(recordStore.getRecordStoreState().isReadable(COUNT_INDEX.getName()));
             TestNoIndexesProto.MySimpleRecord recordA = TestNoIndexesProto.MySimpleRecord.newBuilder()
                     .setNumValue(3).setStrValue("boo").build();
@@ -1956,8 +1929,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
     @Test
     public void orphanedIndexEntry() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
+            uncheckedOpenSimpleRecordStore(context);
 
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
                     .setRecNo(1)
@@ -1979,7 +1951,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         // Delete the "bar" record with the index removed.
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, builder -> {
+            uncheckedOpenSimpleRecordStore(context, builder -> {
                 builder.removeIndex("MySimpleRecord$str_value_indexed");
             });
             recordStore.deleteRecord(Tuple.from(2));
@@ -1989,7 +1961,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         // Scan the records normally, this will fail when it hits the index entry that has no
         // associated record.
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
 
             // Verify our entries
             assertTrue(recordStore.hasIndexEntryRecord(
@@ -2013,7 +1985,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         // Try again, but this time scan allowing orphaned entries.
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             List<FDBIndexedRecord<Message>> records =
                     recordStore.scanIndexRecords("MySimpleRecord$str_value_indexed",
                             IndexScanType.BY_VALUE, TupleRange.ALL, null, IndexOrphanBehavior.RETURN, ScanProperties.FORWARD_SCAN).asList().get();
@@ -2033,7 +2005,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         // Try once again, but this time skipping orphaned entries
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             List<FDBIndexedRecord<Message>> records =
                     recordStore.scanIndexRecords("MySimpleRecord$str_value_indexed",
                             IndexScanType.BY_VALUE, TupleRange.ALL, null, IndexOrphanBehavior.SKIP, ScanProperties.FORWARD_SCAN).asList().get();
@@ -2060,7 +2032,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, metaData.getRecordMetaData());
+            uncheckedOpenRecordStore(context, metaData.getRecordMetaData());
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_EXISTS).join();
             context.commit();
         }
@@ -2068,7 +2040,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         metaData.addIndex("MySimpleRecord", "num_value_2");
 
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, metaData.getRecordMetaData());
+            uncheckedOpenRecordStore(context, metaData.getRecordMetaData());
             timer.reset();
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
             assertEquals(1, timer.getCount(FDBStoreTimer.Events.REBUILD_INDEX));
@@ -2079,7 +2051,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         metaData.removeIndex("MySimpleRecord$num_value_2");
 
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, metaData.getRecordMetaData());
+            uncheckedOpenRecordStore(context, metaData.getRecordMetaData());
             timer.reset();
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
             assertEquals(0, timer.getCount(FDBStoreTimer.Events.REBUILD_INDEX));
@@ -2091,7 +2063,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         metaData.removeIndex("MySimpleRecord$num_value_2");
 
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, metaData.getRecordMetaData());
+            uncheckedOpenRecordStore(context, metaData.getRecordMetaData());
             timer.reset();
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
             assertEquals(0, timer.getCount(FDBStoreTimer.Events.REBUILD_INDEX));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreScanLimitTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreScanLimitTest.java
@@ -321,7 +321,7 @@ public class FDBRecordStoreScanLimitTest extends FDBRecordStoreTestBase {
     public void testSplitContinuation() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
-            recordStore.deleteAllRecords();
+            recordStore.deleteAllRecords(); // Undo setupRecordStore().
             commit(context);
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -117,7 +117,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBRecordStoreTest.class);
 
     private void openLongRecordStore(FDBRecordContext context) throws Exception {
-        createRecordStore(context, RecordMetaData.build(TestRecords2Proto.getDescriptor()));
+        createOrOpenRecordStore(context, RecordMetaData.build(TestRecords2Proto.getDescriptor()));
     }
 
     @SuppressWarnings("deprecation")
@@ -140,7 +140,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void writeRead() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord rec = TestRecords1Proto.MySimpleRecord.newBuilder()
                     .setRecNo(1L)
@@ -165,7 +164,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void writeCheckExists() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord rec = TestRecords1Proto.MySimpleRecord.newBuilder()
                     .setRecNo(1L)
@@ -188,7 +186,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void writeCheckExistsConcurrently() throws Exception {
         try (FDBRecordContext context1 = openContext(); FDBRecordContext context2 = openContext()) {
             openSimpleRecordStore(context1);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord rec = TestRecords1Proto.MySimpleRecord.newBuilder()
                     .setRecNo(1066L)
@@ -231,7 +228,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void writeByteString() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openBytesRecordStore(context);
-            recordStore.deleteAllRecords();
 
             recordStore.saveRecord(TestRecordsBytesProto.ByteStringRecord.newBuilder()
                     .setPkey(byteString(0, 1, 2)).setSecondary(byteString(0, 1, 2)).setName("foo").build());
@@ -255,7 +251,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void writeUniqueByteString() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openBytesRecordStore(context);
-            recordStore.deleteAllRecords();
 
             recordStore.saveRecord(TestRecordsBytesProto.ByteStringRecord.newBuilder()
                     .setPkey(byteString(0, 1, 2)).setSecondary(byteString(0, 1, 2)).setUnique(byteString(0, 2))
@@ -271,7 +266,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void writeNotUnionType() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
-            recordStore.deleteAllRecords();
 
             assertThrows(MetaDataException.class, () -> {
                 TestRecordsWithUnionProto.NotInUnion.Builder recBuilder = TestRecordsWithUnionProto.NotInUnion.newBuilder();
@@ -297,7 +291,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             CompletableFuture<?>[] futures = new CompletableFuture<?>[records.size()];
             for (int i = 0; i < records.size(); i++) {
@@ -321,7 +314,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void asyncNotUniqueInserts() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             CompletableFuture<?>[] futures = new CompletableFuture<?>[2];
             futures[0] = recordStore.saveRecordAsync(TestRecords1Proto.MySimpleRecord.newBuilder()
@@ -356,7 +348,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openLongRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords2Proto.MyLongRecord.Builder recBuilder = TestRecords2Proto.MyLongRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -420,7 +411,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void scanContinuations() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             for (int i = 0; i < 100; i++) {
@@ -480,7 +470,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void delete() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -491,7 +480,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         }
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
             recordStore.deleteRecord(Tuple.from(1L));
             commit(context);
         }
@@ -507,7 +495,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void testCountRecords() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
-            recordStore.deleteAllRecords();
 
             saveSimpleRecord2("a", 1);
 
@@ -573,8 +560,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             builder.getRecordType("MyRecord")
                     .setPrimaryKey(field("header").nest(concatenateFields("path", "num", "rec_no")));
             builder.setRecordCountKey(field("header").nest(concat(field("path"), field("num"))));
-            createRecordStore(context, builder.getRecordMetaData());
-            recordStore.deleteAllRecords();
+            createOrOpenRecordStore(context, builder.getRecordMetaData());
 
             saveHeaderRecord(1, "/FirstPath", 0, "johnny");
             saveHeaderRecord(2, "/FirstPath", 0, "apple");
@@ -634,7 +620,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     private void testDeleteWhere(boolean useCountIndex) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeaderPrimaryKey(context, useCountIndex);
-            recordStore.deleteAllRecords();
 
             saveHeaderRecord(1, "a", 0, "lynx");
             saveHeaderRecord(1, "b", 1, "bobcat");
@@ -696,7 +681,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         };
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeader(context, hook);
-            recordStore.deleteAllRecords();
 
             saveHeaderRecord(1, "a", 0, "lynx");
             saveHeaderRecord(1, "a", 1, "bobcat");
@@ -748,7 +732,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             builder.addIndex("MyRecord", "MyRecord$str_value", concat(field("header").nest("path"),
                     field("str_value")));
             RecordMetaData metaData = builder.getRecordMetaData();
-            createRecordStore(context, metaData);
+            createOrOpenRecordStore(context, metaData);
             assertThrows(Query.InvalidExpressionException.class, () ->
                     recordStore.deleteRecordsWhere(Query.field("header").matches(Query.field("rec_no").equalsValue(1))));
         }
@@ -763,8 +747,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             builder.addIndex("MyRecord", "MyRecord$path_str", concat(field("header").nest("path"),
                     field("str_value")));
             RecordMetaData metaData = builder.getRecordMetaData();
-            createRecordStore(context, metaData);
-            recordStore.deleteAllRecords();
+            createOrOpenRecordStore(context, metaData);
 
             TestRecordsWithHeaderProto.MyRecord.Builder recBuilder = TestRecordsWithHeaderProto.MyRecord.newBuilder();
             TestRecordsWithHeaderProto.HeaderRecord.Builder headerBuilder = recBuilder.getHeaderBuilder();
@@ -804,7 +787,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         assertThrows(FDBExceptions.FDBStoreKeySizeException.class, () -> {
             try (FDBRecordContext context = openContext()) {
                 openSimpleRecordStore(context);
-                recordStore.deleteAllRecords();
 
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
                 recBuilder.setRecNo(1);
@@ -830,7 +812,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
                             IndexTypes.VALUE,
                             Collections.emptyMap()));
                 });
-                recordStore.deleteAllRecords();
 
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
                 recBuilder.setRecNo(1);
@@ -846,7 +827,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void testStoredRecordSizeIsPlausible() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
 
@@ -888,7 +868,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             List<FDBStoredRecord<Message>> saving = new ArrayList<>();
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 10; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -926,7 +905,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void testSplitContinuation() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
-            recordStore.deleteAllRecords();
             commit(context);
         }
 
@@ -971,7 +949,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void testSaveRecordWithDifferentSplits() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
-            recordStore.deleteAllRecords();
             commit(context);
         }
         
@@ -1263,7 +1240,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             recBuilder.setStrValueIndexed("abc");
             recordStore.saveRecord(recBuilder.build());
@@ -1325,7 +1301,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertEquals(0, recordStore.getSnapshotRecordCount().join().longValue());
 
@@ -1390,7 +1365,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             assertEquals(0, recordStore.getSnapshotRecordUpdateCount().join().longValue());
 
@@ -1466,7 +1440,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 recordStore.saveRecord(makeRecord(i, 0, i % 5));
@@ -1516,7 +1489,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         final int value2 = 54321;
         final int value3 = 24567;
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, countMetaDataHook);
+            uncheckedOpenSimpleRecordStore(context, countMetaDataHook);
             recordStore.deleteAllRecords();
             // Simulate the state the store would be in if this were done before counting was added.
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStore.INFO_ADDED_FORMAT_VERSION).build();
@@ -1533,7 +1506,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         countMetaDataHook.baseHook = countKeyHook(key3, useIndex, countMetaDataHook.metaDataVersion);
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, countMetaDataHook);
+            uncheckedOpenSimpleRecordStore(context, countMetaDataHook);
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStore.RECORD_COUNT_ADDED_FORMAT_VERSION).build();
 
             for (int i = 90; i < 100; i++) {
@@ -1543,7 +1516,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         }
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, countMetaDataHook);
+            uncheckedOpenSimpleRecordStore(context, countMetaDataHook);
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStore.RECORD_COUNT_ADDED_FORMAT_VERSION).build();
 
             assertEquals(10, recordStore.getSnapshotRecordCount().join().longValue(), "should only see new records");
@@ -1564,7 +1537,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         };
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, countMetaDataHook);
+            uncheckedOpenSimpleRecordStore(context, countMetaDataHook);
             recordStore.checkVersion(alwaysEnabled, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join(); // Index is rebuilt here automatically in useIndex case
 
             assertEquals(100, recordStore.getSnapshotRecordCount().join().longValue(), "should see all records");
@@ -1577,7 +1550,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         countMetaDataHook.baseHook = countKeyHook(key2, useIndex, countMetaDataHook.metaDataVersion);
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, countMetaDataHook);
+            uncheckedOpenSimpleRecordStore(context, countMetaDataHook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
             if (useIndex) {
@@ -1596,7 +1569,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         }
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, countMetaDataHook);
+            uncheckedOpenSimpleRecordStore(context, countMetaDataHook);
             assertEquals(90, recordStore.getSnapshotRecordCount(key2, Key.Evaluated.scalar(value1)).join().longValue());
             assertEquals(10, recordStore.getSnapshotRecordCount(key2, Key.Evaluated.scalar(value2)).join().longValue());
             assertEquals(32, recordStore.getSnapshotRecordCount(key2, Key.Evaluated.scalar(value3)).join().longValue());
@@ -1607,7 +1580,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         countMetaDataHook.baseHook = countKeyHook(pkey, useIndex, countMetaDataHook.metaDataVersion);
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, countMetaDataHook);
+            uncheckedOpenSimpleRecordStore(context, countMetaDataHook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.NONE).join();
 
             if (useIndex) {
@@ -1633,8 +1606,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, removeCountHook);
-            recordStore.deleteAllRecords();
-            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.NONE).join();
 
             for (int i = 0; i < 10; i++) {
                 recordStore.saveRecord(makeRecord(i, 1066, i % 5));
@@ -1654,7 +1625,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.NONE).join();
             commit(context);
         }
 
@@ -1683,8 +1653,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     @Test
     public void typeChange() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, RecordMetaData.build(TestRecords7Proto.getDescriptor()));
-            recordStore.deleteAllRecords();
+            createOrOpenRecordStore(context, RecordMetaData.build(TestRecords7Proto.getDescriptor()));
 
             TestRecords7Proto.MyRecord1.Builder rec1Builder = TestRecords7Proto.MyRecord1.newBuilder();
             rec1Builder.setRecNo(1);
@@ -1935,7 +1904,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             final long readVersion = context.ensureActive().getReadVersion().get();
 
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -1957,7 +1925,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void testVersionStamp() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -2020,22 +1987,22 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void testSubspaceWriteConflict() throws Exception {
         // Double check that it works to have two contexts on same space without conflict.
         FDBRecordContext context1 = openContext();
-        openSimpleRecordStore(context1);
+        uncheckedOpenSimpleRecordStore(context1);
         FDBRecordStore recordStore1 = recordStore;
         try (FDBRecordContext context2 = openContext()) {
-            openSimpleRecordStore(context2);
+            uncheckedOpenSimpleRecordStore(context2);
             commit(context2);
         }
         commit(context1);
 
         // Again with conflict.
         FDBRecordContext context3 = openContext();
-        openSimpleRecordStore(context3);
+        uncheckedOpenSimpleRecordStore(context3);
         FDBRecordStore recordStore3 = recordStore;
         recordStore3.loadRecord(Tuple.from(0L)); // Need to read something as write-only transactions never conflict
         recordStore3.addConflictForSubspace(true);
         try (FDBRecordContext context4 = openContext()) {
-            openSimpleRecordStore(context4);
+            uncheckedOpenSimpleRecordStore(context4);
             recordStore.addConflictForSubspace(true);
             commit(context4);
         }
@@ -2052,11 +2019,11 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void testSubspaceReadWriteConflict() throws Exception {
         // Double check that it works to have two contexts on same space writing different records without conflict.
         FDBRecordContext context1 = openContext();
-        openSimpleRecordStore(context1);
+        uncheckedOpenSimpleRecordStore(context1);
         FDBRecordStore recordStore1 = recordStore;
         recordStore1.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(1).build());
         try (FDBRecordContext context2 = openContext()) {
-            openSimpleRecordStore(context2);
+            uncheckedOpenSimpleRecordStore(context2);
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(2).build());
             commit(context2);
         }
@@ -2064,12 +2031,12 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         // Again with requested conflict.
         FDBRecordContext context3 = openContext();
-        openSimpleRecordStore(context3);
+        uncheckedOpenSimpleRecordStore(context3);
         FDBRecordStore recordStore3 = recordStore;
         recordStore3.addConflictForSubspace(false);
         recordStore3.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(3).build());
         try (FDBRecordContext context4 = openContext()) {
-            openSimpleRecordStore(context4);
+            uncheckedOpenSimpleRecordStore(context4);
             recordStore.addConflictForSubspace(false);
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(4).build());
             commit(context4);
@@ -2086,19 +2053,19 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     @Test
     public void testFormatVersionUpgrade() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStoreBase.MAX_SUPPORTED_FORMAT_VERSION - 1).create();
             assertEquals(FDBRecordStoreBase.MAX_SUPPORTED_FORMAT_VERSION - 1, recordStore.getFormatVersion());
             commit(context);
         }
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStoreBase.MAX_SUPPORTED_FORMAT_VERSION).open();
             assertEquals(FDBRecordStoreBase.MAX_SUPPORTED_FORMAT_VERSION, recordStore.getFormatVersion());
             commit(context);
         }
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStoreBase.MAX_SUPPORTED_FORMAT_VERSION - 1).open();
             assertEquals(FDBRecordStoreBase.MAX_SUPPORTED_FORMAT_VERSION, recordStore.getFormatVersion());
             commit(context);
@@ -2218,7 +2185,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void unsplitCompatibility() throws Exception {
         TestRecords1Proto.MySimpleRecord rec1 = TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(1415L).build();
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             // Write a record using the old format
             recordStore = recordStore.asBuilder()
                     .setFormatVersion(FDBRecordStore.SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION - 1)
@@ -2294,7 +2261,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             // Add an index so that we have to check the record count. (This automatic upgrade happens only
             // if we are already reading the record count anyway, which is why it happens here.)
-            openSimpleRecordStore(context, metaDataBuilder ->
+            uncheckedOpenSimpleRecordStore(context, metaDataBuilder ->
                     metaDataBuilder.addUniversalIndex(new Index("global$newCount", FDBRecordStoreTestBase.COUNT_INDEX.getRootExpression(), IndexTypes.COUNT))
             );
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStoreBase.SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION).open();
@@ -2319,7 +2286,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             // Read from the now upgraded store with a record store that sets its format version to be older to make sure
             // it correctly switches to the new one.
             // Use same meta-data as last test
-            openSimpleRecordStore(context, metaDataBuilder ->
+            uncheckedOpenSimpleRecordStore(context, metaDataBuilder ->
                     metaDataBuilder.addUniversalIndex(new Index("global$newCount", FDBRecordStoreTestBase.COUNT_INDEX.getRootExpression(), IndexTypes.COUNT))
             );
             recordStore = recordStore.asBuilder().setFormatVersion(FDBRecordStoreBase.SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION - 1).open();
@@ -2356,7 +2323,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
                                                     .setStrValueIndexed(Strings.repeat("x", SplitHelper.SPLIT_RECORD_SIZE + 2))
                                                     .build();
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, metaDataBuilder -> {
+            uncheckedOpenSimpleRecordStore(context, metaDataBuilder -> {
                 metaDataBuilder.removeIndex("MySimpleRecord$str_value_indexed");
                 metaDataBuilder.setStoreRecordVersions(false);
             });
@@ -2382,7 +2349,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             commit(context);
         }
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, TEST_SPLIT_HOOK);
+            uncheckedOpenSimpleRecordStore(context, TEST_SPLIT_HOOK);
             assertTrue(recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).get());
             assertTrue(recordStore.getRecordMetaData().isSplitLongRecords());
 
@@ -2466,7 +2433,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openAnyRecordStore(TestRecordsImportProto.getDescriptor(), context, hook);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -2497,7 +2463,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     public void existenceChecks() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder simple = TestRecords1Proto.MySimpleRecord.newBuilder();
             simple.setRecNo(1);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyIndexTest.java
@@ -134,7 +134,7 @@ public class FunctionKeyIndexTest extends FDBRecordStoreTestBase {
         for (Index index : indexes) {
             metaDataBuilder.addIndex(scalarRecordType, index);
         }
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 
     protected void saveRecords(Records records, Index ... indexes) throws Exception {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyRecordTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FunctionKeyRecordTest.java
@@ -72,7 +72,7 @@ public class FunctionKeyRecordTest extends FDBRecordStoreTestBase {
     private void openRecordStore(@Nonnull FDBRecordContext context, @Nonnull RecordMetaDataHook hook) {
         RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords8Proto.getDescriptor());
         hook.apply(metaData);
-        createRecordStore(context, metaData.getRecordMetaData());
+        createOrOpenRecordStore(context, metaData.getRecordMetaData());
     }
 
     @Test
@@ -86,7 +86,6 @@ public class FunctionKeyRecordTest extends FDBRecordStoreTestBase {
         // Create some records
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             for (int i = 0; i < 5; i++) {
                 recordStore.saveRecord(TestRecords8Proto.StringRecordId.newBuilder()
                         .setRecId("/s" + i + ":foo_" + i)
@@ -301,7 +300,6 @@ public class FunctionKeyRecordTest extends FDBRecordStoreTestBase {
         // Create some records
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             for (int i = 0; i < 5; i++) {
                 TestRecords8Proto.StringRecordId.Builder builder =
                         TestRecords8Proto.StringRecordId.newBuilder()

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/QueryPlanCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/QueryPlanCursorTest.java
@@ -68,7 +68,6 @@ public class QueryPlanCursorTest extends FDBRecordStoreTestBase {
     public void setupStore() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 200; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder builder = TestRecords1Proto.MySimpleRecord.newBuilder();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
@@ -119,7 +119,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
                         Key.Expressions.field("score", KeyExpression.FanType.FanOut).ungrouped(),
                         IndexTypes.RANK));
         hook.apply(metaDataBuilder);
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 
     static final Object[][] RECORDS = new Object[][] {
@@ -496,7 +496,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
         fdb = FDBDatabaseFactory.instance().getDatabase();
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            recordStore.deleteAllRecords();
+            recordStore.deleteAllRecords(); // Undo loadRecords().
 
             TestRecordsRankProto.BasicRankedRecord.Builder rec = TestRecordsRankProto.BasicRankedRecord.newBuilder();
             rec.setName("achilles");
@@ -604,7 +604,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
         fdb = FDBDatabaseFactory.instance().getDatabase();
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            recordStore.deleteAllRecords();
+            recordStore.deleteAllRecords(); // Undo loadRecords().
             
             TestRecordsRankProto.NestedRankedRecord.Builder rec;
             TestRecordsRankProto.NestedRankedRecord.GameScore.Builder score;
@@ -685,7 +685,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
         fdb = FDBDatabaseFactory.instance().getDatabase();
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            recordStore.deleteAllRecords();
+            recordStore.deleteAllRecords(); // Undo loadRecords().
 
             TestRecordsRankProto.RepeatedRankedRecord.Builder rec = TestRecordsRankProto.RepeatedRankedRecord.newBuilder();
 
@@ -1072,6 +1072,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
 
     @Test
     public void uniquenessViolationWithTies() throws Exception {
+        clearAndInitialize();   // Undo loadRecords.
         assertThrows(RecordIndexUniquenessViolation.class, () -> {
             try (FDBRecordContext context = openContext()) {
                 openRecordStore(context, md -> {
@@ -1081,7 +1082,6 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
                             new Index("rank_by_gender", Key.Expressions.field("score").groupBy(Key.Expressions.field("gender")), EmptyKeyExpression.EMPTY,
                                     IndexTypes.RANK, IndexOptions.UNIQUE_OPTIONS));
                 });
-                recordStore.deleteAllRecords();
                 for (Object[] rec : RECORDS) {
                     recordStore.saveRecord(TestRecordsRankProto.BasicRankedRecord.newBuilder()
                             .setName((String) rec[0])
@@ -1098,7 +1098,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
     public void countIfUnique() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            recordStore.deleteAllRecords();
+            recordStore.deleteAllRecords(); // Undo loadRecords().
             commit(context);
         }
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -351,7 +351,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
     @Test
     public void testBuildIndexIndexThreshold() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, BASIC_HOOK);
+            uncheckedOpenSimpleRecordStore(context, BASIC_HOOK);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_EXISTS).join();
             context.commit();
         }
@@ -360,8 +360,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
         saveManyRecords(BASIC_HOOK, 10, 500);
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, BASIC_HOOK);
-
+            uncheckedOpenSimpleRecordStore(context, BASIC_HOOK);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
             assertEquals(10, recordStore.getSnapshotRecordCountForRecordType("MySimpleRecord").join().intValue());
@@ -374,7 +373,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
         };
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, hook);
+            uncheckedOpenSimpleRecordStore(context, hook);
  
             timer.reset();
 
@@ -395,7 +394,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
     @Test
     public void testOnlineIndexBuilder() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, BASIC_HOOK);
+            uncheckedOpenSimpleRecordStore(context, BASIC_HOOK);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_EXISTS).join();
             context.commit();
         }
@@ -403,8 +402,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
         saveManyRecords(BASIC_HOOK, 250, 250);
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, BASIC_HOOK);
-
+            uncheckedOpenSimpleRecordStore(context, BASIC_HOOK);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
             assertEquals(250, recordStore.getSnapshotRecordCountForRecordType("MySimpleRecord").join().intValue());
@@ -417,8 +415,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
         };
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, hook);
-
+            uncheckedOpenSimpleRecordStore(context, hook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
             assertTrue(recordStore.isIndexWriteOnly("newIndex"));
@@ -441,8 +438,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
         }
 
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, hook);
-
+            uncheckedOpenSimpleRecordStore(context, hook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
             assertTrue(recordStore.isIndexReadable("newIndex"));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollectorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollectorTest.java
@@ -53,7 +53,7 @@ public class SizeStatisticsCollectorTest extends FDBRecordStoreTestBase {
     @Test
     public void empty() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
+            uncheckedOpenSimpleRecordStore(context);
             SizeStatisticsCollector statisticsCollector = SizeStatisticsCollector.ofStore(recordStore);
             assertThat(statisticsCollector.collect(context, ExecuteProperties.SERIAL_EXECUTE), is(true));
             assertEquals(0L, statisticsCollector.getKeyCount());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionIntersectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionIntersectionTest.java
@@ -74,7 +74,6 @@ public class UnionIntersectionTest extends FDBRecordStoreTestBase {
     public void setupRecords() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             comparisonKey = recordStore.getRecordMetaData().getRecordType("MySimpleRecord").getPrimaryKey();
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -221,7 +221,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
         metaDataBuilder.getRecordType(COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
         hook.apply(metaDataBuilder);
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        uncheckedOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
         recordStore = recordStore.asBuilder().setSerializer(COMPRESSING_SERIALIZER).build();
         evaluationContext = recordStore.emptyEvaluationContext();
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
@@ -376,7 +376,6 @@ public class FDBAndQueryToIntersectionTest extends FDBRecordStoreQueryTestBase {
                 metaData.removeIndex("MySimpleRecord$num_value_3_indexed");
                 metaData.addIndex("MySimpleRecord", new Index("index_2_3", "num_value_2", "num_value_3_indexed"));
             });
-            recordStore.deleteAllRecords();
         }
         RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
@@ -300,7 +300,6 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeader(context, hook);
-            recordStore.deleteAllRecords();
 
             saveHeaderRecord(1, "a", 0, "lynx");
             saveHeaderRecord(2, "a", 1, "bobcat");
@@ -378,7 +377,6 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             for (int i = 0; i < 20; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
                 recBuilder.setRecNo(i);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
@@ -68,7 +68,6 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
     public void testCrossRecordTypeQuery() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
-            recordStore.deleteAllRecords();
 
             saveSimpleRecord(100, "first", 1);
             saveSimpleRecord(110, "second", 2);
@@ -119,7 +118,6 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
     public void testMultiRecordTypeIndexScan() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
-            recordStore.deleteAllRecords();
 
             saveSimpleRecord(100, "first", 1);
             saveSimpleRecord(110, "second", 2);
@@ -264,7 +262,6 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
     public void testCrossRecordTypeQueryFiltered() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
-            recordStore.deleteAllRecords();
 
             saveSimpleRecord(100, "first", 1);
             saveSimpleRecord(110, "second", 2);
@@ -311,7 +308,6 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
     public void testNestedCrossRecordTypeQueryFilteredAndSorted() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
-            recordStore.deleteAllRecords();
 
             recordStore.saveRecord(TestRecordsWithUnionProto.MySimpleRecord.newBuilder().setRecNo(80).setStrValueIndexed("box").setNested(TestRecordsWithUnionProto.Nested.newBuilder().setEtag(1)).build());
             recordStore.saveRecord(TestRecordsWithUnionProto.MySimpleRecord2.newBuilder().setStrValueIndexed("of").setNested(TestRecordsWithUnionProto.Nested.newBuilder().setEtag(2)).build());
@@ -353,7 +349,6 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
     public void testNestedPartialCrossRecordTypeQuery() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
-            recordStore.deleteAllRecords();
 
             recordStore.saveRecord(TestRecordsWithUnionProto.MySimpleRecord.newBuilder().setRecNo(80).setStrValueIndexed("box").setEtag(1).setNested(TestRecordsWithUnionProto.Nested.newBuilder().setEtag(1)).build());
             recordStore.saveRecord(TestRecordsWithUnionProto.MySimpleRecord2.newBuilder().setStrValueIndexed("of").setEtag(1).setNested(TestRecordsWithUnionProto.Nested.newBuilder().setEtag(2)).build());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBMultiFieldIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBMultiFieldIndexSelectionTest.java
@@ -63,7 +63,6 @@ public class FDBMultiFieldIndexSelectionTest extends FDBRecordStoreQueryTestBase
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recordBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -77,7 +77,6 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     public void hierarchical() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openHierarchicalRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords3Proto.MyHierarchicalRecord.Builder recBuilder = TestRecords3Proto.MyHierarchicalRecord.newBuilder();
             recBuilder.setChildName("photos");
@@ -152,7 +151,6 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     public void nested() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openNestedRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords4Proto.RestaurantReviewer.Builder reviewerBuilder = TestRecords4Proto.RestaurantReviewer.newBuilder();
             reviewerBuilder.setId(1);
@@ -281,7 +279,7 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
             metaDataBuilder.addIndex("OuterRecord", "key_index", concat(
                     field("other_id"),
                     field("map").nest(field("entry", KeyExpression.FanType.FanOut).nest("key"))));
-            createRecordStore(context, metaDataBuilder.getRecordMetaData());
+            createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
             commit(context);
         }
 
@@ -381,7 +379,6 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     public void doublyNested() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openDoublyNestedRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords5Proto.CalendarEvent.Builder eventBuilder = TestRecords5Proto.CalendarEvent.newBuilder();
             eventBuilder.setPath("ev1");
@@ -451,7 +448,6 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     public void testConcatNested() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openConcatNestedRecordStore(context);
-            recordStore.deleteAllRecords();
             recordStore.saveRecord(createVersionedCalendarEvent("ev1", 1, 1));
             recordStore.saveRecord(createVersionedCalendarEvent("ev2", 1, 2));
             recordStore.saveRecord(createVersionedCalendarEvent("ev3", 2, 4));
@@ -518,7 +514,6 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
         };
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeader(context, hook);
-            recordStore.deleteAllRecords();
 
             saveHeaderRecord(1, "a", 0, "able");
             saveHeaderRecord(2, "a", 3, "baker");

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -740,7 +740,6 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     public void testOrQuerySplitContinuations() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             for (int i = 0; i < 100; i++) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -196,7 +196,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
     @Test
     public void testProto2() {
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, proto2MetaData());
+            createOrOpenRecordStore(context, proto2MetaData());
             saveTestRecords(FDBRecordStoreNullQueryTest::buildRecord2);
 
             assertThat(executeQuery(RecordQuery.newBuilder()
@@ -252,7 +252,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
     @MethodSource("testProto3Params")
     public void testProto3(String testName, boolean buildDynamic, boolean scalarFieldsNotNull) {
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, scalarFieldsNotNull ? proto3ScalarNotNullMetaData() : proto3MetaData());
+            createOrOpenRecordStore(context, scalarFieldsNotNull ? proto3ScalarNotNullMetaData() : proto3MetaData());
             saveTestRecords(buildDynamic ?
                             FDBRecordStoreNullQueryTest::buildRecord3Dynamic :
                             FDBRecordStoreNullQueryTest::buildRecord3);
@@ -324,7 +324,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
     @Test
     public void testProto3Nested() {
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, proto3NestedMetaData());
+            createOrOpenRecordStore(context, proto3NestedMetaData());
             saveTestRecords(FDBRecordStoreNullQueryTest::buildRecord3Nested);
 
             assertThat(executeQuery(RecordQuery.newBuilder()
@@ -528,7 +528,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFbytes(TupleFieldsHelper.toProto(ByteString.copyFrom(" ", "UTF-8")))
                 .build();
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, tupleFieldsMetaData());
+            createOrOpenRecordStore(context, tupleFieldsMetaData());
 
             recordStore.saveRecord(nullRecord);
             recordStore.saveRecord(emptyRecord);
@@ -538,7 +538,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
         }
 
         try (FDBRecordContext context = openContext()) {
-            createRecordStore(context, tupleFieldsMetaData());
+            createOrOpenRecordStore(context, tupleFieldsMetaData());
 
             assertEquals(nullId, fieldsRecordId(recordStore.loadRecord(Tuple.from(nullId))));
             assertEquals(otherId, fieldsRecordId(recordStore.loadRecord(Tuple.from(otherId))));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
@@ -93,7 +93,6 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     public void query() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -136,7 +135,6 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     public void queryByteString() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openBytesRecordStore(context);
-            recordStore.deleteAllRecords();
 
             recordStore.saveRecord(TestRecordsBytesProto.ByteStringRecord.newBuilder()
                     .setPkey(byteString(0, 1, 2)).setSecondary(byteString(0, 1, 2)).setUnique(byteString(0, 2))
@@ -479,7 +477,6 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     public void nullQuery() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -557,7 +554,6 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     public void testUncommonPrimaryKey() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openMultiRecordStore(context);
-            recordStore.deleteAllRecords();
 
             Message record = TestRecordsMultiProto.MultiRecordOne.newBuilder()
                     .setId(1066L)
@@ -637,7 +633,6 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     public void queryExcludeNull() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -68,7 +68,6 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
             throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, recordMetaDataHook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder record = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -112,7 +111,6 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
     protected void complexQuerySetup(RecordMetaDataHook hook) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -145,7 +143,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.getRecordType("MyHierarchicalRecord").setPrimaryKey(
                 concatenateFields("parent_path", "child_name"));
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 
     protected void openNestedRecordStore(FDBRecordContext context) throws Exception {
@@ -153,6 +151,10 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
     }
 
     protected void openNestedRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook) throws Exception {
+        createOrOpenRecordStore(context, nestedMetaData(hook));
+    }
+
+    protected RecordMetaData nestedMetaData(@Nullable RecordMetaDataHook hook) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords4Proto.getDescriptor());
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addIndex("RestaurantRecord", "review_rating", field("reviews", FanType.FanOut).nest("rating"));
@@ -164,13 +166,12 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         if (hook != null) {
             hook.apply(metaDataBuilder);
         }
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        return metaDataBuilder.getRecordMetaData();
     }
 
     protected void nestedWithAndSetup(@Nullable RecordMetaDataHook hook) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openNestedRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             TestRecords4Proto.RestaurantReviewer reviewer1 = TestRecords4Proto.RestaurantReviewer.newBuilder()
                     .setId(1L)
@@ -208,7 +209,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
                 field("recurrence", FanType.FanOut).nest("start")));
         metaDataBuilder.addIndex("CalendarEvent", "event_start", field("eventIndex").nest(
                 field("recurrence", FanType.FanOut).nest("start")));
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 
     public void openConcatNestedRecordStore(FDBRecordContext context) throws Exception {
@@ -216,7 +217,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addIndex("CalendarEvent", "versions", concat(field("alarmIndex").nest("version"),
                 field("eventIndex").nest("version")));
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 
     protected List<Object> fetchResultValues(RecordQueryPlan plan, final int fieldNumber, Opener opener,
@@ -254,7 +255,6 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
                                         BiConsumer<Integer, TestRecordsWithHeaderProto.MyRecord.Builder> buildRecord) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeader(context, recordMetaDataHook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 100; i++) {
                 TestRecordsWithHeaderProto.MyRecord.Builder record = TestRecordsWithHeaderProto.MyRecord.newBuilder();
@@ -321,13 +321,12 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         if (hook != null) {
             hook.apply(metaData);
         }
-        createRecordStore(context, metaData.getRecordMetaData());
+        createOrOpenRecordStore(context, metaData.getRecordMetaData());
     }
 
     protected void setupEnumShapes(RecordMetaDataHook hook) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openEnumRecordStore(context, hook);
-            recordStore.deleteAllRecords();
             int n = 0;
             for (TestRecordsEnumProto.MyShapeRecord.Size size : TestRecordsEnumProto.MyShapeRecord.Size.values()) {
                 for (TestRecordsEnumProto.MyShapeRecord.Color color : TestRecordsEnumProto.MyShapeRecord.Color.values()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
@@ -78,7 +78,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
         metaDataBuilder.addUniversalIndex(COUNT_INDEX);
         metaDataBuilder.addIndex("MyRepeatedRecord", "rep_strings", concat(field("s1", FanType.Concatenate), field("s2", FanType.Concatenate)));
         metaDataBuilder.addIndex("MyRepeatedRecord", "s1$concat", field("s1", FanType.Concatenate));
-        createRecordStore(context, metaDataBuilder.getRecordMetaData());
+        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 
     /**
@@ -88,7 +88,6 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     public void doublyRepeated() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openDoublyRepeatedRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords6Proto.MyRepeatedRecord.Builder recBuilder = TestRecords6Proto.MyRepeatedRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -130,7 +129,6 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     public void doublyRepeatedComparison() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openDoublyRepeatedRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords6Proto.MyRepeatedRecord.Builder recBuilder = TestRecords6Proto.MyRepeatedRecord.newBuilder();
             recBuilder.setRecNo(1);
@@ -185,7 +183,6 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     public void sortRepeated() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openNestedRecordStore(context);
-            recordStore.deleteAllRecords();
 
             TestRecords4Proto.RestaurantReviewer reviewer = TestRecords4Proto.RestaurantReviewer.newBuilder()
                     .setId(1L)
@@ -465,7 +462,6 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             TestRecords1Proto.MySimpleRecord.Builder recordBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
 
@@ -530,7 +526,6 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteAllRecords();
 
             for (int i = 0; i < 3; i++) {
                 TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -572,7 +567,6 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeader(context, hook);
-            recordStore.deleteAllRecords();
 
             recordStore.saveRecord(TestRecordsWithHeaderProto.MyRecord.newBuilder()
                     .setHeader(TestRecordsWithHeaderProto.HeaderRecord.newBuilder()

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleJoinQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleJoinQueryTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Tag(Tags.RequiresFDB)
 public class FDBSimpleJoinQueryTest extends FDBRecordStoreQueryTestBase {
     private void openJoinRecordStore(FDBRecordContext context) throws Exception {
-        createRecordStore(context, RecordMetaData.build(TestRecordsParentChildRelationshipProto.getDescriptor()));
+        createOrOpenRecordStore(context, RecordMetaData.build(TestRecordsParentChildRelationshipProto.getDescriptor()));
     }
 
     /**
@@ -126,7 +126,6 @@ public class FDBSimpleJoinQueryTest extends FDBRecordStoreQueryTestBase {
     protected void createJoinRecords(boolean parentToChild) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openJoinRecordStore(context);
-            recordStore.deleteAllRecords();
 
             for (int i = 1; i <= 4; i++) {
                 TestRecordsParentChildRelationshipProto.MyParentRecord.Builder parentBuilder = TestRecordsParentChildRelationshipProto.MyParentRecord.newBuilder();


### PR DESCRIPTION
Also most uses of `deleteAllRecords` aren't needed any more.