### PR TITLE
Resolves #293: Add package-info for fdb-extensions and overview.html files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,7 @@ subprojects {
                 exclude "**/*Proto.java"
                 // warnings are errors
                 options.addBooleanOption('Xwerror', true)
+                options.overview = "src/main/javadoc/overview.html"
             }
             compileJava {
                 //enable compilation in a separate daemon process

--- a/examples/src/main/javadoc/overview.html
+++ b/examples/src/main/javadoc/overview.html
@@ -1,0 +1,36 @@
+<!--
+  ~ overview.html
+  ~
+  ~ This source file is part of the FoundationDB open source project
+  ~
+  ~ Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<HTML>
+<BODY>
+
+Sample code for the FoundationDB Record Layer.
+
+<p>
+The main sample is located within the {@link com.apple.foundationdb.record.sample.Main} class. It goes through
+some basic operations including setting up a record store's meta-data, adding records, and then performing
+a few different queries. This code should be used for reference by others trying to get a feel for the
+<a href="https://foundationdb.github.io/fdb-record-layer">Record Layer</a> API. One should look at the
+<a href="https://javadoc.io/doc/org.foundationdb/fdb-record-layer-core/">API documentation</a> for the core library
+for more details.
+</p>
+
+</BODY>
+</HTML>

--- a/fdb-extensions/README.txt
+++ b/fdb-extensions/README.txt
@@ -1,3 +1,0 @@
-Extensions to the FDB Java API that haven't made it in yet.
-
-Mostly taken from FoundationDB layers.

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/package-info.java
@@ -1,0 +1,38 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility functions for use within an asynchronous environment.
+ *
+ * <p>
+ * The data structures are designed to be compatible for use within a asynchronous environment
+ * in that they are all intended to be non-blocking. They are used within the
+ * <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a> core library
+ * to implement some of the more advanced secondary index types.
+ * </p>
+ *
+ * <p>
+ * The utility functions within the {@link com.apple.foundationdb.async.MoreAsyncUtil} class are
+ * of a kind with the functions in the {@link com.apple.foundationdb.async.AsyncUtil} class within the
+ * FoundationDB Java bindings. They encapsulate a few common uses of the
+ * {@link java.util.concurrent.CompletableFuture} class.
+ * </p>
+ */
+package com.apple.foundationdb.async;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A sorted durable associative array with pluggable serialization.
+ *
+ * <p>
+ * The main class in this package is the {@link com.apple.foundationdb.map.BunchedMap} class. This
+ * presents an API that is similar to a standard sorted associated array or map. It differs
+ * from other such implementations in that it attempts to consolidate multiple entries in
+ * the final map into each FoundationDB key-value pair. This allows the data structure to reduce its
+ * total footprint by spreading its data across fewer keys than a na&iuml;ve implementation might.
+ * The other classes are used to support the {@code BunchedMap} class in various ways.
+ * </p>
+ */
+package com.apple.foundationdb.map;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extensions to the FoundationDB Java API.
+ * Directly within this package, there are only the {@link com.apple.foundationdb.API} stability
+ * annotations which are used within the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
+ * project to annotate the stability of various functions and classes.
+ */
+package com.apple.foundationdb;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility functions for handling tuples and byte arrays.
+ * These are to assist with using the {@link com.apple.foundationdb.tuple.Tuple} class and complement
+ * the {@link com.apple.foundationdb.tuple.ByteArrayUtil} class found within the FoundationDB Java bindings.
+ */
+package com.apple.foundationdb.tuple;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for logging and exception handling.
+ * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
+ * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
+ * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
+ * thrown.
+ */
+package com.apple.foundationdb.util;

--- a/fdb-extensions/src/main/javadoc/overview.html
+++ b/fdb-extensions/src/main/javadoc/overview.html
@@ -1,0 +1,49 @@
+<!--
+  ~ overview.html
+  ~
+  ~ This source file is part of the FoundationDB open source project
+  ~
+  ~ Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<HTML>
+<BODY>
+
+Extensions to the FoundationDB Java API.
+
+<p>
+This utility library contains several durable data structures as well as utility functions that extend the base
+functionality of the FoundationDB Java API. They are developed together with the
+<a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a> project, but they may be generally
+useful to users of the FoundationDB Java API.
+</p>
+
+<p>
+Many of the functions here are unstable as they serve primarily as utility functions for the Record Layer and
+are subject to change at short notice. To assist users with understanding whether a function is stable or unstable
+(and therefore liable to change with little warning), this package also includes the {@link com.apple.foundationdb.API}
+stability annotations. They are used throughout the Record Layer. Users are encouraged to check the API stability of
+any class or method before using it within their own project.
+</p>
+
+<p>
+This library and the <a href="https://javadoc.io/doc/org.foundationdb/fdb-record-layer-core/"><code>fdb-record-layer-core</code></a>
+project are versioned together. It is <i>highly</i> recommended that any users of the
+Record Layer use the same version for this library as for the core library as no other configurations are
+tested or supported.
+</p>
+
+</BODY>
+</HTML>

--- a/fdb-record-layer-core/src/main/javadoc/overview.html
+++ b/fdb-record-layer-core/src/main/javadoc/overview.html
@@ -1,0 +1,54 @@
+<!--
+  ~ overview.html
+  ~
+  ~ This source file is part of the FoundationDB open source project
+  ~
+  ~ Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<HTML>
+<BODY>
+
+A record-oriented layer built for the FoundationDB key-value store.
+
+<p>
+This layer is designed to extend the FoundationDB key-value store by adding a record-oriented data model. Though
+this layer does not attempt to implement SQL, it does provide relational semantics (broadly defined). In particular,
+it attempts to provide solutions to:
+</p>
+
+<ul>
+    <li>Schema management</li>
+    <li>Index maintenance</li>
+    <li>Query planning and optimization</li>
+</ul>
+
+<p>
+The basic unit of data is the "record". This corresponds to a "row" in a traditional relational system or
+to a "document" in a document database. Records are grouped together into "record stores", which are
+somewhat analogous to a "database" in a traditional relational database, and each record also has a "type"
+which is somewhat (but not quite) analogous to a "table". (See, however,
+<a href="https://foundationdb.github.io/fdb-record-layer/FAQ.html#are-record-types-tables">"Are record types tables?"</a>
+in the <a href="https://foundationdb.github.io/fdb-record-layer/FAQ.html">FAQ</a> for an explanation of
+the differences between the two concepts.)
+</p>
+
+<p>
+For a more complete overview of the features and goals of the Record Layer, consult the
+<a href="https://foundationdb.github.io/fdb-record-layer/Overview.html">Record Layer overview</a>.
+</p>
+
+</BODY>
+</HTML>

--- a/gradle/codequality/suppressions.xml
+++ b/gradle/codequality/suppressions.xml
@@ -7,5 +7,5 @@
     <suppress checks=".*"
         files=".*[\\/]protogen[\\/].*"/>
     <suppress checks="JavadocPackage"
-        files="fdb-extensions[\\/].*|.*[\\/]test[\\/].*"/>
+        files=".*[\\/]test[\\/].*"/>
 </suppressions>


### PR DESCRIPTION
This takes a crack at coming up with overview files for the project Javadoc. It also adds packge-info files to the fdb-extensions library.