### PR TITLE
Resolves #3: Use evolved meta-data file descriptor to build meta-data

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.provider.common.DynamicMessageRecordSeriali
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.subspace.Subspace;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -106,7 +107,12 @@ public class FDBRecordStore extends FDBRecordStoreBase<Message> {
         @Override
         @Nonnull
         public Builder setMetaDataProvider(@Nullable RecordMetaDataProvider metaDataProvider) {
-            super.setMetaDataProvider(metaDataProvider);
+            return setMetaDataProvider(metaDataProvider, null);
+        }
+
+        @Nonnull
+        public Builder setMetaDataProvider(@Nullable RecordMetaDataProvider metaDataProvider, @Nullable Descriptors.FileDescriptor evolvedMetaDataFileDescriptor) {
+            super.setMetaDataProvider(metaDataProvider, evolvedMetaDataFileDescriptor);
             return this;
         }
 


### PR DESCRIPTION
Storing a record to a record store used to fail, if the record's meta-data was an evolved version of
the record store's meta-data shared using a meta-data store. This change should fix the issue by
passing the evolved meta-data to the builder.

Testing: ran FDBRecordStoreTest and RecordMetaDataBuilderTest