### PR TITLE
Fixes #322: Versioning guide missing from docs table of contents

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ reliability, and performance in a distributed setting.
 * [Building](Building.md)
 * [Schema Evolution and Meta-data Maintenance](SchemaEvolution.md)
 * [Extending the Record Layer](Extending.md)
+* [Versioning Guide](Versioning.md)
 * [Release Notes](ReleaseNotes.md)
 * [Frequently Asked Questions](FAQ.md)
 * [Contributing](https://github.com/FoundationDB/fdb-record-layer/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
I added the link to the table of contents. I'm not sure what our rule of thumb is for what order the documents should be placed in. The release notes make more sense if you've read the part of the guide on semantic versions, so I put it right before the release notes, but there isn't really a lot of science in it, tbqh.