### PR TITLE
Fixes #305: Add the fields to the pom.xml needed for maven central publishing

### DIFF
--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -41,3 +41,13 @@ test {
         }
     }
 }
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            pom {
+                description = 'Extensions to the FoundationDB Java API.'
+            }
+        }
+    }
+}

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -45,7 +45,9 @@ publishing {
     publications {
         shadow(MavenPublication) { publication ->
             from project.shadow.component(publication)
+            addPublishingInfo(publication) // function imported from publishing.gradle
             publication.pom { pom ->
+                description = 'A record-oriented layer built for FoundationDB (shaded artifacts; proto' + project.protoMajorVersion + ').'
                 pom.withXml { xml ->
                     // Remove any existing dependencies sections
                     def childNodes = xml.asNode().children()

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -106,3 +106,16 @@ task testShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.Shadow
     mergeServiceFiles()
     exclude 'log4j.properties'
 }
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            pom {
+                // Normally, the variable would be included within the string using variable expansion in a Groovy
+                // string. However, the "description" field must be a java.lang.String, hence the use of string
+                // concatenation here.
+                description = 'A record-oriented layer built for FoundationDB (proto' + project.protoMajorVersion + ').'
+            }
+        }
+    }
+}

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -20,12 +20,45 @@
 
 apply plugin: 'com.jfrog.bintray'
 
+// Add various details to the pom file to allow for publishing
+def addPublishingInfo(publication) {
+    publication.pom {
+        name = project.name
+        url = 'https://foundationdb.github.io/fdb-record-layer/'
+
+        licenses {
+            license {
+                name = 'The Apache License, Version 2.0'
+                url = 'https://www.apache.org/licenses/LICENSE-2.0'
+            }
+        }
+
+        developers {
+            developer {
+                name = 'FoundationDB'
+            }
+        }
+
+        scm {
+            url = 'https://github.com/FoundationDB/fdb-record-layer/'
+            connection = 'scm:git:git@github.com:FoundationDB/fdb-record-layer.git'
+            developerConnection = 'scm:git:git@github.com:FoundationDB/fdb-record-layer.git'
+        }
+    }
+}
+
+ext {
+    // Make the "addPublishingInfo" method visible from outside this plugin
+    addPublishingInfo = this.&addPublishingInfo
+}
+
 publishing {
     publications {
-        library(MavenPublication) {
+        library(MavenPublication) { publication ->
             from components.java
             artifact tasks.sourcesJar
             artifact tasks.javadocJar
+            addPublishingInfo(publication)
         }
     }
     def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')


### PR DESCRIPTION
This adds the extra information needed in the pom.xml for maven central publishing that was not present before. Most of that is encapsulated in the gradle/publishing.gradle script plugin, but each subproject has its own description. That configuration remains only in the subprojects.

Note that this PR is against the 2.4.35 branch (in case we need to publish something from there). My plan was to submit a second PR against master once this one is in so that both branches can publish things. I have verified that the pom validation steps on the maven central uploader all pass with the pom generated from artifacts from this PR.

This fixes #305.