### PR TITLE
Merge 2.3.32 branch into master

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -371,6 +371,41 @@ public class RecordCursorTest {
         assertEquals(adjusted, pieces);
     }
 
+    private int iterateGrid(@Nonnull Function<byte[], RecordCursor<Pair<Integer, Integer>>> cursorFunction,
+                            @Nonnull RecordCursor.NoNextReason[] possibleNoNextReasons) {
+        int results = 0;
+        int leftSoFar = -1;
+        int rightSoFar = -1;
+        boolean done = false;
+        byte[] continuation = null;
+        while (!done) {
+            RecordCursor<Pair<Integer, Integer>> cursor = cursorFunction.apply(continuation);
+            while (cursor.hasNext()) {
+                Pair<Integer, Integer> value = cursor.next();
+                assertNotNull(value);
+                assertThat(value.getLeft(), greaterThan(value.getRight()));
+                assertThat(value.getLeft(), greaterThanOrEqualTo(leftSoFar));
+                if (value.getLeft() == leftSoFar) {
+                    assertThat(value.getRight(), greaterThan(rightSoFar));
+                    rightSoFar = value.getRight();
+                } else {
+                    leftSoFar = value.getLeft();
+                    rightSoFar = value.getRight();
+                }
+                results++;
+            }
+            assertThat(cursor.getNoNextReason(), isOneOf(possibleNoNextReasons));
+            continuation = cursor.getContinuation();
+            if (cursor.getNoNextReason().isSourceExhausted()) {
+                assertNull(continuation);
+                done = true;
+            } else {
+                assertNotNull(continuation);
+            }
+        }
+        return results;
+    }
+
     @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "pipelineWithInnerLimits [outOfBand = {0}]")
     public void pipelineWithInnerLimits(TestHelpers.BooleanEnum outOfBandEnum) throws InvalidProtocolBufferException {
@@ -396,35 +431,63 @@ public class RecordCursorTest {
         };
         final Function<byte[], RecordCursor<Integer>> outerFunc = continuation -> RecordCursor.fromList(ints, continuation);
 
-        byte[] continuation = null;
-        int results = 0;
-        int leftSoFar = -1;
-        int rightSoFar = -1;
-        do {
-            RecordCursor<Pair<Integer, Integer>> cursor = RecordCursor.flatMapPipelined(outerFunc, innerFunc, continuation, 5);
-            while (cursor.hasNext()) {
-                Pair<Integer, Integer> value = cursor.next();
-                assertNotNull(value);
-                assertThat(value.getLeft(), greaterThan(value.getRight()));
-                assertThat(value.getLeft(), greaterThanOrEqualTo(leftSoFar));
-                if (value.getLeft() == leftSoFar) {
-                    assertThat(value.getRight(), greaterThan(rightSoFar));
-                    rightSoFar = value.getRight();
-                } else {
-                    leftSoFar = value.getLeft();
-                    rightSoFar = value.getRight();
-                }
-                results++;
-            }
-            assertThat(cursor.getNoNextReason(), isOneOf(possibleNoNextReasons));
-            continuation = cursor.getContinuation();
-        } while (continuation != null);
-
+        int results = iterateGrid(continuation -> RecordCursor.flatMapPipelined(outerFunc, innerFunc, continuation, 5), possibleNoNextReasons);
         int expectedResults = ints.size() * (ints.size() - 1) / 2;
         assertEquals(expectedResults, results);
         assertEquals(ints.size() * ints.size(), timer.getCount(FDBStoreTimer.Counts.QUERY_FILTER_GIVEN));
         assertEquals(expectedResults, timer.getCount(FDBStoreTimer.Counts.QUERY_FILTER_PASSED));
         assertEquals(ints.size() * ints.size() - expectedResults, timer.getCount(FDBStoreTimer.Counts.QUERY_DISCARDED));
+    }
+
+    @EnumSource(TestHelpers.BooleanEnum.class)
+    @ParameterizedTest(name = "pipelineWithOuterLimits [outOfBand = {0}]")
+    public void pipelineWithOuterLimits(TestHelpers.BooleanEnum outOfBandEnum) throws InvalidProtocolBufferException {
+        final boolean outOfBand = outOfBandEnum.toBoolean();
+        final RecordCursor.NoNextReason[] possibleNoNextReasons = new RecordCursor.NoNextReason[]{
+                RecordCursor.NoNextReason.SOURCE_EXHAUSTED,
+                outOfBand ? RecordCursor.NoNextReason.TIME_LIMIT_REACHED : RecordCursor.NoNextReason.RETURN_LIMIT_REACHED
+        };
+        final List<Integer> ints = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        final BiFunction<Integer, byte[], RecordCursor<Pair<Integer, Integer>>> innerFunc = (x, continuation) -> {
+            final RecordCursor<Integer> intCursor = RecordCursor.fromList(ints, continuation);
+            final RecordCursor<Integer> limitedCursor;
+            if (outOfBand) {
+                limitedCursor = new FakeOutOfBandCursor<>(intCursor, 3);
+            } else {
+                limitedCursor = intCursor.limitRowsTo(3);
+            }
+            return limitedCursor.filter(y -> y < x).map(y -> Pair.of(x, y));
+        };
+        final Function<byte[], RecordCursor<Integer>> outerFunc = continuation -> {
+            final RecordCursor<Integer> intCursor = RecordCursor.fromList(ints, continuation);
+            final RecordCursor<Integer> limitedCursor;
+            if (outOfBand) {
+                limitedCursor = new FakeOutOfBandCursor<>(intCursor, 3);
+            } else {
+                limitedCursor = intCursor.limitRowsTo(3);
+            }
+            return limitedCursor.filterInstrumented(x -> x >= 7 && x < 9, timer, FDBStoreTimer.Counts.QUERY_FILTER_GIVEN, FDBStoreTimer.Events.QUERY_FILTER, FDBStoreTimer.Counts.QUERY_FILTER_PASSED, FDBStoreTimer.Counts.QUERY_DISCARDED);
+        };
+
+        int results = iterateGrid(continuation -> RecordCursor.flatMapPipelined(outerFunc, innerFunc, continuation, 5), possibleNoNextReasons);
+        assertEquals(15, results);
+
+        // Note that as only the outer filter is instrumented, these assertions are based on only the outer filter.
+        // Should be:
+        //  Itr 1: 0, 1, 2
+        //  Itr 2: 3, 4, 5
+        //  Itr 3: 6, 7 (0, 1, 2), 8
+        //  Itr 4: 7 (3, 4, 5), 8, 9
+        //  Itr 5: 7 (6, 7, 8), 8, 9
+        //  Itr 6: 7 (9), 8 (0, 1, 2), 9
+        //  Itr 7: 8 (3, 4, 5), 9
+        //  Itr 8: 8 (6, 7, 8), 9
+        //  Itr 9: 8 (9), 9
+        assertEquals(24, timer.getCount(FDBStoreTimer.Counts.QUERY_FILTER_GIVEN));
+        assertEquals(11, timer.getCount(FDBStoreTimer.Counts.QUERY_FILTER_PASSED));
+        assertEquals(13, timer.getCount(FDBStoreTimer.Counts.QUERY_DISCARDED));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionIntersectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionIntersectionTest.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBEvaluationContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
@@ -50,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -147,7 +149,7 @@ public class UnionIntersectionTest extends FDBRecordStoreTestBase {
 
     @Test
     public void intersectionReasons() throws Exception {
-        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> left = continuation -> scanRecordsBetween(10L, 20L, continuation);
+        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> left = continuation -> scanRecordsBetween(7L, 20L, continuation);
         final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> leftLimited = left.andThen(cursor -> new RecordCursorTest.FakeOutOfBandCursor<>(cursor, 3));
         final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> right = continuation -> scanRecordsBetween(12L, 15L, continuation);
         final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> rightLimited = right.andThen(cursor -> new RecordCursorTest.FakeOutOfBandCursor<>(cursor, 2));
@@ -156,6 +158,9 @@ public class UnionIntersectionTest extends FDBRecordStoreTestBase {
             FDBEvaluationContext<Message> evaluationContext = recordStore.emptyEvaluationContext();
 
             RecordCursor<FDBStoredRecord<Message>> cursor = IntersectionCursor.create(evaluationContext, comparisonKey, false, leftLimited, right, null);
+            assertEquals(Collections.emptyList(), cursor.map(this::storedRecordRecNo).asList().get());
+            assertEquals(RecordCursor.NoNextReason.TIME_LIMIT_REACHED, cursor.getNoNextReason());
+            cursor = IntersectionCursor.create(evaluationContext, comparisonKey, false, leftLimited, right, cursor.getContinuation());
             assertEquals(Arrays.asList(12L), cursor.map(this::storedRecordRecNo).asList().get());
             assertEquals(RecordCursor.NoNextReason.TIME_LIMIT_REACHED, cursor.getNoNextReason());
             cursor = IntersectionCursor.create(evaluationContext, comparisonKey, false, left, rightLimited, cursor.getContinuation());
@@ -165,6 +170,32 @@ public class UnionIntersectionTest extends FDBRecordStoreTestBase {
             assertEquals(Collections.emptyList(), cursor.map(this::storedRecordRecNo).asList().get());
             assertEquals(RecordCursor.NoNextReason.SOURCE_EXHAUSTED, cursor.getNoNextReason());
         }
+    }
+
+    @Test
+    public void nonIntersectingReasons() {
+        final List<Integer> leftList = Arrays.asList(0, 2, 4, 6);
+        final Function<byte[], RecordCursor<Integer>> left = continuation -> RecordCursor.fromList(leftList, continuation).limitRowsTo(1);
+        final List<Integer> rightList = Arrays.asList(1, 3, 5, 7);
+        final Function<byte[], RecordCursor<Integer>> right = continuation -> RecordCursor.fromList(rightList, continuation).limitRowsTo(1);
+
+        FDBStoreTimer timer = new FDBStoreTimer();
+        boolean done = false;
+        byte[] continuation = null;
+        List<Integer> results = new ArrayList<>();
+        while (!done) {
+            IntersectionCursor<Integer> intersectionCursor = IntersectionCursor.create(Collections::singletonList, false, left, right, continuation, timer);
+            while (intersectionCursor.hasNext()) {
+                results.add(intersectionCursor.next());
+            }
+            done = intersectionCursor.getNoNextReason().isSourceExhausted();
+            continuation = intersectionCursor.getContinuation();
+            if (!done) {
+                assertEquals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, intersectionCursor.getNoNextReason());
+            }
+        }
+        assertEquals(Collections.emptyList(), results);
+        System.out.println(timer.getKeysAndValues());
     }
 
     @Test


### PR DESCRIPTION
Nominally, this is to make sure the master version has two bug fixes to cursor continuation handling that were addressed in patches to 2.3.32. However, we all know the real reason is to increase the merge conflicts with #213.