### PR TITLE
Resolves #262: Detect blocking calls in an asynchronous context

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -52,7 +52,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Tracing diagnostics to detect blocking calls in an asynchronous context [(Issue #262)](https://github.com/FoundationDB/fdb-record-layer/issues/262)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -68,11 +68,8 @@ test {
 
         // Configure whether or not tests will validate that asyncToSync isn't being called in async
         // context.  See BlockingInAsyncDetection class for details on values.
-        def blockingDetection = "IGNORE_COMPLETE_EXCEPTION_BLOCKING"
-        if (System.getenv('BLOCKING_DETECTION') != null) {
-            blockingDetection = System.getenv('BLOCKING_DETECTION')
-        } 
-        systemProperties = [ "com.apple.foundationdb.record.blockingInAsyncDetection": blockingDetection ]
+        systemProperties = [ "com.apple.foundationdb.record.blockingInAsyncDetection": 
+            System.getenv('BLOCKING_DETECTION') ?: "IGNORE_COMPLETE_EXCEPTION_BLOCKING" ]
 
         // We need the destructive tests to be available in the 'test' task, so that IntelliJ's gradle test runner can
         // find them. However, we _only_ want to run them as part of the 'test' task if we're running from IntelliJ.

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -44,7 +44,7 @@ dependencies {
     testCompileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
     testCompileOnly "com.google.auto.service:auto-service:${autoServiceVersion}"
     testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}" // binding
-    testRuntime "org.apache.logging.log4j:log4j-core:${log4jVersion}" // library
+    testCompile "org.apache.logging.log4j:log4j-core:${log4jVersion}" // library
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testCompile "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
@@ -65,6 +65,14 @@ test {
         if (System.getenv('SKIP_SLOW_TESTS') != null && System.getenv('SKIP_SLOW_TESTS') == 'true') {
             excludeTags 'Slow'
         }
+
+        // Configure whether or not tests will validate that asyncToSync isn't being called in async
+        // context.  See BlockingInAsyncDetection class for details on values.
+        def blockingDetection = "IGNORE_COMPLETE_EXCEPTION_BLOCKING"
+        if (System.getenv('BLOCKING_DETECTION') != null) {
+            blockingDetection = System.getenv('BLOCKING_DETECTION')
+        } 
+        systemProperties = [ "com.apple.foundationdb.record.blockingInAsyncDetection": blockingDetection ]
 
         // We need the destructive tests to be available in the 'test' task, so that IntelliJ's gradle test runner can
         // find them. However, we _only_ want to run them as part of the 'test' task if we're running from IntelliJ.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -34,6 +34,10 @@ public enum LogMessageKeys {
     TITLE("ttl"),
     SUBSPACE("subspace"),
     SUBSPACE_KEY("subspace_key"),
+    CALLING_CLASS("calling_class"),
+    CALLING_METHOD("calling_method"),
+    CALLING_LINE("calling_line"),
+    FUTURE_COMPLETED("future_completed"),
     // record splitting/unsplitting
     KEY("key"),
     KEY_TUPLE("key_tuple"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
@@ -23,10 +23,9 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.API;
 
 /**
- * Indicates whether <code>FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, CompletableFuture)</code> or
- * <code>FDBRecordContext#asyncToSync(FDBStoreTimer.Wait, CompletableFuture)</code> should attempt to detect when
- * it is being called from an asynchronous context and, if so, how it should react to this fact.  When this
- * situation is detected, there are two scenarios that need to be dealt with:
+ * Indicates whether <code>FDBDatabase.asyncToSync()</code> or <code>FDBRecordContext.asyncToSync()</code> should
+ * attempt to detect when it is being called from an asynchronous context and, if so, how it should react to
+ * this fact.  When this situation is detected, there are two scenarios that need to be dealt with:
  * <ul>
  *     <li><b>Completed future</b> - the future that was to be waited on is completed. In some code, this is
  *       normal expected behavior; some prior logic ensured that the future was completed and subsequent calls

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
@@ -1,0 +1,102 @@
+/*
+ * BlockingInAsyncDetection.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.API;
+
+/**
+ * Indicates whether <code>FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, CompletableFuture)</code> or
+ * <code>FDBRecordContext#asyncToSync(FDBStoreTimer.Wait, CompletableFuture)</code> should attempt to detect when
+ * it is being called from an asynchronous context and, if so, how it should react to this fact.  When this
+ * situation is detected, there are two scenarios that need to be dealt with:
+ * <ul>
+ *     <li><b>Completed future</b> - the future that was to be waited on is completed. In some code, this is
+ *       normal expected behavior; some prior logic ensured that the future was completed and subsequent calls
+ *       just "know" they won't block.  Of course, it is possible that there is no such logic and the
+ *       future was simply accidentally completed.  As a result there are two options for dealing with
+ *       the presence of such completed futures: <code>IGNORE_COMPLETE</code> (silently ignore) or
+ *       <code>WARN_COMPLETE</code> (log a warning).</li>
+ *     <li><b>Non-complete future</b> - the future that was to be waited on is not complete. There is (typically) no
+ *       circumstance in which this is acceptable, so the options to react to this scenario are
+ *       <code>EXCEPTION_BLOCKING</code> (throw an exception) or <code>WARN_BLOCKING</code> (log a warning).</li>
+ * </ul>
+ */
+@API(API.Status.EXPERIMENTAL)
+public enum BlockingInAsyncDetection {
+    /**
+     * The detection of blocking in an asynchronous context is disabled.
+     */
+    DISABLED(true, false),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
+     * block, an exception will be thrown.
+     */
+    IGNORE_COMPLETE_EXCEPTION_BLOCKING(true, true),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
+     * block, an exception will be thrown; however, if the future is complete, then a warning will be logged.
+     */
+    WARN_COMPLETE_EXCEPTION_BLOCKING(false, true),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
+     * block, a warning is logged.
+     */
+    IGNORE_COMPLETE_WARN_BLOCKING(true, false),
+
+    /**
+     * When <code>asyncToSync</code> is called in an asynchronous context, a warning is logged.
+     */
+    WARN_COMPLETE_WARN_BLOCKING(false, false)
+    ;
+
+    private final boolean ignoreComplete;
+    private final boolean throwExceptionOnBlocking;
+
+    BlockingInAsyncDetection(boolean ignoreComplete, boolean throwException) {
+        this.ignoreComplete = ignoreComplete;
+        this.throwExceptionOnBlocking = throwException;
+    }
+
+    /**
+     * Indicates how to react if the future passed into <code>asyncToSync()</code> was completed. A return
+     * value of <code>true</code> indicates that this situation should be ignored, and a value of <code>false</code>
+     * indicates that a warning should be logged.
+     *
+     * @return whether completed future should be ignored
+     */
+    public boolean ignoreComplete() {
+        return ignoreComplete;
+    }
+
+    /**
+     * Indicates how to react if the future passed into <code>asyncToSync()</code> has not yet been completed. A return
+     * value of <code>true</code> indicates that this situation should result in a {@link BlockingInAsyncException},
+     * and a value of <code>false</code> indicates that a warning should be logged.
+     *
+     * @return whether non-completed future should throw an exception
+     */
+    public boolean throwExceptionOnBlocking() {
+        return throwExceptionOnBlocking;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncException.java
@@ -1,0 +1,37 @@
+/*
+ * BlockingInAsyncException.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.RecordCoreException;
+
+/**
+ * Exception thrown when <code>asyncToSync</code> detects that it is being called from within an asynchronous context.
+ */
+@SuppressWarnings("serial")
+public class BlockingInAsyncException extends RecordCoreException {
+    public BlockingInAsyncException(String message) {
+        super(message);
+    }
+
+    public BlockingInAsyncException(String message, Throwable location) {
+        super(message, location);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -88,14 +88,14 @@ public class FDBDatabase {
 
     /**
      * Text of message that is logged or exception that is thrown when a blocking API call
-     * (<code>asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, CompletableFuture)</code>, {@link #join(CompletableFuture)},
-     * or {@link #get(CompletableFuture)}) is called from within a <code>CompletableFuture</code> completion state.
+     * (<code>asyncToSync()</code>, {@link #join(CompletableFuture)}, or {@link #get(CompletableFuture)}) is
+     * called from within a <code>CompletableFuture</code> completion state.
      */
     protected static final String BLOCKING_IN_ASYNC_CONTEXT_MESSAGE = "Blocking in an asynchronous context";
 
     /**
      * Message that logged when it is detected that a blocking call is being made in a method that may be producing
-     * a future (specifically a method that ends in "<code>Async</code>".
+     * a future (specifically a method that ends in "<code>Async</code>").
      */
     protected static final String BLOCKING_RETURNING_ASYNC_MESSAGE = "Blocking in future producing call";
 
@@ -748,8 +748,8 @@ public class FDBDatabase {
     }
 
     /**
-     * Join a future, following the same logic that <code>asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, CompletableFuture)</code>
-     * uses to validate that the operation isn't blocking in an asynchronous context.
+     * Join a future, following the same logic that <code>asyncToSync()</code> uses to validate that the operation
+     * isn't blocking in an asynchronous context.
      *
      * @param future the future to be completed
      * @param <T> the type of the value produced by the future
@@ -761,8 +761,8 @@ public class FDBDatabase {
     }
 
     /**
-     * Get a future, following the same logic that <code>asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, CompletableFuture)</code>
-     * uses to validate that the operation isn't blocking in an asynchronous context.
+     * Get a future, following the same logic that <code>asyncToSync()</code> uses to validate that the operation
+     * isn't blocking in an asynchronous context.
      *
      * @param future the future to be completed
      * @param <T> the type of the value produced by the future
@@ -807,7 +807,7 @@ public class FDBDatabase {
         // }
         //
         // There are possibly legitimate situations in which this might occur, but those are probably rare, so
-        // just we will log the fact that this has taken place and where it has taken place here.
+        // we will simply log the fact that this has taken place and where it has taken place here.
         StackTraceElement possiblyAsyncReturningLocation = null;
 
         for (StackTraceElement stackElement : stack) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -308,6 +308,34 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         return database.asyncToSync(timer, event, async);
     }
 
+    /**
+     * Join a future following the same logic that <code>asyncToSync(FDBStoreTimer.Wait, CompletableFuture)</code> uses
+     * to validate that the operation isn't blocking in an asynchronous context.
+     *
+     * @param future the future to be completed
+     * @param <T> the type of the value produced by the future
+     * @return the result value
+     */
+    public <T> T join(CompletableFuture<T> future) {
+        return database.join(future);
+    }
+
+    /**
+     * Get a future following the same logic that <code>asyncToSync(FDBStoreTimer.Wait, CompletableFuture)</code> uses
+     * to validate that the operation isn't blocking in an asynchronous context.
+     *
+     * @param future the future to be completed
+     * @param <T> the type of the value produced by the future
+     * @return the result value
+     *
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws ExecutionException if the future completed exceptionally
+     * @throws InterruptedException if the current thread was interrupted
+     */
+    public <T> T get(CompletableFuture<T> future) throws InterruptedException, ExecutionException {
+        return database.get(future);
+    }
+
     public void timeReadSampleKey(byte[] key) {
         if (timer != null) {
             CompletableFuture<byte[]> future = instrument(FDBStoreTimer.Events.READ_SAMPLE_KEY,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -309,8 +309,8 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Join a future following the same logic that <code>asyncToSync(FDBStoreTimer.Wait, CompletableFuture)</code> uses
-     * to validate that the operation isn't blocking in an asynchronous context.
+     * Join a future following the same logic that <code>asyncToSync()</code> uses to validate that the operation
+     * isn't blocking in an asynchronous context.
      *
      * @param future the future to be completed
      * @param <T> the type of the value produced by the future
@@ -321,8 +321,8 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Get a future following the same logic that <code>asyncToSync(FDBStoreTimer.Wait, CompletableFuture)</code> uses
-     * to validate that the operation isn't blocking in an asynchronous context.
+     * Get a future following the same logic that <code>asyncToSync()</code> uses to validate that the operation
+     * isn't blocking in an asynchronous context.
      *
      * @param future the future to be completed
      * @param <T> the type of the value produced by the future

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1810,8 +1810,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     CompletableFuture<Optional<Range>> builtFuture = firstUnbuiltRange(index);
                     CompletableFuture<Optional<RecordIndexUniquenessViolation>> uniquenessFuture = scanUniquenessViolations(index, 1).first();
                     return CompletableFuture.allOf(builtFuture, uniquenessFuture).thenApply(vignore -> {
-                        Optional<Range> firstUnbuilt = builtFuture.join();
-                        Optional<RecordIndexUniquenessViolation> uniquenessViolation = uniquenessFuture.join();
+                        Optional<Range> firstUnbuilt = context.join(builtFuture);
+                        Optional<RecordIndexUniquenessViolation> uniquenessViolation = context.join(uniquenessFuture);
                         if (firstUnbuilt.isPresent()) {
                             throw new IndexNotBuiltException("Attempted to make unbuilt index readable" , firstUnbuilt.get(),
                                     LogMessageKeys.INDEX_NAME, index.getName(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
@@ -227,7 +227,7 @@ public class FDBReverseDirectoryCache {
 
                     LOGGER.warn(KeyValueLogMessage.of("Value not found in reverse directory cache, need to scan",
                             "provided_key", scopedReverseDirectoryKey,
-                            "subspace", reverseCacheSubspaceFuture.join()));
+                            "subspace", context.join(reverseCacheSubspaceFuture)));
                     final Subspace subdirs = scopedReverseDirectoryKey.getScope().getMappingSubspace();
 
                     return context.instrument(FDBStoreTimer.DetailEvents.RD_CACHE_DIRECTORY_SCAN, findNameForKey(context, subdirs, null, scopedReverseDirectoryKey))

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link FDBDatabaseRunner}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBDatabaseRunnerTest {
+public class FDBDatabaseRunnerTest extends FDBTestBase {
 
     private static final Object[] PATH_OBJECTS = {"record-test", "unit"};
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBMetaDataStore}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBMetaDataStoreTest {
+public class FDBMetaDataStoreTest extends FDBTestBase {
     FDBDatabase fdb;
     FDBMetaDataStore metaDataStore;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
@@ -65,7 +65,7 @@ import java.util.function.Function;
  */
 @Tag(Tags.RequiresFDB)
 @Tag(Tags.Performance)
-public class FDBRecordStorePerformanceTest {
+public class FDBRecordStorePerformanceTest extends FDBTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBRecordStorePerformanceTest.class);
 
     static class DatabaseParameters {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Base class for tests for {@link FDBRecordStore}.
  */
-public abstract class FDBRecordStoreTestBase {
+public abstract class FDBRecordStoreTestBase extends FDBTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBRecordStoreTestBase.class);
 
     private static final Object[] PATH_OBJECTS = new Object[]{"record-test", "unit", "recordStore"};

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -78,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link FDBReverseDirectoryCache}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBReverseDirectoryCacheTest {
+public class FDBReverseDirectoryCacheTest extends FDBTestBase {
 
     private static final Logger logger = LoggerFactory.getLogger(FDBReverseDirectoryCacheTest.class);
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
@@ -1,0 +1,52 @@
+/*
+ * FDBTestBase.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class from which all FDB tests should be derived.
+ */
+public abstract class FDBTestBase {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBTestBase.class);
+
+    public static final String BLOCKING_IN_ASYNC_PROPERTY = "com.apple.foundationdb.record.blockingInAsyncDetection";
+
+    @BeforeAll
+    public static void setupBlockingInAsyncDetection() {
+        final String str = System.getProperty(BLOCKING_IN_ASYNC_PROPERTY);
+        if (str != null) {
+            final BlockingInAsyncDetection detection;
+            try {
+                detection = BlockingInAsyncDetection.valueOf(str);
+            } catch (Exception e) {
+                LOGGER.error("Illegal value provided for " + BLOCKING_IN_ASYNC_PROPERTY + ": " + str);
+                return;
+            }
+            FDBDatabaseFactory.instance().setBlockingInAsyncDetection(detection);
+            if (detection != BlockingInAsyncDetection.DISABLED) {
+                LOGGER.info("Blocking-in-async is " + detection);
+            }
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStoreTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBTypedRecordStore}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBTypedRecordStoreTest {
+public class FDBTypedRecordStoreTest extends FDBTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBTypedRecordStoreTest.class);
 
     FDBDatabase fdb;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * Tests for {@link KeyValueCursor}.
  */
 @Tag(Tags.RequiresFDB)
-public class KeyValueCursorTest {
+public class KeyValueCursorTest extends FDBTestBase {
     private FDBDatabase fdb;
     private Subspace subspace;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OneOfTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Test use of {@code oneof} to define the union message.
  */
 @Tag(Tags.RequiresFDB)
-public class OneOfTest {
+public class OneOfTest extends FDBTestBase {
 
     private static final Object[] PATH = { "record-test", "unit", "recordStore" };
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -110,7 +110,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link OnlineIndexer}.
  */
 @Tag(Tags.RequiresFDB)
-public class OnlineIndexerTest {
+public class OnlineIndexerTest extends FDBTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerTest.class);
 
     private RecordMetaData metaData;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
@@ -102,7 +102,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@code VERSION} type indexes.
  */
 @Tag(Tags.RequiresFDB)
-public class VersionIndexTest {
+public class VersionIndexTest extends FDBTestBase {
     private static final byte VERSIONSTAMP_CODE = Tuple.from(Versionstamp.complete(new byte[10])).pack()[0];
 
     private RecordMetaData metaData;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.cursors;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorTest;
 import com.apple.foundationdb.record.cursors.FirableCursor;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * makes almost no guarantees about the order in which things come in.
  */
 @Tag(Tags.RequiresFDB)
-public class UnorderedUnionCursorTest {
+public class UnorderedUnionCursorTest extends FDBTestBase {
 
     @Nonnull
     private <T> List<Function<byte[], RecordCursor<T>>> functionsFromLists(@Nonnull List<List<T>> lists) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
 import com.apple.foundationdb.tuple.Tuple;
@@ -84,7 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link KeySpaceDirectory}.
  */
 @Tag(Tags.RequiresFDB)
-public class KeySpaceDirectoryTest {
+public class KeySpaceDirectoryTest extends FDBTestBase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KeySpaceDirectoryTest.class);
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver.LocatableResolverLockedException;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.PreWriteCheck;
@@ -94,7 +95,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Tag(Tags.WipesFDB)
 @Tag(Tags.RequiresFDB)
-public abstract class LocatableResolverTest {
+public abstract class LocatableResolverTest extends FDBTestBase {
     protected FDBDatabase database;
     protected LocatableResolver globalScope;
     protected BiFunction<FDBRecordContext, KeySpacePath, LocatableResolver> scopedDirectoryGenerator;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverCreateHooksTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverCreateHooksTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.PreWriteCheck;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
 import com.apple.foundationdb.tuple.Tuple;
@@ -41,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(Tags.RequiresFDB)
-class ResolverCreateHooksTest {
+class ResolverCreateHooksTest extends FDBTestBase {
     private FDBDatabase database;
     private KeySpace keySpace;
     private final Random random = new Random();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
@@ -50,7 +51,7 @@ import static org.hamcrest.Matchers.not;
  * Tests for {@link ResolverMappingDigest}.
  */
 @Tag(Tags.RequiresFDB)
-public class ResolverMappingDigestTest {
+public class ResolverMappingDigestTest extends FDBTestBase {
     private FDBDatabase database;
     private Random random = new Random();
     private KeySpace keySpace;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.record.provider.foundationdb.layers.interning.ScopedInterningLayer;
@@ -55,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@link ResolverMappingReplicator}.
  */
 @Tag(Tags.RequiresFDB)
-public abstract class ResolverMappingReplicatorTest {
+public abstract class ResolverMappingReplicatorTest extends FDBTestBase {
     protected LocatableResolver primary;
     protected LocatableResolver replica;
     protected FDBDatabase database;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/HighContentionAllocatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/HighContentionAllocatorTest.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpace;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
@@ -62,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.RequiresFDB)
-class HighContentionAllocatorTest {
+class HighContentionAllocatorTest extends FDBTestBase {
     private FDBDatabase database;
     private KeySpace keySpace;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayerTest.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverResult;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
@@ -60,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag(Tags.RequiresFDB)
-class StringInterningLayerTest {
+class StringInterningLayerTest extends FDBTestBase {
     private FDBDatabase database;
     private Subspace testSubspace = new Subspace(Tuple.from("test-interning"));
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -49,6 +49,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.query.RecordQuery;
@@ -88,7 +89,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@code TIME_WINDOW_LEADERBOARD} indexes.
  */
 @Tag(Tags.RequiresFDB)
-public class LeaderboardIndexTest {
+public class LeaderboardIndexTest extends FDBTestBase {
     FDBDatabase fdb;
     FDBStoreTimer metrics;
     private static int oldMaxAttempts;


### PR DESCRIPTION
The purpose of this change is to attempt to detect when a blocking call
(`FDBDatabase.asyncToSync()`, `FDBRecordContext.asyncToSync()`,
`CompletableFuture.join()` and `CompletableFuture.get()`) are made while in
an asynchronous context; specificaly those that take place within a
`CompletableFuture` completion stage.  This behavior is undesirable because
it can lead to exhaustion of the executor thread pool and an effective
deadlock situation (ask me how I know).
    
This detection is performed by grabbing a stack trace just prior to the 
blocking operation and seeing if the current thread's stack involves any 
`CompletableFuture` method. This approach is pretty crude, but seems to be
effective.
    
There is also one additional scenario that is watched for in this logic
and that is an attempt to perform a blocking call in a method that is
producing a future.  By contention, the Record Layer library ends methods
returning futures with `Async`, so we treat any method named as such as
a possible source of this problem. There are some legitimate reasons in
which this may be taking place, so these are always logged as a warning.
    
The code changes introduced are as follows:
    
- `FDBDatabaseFactory.setBlockingInAsyncDetection()` allowing you to enable
  logic in asyncToSync calls that checks to see if they are being made from
  within a future completion stage.
- `BlockingInAsyncDetection` describes how the code should react to the 
  situation in which asyncToSync is being called from within a future
  completion.
- `CKFDBDatabase.asyncToSync()` updated to perform the detection
- Added `FDBDatabase.get()`, `FDBDatabase.join()`, `FDBRecordContext.get()`,
  and `FDBRecordContext.join()` that will perform the same sort of detection
  as `asyncToSync`. I have selectively updated a few places to use these
  methods, but I am sure there are more locations in which this can be done.
- Created new abstract `FDBTestBase` class that checks a system property
  (`com.apple.foundationdb.record.blockingInAsyncDetection`) to configure whether or
  not detection is enabled and how to respond to the presence of blocking in async.
- Added testing infrastructure to create assertions on logging messages.
- Updated gradle to enable async detection in our unit tests. I did some benchmarking
  and found that the detection did not noticably impact the performance of the 
  tests.