### PR TITLE
Resolves #59: Apply stability annotations to *.cursors packages.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
@@ -265,6 +265,7 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
      * @see RecordCursorContinuation
      */
     @Nonnull
+    @API(API.Status.EXPERIMENTAL)
     CompletableFuture<RecordCursorResult<T>> onNext();
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/BaseCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/BaseCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 
 /**
@@ -30,5 +31,6 @@ import com.apple.foundationdb.record.RecordCursor;
  * @see CursorLimitManager
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public interface BaseCursor<T> extends RecordCursor<T> {
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -37,6 +38,7 @@ import java.util.function.Function;
  * A cursor that produces items by applying a given function to the previous item.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class ChainedCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final Function<Optional<T>, CompletableFuture<Optional<T>>> nextGenerator;
@@ -72,6 +74,7 @@ public class ChainedCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         return nextGenerator.apply(lastValue).thenApply(nextValue -> {
             if (nextValue.isPresent()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordScanLimiter;
@@ -48,6 +49,7 @@ import java.util.Optional;
  * and {@link IntersectionCursor}) can always make progress. This "free
  * initial pass" is provided per cursor, not per limit: all out-band-limits share the same initial pass.
  */
+@API(API.Status.UNSTABLE)
 public class CursorLimitManager {
     @Nullable
     private final RecordScanLimiter recordScanLimiter;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/EmptyCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/EmptyCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executor;
  * A {@link RecordCursor} that always returns zero items.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class EmptyCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final Executor executor;
@@ -44,6 +46,7 @@ public class EmptyCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         return CompletableFuture.completedFuture(RecordCursorResult.exhausted());
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FilterCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FilterCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -37,6 +38,7 @@ import java.util.function.Function;
  * A cursor that filters elements using a predicate.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class FilterCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final RecordCursor<T> inner;
@@ -58,6 +60,7 @@ public class FilterCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         mayGetContinuation = false;
         return AsyncUtil.whileTrue(() -> inner.onNext().thenApply(innerResult -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.RecordCursor;
@@ -52,6 +53,7 @@ import java.util.function.Function;
  * @param <T> the type of elements of the source cursor
  * @param <V> the type of elements of the cursor produced by the function
  */
+@API(API.Status.MAINTAINED)
 public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
     @Nonnull
     private final RecordCursor<T> outerCursor;
@@ -107,6 +109,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<V>> onNext() {
         mayGetContinuation = false;
         return AsyncUtil.whileTrue(this::tryToFillPipeline, getExecutor()).thenApply(vignore -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FutureCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FutureCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
@@ -36,6 +37,7 @@ import java.util.concurrent.Executor;
  * A cursor that returns a single element when a future completes.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class FutureCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final Executor executor;
@@ -61,6 +63,7 @@ public class FutureCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         if (done) {
             nextResult = RecordCursorResult.exhausted();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IllegalContinuationAccessChecker.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IllegalContinuationAccessChecker.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreException;
 
 /**
@@ -29,6 +30,7 @@ import com.apple.foundationdb.record.RecordCoreException;
  *
  * The check can be enabled / disabled globally.
  */
+@API(API.Status.EXPERIMENTAL)
 public class IllegalContinuationAccessChecker {
     private static boolean shouldCheckContinuationAccess = true;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IteratorCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IteratorCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
@@ -36,9 +37,11 @@ import java.util.concurrent.Executor;
 /**
  * A cursor that returns the elements of an ordinary synchronous iterator.
  * While it supports continuation, resuming an iterator cursor with a continuation is very inefficient since it needs to
- * advance the underlying iterator up to the point that stopped.
+ * advance the underlying iterator up to the point that stopped. For that reason, the {@link ListCursor} should be used
+ * instead where possible.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class IteratorCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final Executor executor;
@@ -62,6 +65,7 @@ public class IteratorCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         boolean hasNext = iterator.hasNext();
         mayGetContinuation = !hasNext;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/LazyCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/LazyCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -47,6 +48,7 @@ import java.util.concurrent.Executor;
  * about the state of the cursor until <code>onHasNext()</code> has been called.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class LazyCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final CompletableFuture<RecordCursor<T>> futureCursor;
@@ -80,6 +82,7 @@ public class LazyCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         if (inner == null) {
             return futureCursor.thenAccept(cursor -> inner = cursor).thenCompose(vignore -> this.onNext());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ListCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ListCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -38,6 +39,7 @@ import java.util.concurrent.ForkJoinPool;
  * A cursor that returns the elements of a list.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class ListCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final Executor executor;
@@ -62,6 +64,7 @@ public class ListCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         if (nextPosition < list.size()) {
             nextResult = RecordCursorResult.withNextValue(list.get(nextPosition), new Continuation(nextPosition + 1, list.size()));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
@@ -36,6 +37,7 @@ import java.util.function.Function;
  * @param <T> the type of elements of the source cursor
  * @param <V> the type of elements of the cursor after applying the function
  */
+@API(API.Status.MAINTAINED)
 public class MapCursor<T, V> implements RecordCursor<V> {
     @Nonnull
     private final RecordCursor<T> inner;
@@ -56,6 +58,7 @@ public class MapCursor<T, V> implements RecordCursor<V> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<V>> onNext() {
         mayGetContinuation = false;
         return inner.onNext().thenApply(result -> result.map(func))

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
@@ -47,6 +48,7 @@ import java.util.function.Function;
  * @param <T> the type of elements of the source cursor
  * @param <V> the type of elements of the cursor after applying the function and completing the future it returns
  */
+@API(API.Status.MAINTAINED)
 public class MapPipelinedCursor<T, V> implements RecordCursor<V> {
     @Nonnull
     private final RecordCursor<T> inner;
@@ -79,6 +81,7 @@ public class MapPipelinedCursor<T, V> implements RecordCursor<V> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<V>> onNext() {
         mayGetContinuation = false;
         return AsyncUtil.whileTrue(this::tryToFillPipeline, getExecutor())

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapWhileCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapWhileCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -40,6 +41,7 @@ import java.util.function.Function;
  * @param <T> the type of elements of the source cursor
  * @param <V> the type of elements of the cursor after applying the function
  */
+@API(API.Status.MAINTAINED)
 public class MapWhileCursor<T, V> implements RecordCursor<V> {
     /**
      * What to return for {@link #getContinuation()} after stopping.
@@ -82,6 +84,7 @@ public class MapWhileCursor<T, V> implements RecordCursor<V> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<V>> onNext() {
         return inner.onNext().thenApply(innerResult -> {
             if (!innerResult.hasNext()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/OrElseCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/OrElseCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
@@ -35,6 +36,7 @@ import java.util.function.Function;
  * A cursor that returns the elements of one cursor followed by the elements of another cursor if the first was empty.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class OrElseCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final RecordCursor<T> inner;
@@ -62,6 +64,7 @@ public class OrElseCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         if (first) {
             return inner.onNext().thenCompose(result -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RowLimitedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RowLimitedCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executor;
  * A cursor that limits the number of elements that it allows through.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class RowLimitedCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final RecordCursor<T> inner;
@@ -57,6 +59,7 @@ public class RowLimitedCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         if (limitReached()) {
             mayGetContinuation = true;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/SkipCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/SkipCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -35,6 +36,7 @@ import java.util.concurrent.Executor;
  * A cursor that skips a specified number of initial elements.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.MAINTAINED)
 public class SkipCursor<T> implements RecordCursor<T> {
     @Nonnull
     private final RecordCursor<T> inner;
@@ -55,6 +57,7 @@ public class SkipCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         if (skipRemaining <= 0) {
             return inner.onNext().thenApply(result -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/TimeLimitedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/TimeLimitedCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -40,6 +41,7 @@ import java.util.concurrent.Executor;
  * deprecated {@link #limitTimeTo(long)} methods.
  * @param <T> the type of elements of the cursor
  */
+@API(API.Status.DEPRECATED)
 public class TimeLimitedCursor<T> implements RecordCursor<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(TimeLimitedCursor.class);
 
@@ -71,6 +73,7 @@ public class TimeLimitedCursor<T> implements RecordCursor<T> {
 
     @Nonnull
     @Override
+    @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
         if (timedOutResult != null) {
             nextResult = timedOutResult;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBEvaluationContext;
@@ -41,6 +42,7 @@ import java.util.function.Function;
  * @param <T> the type of elements returned by the cursor
  * @see IntersectionMultiCursor
  */
+@API(API.Status.MAINTAINED)
 public class IntersectionCursor<T> extends IntersectionCursorBase<T, T> {
 
     private IntersectionCursor(@Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 
@@ -37,6 +38,7 @@ import java.util.function.Function;
  * @param <T> the type of elements returned by the child cursors
  * @see IntersectionCursor
  */
+@API(API.Status.EXPERIMENTAL)
 public class IntersectionMultiCursor<T> extends IntersectionCursorBase<T, List<T>> {
 
     private IntersectionMultiCursor(@Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/KeyComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/KeyComparisons.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
 import java.util.Comparator;
@@ -28,6 +29,7 @@ import java.util.List;
 /**
  * {@link Comparator}s for key expressions.
  */
+@API(API.Status.MAINTAINED)
 public class KeyComparisons {
     @SuppressWarnings("unchecked")
     public static final Comparator<Object> FIELD_COMPARATOR = (o1, o2) ->  {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -40,6 +41,7 @@ import java.util.function.Function;
  * A cursor that implements a union of all the records from a set of cursors all of whom are ordered compatibly.
  * @param <T> the type of elements returned by the cursor
  */
+@API(API.Status.MAINTAINED)
 public class UnionCursor<T> extends UnionCursorBase<T> {
     @Nonnull
     private final Function<? super T, ? extends List<Object>> comparisonKeyFunction;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
-import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
@@ -63,7 +62,6 @@ import java.util.stream.Collectors;
  *
  * @param <T> the type of elements returned by each child cursor
  */
-@API(API.Status.INTERNAL)
 abstract class UnionCursorBase<T> implements RecordCursor<T> {
     @Nonnull
     private final List<CursorState<T>> cursorStates;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -45,6 +46,7 @@ import java.util.function.Function;
  *
  * @param <T> the type of elements returned by the cursor
  */
+@API(API.Status.EXPERIMENTAL)
 public class UnorderedUnionCursor<T> extends UnionCursorBase<T> {
 
     protected UnorderedUnionCursor(@Nonnull List<CursorState<T>> cursorStates,


### PR DESCRIPTION
Apply API stability annotations to public classes in the packages:
```
com.apple.foundationdb.record.cursors
com.apple.foundationdb.record.provider.foundationdb.cursors
```
I also marked all of the implementations of the new `RecordCursor.onNext()` methods (introduced in #213) as `EXPERIMENTAL` since they're brand new.

Generally, I marked cursors `STABLE`, except where they were new and specialized (like `UnorderedUnionCursor` and `IntersectionMultiCursor`), in which case they were marked `EXPERIMENTAL` or quasi-deprecated (like `TimeLimitedCursor`), in which case they were marked `DEPRECATED`.

I'd be willing to change the general annotation to something like `MAINTAINED` or even `UNSTABLE`, since what's really important is that the `RecordCursor` API and various functions on the cursor algebra (also in `RecordCursor`) are stable. Then again, it's pretty important that cursors don't randomly change their contracts and we've always aimed for backwards compatibility.