### PR TITLE
Resolves #237: Disallow repeated union fields

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
@@ -541,6 +541,10 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
                 throw new MetaDataException("Union field " + unionField.getName() +
                                             " is not a message");
             }
+            if (unionField.isRepeated()) {
+                throw new MetaDataException("Union field " + unionField.getName() +
+                                            " should not be repeated");
+            }
             Descriptors.Descriptor descriptor = unionField.getMessageType();
             if (!unionFields.containsKey(descriptor)) {
                 RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = descriptor.getOptions()

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/RecordMetaDataBuilderTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/RecordMetaDataBuilderTest.java
@@ -25,6 +25,8 @@ import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TestRecordsBadUnion1Proto;
+import com.apple.foundationdb.record.TestRecordsBadUnion2Proto;
 import com.apple.foundationdb.record.TestRecordsChained1Proto;
 import com.apple.foundationdb.record.TestRecordsUnsigned1Proto;
 import com.apple.foundationdb.record.TestRecordsUnsigned2Proto;
@@ -52,7 +54,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link RecordMetaDataBuilder}.
@@ -136,36 +137,21 @@ public class RecordMetaDataBuilderTest {
 
     @Test
     public void unsignedFields() {
-        try {
-            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned1Proto.getDescriptor());
-            fail("Did not throw exception for TestRecordsUnsigned1Proto");
-        } catch (MetaDataException e) {
-            assertEquals("Field unsigned_rec_no in message com.apple.foundationdb.record.unsigned.SimpleUnsignedRecord has illegal unsigned type UINT64", e.getMessage());
-        }
-        try {
-            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned2Proto.getDescriptor());
-            fail("Did not throw exception for TestRecordsUnsigned2Proto");
-        } catch (MetaDataException e) {
-            assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.NestedWithUnsigned has illegal unsigned type UINT32", e.getMessage());
-        }
-        try {
-            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned3Proto.getDescriptor());
-            fail("Did not throw exception for TestRecordsUnsigned3Proto");
-        } catch (MetaDataException e) {
-            assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.Fixed32UnsignedRecord has illegal unsigned type FIXED32", e.getMessage());
-        }
-        try {
-            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned4Proto.getDescriptor());
-            fail("Did not throw exception for TestRecordsUnsigned4Proto");
-        } catch (MetaDataException e) {
-            assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.Fixed64UnsignedRecord has illegal unsigned type FIXED64", e.getMessage());
-        }
-        try {
-            RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned5Proto.getDescriptor());
-            fail("Did not throw exception for TestRecordsUnsigned5Proto");
-        } catch (MetaDataException e) {
-            assertEquals("Field unsigned_rec_no in message com.apple.foundationdb.record.unsigned.SimpleUnsignedRecord has illegal unsigned type UINT64", e.getMessage());
-        }
+        Throwable t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned1Proto.getDescriptor()));
+        assertEquals("Field unsigned_rec_no in message com.apple.foundationdb.record.unsigned.SimpleUnsignedRecord has illegal unsigned type UINT64", t.getMessage());
+        t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned2Proto.getDescriptor()));
+        assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.NestedWithUnsigned has illegal unsigned type UINT32", t.getMessage());
+        t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned3Proto.getDescriptor()));
+        assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.Fixed32UnsignedRecord has illegal unsigned type FIXED32", t.getMessage());
+        t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned4Proto.getDescriptor()));
+        assertEquals("Field unsigned_field in message com.apple.foundationdb.record.unsigned.Fixed64UnsignedRecord has illegal unsigned type FIXED64", t.getMessage());
+        t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(TestRecordsUnsigned5Proto.getDescriptor()));
+        assertEquals("Field unsigned_rec_no in message com.apple.foundationdb.record.unsigned.SimpleUnsignedRecord has illegal unsigned type UINT64", t.getMessage());
     }
 
     @Test
@@ -227,5 +213,15 @@ public class RecordMetaDataBuilderTest {
         t = assertThrows(MetaDataException.class, () ->
                 builder.getRecordMetaData().getIndex("MySimpleRecord$testIndex"));
         assertEquals("Index MySimpleRecord$testIndex not defined", t.getMessage());
+    }
+
+    @Test
+    public void badUnionFields() {
+        Throwable t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(TestRecordsBadUnion1Proto.getDescriptor()));
+        assertEquals("Union field not_a_record is not a message", t.getMessage());
+        t = assertThrows(MetaDataException.class, () ->
+                RecordMetaData.newBuilder().setRecords(TestRecordsBadUnion2Proto.getDescriptor()));
+        assertEquals("Union field _MySimpleRecord should not be repeated", t.getMessage());
     }
 }

--- a/fdb-record-layer-core/src/test/proto/test_records_bad_union_1.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_bad_union_1.proto
@@ -1,0 +1,29 @@
+/*
+ * test_records_bad_union_1.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.testBadUnion1;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecordsBadUnion1Proto";
+
+message RecordTypeUnion {
+  optional string not_a_record = 1;
+}

--- a/fdb-record-layer-core/src/test/proto/test_records_bad_union_2.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_bad_union_2.proto
@@ -1,0 +1,33 @@
+/*
+ * test_records_bad_union_2.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.testBadUnion2;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecordsBadUnion2Proto";
+
+message MySimpleRecord {
+  optional int64 rec_no = 1;
+}
+
+message RecordTypeUnion {
+  repeated MySimpleRecord _MySimpleRecord = 1;
+}


### PR DESCRIPTION
Note that the check isn't actually in the validator. It could be moved, but this puts it adjacent to another test with similar effects.