### PR TITLE
Merge faulty branch into fdb-record-layer-2.3.32

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -114,7 +114,7 @@ As the `Index` class now tracks the created and last modified version separately
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** The `UnorderedUnionCursor` now continues returning results until all children have hit a limit or are exhausted [(Issue #332)](https://github.com/FoundationDB/fdb-record-layer/issues/332)
+* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
@@ -137,6 +137,10 @@ As the `Index` class now tracks the created and last modified version separately
 
 // end next release
 -->
+
+### 2.3.32.13
+
+* **Bug fix** The `UnorderedUnionCursor` now continues returning results until all children have hit a limit or are exhausted [(Issue #332)](https://github.com/FoundationDB/fdb-record-layer/issues/332)
 
 ### 2.3.32.10
 


### PR DESCRIPTION
There was a problem where something that was supposed to push to the fdb-record-layer-2.3.32 branch on its "origin" remove actually pushed to a new branch named "origin/fdb-record-layer-2.3.32".  This gets that commit onto the right branch so that other things can be merged on top of it.