### PR TITLE
Resolves #302: Bump PMD version to 6.10.0

### DIFF
--- a/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
+++ b/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
@@ -254,7 +254,7 @@ public class Main {
         // NOTE: This operation is dangerous if you have existing data! Existing records are *not*
         // automatically migrated.
         rmdBuilder.getRecordType("Customer").setPrimaryKey(
-                Key.Expressions.concatenateFields("last_name", "first_name", "customer_id"));
+                concatenateFields("last_name", "first_name", "customer_id"));
 
         // Add a global count index. Most record stores should probably add this index as it allows
         // the database to make intelligent decisions based on the current size of the record store.

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -412,10 +412,8 @@ public class MoreAsyncUtil {
                             return nextFuture;
                         }
                         nextFuture = whileTrue(() -> {
-                            CompletableFuture<Boolean> outer = null;
-                            CompletableFuture<Boolean> inner = null;
                             List<CompletableFuture<Boolean>> waitOn = new ArrayList<>(2);
-                            outer = iterator.onHasNext();
+                            CompletableFuture<Boolean> outer = iterator.onHasNext();
                             if (outer.isDone()) {
                                 if (outer.getNow(false) && (pipeline.size() < pipelineSize)) {
                                     AsyncIterator<T2> next = func.apply(iterator.next()).iterator();
@@ -427,6 +425,7 @@ public class MoreAsyncUtil {
                                 waitOn.add(outer);
                             }
 
+                            CompletableFuture<Boolean> inner;
                             AsyncIterator<T2> current = pipeline.peek();
                             if (current != null) {
                                 inner = current.onHasNext();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
@@ -63,6 +63,10 @@ public class RankedSet {
     public static final int MAX_LEVELS = Integer.SIZE / LEVEL_FAN_POW;
     public static final int DEFAULT_LEVELS = 6;
 
+    protected final Subspace subspace;
+    protected final Executor executor;
+    protected final int nlevels;
+
     static {
         LEVEL_FAN_VALUES = new int[MAX_LEVELS];
         for (int i = 0; i < MAX_LEVELS; ++i) {
@@ -80,10 +84,6 @@ public class RankedSet {
     private static long decodeLong(byte[] v) {
         return ByteBuffer.wrap(v).order(ByteOrder.LITTLE_ENDIAN).getLong();
     }
-
-    protected final Subspace subspace;
-    protected final Executor executor;
-    protected final int nlevels;
 
     /**
      * Initialize a new ranked set.
@@ -323,7 +323,7 @@ public class RankedSet {
     }
 
     protected interface Lookup {
-        public CompletableFuture<Boolean> next(ReadTransaction tr);
+        CompletableFuture<Boolean> next(ReadTransaction tr);
     }
 
     class RankLookup implements Lookup {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
@@ -136,7 +136,6 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
                 Subspace nextSubspace = splitter.subspaceOf(nextKv.getKey());
                 byte[] nextSubspaceKey = nextSubspace.getKey();
                 byte[] nextSubspaceSuffix = Arrays.copyOfRange(nextSubspaceKey, subspaceKey.length, nextSubspaceKey.length);
-                T nextSubspaceTag = splitter.subspaceTag(nextSubspace);
                 K continuationKey = null;
                 if (!continuationSatisfied) {
                     if (ByteArrayUtil.startsWith(continuation, nextSubspaceSuffix)) {
@@ -171,6 +170,7 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
                         (limit == ReadTransaction.ROW_LIMIT_UNLIMITED) ? ReadTransaction.ROW_LIMIT_UNLIMITED : limit - returned,
                         reverse
                 );
+                final T nextSubspaceTag = splitter.subspaceTag(nextSubspace);
                 return nextMapIterator.onHasNext().thenCompose(mapHasNext -> {
                     if (mapHasNext) {
                         currentSubspace = nextSubspace;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -65,8 +65,7 @@ public class ByteArrayUtil2 {
         } else {
             StringBuilder sb = new StringBuilder();
 
-            for (int i = 0; i < bytes.length; ++i) {
-                byte b = bytes[i];
+            for (byte b : bytes) {
                 // remove '=' and '"' because they confuse parsing of key=value log messages
                 if (b >= MINIMUM_PRINTABLE_CHARACTER && b < MAXIMUM_PRINTABLE_CHARACTER &&
                         b != BACKSLASH_CHARACTER && b != EQUALS_CHARACTER && b != DOUBLE_QUOTE_CHARACTER) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleHelpers.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.tuple;
 import com.apple.foundationdb.API;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -71,6 +72,25 @@ public class TupleHelpers {
             }
         }
         return t1Len - t2Len;
+    }
+
+    /**
+     * Determine if two {@link Tuple}s have the same contents. Unfortunately, the implementation of
+     * {@link Tuple#equals(Object) Tuple.equals()} serializes both {@code Tuple}s to byte arrays,
+     * so it is fairly expensive. This method avoids serializing either {@code Tuple}, and it also
+     * adds a short-circuit to return early if the two {@code Tuple}s are pointer-equal.
+     *
+     * @param t1 the first {@link Tuple} to compare
+     * @param t2 the second {@link Tuple} to compare
+     * @return {@code true} if the two {@link Tuple}s would serialize to the same array and {@code false} otherwise
+     */
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public static boolean equals(@Nullable Tuple t1, @Nullable Tuple t2) {
+        if (t1 == null) {
+            return t2 == null;
+        } else {
+            return t2 != null && (t1 == t2 || compare(t1, t2) == 0);
+        }
     }
 
     private TupleHelpers() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexScanType.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexScanType.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.API;
 
+import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -34,6 +35,17 @@ import java.util.Objects;
  */
 @API(API.Status.MAINTAINED)
 public class IndexScanType implements PlanHashable {
+    @Nonnull
+    public static final IndexScanType BY_VALUE = new IndexScanType("BY_VALUE");
+    @Nonnull
+    public static final IndexScanType BY_RANK = new IndexScanType("BY_RANK");
+    @Nonnull
+    public static final IndexScanType BY_GROUP = new IndexScanType("BY_GROUP");
+    @Nonnull
+    public static final IndexScanType BY_TIME_WINDOW = new IndexScanType("BY_TIME_WINDOW");
+    @Nonnull
+    public static final IndexScanType BY_TEXT_TOKEN = new IndexScanType("BY_TEXT_TOKEN");
+
     private final String name;
 
     public IndexScanType(String name) {
@@ -66,10 +78,4 @@ public class IndexScanType implements PlanHashable {
     public int planHash() {
         return hashCode();
     }
-
-    public static final IndexScanType BY_VALUE = new IndexScanType("BY_VALUE");
-    public static final IndexScanType BY_RANK = new IndexScanType("BY_RANK");
-    public static final IndexScanType BY_GROUP = new IndexScanType("BY_GROUP");
-    public static final IndexScanType BY_TIME_WINDOW = new IndexScanType("BY_TIME_WINDOW");
-    public static final IndexScanType BY_TEXT_TOKEN = new IndexScanType("BY_TEXT_TOKEN");
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/MutableRecordStoreState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/MutableRecordStoreState.java
@@ -40,6 +40,12 @@ public class MutableRecordStoreState extends RecordStoreState {
     private static final long READ_MASK = 0xFFFF0000;
     private static final long WRITE_MASK = 0x0000FFFF;
 
+    private final AtomicLong users = new AtomicLong();
+
+    public MutableRecordStoreState(@Nullable Map<String, IndexState> indexStateMap) {
+        super(indexStateMap);
+    }
+
     private static long readIncrement(long u) {
         return ((((u >> 32) + 1) << 32) & READ_MASK) | (u & WRITE_MASK);
     }
@@ -54,12 +60,6 @@ public class MutableRecordStoreState extends RecordStoreState {
 
     private static long writeDecrement(long u) {
         return (u & READ_MASK) | (((u & WRITE_MASK) - 1) & WRITE_MASK);
-    }
-
-    private final AtomicLong users = new AtomicLong();
-
-    public MutableRecordStoreState(@Nullable Map<String, IndexState> indexStateMap) {
-        super(indexStateMap);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/PipelineOperation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/PipelineOperation.java
@@ -22,6 +22,8 @@ package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.API;
 
+import javax.annotation.Nonnull;
+
 /**
  * Kind of asynchronous pipelined operation being performed.
  *
@@ -32,6 +34,21 @@ import com.apple.foundationdb.API;
  */
 @API(API.Status.MAINTAINED)
 public class PipelineOperation {
+    @Nonnull
+    public static final PipelineOperation INDEX_TO_RECORD = new PipelineOperation("INDEX_TO_RECORD");
+    @Nonnull
+    public static final PipelineOperation KEY_TO_RECORD = new PipelineOperation("KEY_TO_RECORD");
+    @Nonnull
+    public static final PipelineOperation RECORD_ASYNC_FILTER = new PipelineOperation("RECORD_ASYNC_FILTER");
+    @Nonnull
+    public static final PipelineOperation RECORD_FUNCTION = new PipelineOperation("RECORD_FUNCTION");
+    @Nonnull
+    public static final PipelineOperation RESOLVE_UNIQUENESS = new PipelineOperation("RESOLVE_UNIQUENESS");
+    @Nonnull
+    public static final PipelineOperation IN_JOIN = new PipelineOperation("IN_JOIN");
+    @Nonnull
+    public static final PipelineOperation TEXT_INDEX_UPDATE = new PipelineOperation("TEXT_INDEX_UPDATE");
+
     private final String name;
 
     public PipelineOperation(String name) {
@@ -46,13 +63,4 @@ public class PipelineOperation {
     public String toString() {
         return name;
     }
-
-    public static final PipelineOperation INDEX_TO_RECORD = new PipelineOperation("INDEX_TO_RECORD");
-    public static final PipelineOperation KEY_TO_RECORD = new PipelineOperation("KEY_TO_RECORD");
-    public static final PipelineOperation RECORD_ASYNC_FILTER = new PipelineOperation("RECORD_ASYNC_FILTER");
-    public static final PipelineOperation RECORD_FUNCTION = new PipelineOperation("RECORD_FUNCTION");
-    public static final PipelineOperation RESOLVE_UNIQUENESS = new PipelineOperation("RESOLVE_UNIQUENESS");
-    public static final PipelineOperation IN_JOIN = new PipelineOperation("IN_JOIN");
-    public static final PipelineOperation TEXT_INDEX_UPDATE = new PipelineOperation("TEXT_INDEX_UPDATE");
-
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
@@ -114,6 +114,7 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
     @Nonnull
     CompletableFuture<Boolean> onHasNext();
 
+    @Override
     default boolean hasNext() {
         try {
             return onHasNext().get();
@@ -126,6 +127,7 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
     }
 
     @Nullable
+    @Override
     T next();
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
@@ -62,6 +62,11 @@ import java.util.function.Function;
  */
 @API(API.Status.EXPERIMENTAL)
 public class RecordCursorResult<T> {
+
+    @Nonnull
+    private static final RecordCursorResult<Object> EXHAUSTED = new RecordCursorResult<>(RecordCursorEndContinuation.END,
+            RecordCursor.NoNextReason.SOURCE_EXHAUSTED);
+
     private final boolean hasNext;
     @Nullable
     private final T nextValue;
@@ -249,10 +254,6 @@ public class RecordCursorResult<T> {
         }
         return (RecordCursorResult<T>) withoutNext;
     }
-
-    @Nonnull
-    private static final RecordCursorResult<Object> EXHAUSTED = new RecordCursorResult<>(RecordCursorEndContinuation.END,
-            RecordCursor.NoNextReason.SOURCE_EXHAUSTED);
 
     /**
      * Obtain the static result that a cursor can return when it is completely exhausted.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorStartContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorStartContinuation.java
@@ -37,6 +37,9 @@ import javax.annotation.Nullable;
 public class RecordCursorStartContinuation implements RecordCursorContinuation {
     public static final RecordCursorContinuation START = new RecordCursorStartContinuation();
 
+    private RecordCursorStartContinuation() {
+    }
+
     @Override
     public boolean isEnd() {
         return false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordFunction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordFunction.java
@@ -44,6 +44,7 @@ public abstract class RecordFunction<T> implements PlanHashable {
         return name;
     }
 
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     public void validate(@Nonnull Descriptors.Descriptor descriptor) {
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
@@ -276,6 +276,11 @@ public class RecordMetaData implements RecordMetaDataProvider {
         return recordTypes.values().stream().allMatch(RecordType::primaryKeyHasRecordTypePrefix);
     }
 
+    /**
+     * Get this <code>RecordMetaData</code> instance.
+     *
+     * @return this <code>RecordMetaData</code> instance
+     */
     @Nonnull
     @Override
     public RecordMetaData getRecordMetaData() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
@@ -748,7 +748,7 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
      */
     public void addMultiTypeIndex(@Nullable List<RecordTypeBuilder> recordTypes, @Nonnull Index index) {
         addIndexCommon(index);
-        if (recordTypes == null || recordTypes.size() == 0) {
+        if (recordTypes == null || recordTypes.isEmpty()) {
             universalIndexes.put(index.getName(), index);
         } else if (recordTypes.size() == 1) {
             recordTypes.get(0).getIndexes().add(index);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataProvider.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataProvider.java
@@ -32,7 +32,13 @@ import javax.annotation.Nonnull;
 @API(API.Status.STABLE)
 public interface RecordMetaDataProvider {
 
+    /**
+     * Provide an instance of {@link RecordMetaData}.
+     * Implementors should assume that this method will be called frequently, so it may
+     * be necessary to cache the result if generating the {@link RecordMetaData} is expensive.
+     *
+     * @return an instance of {@link RecordMetaData}
+     */
     @Nonnull
-    public RecordMetaData getRecordMetaData();
-
+    RecordMetaData getRecordMetaData();
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/TupleRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/TupleRange.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -135,8 +136,9 @@ public class TupleRange {
         }
     }
 
+    @SuppressWarnings("PMD.UnusedNullCheckInEquals") // uses TupleHelpers::equals for efficiency reasons
     public boolean isEquals() {
-        return low == high && low != null &&
+        return low != null && TupleHelpers.equals(low, high) &&
                 lowEndpoint == EndpointType.RANGE_INCLUSIVE && highEndpoint == EndpointType.RANGE_INCLUSIVE;
     }
 
@@ -152,6 +154,7 @@ public class TupleRange {
      * @return a new <code>TupleRange</code> over all keys in this range but prepended with <code>beginning</code>
      */
     @Nonnull
+    @SuppressWarnings("PMD.UnusedNullCheckInEquals") // uses TupleHelpers::equals for efficiency reasons
     public TupleRange prepend(@Nonnull Tuple beginning) {
         Tuple newLow;
         EndpointType newLowEndpoint;
@@ -170,7 +173,7 @@ public class TupleRange {
             newHigh = beginning;
             newHighEndpoint = EndpointType.RANGE_INCLUSIVE;
         } else {
-            if (low == high) {
+            if (TupleHelpers.equals(low, high)) {
                 newHigh = newLow;
             } else {
                 newHigh = beginning.addAll(high);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IllegalContinuationAccessChecker.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IllegalContinuationAccessChecker.java
@@ -44,6 +44,7 @@ public class IllegalContinuationAccessChecker {
         IllegalContinuationAccessChecker.shouldCheckContinuationAccess = shouldCheckContinuationAccess;
     }
 
+    @SuppressWarnings("PMD.BooleanGetMethodName")
     public static boolean getShouldCheckContinuationAccess() {
         return shouldCheckContinuationAccess;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapWhileCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapWhileCursor.java
@@ -74,6 +74,7 @@ public class MapWhileCursor<T, V> implements RecordCursor<V> {
     private RecordCursorResult<V> nextResult = RecordCursorResult.withNextValue(null, RecordCursorStartContinuation.START);
 
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP2")
+    @SuppressWarnings("PMD.UnusedFormalParameter") // for compatibility reasons
     public MapWhileCursor(@Nonnull RecordCursor<T> inner, @Nonnull Function<T, Optional<V>> func,
                           @Nonnull StopContinuation stopContinuation, @Nullable byte[] initialContinuation,
                           @Nonnull NoNextReason noNextReason) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/OrElseCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/OrElseCursor.java
@@ -44,8 +44,6 @@ public class OrElseCursor<T> implements RecordCursor<T> {
     private final Function<Executor, RecordCursor<T>> func;
     private boolean first;
     @Nullable
-    private CompletableFuture<Boolean> firstFuture;
-    @Nullable
     private RecordCursor<T> other;
 
     @Nullable
@@ -69,7 +67,6 @@ public class OrElseCursor<T> implements RecordCursor<T> {
         if (first) {
             return inner.onNext().thenCompose(result -> {
                 first = false;
-                firstFuture = null;
                 if (result.hasNext() || result.getNoNextReason().isOutOfBand()) {
                     // Either have result or do not know whether to select else yet or not.
                     return CompletableFuture.completedFuture(result);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
@@ -40,7 +40,7 @@ public class KeyValueLogMessage {
     private final long timestamp;
     private final String staticMessage;
 
-    private final TreeMap<String, String> keyValueMap;
+    private final Map<String, String> keyValueMap;
 
     public static String of(@Nonnull final String staticMessage, @Nullable final Object... keysAndValues) {
         return new KeyValueLogMessage(staticMessage, keysAndValues).toString();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Index.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Index.java
@@ -50,6 +50,9 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.keyWithValu
 @API(API.Status.MAINTAINED)
 public class Index {
     @Nonnull
+    public static final KeyExpression EMPTY_VALUE = EmptyKeyExpression.EMPTY;
+
+    @Nonnull
     private final String name;
     @Nonnull
     private final String type;
@@ -71,8 +74,6 @@ public class Index {
         }
         return tuple.get(0);
     }
-
-    public static final KeyExpression EMPTY_VALUE = EmptyKeyExpression.EMPTY;
 
     /**
      * Construct new index meta-data.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -34,8 +34,6 @@ import java.util.Map;
  */
 @API(API.Status.MAINTAINED)
 public class IndexOptions {
-    private IndexOptions() {
-    }
 
     /**
      * No options.
@@ -90,4 +88,7 @@ public class IndexOptions {
      * The default is {@link com.apple.foundationdb.async.RankedSet#DEFAULT_LEVELS} = {@value com.apple.foundationdb.async.RankedSet#DEFAULT_LEVELS}.
      */
     public static final String RANK_NLEVELS = "rankNLevels";
+
+    private IndexOptions() {
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidatorRegistry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidatorRegistry.java
@@ -31,5 +31,5 @@ import javax.annotation.Nonnull;
 @API(API.Status.STABLE)
 public interface IndexValidatorRegistry {
     @Nonnull
-    public IndexValidator getIndexValidator(@Nonnull Index index);
+    IndexValidator getIndexValidator(@Nonnull Index index);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
@@ -57,6 +57,12 @@ public class Key {
      * Holder class for the static methods for creating Key Expressions.
      */
     public static class Expressions {
+        /** The name of the key field in Protobuf {@code map} messages. */
+        @Nonnull
+        public static final String MAP_KEY_FIELD = "key";
+        /** The name of the value field in Protobuf {@code map} messages. */
+        @Nonnull
+        public static final String MAP_VALUE_FIELD = "value";
 
         private Expressions() {}
 
@@ -159,13 +165,6 @@ public class Key {
             }
             return new ThenKeyExpression(exprs);
         }
-
-        /** The name of the key field in Protobuf {@code map} messages. */
-        @Nonnull
-        public static final String MAP_KEY_FIELD = "key";
-        /** The name of the value field in Protobuf {@code map} messages. */
-        @Nonnull
-        public static final String MAP_VALUE_FIELD = "value";
 
         /**
          * Index key and value from a {@code map}.
@@ -346,7 +345,7 @@ public class Key {
         /**
          * Values used in index keys in place of missing fields.
          */
-        public static enum NullStandin {
+        public enum NullStandin {
             NULL(RecordMetaDataProto.Field.NullInterpretation.NOT_UNIQUE), // Missing field here skips uniqueness checks.
             NULL_UNIQUE(RecordMetaDataProto.Field.NullInterpretation.UNIQUE), // Missing field here like ordinary value, but null, for uniqueness.
             NOT_NULL(RecordMetaDataProto.Field.NullInterpretation.NOT_NULL); // Missing field has type's ordinary default value.
@@ -504,6 +503,7 @@ public class Key {
         }
 
         @Nullable
+        @SuppressWarnings("PMD.PreserveStackTrace")
         public <T> T getObject(int idx, Class<T> clazz) {
             final Object result = toTupleAppropriateValue(values.get(idx));
             try {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/EmptyKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/EmptyKeyExpression.java
@@ -39,6 +39,7 @@ import java.util.List;
  * A single empty key.
  */
 @API(API.Status.MAINTAINED)
+@SuppressWarnings("PMD.MissingSerialVersionUID") // this appears to be a false positive
 public class EmptyKeyExpression extends BaseKeyExpression implements KeyExpression, KeyExpressionWithoutChildren {
     public static final EmptyKeyExpression EMPTY = new EmptyKeyExpression();
     public static final RecordMetaDataProto.KeyExpression EMPTY_PROTO =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
@@ -234,7 +234,7 @@ public abstract class FunctionKeyExpression extends BaseKeyExpression implements
         try {
             return create(function.getName(), KeyExpression.fromProto(function.getArguments()));
         } catch (RecordCoreException e) {
-            throw new DeserializationException(e.getMessage());
+            throw new DeserializationException(e.getMessage(), e);
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -131,7 +131,7 @@ public interface KeyExpression extends PlanHashable, PlannerExpression {
      * These names don't technically meet our naming convention but changing them is a lot of work because of all of
      * the string constants.
      */
-    @SuppressWarnings("squid:S00115")
+    @SuppressWarnings({"squid:S00115", "PMD.FieldNamingConventions"})
     enum FanType {
         /**
          * Convert a repeated field into a single list.
@@ -284,8 +284,12 @@ public interface KeyExpression extends PlanHashable, PlannerExpression {
      */
     @SuppressWarnings("serial")
     class SerializationException extends RecordCoreException {
-        public SerializationException(String message) {
+        public SerializationException(@Nonnull String message) {
             super(message);
+        }
+
+        public SerializationException(@Nonnull String message, @Nullable Exception cause) {
+            super(message, cause);
         }
     }
 
@@ -294,8 +298,12 @@ public interface KeyExpression extends PlanHashable, PlannerExpression {
      */
     @SuppressWarnings("serial")
     class DeserializationException extends RecordCoreException {
-        public DeserializationException(String message) {
+        public DeserializationException(@Nonnull String message) {
             super(message);
+        }
+
+        public DeserializationException(@Nonnull String message, @Nullable Exception cause) {
+            super(message, cause);
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
@@ -79,14 +79,13 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
     @Override
     public List<Descriptors.FieldDescriptor> validate(@Nonnull Descriptors.Descriptor descriptor) {
         KeyExpression key = getInnerKey();
-        List<Descriptors.FieldDescriptor> results = key.validate(descriptor);
         if (key.getColumnSize() < splitPoint) {
             throw new InvalidExpressionException("Child expression of covering expression returns too few columns")
                     .addLogInfo(
                             "split_point", splitPoint,
                             "child_columns", key.getColumnSize());
         }
-        return results;
+        return key.validate(descriptor);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
@@ -88,14 +88,13 @@ public class SplitKeyExpression extends BaseKeyExpression implements AtomKeyExpr
 
     @Override
     public List<Descriptors.FieldDescriptor> validate(@Nonnull Descriptors.Descriptor descriptor) {
-        List<Descriptors.FieldDescriptor> fields = getJoined().validate(descriptor);
         if (getJoined().getColumnSize() != 1) {
             throw new InvalidExpressionException("Must have a single key before splitting");
         }
         if (!getJoined().createsDuplicates()) {
             throw new InvalidExpressionException("Must produce multiple values for splitting");
         }
-        return fields;
+        return getJoined().validate(descriptor);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
@@ -124,8 +124,8 @@ public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressio
     }
 
     public boolean createsDuplicatesAfter(int index) {
-        while (index < children.size()) {
-            if (children.get(index++).get().createsDuplicates()) {
+        for (int i = index; i < children.size(); i++) {
+            if (children.get(i).get().createsDuplicates()) {
                 return true;
             }
         }
@@ -226,6 +226,7 @@ public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressio
     }
 
     @Nonnull
+    @Override
     public List<KeyExpression> getChildren() {
         return children.stream().map(ExpressionRef::get).collect(Collectors.toList());
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/TupleFieldsHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/TupleFieldsHelper.java
@@ -37,9 +37,7 @@ import java.util.UUID;
  */
 @API(API.Status.INTERNAL)
 public class TupleFieldsHelper {
-    private TupleFieldsHelper() {
-    }
-
+    @Nonnull
     private static final Set<Descriptors.Descriptor> DESCRIPTORS = ImmutableSet.of(
             TupleFieldsProto.UUID.getDescriptor(),
             TupleFieldsProto.NullableDouble.getDescriptor(),
@@ -274,5 +272,8 @@ public class TupleFieldsHelper {
     @Nonnull
     public static TupleFieldsProto.NullableBytes toProto(@Nonnull ByteString value) {
         return TupleFieldsProto.NullableBytes.newBuilder().setValue(value) .build();
+    }
+
+    private TupleFieldsHelper() {
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializerBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializerBase.java
@@ -84,7 +84,8 @@ public abstract class MessageBuilderRecordSerializerBase<M extends Message, U ex
 
     @Nonnull
     @Override
-    @SuppressWarnings({"unchecked", "squid:S1193"}) // exception type checking is less clumsy
+    @SuppressWarnings({"unchecked", "squid:S1193", "PMD.AvoidInstanceofChecksInCatchClause", // exception type checking is less clunky
+                       "PMD.PreserveStackTrace"})
     public M deserialize(@Nonnull RecordMetaData metaData,
                          @Nonnull Tuple primaryKey,
                          @Nonnull byte[] serialized,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -53,7 +54,13 @@ import java.util.stream.Stream;
  */
 @API(API.Status.MAINTAINED)
 public class StoreTimer {
-    static final Counter EMPTY_COUNTER = new Counter();
+    @Nonnull
+    private static final Counter EMPTY_COUNTER = new Counter();
+
+    @Nonnull
+    protected final Map<Event, Counter> counters;
+    @Nonnull
+    protected final Map<Event, Counter> timeoutCounters;
 
     /**
      * Confirm that there is no naming conflict among the event names that will be used.
@@ -133,9 +140,6 @@ public class StoreTimer {
             count.addAndGet(amount);
         }
     }
-
-    protected final Map<Event, Counter> counters;
-    protected final Map<Event, Counter> timeoutCounters;
 
     public StoreTimer() {
         counters = new ConcurrentHashMap<>();
@@ -304,7 +308,7 @@ public class StoreTimer {
         for (Map.Entry<Event, Counter> entry : counters.entrySet()) {
             Event event = entry.getKey();
             Counter counter = entry.getValue();
-            String prefix = event.name().toLowerCase();
+            String prefix = event.name().toLowerCase(Locale.ROOT);
             result.put(prefix + "_count", counter.count.get());
             if (!(event instanceof Count)) {
                 result.put(prefix + "_micros", counter.timeNanos.get() / 1000);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -90,6 +90,22 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
     protected static final int MIN_COMPRESSION_VERSION = 1;
     protected static final int MAX_COMPRESSION_VERSION = 1;
 
+    @Nonnull
+    protected final RecordSerializer<M> inner;
+    protected final boolean compressWhenSerializing;
+    protected final int compressionLevel;
+    protected final boolean encryptWhenSerializing;
+
+    protected TransformedRecordSerializer(@Nonnull RecordSerializer<M> inner,
+                                          boolean compressWhenSerializing,
+                                          int compressionLevel,
+                                          boolean encryptWhenSerializing) {
+        this.inner = inner;
+        this.compressWhenSerializing = compressWhenSerializing;
+        this.compressionLevel = compressionLevel;
+        this.encryptWhenSerializing = encryptWhenSerializing;
+    }
+
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
     protected static class TransformState {
         public boolean compressed;
@@ -136,22 +152,6 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
             this.offset = offset;
             this.length = length;
         }
-    }
-
-    @Nonnull
-    protected final RecordSerializer<M> inner;
-    protected final boolean compressWhenSerializing;
-    protected final int compressionLevel;
-    protected final boolean encryptWhenSerializing;
-
-    protected TransformedRecordSerializer(@Nonnull RecordSerializer<M> inner,
-                                          boolean compressWhenSerializing,
-                                          int compressionLevel,
-                                          boolean encryptWhenSerializing) {
-        this.inner = inner;
-        this.compressWhenSerializing = compressWhenSerializing;
-        this.compressionLevel = compressionLevel;
-        this.encryptWhenSerializing = encryptWhenSerializing;
     }
 
     protected void compress(@Nonnull TransformState state, @Nullable StoreTimer timer) {
@@ -268,6 +268,7 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
 
     @Nonnull
     @Override
+    @SuppressWarnings("PMD.PreserveStackTrace")
     public M deserialize(@Nonnull RecordMetaData metaData,
                          @Nonnull Tuple primaryKey,
                          @Nonnull byte[] serialized,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistryImpl.java
@@ -47,8 +47,13 @@ import java.util.ServiceLoader;
  */
 @API(API.Status.EXPERIMENTAL)
 public class TextTokenizerRegistryImpl implements TextTokenizerRegistry {
+    @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(TextTokenizerRegistryImpl.class);
+    @Nonnull
     private static final TextTokenizerRegistryImpl INSTANCE = new TextTokenizerRegistryImpl();
+
+    @Nonnull
+    private Map<String, TextTokenizerFactory> registry;
 
     @Nonnull
     private static Map<String, TextTokenizerFactory> initRegistry() {
@@ -73,9 +78,6 @@ public class TextTokenizerRegistryImpl implements TextTokenizerRegistry {
     public static TextTokenizerRegistry instance() {
         return INSTANCE;
     }
-
-    @Nonnull
-    private Map<String, TextTokenizerFactory> registry;
 
     private TextTokenizerRegistryImpl() {
         registry = initRegistry();
@@ -104,6 +106,7 @@ public class TextTokenizerRegistryImpl implements TextTokenizerRegistry {
     // Synchronize this method so that we don't need a ConcurrentHashMap but so that
     // it is still thread safe.
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public synchronized void register(@Nonnull TextTokenizerFactory tokenizerFactory) {
         final String name = tokenizerFactory.getName();
         TextTokenizerFactory oldFactory = registry.putIfAbsent(name, tokenizerFactory);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -82,22 +82,8 @@ import java.util.function.Supplier;
  */
 @API(API.Status.STABLE)
 public class FDBDatabase {
+    @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabase.class);
-
-    /**
-     * Function for mapping an underlying exception to a synchronous failure.
-     *
-     * It is possible for this function to be called with the result of calling it previously.
-     * Therefore, if wrapping exceptions with some application-specific exception class, it is best
-     * to check for being passed an {@code ex} that is already of that class and in that case just return it.
-     * @see #setAsyncToSyncExceptionMapper
-     * @see #asyncToSync
-     * @see FDBExceptions#wrapException(Throwable)
-     */
-    @FunctionalInterface
-    public static interface ExceptionMapper {
-        public RuntimeException apply(@Nonnull Throwable ex, @Nullable FDBStoreTimer.Event event);
-    }
 
     @Nonnull
     private final FDBDatabaseFactory factory;
@@ -137,7 +123,9 @@ public class FDBDatabase {
 
     private String datacenterId;
 
+    @Nonnull
     private static ImmutablePair<Long, Long> initialVersionPair = new ImmutablePair<>(null, null);
+    @Nonnull
     private AtomicReference<ImmutablePair<Long, Long>> lastSeenFDBVersion = new AtomicReference<>(initialVersionPair);
 
     @VisibleForTesting
@@ -157,6 +145,21 @@ public class FDBDatabase {
                 .recordStats()
                 .build();
         this.resolverStateCache = new AsyncLoadingCache<>(factory.getStateRefreshTimeMillis());
+    }
+
+    /**
+     * Function for mapping an underlying exception to a synchronous failure.
+     *
+     * It is possible for this function to be called with the result of calling it previously.
+     * Therefore, if wrapping exceptions with some application-specific exception class, it is best
+     * to check for being passed an {@code ex} that is already of that class and in that case just return it.
+     * @see #setAsyncToSyncExceptionMapper
+     * @see #asyncToSync
+     * @see FDBExceptions#wrapException(Throwable)
+     */
+    @FunctionalInterface
+    public interface ExceptionMapper {
+        RuntimeException apply(@Nonnull Throwable ex, @Nullable FDBStoreTimer.Event event);
     }
 
     protected synchronized void openFDB() {
@@ -264,6 +267,7 @@ public class FDBDatabase {
      * @see Database#createTransaction
      */
     @Nonnull
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public FDBRecordContext openContext(@Nullable Map<String, String> mdcContext,
                                         @Nullable FDBStoreTimer timer,
                                         @Nullable WeakReadSemantics weakReadSemantics) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -167,6 +167,7 @@ public class FDBDatabaseFactory {
         return directoryCacheSize;
     }
 
+    @SuppressWarnings("PMD.BooleanGetMethodName")
     public synchronized boolean getTrackLastSeenVersion() {
         return trackLastSeenVersion;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
@@ -361,7 +361,7 @@ public class FDBDatabaseRunner implements AutoCloseable {
                     return retriable.apply(context).thenCompose(val ->
                         context.commitAsync().thenApply( vignore -> val)
                     ).handle(this::handle).thenCompose(Function.identity());
-                } catch (Throwable e) {
+                } catch (Exception e) {
                     return handle(null, e);
                 }
             }, getExecutor()).handle((vignore, e) -> {
@@ -388,7 +388,7 @@ public class FDBDatabaseRunner implements AutoCloseable {
                     T ret = retriable.apply(context);
                     context.commit();
                     again = database.asyncToSync(timer, FDBStoreTimer.Waits.WAIT_RETRY_DELAY, handle(ret, null));
-                } catch (Throwable e) {
+                } catch (Exception e) {
                     again = database.asyncToSync(timer, FDBStoreTimer.Waits.WAIT_RETRY_DELAY, handle(null, e));
                 } finally {
                     if (context != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRecord.java
@@ -88,25 +88,30 @@ public class FDBIndexedRecord<M extends Message> implements FDBRecord<M>, FDBSto
     }
 
     @Nonnull
+    @Override
     public Tuple getPrimaryKey() {
         return getStoredRecord().getPrimaryKey();
     }
 
     @Nonnull
+    @Override
     public RecordType getRecordType() {
         return getStoredRecord().getRecordType();
     }
 
     @Nonnull
+    @Override
     public M getRecord() {
         return getStoredRecord().getRecord();
     }
 
+    @Override
     public boolean hasVersion() {
         return getStoredRecord().hasVersion();
     }
 
     @Nullable
+    @Override
     public FDBRecordVersion getVersion() {
         return getStoredRecord().getVersion();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
@@ -58,6 +58,15 @@ import java.util.concurrent.CompletableFuture;
 public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBMetaDataStore.class);
 
+    // All keys in subspace are taken by SplitHelper.
+    // Normally meta-data fits into UNSPLIT_RECORD (0).
+    public static final Tuple CURRENT_KEY = Tuple.from((Object)null);
+    public static final Tuple HISTORY_KEY_PREFIX = Tuple.from("H");
+
+    // TODO: Previously, meta-data was stored directly in the store's root.
+    //  This can be removed at some point after existing stores have been updated.
+    public static final Tuple OLD_FORMAT_KEY = TupleHelpers.EMPTY;
+
     @Nonnull
     private Descriptors.FileDescriptor[] dependencies = new Descriptors.FileDescriptor[0];
     @Nullable
@@ -81,15 +90,6 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
     public FDBMetaDataStore(@Nonnull FDBRecordContext context, @Nonnull KeySpacePath path) {
         this(context, new Subspace(path.toTuple(context)), null);
     }
-
-    // All keys in subspace are taken by SplitHelper.
-    // Normally meta-data fits into UNSPLIT_RECORD (0).
-    public static final Tuple CURRENT_KEY = Tuple.from((Object)null);
-    public static final Tuple HISTORY_KEY_PREFIX = Tuple.from("H");
-
-    // TODO: Previously, meta-data was stored directly in the store's root.
-    //  This can be removed at some point after existing stores have been updated.
-    public static final Tuple OLD_FORMAT_KEY = TupleHelpers.EMPTY;
 
     /**
      * Set dependencies upon which record descriptors may depend.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBQueriedRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBQueriedRecord.java
@@ -73,6 +73,7 @@ public abstract class FDBQueriedRecord<M extends Message> implements FDBRecord<M
         return new Covered<>(index, indexEntry, primaryKey, recordType, record);
     }
 
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
     static class Indexed<M extends Message> extends FDBQueriedRecord<M> {
         private final FDBIndexedRecord<M> indexed;
 
@@ -128,6 +129,7 @@ public abstract class FDBQueriedRecord<M extends Message> implements FDBRecord<M
         }
     }
 
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
     static class Stored<M extends Message> extends FDBQueriedRecord<M> {
         private final FDBStoredRecord<M> stored;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -859,8 +859,8 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
         } else {
             primaryKeys = new ArrayList<>(positions.length);
             int after = index.getColumnSize();
-            for (int i = 0; i < positions.length; i++) {
-                primaryKeys.add(entryKeys.get(positions[i] < 0 ? after++ : positions[i]));
+            for (int position : positions) {
+                primaryKeys.add(entryKeys.get(position < 0 ? after++ : position));
             }
         }
         return Tuple.fromList(primaryKeys);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executor;
  * some {@link Subspace} in the database.
  */
 @API(API.Status.STABLE)
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class FDBStoreBase {
     @Nonnull
     protected final FDBRecordContext context;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -433,6 +433,7 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
         }
 
         @Nonnull
+        @Override
         public FDBTypedRecordStore<M> build() {
             if (typedSerializer == null) {
                 throw new RecordCoreException("typed serializer must be specified");

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
@@ -51,7 +51,7 @@ public interface IndexMaintainerFactory {
      * @return a collection of strings of index types supported by this factory
      */
     @Nonnull
-    public Iterable<String> getIndexTypes();
+    Iterable<String> getIndexTypes();
 
     /**
      * Get a validator for the given index meta-data.
@@ -59,7 +59,7 @@ public interface IndexMaintainerFactory {
      * @return a validator for this kind of index
      */
     @Nonnull
-    public IndexValidator getIndexValidator(Index index);
+    IndexValidator getIndexValidator(Index index);
 
     /**
      * Get an index maintainer for the given record store and index meta-data.
@@ -67,5 +67,5 @@ public interface IndexMaintainerFactory {
      * @return a new index maintainer for the type of index given
      */
     @Nonnull
-    public IndexMaintainer getIndexMaintainer(IndexMaintainerState state);
+    IndexMaintainer getIndexMaintainer(IndexMaintainerState state);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
@@ -38,20 +38,20 @@ import java.util.ServiceLoader;
  */
 @API(API.Status.INTERNAL)
 public class IndexMaintainerRegistryImpl implements IndexMaintainerRegistry {
+    @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexMaintainerRegistryImpl.class);
-
+    @Nonnull
     protected static final IndexMaintainerRegistryImpl INSTANCE = new IndexMaintainerRegistryImpl();
 
+    @Nonnull
+    private final Map<String, IndexMaintainerFactory> registry;
+
+    @Nonnull
     public static IndexMaintainerRegistry instance() {
         return INSTANCE;
     }
 
-    private final Map<String, IndexMaintainerFactory> registry;
-    
-    protected IndexMaintainerRegistryImpl() {
-        registry = initRegistry();
-    }
-
+    @Nonnull
     protected static Map<String, IndexMaintainerFactory> initRegistry() {
         final Map<String, IndexMaintainerFactory> registry = new HashMap<>();
         for (IndexMaintainerFactory factory : ServiceLoader.load(IndexMaintainerFactory.class)) {
@@ -66,6 +66,10 @@ public class IndexMaintainerRegistryImpl implements IndexMaintainerRegistry {
             }
         }
         return registry;
+    }
+
+    protected IndexMaintainerRegistryImpl() {
+        registry = initRegistry();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintenanceFilter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintenanceFilter.java
@@ -33,12 +33,34 @@ import javax.annotation.Nonnull;
  */
 @API(API.Status.MAINTAINED)
 public interface IndexMaintenanceFilter {
+
+    /**
+     * All records should be added to the index. This is the default behavior.
+     */
+    IndexMaintenanceFilter NORMAL = (i, r) -> IndexValues.ALL;
+
+    /**
+     * Do not put <code>null</code> values into the index.
+     */
+    IndexMaintenanceFilter NO_NULLS = new IndexMaintenanceFilter() {
+        @Override
+        public IndexValues maintainIndex(@Nonnull Index index, @Nonnull MessageOrBuilder record) {
+            return IndexValues.SOME;
+        }
+
+        @Override
+        public boolean maintainIndexValue(@Nonnull Index index, @Nonnull MessageOrBuilder record,
+                                          @Nonnull IndexEntry indexEntry) {
+            return !indexEntry.keyContainsNonUniqueNull();
+        }
+    };
+
     /**
      * Whether to maintain a subset of the indexable values for the given record.
      */
     enum IndexValues { ALL, NONE, SOME }
 
-    public IndexValues maintainIndex(@Nonnull Index index, @Nonnull MessageOrBuilder record);
+    IndexValues maintainIndex(@Nonnull Index index, @Nonnull MessageOrBuilder record);
 
     /**
      * Get whether a specific index entry should be maintained.
@@ -48,26 +70,9 @@ public interface IndexMaintenanceFilter {
      * @param indexEntry potential entry in the index
      * @return {@code true} if the given entry should be maintained in the given index
      */
-    public default boolean maintainIndexValue(@Nonnull Index index, @Nonnull MessageOrBuilder record,
-                                              @Nonnull IndexEntry indexEntry) {
+    default boolean maintainIndexValue(@Nonnull Index index, @Nonnull MessageOrBuilder record,
+                                       @Nonnull IndexEntry indexEntry) {
         return true;
     }
 
-    public static final IndexMaintenanceFilter NORMAL = (i, r) -> IndexValues.ALL;
-
-    /**
-     * Do not put <code>null</code> values into the index.
-     */
-    public static final IndexMaintenanceFilter NO_NULLS = new IndexMaintenanceFilter() {
-            @Override
-            public IndexValues maintainIndex(@Nonnull Index index, @Nonnull MessageOrBuilder record) {
-                return IndexValues.SOME;
-            }
-
-            @Override
-            public boolean maintainIndexValue(@Nonnull Index index, @Nonnull MessageOrBuilder record,
-                                              @Nonnull IndexEntry indexEntry) {
-                return !indexEntry.keyContainsNonUniqueNull();
-            }
-        };
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexOperation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexOperation.java
@@ -28,5 +28,6 @@ import com.apple.foundationdb.API;
  * For example, an index that adds time-related entries might expire old ones occasionally.
  */
 @API(API.Status.STABLE)
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class IndexOperation {
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexOperationResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexOperationResult.java
@@ -26,5 +26,6 @@ import com.apple.foundationdb.API;
  * The result of an {@link IndexOperation}.
  */
 @API(API.Status.STABLE)
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class IndexOperationResult {
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1256,10 +1256,10 @@ public class OnlineIndexer implements AutoCloseable {
         // Check pointer equality to make sure other objects really came from given metaData.
         // Also resolve record types to use if not specified.
         private void validateIndex() {
-            final RecordMetaData metaData = getRecordMetaData();
             if (index == null) {
                 throw new MetaDataException("index must be set");
             }
+            final RecordMetaData metaData = getRecordMetaData();
             if (!metaData.hasIndex(index.getName()) || index != metaData.getIndex(index.getName())) {
                 throw new MetaDataException("Index " + index.getName() + " not contained within specified metadata");
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -707,6 +707,7 @@ public class SplitHelper {
             return nextResult.get();
         }
 
+        @Override
         @Nullable
         @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
         public byte[] getContinuation() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
@@ -54,7 +54,7 @@ public class TracedTransaction implements Transaction {
         this.transaction = transaction;
     }
 
-    @SuppressWarnings({"NoFinalizer", "squid:ObjectFinalizeOverridenCheck", "deprecation"})
+    @SuppressWarnings({"NoFinalizer", "squid:ObjectFinalizeOverridenCheck", "PMD.FinalizeDoesNotCallSuperFinalize", "deprecation"})
     @Override
     protected void finalize() {
         if (transaction != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
@@ -393,6 +393,7 @@ abstract class UnionCursorBase<T> implements RecordCursor<T> {
             this.cachedProto = proto;
         }
 
+        @SuppressWarnings("PMD.PreserveStackTrace")
         public static UnionContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
             if (bytes == null) {
                 return new UnionContinuation(Collections.nCopies(numberOfChildren, RecordCursorStartContinuation.START));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutation.java
@@ -44,7 +44,7 @@ public interface AtomicMutation {
      * @return the underlying mutation type
      */
     @Nonnull
-    public MutationType getMutationType();
+    MutationType getMutationType();
 
     /**
      * Get the underlying argument to the FDB API.
@@ -53,7 +53,7 @@ public interface AtomicMutation {
      * @return a byte array to pass to the FDB API or {@code null} to do nothing for this mutation
      */
     @Nullable
-    public byte[] getMutationParam(IndexEntry value, boolean remove);
+    byte[] getMutationParam(IndexEntry value, boolean remove);
 
     /**
      * Get a function to aggregate multiple index entries.
@@ -62,7 +62,7 @@ public interface AtomicMutation {
      * @see com.apple.foundationdb.record.RecordCursor#reduce
      */
     @Nonnull
-    public BiFunction<Tuple,Tuple,Tuple> getAggregator();
+    BiFunction<Tuple,Tuple,Tuple> getAggregator();
 
     /**
      * Get the initial value for aggregating multiple index entries.
@@ -70,7 +70,7 @@ public interface AtomicMutation {
      * @see com.apple.foundationdb.record.RecordCursor#reduce
      */
     @Nullable
-    public Tuple getIdentity();
+    Tuple getIdentity();
 
     /**
      * Determine whether this type aggregates values (as opposed to something like counting records).
@@ -78,19 +78,19 @@ public interface AtomicMutation {
      * The values are specified in the grouped part of the {@link com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression}.
      * @return {@code true} if values are allowed
      */
-    public boolean hasValues();
+    boolean hasValues();
 
     /**
      * Determine whether this type aggregates exactly one value.
      * @return {@code true} if only a single value is allowed
      */
-    public boolean hasSingleValue();
+    boolean hasSingleValue();
 
     /**
      * Determine whether this type aggregates long (integer) values.
      * @return {@code true} if only a long value is allowed
      */
-    public boolean hasLongValue();
+    boolean hasLongValue();
 
     /**
      * Determine whether this type allows negative values.
@@ -99,20 +99,20 @@ public interface AtomicMutation {
      * value in the indexed field.
      * @return {@code true} if negative values are allowed
      */
-    public boolean allowsNegative();
+    boolean allowsNegative();
 
     /**
      * Determine whether this type is idempotent.
      * Max and min type operations are idempotent; sum and count type operations are not.
      * @return {@code true} if updating the index multiple times with the same value yields the same result
      */
-    public boolean isIdempotent();
+    boolean isIdempotent();
 
     /**
      * The atomic mutations implemented straightforwardly by the FDB API.
      */
     @API(API.Status.MAINTAINED)
-    public enum Standard implements AtomicMutation {
+    enum Standard implements AtomicMutation {
         COUNT(MutationType.ADD),
         COUNT_UPDATES(MutationType.ADD),
         COUNT_NOT_NULL(MutationType.ADD),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -69,8 +69,8 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
         return Arrays.asList(TYPES);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public IndexValidator getIndexValidator(Index index) {
         return new IndexValidator(index) {
             final AtomicMutation mutation = AtomicMutationIndexMaintainer.getAtomicMutation(index);
@@ -125,6 +125,7 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
         };
     }
 
+    @Override
     @Nonnull
     public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
         return new AtomicMutationIndexMaintainer(state);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
@@ -47,8 +47,8 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
         return Arrays.asList(TYPES);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public IndexValidator getIndexValidator(Index index) {
         return new IndexValidator(index) {
             @Override
@@ -60,6 +60,7 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
         };
     }
 
+    @Override
     @Nonnull
     public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
         return new RankIndexMaintainer(state);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
@@ -81,6 +81,7 @@ import static com.apple.foundationdb.record.provider.foundationdb.SplitHelper.un
 @API(API.Status.MAINTAINED)
 public abstract class StandardIndexMaintainer extends IndexMaintainer {
     private static final Logger LOGGER = LoggerFactory.getLogger(StandardIndexMaintainer.class);
+    protected static final int TOO_LARGE_VALUE_MESSAGE_LIMIT = 100;
 
     protected StandardIndexMaintainer(IndexMaintainerState state) {
         super(state);
@@ -154,7 +155,6 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
     public boolean skipUpdateForUnchangedKeys() {
         return true;
     }
-
 
     @Override
     @Nonnull
@@ -381,8 +381,6 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
                         LogMessageKeys.INDEX_NAME, state.index.getName());
         }
     }
-
-    protected static final int TOO_LARGE_VALUE_MESSAGE_LIMIT = 100;
 
     protected static String trimTooLargeTuple(@Nonnull Tuple tuple) {
         final String fullString = tuple.toString();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
@@ -167,6 +167,7 @@ public class TextIndexMaintainer extends StandardIndexMaintainer {
      * @param index the index to get the tokenizer version of
      * @return the tokenizer version associated with the given index
      */
+    @SuppressWarnings("PMD.PreserveStackTrace")
     public static int getIndexTokenizerVersion(@Nonnull Index index) {
         String versionStr = index.getOption(IndexOptions.TEXT_TOKENIZER_VERSION_OPTION);
         if (versionStr != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
@@ -47,8 +47,8 @@ public class ValueIndexMaintainerFactory implements IndexMaintainerFactory {
         return Arrays.asList(TYPES);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public IndexValidator getIndexValidator(Index forIndex) {
         return new IndexValidator(forIndex) {
             @Override
@@ -60,9 +60,9 @@ public class ValueIndexMaintainerFactory implements IndexMaintainerFactory {
         };
     }
 
+    @Override
     @Nonnull
     public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
         return new ValueIndexMaintainer(state);
     }
-
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
@@ -102,8 +102,8 @@ public class KeySpacePathWrapper implements KeySpacePath {
     }
 
     @Deprecated
-    @Nonnull
     @Override
+    @Nonnull
     public FDBRecordContext getContext() {
         return inner.getContext();
     }
@@ -149,8 +149,8 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.getValue();
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public PathValue getStoredValue() {
         return inner.getStoredValue();
     }
@@ -166,6 +166,7 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.resolveAsync(context);
     }
 
+    @Override
     @Nonnull
     public CompletableFuture<Tuple> toTupleAsync(@Nonnull FDBRecordContext context) {
         return inner.toTupleAsync(context);
@@ -177,20 +178,20 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.flatten();
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public CompletableFuture<Boolean> hasDataAsync(@Nonnull FDBRecordContext context) {
         return inner.hasDataAsync(context);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public CompletableFuture<Void> deleteAllDataAsync(@Nonnull FDBRecordContext context) {
         return inner.deleteAllDataAsync(context);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public RecordCursor<KeySpacePath> listAsync(@Nonnull FDBRecordContext context,
                                                 @Nonnull String subdirName,
                                                 @Nullable ValueRange<?> range,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -458,7 +458,7 @@ public abstract class LocatableResolver {
             try {
                 return ResolverStateProto.State.parseFrom(bytes);
             } catch (InvalidProtocolBufferException exception) {
-                throw new RecordCoreException("invalid state value")
+                throw new RecordCoreException("invalid state value", exception)
                         .addLogInfo("valueBytes", ByteArrayUtil2.loggable(bytes));
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/HighContentionAllocator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/HighContentionAllocator.java
@@ -226,7 +226,7 @@ public class HighContentionAllocator {
             if (windowBegin < 255) {
                 return 1 << 6;
             }
-            if (windowBegin < 65535) {
+            if (windowBegin < 65_535) {
                 return 1 << 10;
             }
             return 1 << 12;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayer.java
@@ -197,7 +197,7 @@ public class StringInterningLayer {
                     interned.getInternedValue(),
                     interned.hasMetadata() ? interned.getMetadata().toByteArray() : null);
         } catch (InvalidProtocolBufferException exception) {
-            throw new RecordCoreException("invalid interned value")
+            throw new RecordCoreException("invalid interned value", exception)
                     .addLogInfo("internedBytes", ByteArrayUtil2.loggable(bytes))
                     .addLogInfo("mappingSubspace", mappingSubspace);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -307,7 +307,7 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
 
     @Override
     @Nonnull
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "PMD.UnnecessaryLocalBeforeReturn"})
     @SpotBugsSuppressWarnings("BC_UNCONFIRMED_CAST")
     public <T, M extends Message> CompletableFuture<T> evaluateRecordFunction(@Nonnull EvaluationContext context,
                                                                               @Nonnull IndexRecordFunction<T> function,
@@ -721,6 +721,7 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
             return indexEntry.hashCode();
         }
 
+        @Override
         public int compareTo(OrderedScoreIndexKey that) {
             return this.scoreKey.compareTo(that.scoreKey);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
@@ -47,8 +47,8 @@ public class TimeWindowLeaderboardIndexMaintainerFactory implements IndexMaintai
         return Arrays.asList(TYPES);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public IndexValidator getIndexValidator(Index index) {
         return new IndexValidator(index) {
             @Override
@@ -60,6 +60,7 @@ public class TimeWindowLeaderboardIndexMaintainerFactory implements IndexMaintai
         };
     }
 
+    @Override
     @Nonnull
     public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
         return new TimeWindowLeaderboardIndexMaintainer(state);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardWindowUpdate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardWindowUpdate.java
@@ -32,7 +32,7 @@ public class TimeWindowLeaderboardWindowUpdate extends IndexOperation {
     /**
      * When to completely rebuild an index.
      */
-    public static enum Rebuild {
+    public enum Rebuild {
         ALWAYS, NEVER, IF_OVERLAPPING_CHANGED
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -825,6 +825,7 @@ public class Comparisons {
 
         @Nullable
         @Override
+        @SuppressWarnings("PMD.CompareObjectsWithEquals")
         public Boolean eval(@Nonnull FDBRecordStoreBase<?> store, @Nonnull EvaluationContext context, @Nullable Object value) {
             final Object comparand = context.getBinding(parameter);
             if (comparand == null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
@@ -208,7 +208,7 @@ public class Field {
         if (comparand instanceof List) {
             @SuppressWarnings("rawtypes")
             List list = (List) comparand;
-            if (list.size() > 0) {
+            if (!list.isEmpty()) {
                 return new FieldWithComparison(fieldName,
                         new Comparisons.ListComparison(type, list));
             } else {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NotComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NotComponent.java
@@ -92,6 +92,7 @@ public class NotComponent implements ComponentWithSingleChild {
     /**
      * Child for this component.
      */
+    @Override
     @Nonnull
     public QueryComponent getChild() {
         return child.get();
@@ -124,8 +125,8 @@ public class NotComponent implements ComponentWithSingleChild {
         return getChild().planHash() + 1;
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     @API(API.Status.EXPERIMENTAL)
     public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
         return Iterators.singletonIterator(this.child);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComparison.java
@@ -78,6 +78,7 @@ public class OneOfThemWithComparison extends BaseRepeatedField implements Compon
         getComparison().validate(field, true);
     }
 
+    @Override
     @Nonnull
     public Comparisons.Comparison getComparison() {
         return comparison.get();
@@ -88,8 +89,8 @@ public class OneOfThemWithComparison extends BaseRepeatedField implements Compon
         return new OneOfThemWithComparison(getFieldName(), comparison);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     @API(API.Status.EXPERIMENTAL)
     public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
         return Iterators.singletonIterator(this.comparison);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
@@ -83,13 +83,14 @@ public class OneOfThemWithComponent extends BaseRepeatedField implements Compone
         component.validate(field.getMessageType());
     }
 
+    @Override
     @Nonnull
     public QueryComponent getChild() {
         return child.get();
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     @API(API.Status.EXPERIMENTAL)
     public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
         return Iterators.singletonIterator(this.child);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
@@ -59,6 +59,7 @@ public class QueryRecordFunctionWithComparison implements ComponentWithCompariso
         return function;
     }
 
+    @Override
     @Nonnull
     public Comparisons.Comparison getComparison() {
         return comparison.get();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
@@ -46,83 +46,6 @@ import java.util.Set;
  */
 @API(API.Status.MAINTAINED)
 public class RecordTypeKeyComparison implements ComponentWithComparison {
-    static class RecordTypeComparison implements Comparisons.Comparison {
-        private final String recordTypeName;
-
-        RecordTypeComparison(String recordTypeName) {
-            this.recordTypeName = recordTypeName;
-        }
-
-        @Nullable
-        @Override
-        public Boolean eval(@Nonnull FDBRecordStoreBase<?> store, @Nonnull EvaluationContext context, @Nullable Object value) {
-            if (value == null) {
-                return null;
-            }
-            return ((Message)value).getDescriptorForType().getName().equals(recordTypeName);
-        }
-
-        @Override
-        public void validate(@Nonnull Descriptors.FieldDescriptor descriptor, boolean fannedOut) {
-            // Do not actually apply to any particular field.
-        }
-
-        @Nonnull
-        @Override
-        public Comparisons.Type getType() {
-            return Comparisons.Type.EQUALS;
-        }
-
-        @Nullable
-        @Override
-        public Object getComparand(@Nullable FDBRecordStoreBase<?> store, @Nullable EvaluationContext context) {
-            if (store == null) {
-                throw new Comparisons.EvaluationContextRequiredException("Cannot get record type key without store");
-            }
-            return store.getRecordMetaData().getRecordType(recordTypeName).getRecordTypeKey();
-        }
-
-        @Nonnull
-        @Override
-        public String typelessString() {
-            return recordTypeName;
-        }
-
-        @Override
-        public int planHash() {
-            return PlanHashable.objectPlanHash(recordTypeName);
-        }
-
-        @Nonnull
-        @Override
-        @API(API.Status.EXPERIMENTAL)
-        public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
-            return Collections.emptyIterator();
-        }
-
-        @Override
-        public String toString() {
-            return "IS " + recordTypeName;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            RecordTypeComparison that = (RecordTypeComparison)o;
-            return Objects.equals(recordTypeName, that.recordTypeName);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(recordTypeName);
-        }
-    }
-
     @Nonnull
     private final ExpressionRef<RecordTypeComparison> comparison;
 
@@ -201,5 +124,82 @@ public class RecordTypeKeyComparison implements ComponentWithComparison {
     @Override
     public QueryComponent withOtherComparison(Comparisons.Comparison comparison) {
         throw new UnsupportedOperationException("Cannot change comparison");
+    }
+
+    static class RecordTypeComparison implements Comparisons.Comparison {
+        private final String recordTypeName;
+
+        RecordTypeComparison(String recordTypeName) {
+            this.recordTypeName = recordTypeName;
+        }
+
+        @Nullable
+        @Override
+        public Boolean eval(@Nonnull FDBRecordStoreBase<?> store, @Nonnull EvaluationContext context, @Nullable Object value) {
+            if (value == null) {
+                return null;
+            }
+            return ((Message)value).getDescriptorForType().getName().equals(recordTypeName);
+        }
+
+        @Override
+        public void validate(@Nonnull Descriptors.FieldDescriptor descriptor, boolean fannedOut) {
+            // Do not actually apply to any particular field.
+        }
+
+        @Nonnull
+        @Override
+        public Comparisons.Type getType() {
+            return Comparisons.Type.EQUALS;
+        }
+
+        @Nullable
+        @Override
+        public Object getComparand(@Nullable FDBRecordStoreBase<?> store, @Nullable EvaluationContext context) {
+            if (store == null) {
+                throw new Comparisons.EvaluationContextRequiredException("Cannot get record type key without store");
+            }
+            return store.getRecordMetaData().getRecordType(recordTypeName).getRecordTypeKey();
+        }
+
+        @Nonnull
+        @Override
+        public String typelessString() {
+            return recordTypeName;
+        }
+
+        @Override
+        public int planHash() {
+            return PlanHashable.objectPlanHash(recordTypeName);
+        }
+
+        @Nonnull
+        @Override
+        @API(API.Status.EXPERIMENTAL)
+        public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public String toString() {
+            return "IS " + recordTypeName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            RecordTypeComparison that = (RecordTypeComparison)o;
+            return Objects.equals(recordTypeName, that.recordTypeName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(recordTypeName);
+        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
@@ -43,11 +43,6 @@ import java.util.TreeMap;
  */
 @API(API.Status.INTERNAL)
 public class IndexKeyValueToPartialRecord {
-    static interface Copier {
-        public void copy(@Nonnull Descriptors.Descriptor recordDescriptor, @Nonnull Message.Builder recordBuilder,
-                         @Nonnull IndexEntry kv);
-    }
-
     @Nonnull
     private final List<Copier> copiers;
 
@@ -88,8 +83,13 @@ public class IndexKeyValueToPartialRecord {
     /**
      * Which side of the {@link IndexEntry} to take a field from.
      */
-    public static enum TupleSource {
+    public enum TupleSource {
         KEY, VALUE
+    }
+
+    interface Copier {
+        void copy(@Nonnull Descriptors.Descriptor recordDescriptor, @Nonnull Message.Builder recordBuilder,
+                  @Nonnull IndexEntry kv);
     }
 
     static class FieldCopier implements Copier {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -553,7 +553,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             comparisonKey = getKeyForMerge(sort, comparisonKey);
             ScoredPlan intersectionPlan = planIntersection(intersectionCandidates, comparisonKey);
             if (intersectionPlan != null) {
-                if (intersectionPlan.unsatisfiedFilters.size() == 0) {
+                if (intersectionPlan.unsatisfiedFilters.isEmpty()) {
                     return intersectionPlan;
                 } else if (bestPlan.unsatisfiedFilters.size() > intersectionPlan.unsatisfiedFilters.size()) {
                     bestPlan = intersectionPlan;
@@ -633,8 +633,8 @@ public class RecordQueryPlanner implements QueryPlanner {
             }
             if (plan != null) {
                 List<QueryComponent> unsatisfied;
-                if (plan.unsatisfiedFilters.size() > 0) {
-                    unsatisfied = Collections.<QueryComponent>singletonList(filter);
+                if (!plan.unsatisfiedFilters.isEmpty()) {
+                    unsatisfied = Collections.singletonList(filter);
                 } else {
                     unsatisfied = Collections.emptyList();
                 }
@@ -707,7 +707,7 @@ public class RecordQueryPlanner implements QueryPlanner {
                 }
             }
 
-            if (childPlan != null && childPlan.unsatisfiedFilters.size() > 0) {
+            if (childPlan != null && !childPlan.unsatisfiedFilters.isEmpty()) {
                 // Add the parent to the unsatisfied filters of this ScoredPlan if non-zero.
                 QueryComponent unsatisfiedFilter;
                 if (childPlan.unsatisfiedFilters.size() > 1) {
@@ -1174,7 +1174,6 @@ public class RecordQueryPlanner implements QueryPlanner {
         }
         boolean reverse = subplans.get(0).plan.isReverse();
         boolean anyDuplicates = false;
-        boolean showComparisonKey = !comparisonKey.equals(planContext.commonPrimaryKey);
         Set<RankComparisons.RankComparison> includedRankComparisons = null;
         List<RecordQueryPlan> childPlans = new ArrayList<>(subplans.size());
         for (ScoredPlan subplan : subplans) {
@@ -1186,6 +1185,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             anyDuplicates |= subplan.createsDuplicates;
             includedRankComparisons = mergeRankComparisons(includedRankComparisons, subplan.includedRankComparisons);
         }
+        boolean showComparisonKey = !comparisonKey.equals(planContext.commonPrimaryKey);
         final RecordQueryPlan unionPlan = new RecordQueryUnionPlan(childPlans, comparisonKey, reverse, showComparisonKey);
         if (unionPlan.getComplexity() > complexityThreshold) {
             throw new RecordQueryPlanComplexityException(unionPlan);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
@@ -111,7 +111,7 @@ public class ScanComparisons implements PlanHashable {
     /**
      * The type of a comparison.
      */
-    public static enum ComparisonType {
+    public enum ComparisonType {
         EQUALITY, INEQUALITY, NONE
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/RankComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/RankComparisons.java
@@ -67,74 +67,7 @@ import java.util.stream.Collectors;
  */
 @API(API.Status.INTERNAL)
 public class RankComparisons {
-    /**
-     * A single rank function comparison.
-     */
-    public static class RankComparison {
-        @Nonnull
-        private final QueryRecordFunctionWithComparison comparison;
-
-        @Nonnull
-        private final Index index;
-        @Nonnull
-        private final List<QueryComponent> groupFilters;
-        @Nullable
-        private final List<Comparisons.Comparison> groupComparisons;
-        @Nullable
-        private final QueryComponent substitute;
-        @Nullable
-        private final String bindingName;
-
-        protected RankComparison(@Nonnull QueryRecordFunctionWithComparison comparison,
-                                 @Nonnull Index index,
-                                 @Nonnull List<QueryComponent> groupFilters,
-                                 @Nonnull List<Comparisons.Comparison> groupComparisons,
-                                 @Nullable QueryComponent substitute,
-                                 @Nullable String bindingName) {
-            this.comparison = comparison;
-            this.index = index;
-            this.groupFilters = groupFilters;
-            this.groupComparisons = groupComparisons;
-            this.substitute = substitute;
-            this.bindingName = bindingName;
-        }
-
-        @Nonnull
-        public Index getIndex() {
-            return index;
-        }
-
-        @Nonnull
-        public List<QueryComponent> getGroupFilters() {
-            return groupFilters;
-        }
-
-        public ScanComparisons getScanComparisons() {
-            final ScanComparisons rankComparison = ScanComparisons.from(comparison.getComparison());
-            if (groupComparisons.isEmpty()) {
-                return rankComparison;
-            } else {
-                return new ScanComparisons(groupComparisons, Collections.emptyList()).append(rankComparison);
-            }
-        }
-
-        @Nullable
-        public QueryComponent getSubstitute() {
-            return substitute;
-        }
-
-        @Nonnull
-        public RecordQueryScoreForRankPlan.ScoreForRank getScoreForRank(@Nonnull RecordMetaData metaData) {
-            final String functionName = scoreForRankFunction(comparison);
-            final IndexAggregateFunction function = new IndexAggregateFunction(functionName,
-                    ((IndexRecordFunction<?>)comparison.getFunction()).getOperand(), index.getName());
-            final List<Comparisons.Comparison> comparisons = new ArrayList<>(groupComparisons);
-            comparisons.add(comparison.getComparison());
-            final Function<Tuple, Object> bindingFunction = BindingFunctions.comparisonBindingFunction(substitute, index, metaData);
-            return new RecordQueryScoreForRankPlan.ScoreForRank(bindingName, bindingFunction, function, comparisons);
-        }
-    }
-
+    @Nonnull
     private final Map<QueryRecordFunctionWithComparison, RankComparison> comparisons = new HashMap<>();
 
     public RankComparisons(@Nullable QueryComponent filter, @Nonnull List<Index> indexes) {
@@ -282,6 +215,74 @@ public class RankComparisons {
                 comparisons.put(comparison, new RankComparison(comparison, matchingIndex.get(),
                         groupFilters, groupComparisons, substitute, bindingName));
             }
+        }
+    }
+
+    /**
+     * A single rank function comparison.
+     */
+    public static class RankComparison {
+        @Nonnull
+        private final QueryRecordFunctionWithComparison comparison;
+
+        @Nonnull
+        private final Index index;
+        @Nonnull
+        private final List<QueryComponent> groupFilters;
+        @Nullable
+        private final List<Comparisons.Comparison> groupComparisons;
+        @Nullable
+        private final QueryComponent substitute;
+        @Nullable
+        private final String bindingName;
+
+        protected RankComparison(@Nonnull QueryRecordFunctionWithComparison comparison,
+                                 @Nonnull Index index,
+                                 @Nonnull List<QueryComponent> groupFilters,
+                                 @Nonnull List<Comparisons.Comparison> groupComparisons,
+                                 @Nullable QueryComponent substitute,
+                                 @Nullable String bindingName) {
+            this.comparison = comparison;
+            this.index = index;
+            this.groupFilters = groupFilters;
+            this.groupComparisons = groupComparisons;
+            this.substitute = substitute;
+            this.bindingName = bindingName;
+        }
+
+        @Nonnull
+        public Index getIndex() {
+            return index;
+        }
+
+        @Nonnull
+        public List<QueryComponent> getGroupFilters() {
+            return groupFilters;
+        }
+
+        public ScanComparisons getScanComparisons() {
+            final ScanComparisons rankComparison = ScanComparisons.from(comparison.getComparison());
+            if (groupComparisons.isEmpty()) {
+                return rankComparison;
+            } else {
+                return new ScanComparisons(groupComparisons, Collections.emptyList()).append(rankComparison);
+            }
+        }
+
+        @Nullable
+        public QueryComponent getSubstitute() {
+            return substitute;
+        }
+
+        @Nonnull
+        public RecordQueryScoreForRankPlan.ScoreForRank getScoreForRank(@Nonnull RecordMetaData metaData) {
+            final String functionName = scoreForRankFunction(comparison);
+            final IndexAggregateFunction function = new IndexAggregateFunction(functionName,
+                    ((IndexRecordFunction<?>)comparison.getFunction()).getOperand(), index.getName());
+            final List<Comparisons.Comparison> comparisons = new ArrayList<>(groupComparisons);
+            comparisons.add(comparison.getComparison());
+            final Function<Tuple, Object> bindingFunction = BindingFunctions.comparisonBindingFunction(substitute, index, metaData);
+            return new RecordQueryScoreForRankPlan.ScoreForRank(bindingName, bindingFunction, function, comparisons);
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
@@ -50,6 +50,9 @@ import java.util.Set;
  */
 @API(API.Status.MAINTAINED)
 public abstract class RecordQueryInJoinPlan implements RecordQueryPlanWithChild {
+    @SuppressWarnings("unchecked")
+    protected static final Comparator<Object> VALUE_COMPARATOR = (o1, o2) -> ((Comparable)o1).compareTo((Comparable)o2);
+
     protected final ExpressionRef<RecordQueryPlan> plan;
     protected final List<ExpressionRef<? extends PlannerExpression>> children;
     protected final String bindingName;
@@ -173,9 +176,6 @@ public abstract class RecordQueryInJoinPlan implements RecordQueryPlanWithChild 
         copy.sort(sortReverse ? VALUE_COMPARATOR.reversed() : VALUE_COMPARATOR);
         return copy;
     }
-
-    @SuppressWarnings("unchecked")
-    protected static final Comparator<Object> VALUE_COMPARATOR = (o1, o2) -> ((Comparable)o1).compareTo((Comparable)o2);
 
     @Nullable
     protected abstract List<Object> getValues(EvaluationContext context);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -86,6 +86,7 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
     }
 
     @Nonnull
+    @Override
     public IndexScanType getScanType() {
         return scanType;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -52,13 +52,6 @@ import java.util.Set;
  */
 @API(API.Status.MAINTAINED)
 public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren {
-    /**
-     * A source for the primary keys for records.
-     */
-    public interface KeysSource extends PlanHashable, PlannerExpression {
-        List<Tuple> getPrimaryKeys(@Nonnull EvaluationContext context);
-    }
-
     @Nonnull
     private final ExpressionRef<KeysSource> keysSource;
 
@@ -216,6 +209,13 @@ public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren 
         public int planHash() {
             return hashCode();
         }
+    }
+
+    /**
+     * A source for the primary keys for records.
+     */
+    public interface KeysSource extends PlanHashable, PlannerExpression {
+        List<Tuple> getPrimaryKeys(@Nonnull EvaluationContext context);
     }
 
     private static class ParameterKeySource implements KeysSource {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -59,63 +59,6 @@ import java.util.stream.Collectors;
  */
 @API(API.Status.MAINTAINED)
 public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
-    /**
-     * A single conversion of a rank to a score to be bound to some name.
-     */
-    public static class ScoreForRank implements PlanHashable {
-        @Nonnull
-        private final String bindingName;
-        @Nonnull
-        private final Function<Tuple, Object> bindingFunction;
-        @Nonnull
-        private final IndexAggregateFunction function;
-        @Nonnull
-        private final List<Comparisons.Comparison> comparisons;
-
-        public ScoreForRank(@Nonnull String bindingName, @Nonnull Function<Tuple, Object> bindingFunction,
-                            @Nonnull IndexAggregateFunction function, @Nonnull List<Comparisons.Comparison> comparisons) {
-            this.bindingName = bindingName;
-            this.bindingFunction = bindingFunction;
-            this.function = function;
-            this.comparisons = comparisons;
-        }
-
-        @Nonnull
-        public String getBindingName() {
-            return bindingName;
-        }
-
-        @Override
-        public String toString() {
-            return bindingName + " = " + function.getIndex() + "." + function.getName() + comparisons.stream().map(Comparisons.Comparison::typelessString).collect(Collectors.joining(", ", "(", ")"));
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            ScoreForRank that = (ScoreForRank) o;
-            return Objects.equals(bindingName, that.bindingName) &&
-                    Objects.equals(bindingFunction, that.bindingFunction) &&
-                    Objects.equals(function, that.function) &&
-                    Objects.equals(comparisons, that.comparisons);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(bindingName, bindingFunction, function, comparisons);
-        }
-
-        @Override
-        public int planHash() {
-            return bindingName.hashCode() + function.getName().hashCode() + PlanHashable.planHash(comparisons);
-        }
-    }
-
     @Nonnull
     private final ExpressionRef<RecordQueryPlan> plan;
     @Nonnull
@@ -243,5 +186,62 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
     @Override
     public int getComplexity() {
         return 1 + getChild().getComplexity();
+    }
+
+    /**
+     * A single conversion of a rank to a score to be bound to some name.
+     */
+    public static class ScoreForRank implements PlanHashable {
+        @Nonnull
+        private final String bindingName;
+        @Nonnull
+        private final Function<Tuple, Object> bindingFunction;
+        @Nonnull
+        private final IndexAggregateFunction function;
+        @Nonnull
+        private final List<Comparisons.Comparison> comparisons;
+
+        public ScoreForRank(@Nonnull String bindingName, @Nonnull Function<Tuple, Object> bindingFunction,
+                            @Nonnull IndexAggregateFunction function, @Nonnull List<Comparisons.Comparison> comparisons) {
+            this.bindingName = bindingName;
+            this.bindingFunction = bindingFunction;
+            this.function = function;
+            this.comparisons = comparisons;
+        }
+
+        @Nonnull
+        public String getBindingName() {
+            return bindingName;
+        }
+
+        @Override
+        public String toString() {
+            return bindingName + " = " + function.getIndex() + "." + function.getName() + comparisons.stream().map(Comparisons.Comparison::typelessString).collect(Collectors.joining(", ", "(", ")"));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ScoreForRank that = (ScoreForRank) o;
+            return Objects.equals(bindingName, that.bindingName) &&
+                   Objects.equals(bindingFunction, that.bindingFunction) &&
+                   Objects.equals(function, that.function) &&
+                   Objects.equals(comparisons, that.comparisons);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(bindingName, bindingFunction, function, comparisons);
+        }
+
+        @Override
+        public int planHash() {
+            return bindingName.hashCode() + function.getName().hashCode() + PlanHashable.planHash(comparisons);
+        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
@@ -52,7 +52,7 @@ public interface ExpressionRef<T extends PlannerExpression> extends Bindable {
      * This exceeds the normal maximum inheritance depth because of the depth of the <code>RecordCoreException</code>
      * hierarchy.
      */
-    public static class UngettableReferenceException extends RecordCoreException {
+    class UngettableReferenceException extends RecordCoreException {
         private static final long serialVersionUID = 1;
 
         public UngettableReferenceException(String message) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerExpression.java
@@ -65,6 +65,7 @@ public interface PlannerExpression extends Bindable {
      * @param existing an existing map of bindings
      * @return the existing bindings extended with some new ones if the match was successful or <code>Optional.empty()</code> otherwise
      */
+    @Override
     @Nonnull
     default Optional<PlannerBindings> bindWithExisting(@Nonnull ExpressionMatcher<? extends Bindable> binding, @Nonnull PlannerBindings existing) {
         if (existing.containsKey(binding)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/SingleExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/SingleExpressionRef.java
@@ -42,6 +42,7 @@ public class SingleExpressionRef<T extends PlannerExpression> implements Mutable
         this.expression = expression;
     }
 
+    @Override
     @Nonnull
     public T get() {
         return expression;
@@ -78,8 +79,8 @@ public class SingleExpressionRef<T extends PlannerExpression> implements Mutable
      * @param existing an existing map of bindings
      * @return a map of bindings if the match succeeded, or an empty <code>Optional</code> if it failed
      */
-    @Nonnull
     @Override
+    @Nonnull
     public Optional<PlannerBindings> bindWithExisting(@Nonnull ExpressionMatcher<? extends Bindable> binding, @Nonnull PlannerBindings existing) {
         switch (binding.matches(this)) {
             case UNKNOWN:

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalTypeFilterExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalTypeFilterExpression.java
@@ -55,12 +55,13 @@ public class LogicalTypeFilterExpression implements TypeFilterExpression {
         this.expressionChildren = ImmutableList.of(this.inner);
     }
 
-    @Nonnull
     @Override
+    @Nonnull
     public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
         return expressionChildren.iterator();
     }
 
+    @Override
     @Nonnull
     public Collection<String> getRecordTypes() {
         return recordTypes;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
@@ -41,10 +41,10 @@ import javax.annotation.Nonnull;
  */
 @API(API.Status.EXPERIMENTAL)
 public class CombineFilterRule extends PlannerRule<LogicalFilterExpression> {
-    public static final ExpressionMatcher<ExpressionRef<QueryComponent>> firstMatcher = ReferenceMatcher.anyRef();
-    public static final ExpressionMatcher<ExpressionRef<QueryComponent>> secondMatcher = ReferenceMatcher.anyRef();
-    public static final ExpressionMatcher<ExpressionRef<RelationalPlannerExpression>> childMatcher = ReferenceMatcher.anyRef();
-    public static final ExpressionMatcher<LogicalFilterExpression> root = TypeMatcher.of(LogicalFilterExpression.class,
+    private static final ExpressionMatcher<ExpressionRef<QueryComponent>> firstMatcher = ReferenceMatcher.anyRef();
+    private static final ExpressionMatcher<ExpressionRef<QueryComponent>> secondMatcher = ReferenceMatcher.anyRef();
+    private static final ExpressionMatcher<ExpressionRef<RelationalPlannerExpression>> childMatcher = ReferenceMatcher.anyRef();
+    private static final ExpressionMatcher<LogicalFilterExpression> root = TypeMatcher.of(LogicalFilterExpression.class,
             firstMatcher,
             TypeMatcher.of(LogicalFilterExpression.class,
                     secondMatcher, childMatcher));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.metadata.ExpressionTestsProto.NestedField;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.SubString;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.SubStrings;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.TestScalarFieldAccess;
+import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -58,6 +60,9 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.value;
 import static com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression.EMPTY;
 import static com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression.VERSION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -196,6 +201,18 @@ public class KeyExpressionTest {
             .addSubstrings(SubString.newBuilder().setContent("jay").setStart(0).setEnd(1))
             .addSubstrings(SubString.newBuilder().setContent("christos").setStart(5).setEnd(8))
             .build();
+
+    /**
+     * One of the static analysis tools used flagged the EmptyKeyExpression class as not including
+     * the serialVersionUID field even though it implemented {@link Serializable}. However,
+     * that class doesn't implement it, as verified by this test. So the check was disabled for that
+     * class. If this test ever fails, then a serial version UID should probably be added and that
+     * check un-suppressed.
+     */
+    @Test
+    public void testEmptyNotSerializable() {
+        assertThat(EmptyKeyExpression.EMPTY, not(instanceOf(Serializable.class)));
+    }
 
     @Test
     public void testScalarFieldAccess() throws Exception {

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -120,7 +120,7 @@ pmd {
     ignoreFailures = false
     targetJdk = '1.7'
     sourceSets = [sourceSets.main]
-    toolVersion = '5.1.2'
+    toolVersion = '6.10.0'
     // an annoying hack to get around Gradle defaults
     // See https://ncona.com/2015/01/unable-to-exclude-pmd-rule-after-upgrading-to-gradle-2/
     ruleSets = []

--- a/gradle/codequality/pmd-rules.xml
+++ b/gradle/codequality/pmd-rules.xml
@@ -9,25 +9,61 @@
         Record Layer PMD ruleset
     </description>
 
-    <rule ref="rulesets/java/basic.xml">
-        <exclude name="CollapsibleIfStatements"/>
-    </rule>    
-
-    <rule ref="rulesets/java/braces.xml"/>
-
-    <rule ref="rulesets/java/empty.xml"/>
-
-    <rule ref="rulesets/java/imports.xml"/>
-
-    <rule ref="rulesets/java/unnecessary.xml">
-        <exclude name="UselessParentheses"/>
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="ArrayIsStoredDirectly" />
+        <exclude name="AvoidReassigningParameters" />
+        <!-- This rule is perfectly fine but SpotBugs handles it for us. -->
+        <exclude name="MethodReturnsInternalArray" />
+        <exclude name="UseVarargs" />
     </rule>
 
-    <rule ref="rulesets/java/strings.xml">
-        <exclude name="AppendCharacterWithChar"/>
-        <exclude name="AvoidDuplicateLiterals"/>
-        <exclude name="ConsecutiveLiteralAppends"/>
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="AtLeastOneConstructor" />
+        <exclude name="AvoidFinalLocalVariable" />
+        <exclude name="CallSuperInConstructor" />
+        <exclude name="ClassNamingConventions" />
+        <exclude name="CommentDefaultAccessModifier" />
+        <exclude name="ConfusingTernary" />
+        <exclude name="DefaultPackage" />
+        <exclude name="FieldNamingConventions" />
+        <exclude name="LocalVariableCouldBeFinal" />
+        <exclude name="LinguisticNaming" />
+        <exclude name="LongVariable" />
+        <exclude name="MethodArgumentCouldBeFinal" />
+        <exclude name="OnlyOneReturn" />
+        <exclude name="PrematureDeclaration" />
+        <exclude name="ShortClassName" />
+        <exclude name="ShortMethodName" />
+        <exclude name="ShortVariable" />
+        <exclude name="UnnecessaryConstructor" />
+        <exclude name="UselessParentheses" />
+    </rule>
+    <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+        <properties>
+            <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+" />
+        </properties>
+    </rule>
+    <rule ref="category/java/codestyle.xml/FieldNamingConventions">
+        <properties>
+            <!--
+                We appear to follow both the "lower-case, camel case" and "all caps convention", so
+                this essentially asserts to do one or the other. Note that *public* constants are
+                still required to be all caps.
+            -->
+            <property name="constantPattern" value="[A-Z][A-Z_0-9]+|[a-z][a-zA-Z0-9]+" />
+        </properties>
     </rule>
 
-    <rule ref="rulesets/java/logging-java.xml"/>
+    <rule ref="category/java/errorprone.xml"> 
+        <exclude name="AvoidDuplicateLiterals" />
+        <exclude name="AvoidFieldNameMatchingMethodName" />
+        <exclude name="AvoidLiteralsInIfCondition" />
+        <exclude name="BeanMembersShouldSerialize" />
+        <exclude name="ConstructorCallsOverridableMethod" />
+        <!-- The rule below appears to have bugs when run: https://github.com/pmd/pmd/issues/873 -->
+        <exclude name="DataflowAnomalyAnalysis" />
+        <exclude name="NullAssignment" />
+        <exclude name="ReturnEmptyArrayRatherThanNull" />
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
This updates the ruleset with their new file locations and tweaks the exclusions so that it mostly matches our coding style/level of cleanliness. It also makes some changes to match a few rules that I thought should be updated.

A few highlights:

* I kept a rule stating that field declarations should come before anything else in a class. We were already (mostly) following that rule, with a few one-off exceptions of some constants (that I fixed--I don't think that should be controversial) as well as a few other cases where there were static methods or classes were defined before fields. In order to keep constructors near the fields they initialized, I decided to move some code around. The code in question *generally* had very little history (as it has been unchanged since the initial repository commit).
* There is a rule called "PrematureDeclaration" that complains if one creates a local variable before a potential exit point. I began to fix those, but then I got to more complicated examples where it was unclear to me if rearranging lines was safe, so I just decided to disable the rule.

Before merging, there should probably be one more rebase from master (as this is prone to merge skew), and once it's merged, all other PRs should probably rebase from it for similar reasons.