### PR TITLE
 Resovles #329: Include fdb-extensions in shaded jars to avoid leaking guava

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -55,7 +55,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Feature** A KPI to track occurrences of index entries that do not point to valid records [(Issue #310)](https://github.com/FoundationDB/fdb-record-layer/issues/310)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The shaded artifacts now include the `fdb-extensions` library and no longer include guava as a transitive dependency [(Issue #329)](https://github.com/FoundationDB/fdb-record-layer/issues/329)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -31,6 +31,7 @@ shadowJar {
     relocate 'com.google', 'com.apple.foundationdb.record.shaded.com.google'
     dependencies {
         include(dependency(coreProject))
+        include(dependency(':fdb-extensions'))
         include(dependency('com.google.guava:guava'))
         include(dependency('com.google.protobuf:protobuf-java'))
     }
@@ -46,6 +47,7 @@ task shadedSourcesJar(type: Jar) {
     appendix = null
     classifier = "sources"
     from project(coreProject).sourceSets.main.allSource
+    from project(':fdb-extensions').sourceSets.main.allSource
 }
 
 task shadedJavadocJar(type: Jar) {
@@ -54,6 +56,20 @@ task shadedJavadocJar(type: Jar) {
     appendix = null
     classifier = "javadoc"
     from project(coreProject).tasks.javadoc
+}
+
+ext.shadedDependencyNames = ['guava', 'protobuf-java', 'fdb-extensions']
+
+def addDependencies(projectObj, dependenciesNode) {
+    projectObj.configurations.compile.getDependencies().forEach {
+        if (!shadedDependencyNames.contains(it.name)) {
+            def dependencyNode = dependenciesNode.appendNode('dependency')
+            dependencyNode.appendNode('groupId', it.group)
+            dependencyNode.appendNode('artifactId', it.name)
+            dependencyNode.appendNode('version', it.version)
+            dependencyNode.appendNode('scope', 'compile')
+        }
+    }
 }
 
 apply from: rootProject.file('gradle/publishing.gradle')
@@ -78,15 +94,8 @@ publishing {
                     }
                     // Add a section containing all non-shaded dependencies
                     def dependenciesNode = xml.asNode().appendNode('dependencies')
-                    project(coreProject).configurations.compile.getDependencies().forEach {
-                        if (!it.name.equals('guava') && !it.name.equals('protobuf-java')) {
-                            def dependencyNode = dependenciesNode.appendNode('dependency')
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
-                            dependencyNode.appendNode('scope', 'compile')
-                        }
-                    }
+                    addDependencies(project(coreProject), dependenciesNode)
+                    addDependencies(project(':fdb-extensions'), dependenciesNode)
                 }
             }
             artifact tasks.shadedSourcesJar


### PR DESCRIPTION
This resovles #329 by tweaking how we choose things for the shaded jar. It includes the `fdb-extensions` subproject, which means that anything that was explicitly depending on both `fdb-record-layer-core-shaded` and `fdb-extensions` may get clashing jars. It should be the case that they can just remove the `fdb-extensions` dependency, but they should be aware that they need to do that.

The upshot is that guava is no longer a transitive dependency of the shaded plugin, which means that it is *actually* safe to upgrade the guava dependency without messing up anyone who depends on the shaded artifact, which wasn't actually the case before despite the fact that we were going through all of the trouble to shade guava, which seemed like a waste.

This includes the changes in #330. I did this because they touch the same file and I didn't want to have to do deal with merge conflicts. This also adds the sources for `fdb-extensions` to the sources jar produced for shaded things so that we include all of our source files (at least) in that Jar. It doesn't merge the Javadocs because, um, that's harder.