### PR TITLE
Resolves #317: Make the PlannerProperty visitor more expressive.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
@@ -42,7 +42,7 @@ public interface ExpressionRef<T extends PlannerExpression> extends Bindable {
     @Nonnull
     T get();
 
-    boolean acceptPropertyVisitor(@Nonnull PlannerProperty property);
+    <U> U acceptPropertyVisitor(@Nonnull PlannerProperty<U> property);
 
     /**
      * An exception thrown when {@link #get()} is called on a reference that does not support it, such as a group reference.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerProperty.java
@@ -23,50 +23,73 @@ package com.apple.foundationdb.record.query.plan.temp;
 import com.apple.foundationdb.API;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
- * An interface for hierarchical visitors that represent Cascades properties. In Cascades, properties are measurable
- * features of an expression other than the structure of the expression tree. For example, the sort order and set of
- * record types produced by a {@link com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression}
- * could be represented by a property.
+ * An interface for certain Cascades-style properties, which are measurable features of an expression other than the
+ * structure of the expression tree. In particular, a {@code PlannerProperty} is a property that depends on (much of)
+ * the contents of the subtree rooted at the expression on which it is evaluated, rather than just a finite depth set
+ * of paths as a {@link com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher} would. For example,
+ * the sort order and set of record types produced by a
+ * {@link com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression} could be a
+ * {@code PlannerProperty}.
  *
+ * <p>
  * To avoid littering {@link PlannerExpression} classes with methods for various properties, properties are implemented
- * as visitors on the tree of {@code PlannerExpression}s and {@link ExpressionRef}s. A property can be evaluated against
- * an expression tree by having the visitor traverse the tree.
+ * using a variant of the hierarchical visitor pattern the tree of {@code PlannerExpression}s and {@link ExpressionRef}s.
+ * A property can be evaluated against an expression tree by having the visitor traverse the tree. Note that the
+ * "{@code visitLeave()}" methods {@link #evaluateAtExpression} and {@link #evaluateAtRef} are handed the results of the
+ * visitor evaluated at their children and members respectively. Since most properties are easy to describe as a
+ * recursion with depth one, this makes properties easier to read and write.
+ * </p>
+ *
+ * @param <T> the result type of the property
  */
 @API(API.Status.EXPERIMENTAL)
-public interface PlannerProperty {
+public interface PlannerProperty<T> {
     /**
+     * Return whether the property should visit the subtree rooted at the given expression.
      * Called on nodes in the expression tree in visit pre-order of the depth-first traversal of the tree.
-     * That is, as each node is visited for the first time, <code>visitEnter()</code> is called on that node.
+     * That is, as each node is visited for the first time, {@code shouldVisit()} is called on that node.
+     * If {@code shouldVisit()} returns {@code false}, then {@link #evaluateAtExpression(PlannerExpression, List)} will
+     * not be called on the given expression.
      * @param expression the planner expression to visit
-     * @return <code>true</code> if the children of <code>cursor</code> should be visited, and <code>false</code> if they should not be visited
+     * @return {@code true} if the children of {@code expression} should be visited and {@code false} if they should not be visited
      */
-    boolean visitEnter(@Nonnull PlannerExpression expression);
+    boolean shouldVisit(@Nonnull PlannerExpression expression);
 
     /**
+     * Return whether the property should visit the subtree rooted at the given expression.
      * Called on nodes in the expression tree in visit pre-order of the depth-first traversal of the tree.
-     * That is, as each node is visited for the first time, <code>visitEnter()</code> is called on that node.
+     * That is, as each node is visited for the first time, {@code shouldVisit()} is called on that node.
+     * If {@code shouldVisit()} returns {@code false}, then {@link #evaluateAtRef(ExpressionRef, List)} will
+     * not be called on the given expression.
      * @param ref the expression reference to visit
-     * @return <code>true</code> if the children of <code>cursor</code> should be visited, and <code>false</code> if they should not be visited
+     * @return {@code true} if the members of {@code ref} should be visited and {@code false} if they should not be visited
      */
-    boolean visitEnter(@Nonnull ExpressionRef<? extends PlannerExpression> ref);
+    boolean shouldVisit(@Nonnull ExpressionRef<? extends PlannerExpression> ref);
 
     /**
+     * Evaluate the property at the given expression, using the results of evaluating the property at its children.
      * Called on nodes in the expression tree in visit post-order of the depth-first traversal of the tree.
      * That is, as each node is visited for the last time (after all of its children have been visited, if applicable),
-     * <code>visitLeave()</code> is called on that node.
+     * {@code evaluateAtExpression()} is called on that node.
      * @param expression the cursor to visit
-     * @return <code>true</code> if the subsequent siblings of the <code>cursor</code> should be visited, and <code>false</code> otherwise
+     * @param childResults the results of the property evaluated at the children of {@code expression}
+     * @return the value of property at the given expression
      */
-    boolean visitLeave(@Nonnull PlannerExpression expression);
+    @Nonnull
+    T evaluateAtExpression(@Nonnull PlannerExpression expression, @Nonnull List<T> childResults);
 
     /**
+     * Evaluate the property at the given reference, using the results of evaluating the property at its members.
      * Called on nodes in the expression tree in visit post-order of the depth-first traversal of the tree.
      * That is, as each node is visited for the last time (after all of its children have been visited, if applicable),
-     * <code>visitLeave()</code> is called on that node.
+     * {@code evaluateAtRef()} is called on that node.
      * @param ref the expression reference to visit
-     * @return <code>true</code> if the subsequent siblings of the <code>cursor</code> should be visited, and <code>false</code> otherwise
+     * @param memberResults the results of the property evaluated at the members of {@code ref}
+     * @return the value of property at the given reference
      */
-    boolean visitLeave(@Nonnull ExpressionRef<? extends PlannerExpression> ref);
+    @Nonnull
+    T evaluateAtRef(@Nonnull ExpressionRef<? extends PlannerExpression> ref, @Nonnull List<T> memberResults);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/SingleExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/SingleExpressionRef.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -57,11 +58,14 @@ public class SingleExpressionRef<T extends PlannerExpression> implements Mutable
     }
 
     @Override
-    public boolean acceptPropertyVisitor(@Nonnull PlannerProperty visitor) {
-        if (visitor.visitEnter(this)) {
-            expression.acceptPropertyVisitor(visitor);
+    public <U> U acceptPropertyVisitor(@Nonnull PlannerProperty<U> visitor) {
+        if (visitor.shouldVisit(this)) {
+            final U memberResult = expression.acceptPropertyVisitor(visitor);
+            if (memberResult != null) {
+                return visitor.evaluateAtRef(this, Collections.singletonList(memberResult));
+            }
         }
-        return visitor.visitLeave(this);
+        return null;
     }
 
     public static <T extends PlannerExpression> SingleExpressionRef<T> of(@Nonnull T expression) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
@@ -24,23 +24,22 @@ import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalExpressionWithChildren;
 import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
 import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,73 +48,90 @@ import java.util.stream.Collectors;
  * could produce. This property is used in determining whether type filters are necessary, among other things.
  */
 @API(API.Status.EXPERIMENTAL)
-public class RecordTypesProperty implements PlannerProperty {
+public class RecordTypesProperty implements PlannerProperty<Set<String>> {
     @Nonnull
     private final PlanContext context;
-    @Nonnull
-    private Deque<Set<String>> possibleTypeSets = new ArrayDeque<>();
 
     private RecordTypesProperty(@Nonnull PlanContext context) {
         this.context = context;
     }
 
     @Override
-    public boolean visitEnter(@Nonnull PlannerExpression expression) {
+    public boolean shouldVisit(@Nonnull PlannerExpression expression) {
         return expression instanceof RelationalPlannerExpression;
     }
 
     @Override
-    public boolean visitEnter(@Nonnull ExpressionRef<? extends PlannerExpression> ref) {
-        return true;
-    }
-
-
-    @Override
-    public boolean visitLeave(@Nonnull PlannerExpression expression) {
-        if (expression instanceof RecordQueryScanPlan) {
-            possibleTypeSets.push(context.getMetaData().getRecordTypes().keySet());
-        } else if (expression instanceof RecordQueryIndexPlan) {
-            Index index = context.getIndexByName(((RecordQueryIndexPlan)expression).getIndexName());
-            possibleTypeSets.push(context.getMetaData().recordTypesForIndex(index).stream()
-                    .map(RecordType::getName).collect(Collectors.toSet()));
-        } else if (expression instanceof TypeFilterExpression) {
-            Set<String> childTypeSet = possibleTypeSets.pop();
-            possibleTypeSets.push(Sets.filter(childTypeSet,
-                    ((TypeFilterExpression)expression).getRecordTypes()::contains));
-        } else if (expression instanceof RelationalExpressionWithChildren &&
-                   ((RelationalExpressionWithChildren)expression).getRelationalChildCount() > 1) {
-            // If we have a single child, then there is a reasonable default for how most relational expressions will
-            // change the set of record types (i.e., they won't change them at all). However, if you have several relational
-            // children (like a union or intersection expression) then we must specify some way to combine them.
-            int relationalChildCount = ((RelationalExpressionWithChildren)expression).getRelationalChildCount();
-            if (expression instanceof RecordQueryUnionPlan || expression instanceof RecordQueryIntersectionPlan) {
-                Set<String> union = new HashSet<>();
-                for (int i = 0; i < relationalChildCount; i++) {
-                    union.addAll(possibleTypeSets.pop());
-                }
-                possibleTypeSets.push(union);
-            } else {
-                throw new RecordCoreException("tried to find record types for a relational expression with multiple " +
-                                              "relational children, but no combiner was specified");
-            }
-        }
-
-        return true; // always proceed to inspect siblings
-    }
-
-    @Override
-    public boolean visitLeave(@Nonnull ExpressionRef<? extends PlannerExpression> ref) {
+    public boolean shouldVisit(@Nonnull ExpressionRef<? extends PlannerExpression> ref) {
         return true;
     }
 
     @Nonnull
-    public static Set<String> evaluate(@Nonnull PlanContext context, ExpressionRef<? extends PlannerExpression> ref) {
-        RecordTypesProperty visitor = new RecordTypesProperty(context);
-        ref.acceptPropertyVisitor(visitor);
-        if (visitor.possibleTypeSets.size() != 1) {
-            throw new RecordCoreException("error while finding record types: several possible type sets left after completing traversal");
+    @Override
+    public Set<String> evaluateAtExpression(@Nonnull PlannerExpression expression, @Nonnull List<Set<String>> childResults) {
+        // shouldVisit() ensures that we only visit relational planner expressions
+        // If we mess this up, better to find out sooner rather than later.
+        final RelationalPlannerExpression relationalExpression = (RelationalPlannerExpression) expression;
+
+        if (relationalExpression instanceof RecordQueryScanPlan) {
+            return context.getMetaData().getRecordTypes().keySet();
+        } else if (relationalExpression instanceof RecordQueryPlanWithIndex) {
+            Index index = context.getIndexByName(((RecordQueryPlanWithIndex) relationalExpression).getIndexName());
+            return context.getMetaData().recordTypesForIndex(index).stream()
+                    .map(RecordType::getName).collect(Collectors.toSet());
+        } else if (relationalExpression instanceof TypeFilterExpression) {
+            return Sets.filter(childResults.get(0), ((TypeFilterExpression)relationalExpression).getRecordTypes()::contains);
+        } else if (childResults.isEmpty()) {
+            throw new RecordCoreException("tried to find record types for a relational expression with no children" +
+                                          "but case wasn't handled");
+        } else {
+            int nonNullChildResult = 0;
+            Set<String> firstChildResult = null;
+            for (Set<String> result : childResults) {
+                if (result != null) {
+                    nonNullChildResult++;
+                    if (firstChildResult == null) {
+                        firstChildResult = result;
+                    }
+                }
+            }
+
+            if (nonNullChildResult == 1) {
+                return firstChildResult;
+            } else  {
+                // If we have a single child, then there is a reasonable default for how most relational expressions will
+                // change the set of record types (i.e., they won't change them at all). However, if you have several relational
+                // children (like a union or intersection expression) then we must specify some way to combine them.
+                if (expression instanceof RecordQueryUnionPlan ||
+                        expression instanceof RecordQueryUnorderedUnionPlan ||
+                        expression instanceof RecordQueryIntersectionPlan) {
+                    final Set<String> union = new HashSet<>();
+                    for (Set<String> childResulSet : childResults) {
+                        union.addAll(childResulSet);
+                    }
+                    return union;
+                } else {
+                    throw new RecordCoreException("tried to find record types for a relational expression with multiple " +
+                                                  "relational children, but no combiner was specified");
+                }
+            }
         }
-        return visitor.possibleTypeSets.getFirst();
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> evaluateAtRef(@Nonnull ExpressionRef<? extends PlannerExpression> ref,
+                                     @Nonnull List<Set<String>> memberResults) {
+        final Set<String> union = new HashSet<>();
+        for (Set<String> resultSet : memberResults) {
+            union.addAll(resultSet);
+        }
+        return union;
+    }
+
+    @Nonnull
+    public static Set<String> evaluate(@Nonnull PlanContext context, ExpressionRef<? extends PlannerExpression> ref) {
+        return ref.acceptPropertyVisitor(new RecordTypesProperty(context));
     }
 
 }


### PR DESCRIPTION
Prior to this change, writing properties as visitors was very tedious. Most properties can be expressed as a depth-one recursion, so augmenting the `visitLeave()` methods with the results of calling `visitLeave()` on its children (or members, in the case of references) makes properties easier
to read and write. This change also renames the visitor methods, changing `visitEnter()` to `shouldVisit()` and `visitLeave()` to `evaluateAtExpression()` and `evaluateAtRef()`, which also aids in
comprehension.

I discussed this change with @ScottDugas. I hope that the example property already in the code base (`RecordTypesProperty`) illustrates how this change is helpful.