### PR TITLE
 Resolves #262: Detect blocking calls in an asynchronous context

### DIFF
--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -66,6 +66,14 @@ test {
             excludeTags 'Slow'
         }
 
+        // Configure whether or not tests will validate that asyncToSync isn't being called in async
+        // context.  See BlockingInAsyncDetection class for details on values.
+        def blockingDetection = "IGNORE_COMPLETE_EXCEPTION_BLOCKING"
+        if (System.getenv('BLOCKING_DETECTION') != null) {
+            blockingDetection = System.getenv('BLOCKING_DETECTION')
+        } 
+        systemProperties = [ "com.apple.foundationdb.record.blockingInAsyncDetection": blockingDetection ]
+
         // We need the destructive tests to be available in the 'test' task, so that IntelliJ's gradle test runner can
         // find them. However, we _only_ want to run them as part of the 'test' task if we're running from IntelliJ.
         // This isn't a great way to detect it, but it's the only one I could find. If this ever breaks, I'd look here first.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
@@ -1,0 +1,93 @@
+/*
+ * BlockingInAsyncDetection.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.API;
+
+/**
+ * Indicates whether <code>FDBDatabase.asyncToSync()</code> or <code>FDBRecordContext.asyncToSync()</code> should
+ * attempt to detect when it is being called from an asynchronous context and, if so, how it should react to this fact.
+ * WHen it is detected that <code>asyncToSync</code> is being called in an asynchronous context, there are two
+ * scenarios that need to be dealt with:
+ * <ul>
+ *     <li><b>Completed future</b> - the future that was to be waited on is completed. In some code this is
+ *       normal expected behavior; some prior logic ensured that the future was completed and subsequent calls
+ *       just "know" they won't block.  Of course, it is possible that there is no such logic and the
+ *       future was simply accidentally completed.  As a result there are two options for dealing with
+ *       the presence of such completed futures: <code>IGNORE_COMPLETE</code> (silently ignore) or
+ *       <code>WARN_COMPLETE</code> (log a warning).</li>
+ *     <li><b>Non-complete future</b> - the future that was to be waited on is not complete. There is (typically) no
+ *       circumstance in which this is acceptable, so the options to react to this scenario are
+ *       <code>EXCEPTION_BLOCKING</code> (throw an exception) or <code>WARN_BLOCKING</code> (log a warning).</li>
+ * </ul>
+ */
+@API(API.Status.EXPERIMENTAL)
+public enum BlockingInAsyncDetection {
+    /**
+     * The detection of blocking in an asynchronous context is disabled.
+     */
+    DISABLED(true, false),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
+     * block, an exception will be thrown.
+     */
+    IGNORE_COMPLETE_EXCEPTION_BLOCKING(true, true),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
+     * block an exception will be thrown, however if the future is complete then a warning will be logged.
+     */
+    WARN_COMPLETE_EXCEPTION_BLOCKING(false, true),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
+     * block, a warning is logged.
+     */
+    IGNORE_COMPLETE_WARN_BLOCKING(true, false),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context a warning is logged.
+     */
+    WARN_COMPLETE_WARN_BLOCKING(false, false)
+    ;
+
+    private final boolean ignoreComplete;
+    private final boolean throwExceptionOnBlocking;
+
+    private BlockingInAsyncDetection(boolean ignoreComplete, boolean throwException) {
+        this.ignoreComplete = ignoreComplete;
+        this.throwExceptionOnBlocking = throwException;
+    }
+
+    /**
+     * Indicates how to react if the future passed into <code>asyncToSync()</code> was completed.
+     *
+     * @return true if completed futures should be ignored, false indicates that a warning will be logged.
+     */
+    public boolean ignoreComplete() {
+        return ignoreComplete;
+    }
+
+    public boolean throwExceptionOnBlocking() {
+        return throwExceptionOnBlocking;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncException.java
@@ -1,0 +1,33 @@
+/*
+ * BlockingInAsyncException.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.RecordCoreException;
+
+/**
+ * Exception thrown when <code>asyncToSync</code> detects that it is being called from within an asynchronous context.
+ */
+@SuppressWarnings("serial")
+public class BlockingInAsyncException extends RecordCoreException {
+    public BlockingInAsyncException(String message, Throwable location) {
+        super(message, location);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -723,11 +723,42 @@ public class FDBDatabase {
         }
     }
 
+    /**
+     * Join a future, following the same logic that asyncToSync uses to validate that the operation isn't blocking
+     * in an asynchronous context.
+     *
+     * @param future the future to be completed
+     * @param <T> the type of the value produced by the future
+     * @return the result value
+     */
+    public <T> T join(CompletableFuture<T> future) {
+        checkIfBlockingInAsync(future);
+        return future.join();
+    }
+
+    /**
+     * Get a future, following the same logic that asyncToSync uses to validate that the operation isn't blocking
+     * in an asynchronous context.
+     *
+     * @param future the future to be completed
+     * @param <T> the type of the value produced by the future
+     * @return the result value
+     *
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws ExecutionException if the future completed exceptionally
+     * @throws InterruptedException if the current thread was interrupted
+     */
+    public <T> T get(CompletableFuture<T> future) throws InterruptedException, ExecutionException {
+        checkIfBlockingInAsync(future);
+        return future.get();
+    }
+
     @API(API.Status.INTERNAL)
     public BlockingInAsyncDetection getBlockingInAsyncDetection() {
         return blockingInAsyncDetectionSupplier.get();
     }
 
+    @API(API.Status.INTERNAL)
     private void checkIfBlockingInAsync(CompletableFuture<?> future) {
         BlockingInAsyncDetection behavior = getBlockingInAsyncDetection();
         if (behavior == BlockingInAsyncDetection.DISABLED) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -758,7 +758,6 @@ public class FDBDatabase {
         return blockingInAsyncDetectionSupplier.get();
     }
 
-    @API(API.Status.INTERNAL)
     private void checkIfBlockingInAsync(CompletableFuture<?> future) {
         BlockingInAsyncDetection behavior = getBlockingInAsyncDetection();
         if (behavior == BlockingInAsyncDetection.DISABLED) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -45,8 +45,6 @@ import java.util.function.Supplier;
 public class FDBDatabaseFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabaseFactory.class);
 
-    public static final String BLOCKING_IN_ASYNC_PROPERTY = "com.apple.foundationdb.record.blockingInAsyncDetection";
-
     @Nonnull
     private static final FDBDatabaseFactory INSTANCE = new FDBDatabaseFactory();
 
@@ -80,7 +78,7 @@ public class FDBDatabaseFactory {
      * (such as by request) using {@link #setTransactionIsTracedSupplier(Supplier)}.
      */
     private Supplier<Boolean> transactionIsTracedSupplier = LOGGER::isTraceEnabled;
-    private Supplier<BlockingInAsyncDetection> blockingInAsyncDetectionSupplier = getDefaultBlockInAsyncDetection();
+    private Supplier<BlockingInAsyncDetection> blockingInAsyncDetectionSupplier = () -> BlockingInAsyncDetection.DISABLED;
 
     private final Map<String, FDBDatabase> databases = new HashMap<>();
 
@@ -401,17 +399,4 @@ public class FDBDatabaseFactory {
     public synchronized FDBDatabase getDatabase() {
         return getDatabase(null);
     }
-
-    private static Supplier<BlockingInAsyncDetection> getDefaultBlockInAsyncDetection() {
-        final String str = System.getProperty(BLOCKING_IN_ASYNC_PROPERTY);
-        if (str != null) {
-            try {
-                return () -> BlockingInAsyncDetection.valueOf(str);
-            } catch (Exception e) {
-                System.err.println("Illegal value provided for " + BLOCKING_IN_ASYNC_PROPERTY + ": " + str);
-            }
-        }
-        return () -> BlockingInAsyncDetection.DISABLED;
-    }
-
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -304,6 +304,34 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         return database.asyncToSync(timer, event, async);
     }
 
+    /**
+     * Join a future, following the same logic that asyncToSync uses to validate that the operation isn't blocking
+     * in an asynchronous context.
+     *
+     * @param future the future to be completed
+     * @param <T> the type of the value produced by the future
+     * @return the result value
+     */
+    public <T> T join(CompletableFuture<T> future) {
+        return database.join(future);
+    }
+
+    /**
+     * Get a future, following the same logic that asyncToSync uses to validate that the operation isn't blocking
+     * in an asynchronous context.
+     *
+     * @param future the future to be completed
+     * @param <T> the type of the value produced by the future
+     * @return the result value
+     *
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws ExecutionException if the future completed exceptionally
+     * @throws InterruptedException if the current thread was interrupted
+     */
+    public <T> T get(CompletableFuture<T> future) throws InterruptedException, ExecutionException {
+        return database.get(future);
+    }
+
     public void timeReadSampleKey(byte[] key) {
         if (timer != null) {
             CompletableFuture<byte[]> future = instrument(FDBStoreTimer.Events.READ_SAMPLE_KEY,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1805,8 +1805,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     CompletableFuture<Optional<Range>> builtFuture = firstUnbuiltRange(index);
                     CompletableFuture<Optional<RecordIndexUniquenessViolation>> uniquenessFuture = scanUniquenessViolations(index, 1).first();
                     return CompletableFuture.allOf(builtFuture, uniquenessFuture).thenApply(vignore -> {
-                        Optional<Range> firstUnbuilt = builtFuture.join();
-                        Optional<RecordIndexUniquenessViolation> uniquenessViolation = uniquenessFuture.join();
+                        Optional<Range> firstUnbuilt = context.join(builtFuture);
+                        Optional<RecordIndexUniquenessViolation> uniquenessViolation = context.join(uniquenessFuture);
                         if (firstUnbuilt.isPresent()) {
                             throw new IndexNotBuiltException("Attempted to make unbuilt index readable" , firstUnbuilt.get(),
                                     LogMessageKeys.INDEX_NAME, index.getName(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
@@ -227,7 +227,7 @@ public class FDBReverseDirectoryCache {
 
                     LOGGER.warn(KeyValueLogMessage.of("Value not found in reverse directory cache, need to scan",
                             "provided_key", scopedReverseDirectoryKey,
-                            "subspace", reverseCacheSubspaceFuture.join()));
+                            "subspace", context.join(reverseCacheSubspaceFuture)));
                     final Subspace subdirs = scopedReverseDirectoryKey.getScope().getMappingSubspace();
 
                     return context.instrument(FDBStoreTimer.DetailEvents.RD_CACHE_DIRECTORY_SCAN, findNameForKey(context, subdirs, null, scopedReverseDirectoryKey))

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link FDBDatabaseRunner}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBDatabaseRunnerTest {
+public class FDBDatabaseRunnerTest extends FDBTestBase {
 
     private static final Object[] PATH_OBJECTS = {"record-test", "unit"};
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBDatabase}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBDatabaseTest {
+public class FDBDatabaseTest extends FDBTestBase {
 
     private static final Object[] PATH_OBJECTS = {"record-test", "unit"};
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBMetaDataStore}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBMetaDataStoreTest {
+public class FDBMetaDataStoreTest extends FDBTestBase {
     FDBDatabase fdb;
     FDBMetaDataStore metaDataStore;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
@@ -65,7 +65,7 @@ import java.util.function.Function;
  */
 @Tag(Tags.RequiresFDB)
 @Tag(Tags.Performance)
-public class FDBRecordStorePerformanceTest {
+public class FDBRecordStorePerformanceTest extends FDBTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBRecordStorePerformanceTest.class);
 
     static class DatabaseParameters {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Base class for tests for {@link FDBRecordStore}.
  */
-public abstract class FDBRecordStoreTestBase {
+public abstract class FDBRecordStoreTestBase extends FDBTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBRecordStoreTestBase.class);
 
     private static final Object[] PATH_OBJECTS = new Object[]{"record-test", "unit", "recordStore"};

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -78,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link FDBReverseDirectoryCache}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBReverseDirectoryCacheTest {
+public class FDBReverseDirectoryCacheTest extends FDBTestBase {
 
     private static final Logger logger = LoggerFactory.getLogger(FDBReverseDirectoryCacheTest.class);
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
@@ -1,0 +1,52 @@
+/*
+ * FDBTestBase.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class from which all FDB tests should be derived.
+ */
+public abstract class FDBTestBase {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBTestBase.class);
+
+    public static final String BLOCKING_IN_ASYNC_PROPERTY = "com.apple.foundationdb.record.blockingInAsyncDetection";
+
+    @BeforeAll
+    public static void setupBlockingInAsyncDetection() {
+        final String str = System.getProperty(BLOCKING_IN_ASYNC_PROPERTY);
+        if (str != null) {
+            final BlockingInAsyncDetection detection;
+            try {
+                detection = BlockingInAsyncDetection.valueOf(str);
+            } catch (Exception e) {
+                LOGGER.error("Illegal value provided for " + BLOCKING_IN_ASYNC_PROPERTY + ": " + str);
+                return;
+            }
+            FDBDatabaseFactory.instance().setBlockingInAsyncDetection(detection);
+            if (detection != BlockingInAsyncDetection.DISABLED) {
+                LOGGER.info("Blocking-in-async is " + detection);
+            }
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStoreTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBTypedRecordStore}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBTypedRecordStoreTest {
+public class FDBTypedRecordStoreTest extends FDBTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBTypedRecordStoreTest.class);
 
     FDBDatabase fdb;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * Tests for {@link KeyValueCursor}.
  */
 @Tag(Tags.RequiresFDB)
-public class KeyValueCursorTest {
+public class KeyValueCursorTest extends FDBTestBase {
     private FDBDatabase fdb;
     private Subspace subspace;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Test use of {@code oneof} to define the union message.
  */
 @Tag(Tags.RequiresFDB)
-public class OneOfTest {
+public class OneOfTest extends FDBTestBase {
 
     private static final Object[] PATH = { "record-test", "unit", "recordStore" };
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -110,7 +110,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link OnlineIndexer}.
  */
 @Tag(Tags.RequiresFDB)
-public class OnlineIndexerTest {
+public class OnlineIndexerTest extends FDBTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerTest.class);
 
     private RecordMetaData metaData;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
@@ -102,7 +102,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@code VERSION} type indexes.
  */
 @Tag(Tags.RequiresFDB)
-public class VersionIndexTest {
+public class VersionIndexTest extends FDBTestBase {
     private static final byte VERSIONSTAMP_CODE = Tuple.from(Versionstamp.complete(new byte[10])).pack()[0];
 
     private RecordMetaData metaData;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.cursors;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorTest;
 import com.apple.foundationdb.record.cursors.FirableCursor;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * makes almost no guarantees about the order in which things come in.
  */
 @Tag(Tags.RequiresFDB)
-public class UnorderedUnionCursorTest {
+public class UnorderedUnionCursorTest extends FDBTestBase {
 
     @Nonnull
     private <T> List<Function<byte[], RecordCursor<T>>> functionsFromLists(@Nonnull List<List<T>> lists) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
 import com.apple.foundationdb.tuple.Tuple;
@@ -84,7 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link KeySpaceDirectory}.
  */
 @Tag(Tags.RequiresFDB)
-public class KeySpaceDirectoryTest {
+public class KeySpaceDirectoryTest extends FDBTestBase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeySpaceDirectoryTest.class);
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver.LocatableResolverLockedException;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.PreWriteCheck;
@@ -94,7 +95,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Tag(Tags.WipesFDB)
 @Tag(Tags.RequiresFDB)
-public abstract class LocatableResolverTest {
+public abstract class LocatableResolverTest extends FDBTestBase {
     protected FDBDatabase database;
     protected LocatableResolver globalScope;
     protected BiFunction<FDBRecordContext, KeySpacePath, LocatableResolver> scopedDirectoryGenerator;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverCreateHooksTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverCreateHooksTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.PreWriteCheck;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
 import com.apple.foundationdb.tuple.Tuple;
@@ -41,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.RequiresFDB)
-class ResolverCreateHooksTest {
+class ResolverCreateHooksTest extends FDBTestBase {
     private FDBDatabase database;
     private KeySpace keySpace;
     private final Random random = new Random();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
@@ -50,7 +51,7 @@ import static org.hamcrest.Matchers.not;
  * Tests for {@link ResolverMappingDigest}.
  */
 @Tag(Tags.RequiresFDB)
-public class ResolverMappingDigestTest {
+public class ResolverMappingDigestTest extends FDBTestBase {
     private FDBDatabase database;
     private Random random = new Random();
     private KeySpace keySpace;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
@@ -55,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link ResolverMappingReplicator}.
  */
 @Tag(Tags.RequiresFDB)
-public abstract class ResolverMappingReplicatorTest {
+public abstract class ResolverMappingReplicatorTest extends FDBTestBase {
     protected LocatableResolver primary;
     protected LocatableResolver replica;
     protected FDBDatabase database;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/HighContentionAllocatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/HighContentionAllocatorTest.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpace;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
@@ -62,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.RequiresFDB)
-class HighContentionAllocatorTest {
+class HighContentionAllocatorTest extends FDBTestBase {
     private FDBDatabase database;
     private KeySpace keySpace;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayerTest.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverResult;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
@@ -60,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.RequiresFDB)
-class StringInterningLayerTest {
+class StringInterningLayerTest extends FDBTestBase {
     private FDBDatabase database;
     private Subspace testSubspace = new Subspace(Tuple.from("test-interning"));
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -49,6 +49,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.query.RecordQuery;
@@ -88,7 +89,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@code TIME_WINDOW_LEADERBOARD} indexes.
  */
 @Tag(Tags.RequiresFDB)
-public class LeaderboardIndexTest {
+public class LeaderboardIndexTest extends FDBTestBase {
     FDBDatabase fdb;
     FDBStoreTimer metrics;
     private static int oldMaxAttempts;


### PR DESCRIPTION
See comments on the individual commits for details there.

Note that there is still a lot of code that directly calls `join()` or `get()`.  Also, when I enable the logging of warnings when `asyncToSync()` is called on a completed future, I see a few places that might be suspect...for example, `FDBRecordContext.commitAsync()` attempts to complete the version future.