### PR TITLE
Resolves #242: TextCursors do not report metrics on keys read

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -299,8 +299,12 @@ public class FDBStoreTimer extends StoreTimer {
         SAVE_RECORD_KEY_BYTES("number of record key bytes saved", true),
         /** The size of values for record key-value pairs saved. */
         SAVE_RECORD_VALUE_BYTES("number of record value bytes saved", true),
+        /** The number of entries (e.g., key-value pairs or text index entries) loaded by a scan. */
+        LOAD_SCAN_ENTRY("number of entries loaded by some scan", false),
         /** The number of key-value pairs loaded by a range scan. */
         LOAD_KEY_VALUE("number of keys loaded", false),
+        /** The number of entries loaded when scanning a text index. */
+        LOAD_TEXT_ENTRY("number of text entries loaded", false),
         /** The number of record key-value pairs loaded. */
         LOAD_RECORD_KEY("number of record keys loaded", false),
         /** The size of keys for record key-value pairs loaded. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -150,6 +150,7 @@ public class KeyValueCursor implements BaseCursor<KeyValue> {
                 if (hasNext) {
                     KeyValue kv = iter.next();
                     if (context != null) {
+                        context.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
                         context.increment(FDBStoreTimer.Counts.LOAD_KEY_VALUE);
                     }
                     // Note that this mutates the pointer and NOT the array.


### PR DESCRIPTION
This adds an increment to the `LOAD_KEY_VALUE` metric when emitting a value. It also adds a test that attempts to limit a text query and checks that metric to verify that the limit is honored.

I think if there's something objectionable about this PR is that I didn't introduce a new metric (`LOAD_TEXT_ENTRY`?). In addition to not wanting to pollute the metrics with something weird like that, I feel like there should be some metric that is equal to whatever the scan limiter is limiting. I suppose that could be a different metric, and then we could keep `LOAD_KEY_VALUE` for, like, actually loading keys and values if want.