### PR TITLE
Resolves #257: Non empty record store with no info header …

### DIFF
--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBuilder.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBuilder.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.API;
+import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
@@ -353,10 +354,10 @@ public abstract class FDBRecordStoreBuilder<M extends Message, R extends FDBReco
     @Nonnull
     public CompletableFuture<R> uncheckedOpenAsync() {
         final CompletableFuture<Void> preloadMetaData = preloadMetaData();
-        final CompletableFuture<Subspace> subspaceFuture = subspaceProvider.getSubspaceAsync();
         R recordStore = build();
-        final CompletableFuture<Void> loadStoreState = recordStore.preloadRecordStoreStateAsync();
-        return CompletableFuture.allOf(preloadMetaData, subspaceFuture, loadStoreState).thenApply(vignore -> recordStore);
+        final CompletableFuture<Void> subspaceFuture = recordStore.preloadSubspaceAsync();
+        final CompletableFuture<Void> loadStoreState = subspaceFuture.thenCompose(vignore -> recordStore.preloadRecordStoreStateAsync());
+        return CompletableFuture.allOf(preloadMetaData, loadStoreState).thenApply(vignore -> recordStore);
     }
 
     private CompletableFuture<Void> preloadMetaData() {
@@ -367,19 +368,41 @@ public abstract class FDBRecordStoreBuilder<M extends Message, R extends FDBReco
         }
     }
 
+    /**
+     * Synchronous version of {@link #createAsync}.
+     * @return a newly created record store
+     */
     @Nonnull
     public R create() {
         return context.asyncToSync(FDBStoreTimer.Waits.WAIT_CHECK_VERSION, createAsync());
     }
 
+    /**
+     * Synchronous version of {@link #openAsync}.
+     * @return an open record store
+     */
     @Nonnull
     public R open() {
         return context.asyncToSync(FDBStoreTimer.Waits.WAIT_CHECK_VERSION, openAsync());
     }
 
+    /**
+     * Synchronous version of {@link #createOrOpenAsync()}.
+     * @return an open record store
+     */
     @Nonnull
     public R createOrOpen() {
         return context.asyncToSync(FDBStoreTimer.Waits.WAIT_CHECK_VERSION, createOrOpenAsync());
+    }
+
+    /**
+     * Synchronous version of {@link #createOrOpenAsync(FDBRecordStoreBase.StoreExistenceCheck)}.
+     * @param existenceCheck whether the store must already exist
+     * @return an open record store
+     */
+    @Nonnull
+    public R createOrOpen(@Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_CHECK_VERSION, createOrOpenAsync(existenceCheck));
     }
 
     /**
@@ -408,7 +431,7 @@ public abstract class FDBRecordStoreBuilder<M extends Message, R extends FDBReco
      */
     @Nonnull
     public CompletableFuture<R> createOrOpenAsync() {
-        return createOrOpenAsync(FDBRecordStoreBase.StoreExistenceCheck.NONE);
+        return createOrOpenAsync(FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NO_INFO_AND_NOT_EMPTY);
     }
 
     /**
@@ -418,14 +441,14 @@ public abstract class FDBRecordStoreBuilder<M extends Message, R extends FDBReco
      */
     @Nonnull
     public CompletableFuture<R> createOrOpenAsync(@Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck) {
-        // Might be as many as three reads: meta-data store, store index state, store info header. Try to do them in parallel.
+        // Might be as many as four reads: meta-data store, keyspace path, store index state, store info header.
+        // Try to do them as much in parallel as possible.
         final CompletableFuture<Void> preloadMetaData = preloadMetaData();
-        final CompletableFuture<Subspace> subspaceFuture = subspaceProvider.getSubspaceAsync();
         R recordStore = build();
-        final CompletableFuture<Void> loadStoreState = recordStore.preloadRecordStoreStateAsync();
-        final CompletableFuture<byte[]> loadStoreInfo = recordStore.readStoreInfo();
-        final CompletableFuture<byte[]> combinedFuture = CompletableFuture.allOf(preloadMetaData, subspaceFuture,
-                loadStoreState).thenCombine(loadStoreInfo, (v, b) -> b);
+        final CompletableFuture<Void> subspaceFuture = recordStore.preloadSubspaceAsync();
+        final CompletableFuture<Void> loadStoreState = subspaceFuture.thenCompose(vignore -> recordStore.preloadRecordStoreStateAsync());
+        final CompletableFuture<KeyValue> loadStoreInfo = subspaceFuture.thenCompose(vignore -> recordStore.readStoreFirstKey());
+        final CompletableFuture<KeyValue> combinedFuture = CompletableFuture.allOf(preloadMetaData, loadStoreState).thenCombine(loadStoreInfo, (v, kv) -> kv);
         final CompletableFuture<Boolean> checkVersion = recordStore.checkVersion(combinedFuture, userVersionChecker, existenceCheck);
         return checkVersion.thenApply(vignore -> recordStore);
     }

--- a/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/RecordStoreNoInfoAndNotEmptyException.java
+++ b/fdb-record-layer-core/src/com/apple/foundationdb/record/provider/foundationdb/RecordStoreNoInfoAndNotEmptyException.java
@@ -1,0 +1,40 @@
+/*
+ * RecordStoreNoInfoAndNotEmptyException.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.RecordCoreStorageException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Exception thrown when {@link FDBRecordStoreBuilder#createOrOpen} is called, and the record store does
+ * not have a store info header, but does have something else.
+ * @see FDBRecordStoreBase.StoreExistenceCheck#ERROR_IF_NO_INFO_AND_NOT_EMPTY
+ */
+@SuppressWarnings("serial")
+@API(API.Status.STABLE)
+public class RecordStoreNoInfoAndNotEmptyException extends RecordCoreStorageException {
+    public RecordStoreNoInfoAndNotEmptyException(@Nonnull String msg, @Nullable Object ... keyValues) {
+        super(msg, keyValues);
+    }
+}

--- a/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/test/unit/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -187,7 +187,7 @@ public class OnlineIndexerTest {
         FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
                 .setMetaDataProvider(metaData).setContext(context).setSubspace(subspace);
         if (checked) {
-            recordStore = builder.createOrOpen();
+            recordStore = builder.createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
         } else {
             recordStore = builder.uncheckedOpen();
         }


### PR DESCRIPTION
… should be an error by default

Also fixes #258: FDBRecordStoreBuilder.createOrOpenAsync could block for keyspace path, which I saw when I went to change `checkVersion`.

Note targeted at 2.3.32.