### PR TITLE
Address #328: Generate sources and javadoc jars for the shaded artifacts

### DIFF
--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -40,6 +40,22 @@ build.dependsOn {
     shadowJar
 }
 
+task shadedSourcesJar(type: Jar) {
+    description = "Assembles a Jar archive containing the main sources."
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    appendix = null
+    classifier = "sources"
+    from project(coreProject).sourceSets.main.allSource
+}
+
+task shadedJavadocJar(type: Jar) {
+    description = "Assembles a Jar archive containing the main Javadoc."
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    appendix = null
+    classifier = "javadoc"
+    from project(coreProject).tasks.javadoc
+}
+
 apply from: rootProject.file('gradle/publishing.gradle')
 publishing {
     publications {
@@ -73,6 +89,8 @@ publishing {
                     }
                 }
             }
+            artifact tasks.shadedSourcesJar
+            artifact tasks.shadedJavadocJar
         }
     }
     bintray {


### PR DESCRIPTION
This only "addresses" #328 rather than "resolves" it as this does not correctly merge the sources or fix the shaded paths. It does, however, generate non-empty sources and Javadoc jars for the shaded artifacts, which is good enough for some amount of work. In particular, I was able to verify that IntelliJ was able to use these Jars and give Javadocs and fill in parameter names, which is a good start. I think I would still prefer if it combined the Jars correctly, but this probably is good enough to get most people unstuck.