### PR TITLE
Resolves #261: Remove blocking calls from LocatableResolver constructors

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -47,7 +47,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Remove blocking calls from LocatableResolver constructors [(Issue #261)](https://github.com/FoundationDB/fdb-record-layer/issues/261)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathImpl.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nonnull;
@@ -301,24 +300,12 @@ class KeySpacePathImpl implements KeySpacePath {
 
     @Override
     public int hashCode() {
-        ImmutableList.Builder<Object> listBuilder = ImmutableList.builder();
-
-        listBuilder.add(getDirectory().getKeyType());
-        listBuilder.add(getDirectory().getName());
-
-        if (getDirectory().getValue() != null) {
-            listBuilder.add(getDirectory().getValue());
-        }
-
-        if (getValue() != null) {
-            listBuilder.add(getValue());
-        }
-
-        if (parent != null) {
-            listBuilder.add(parent);
-        }
-
-        return Objects.hash(listBuilder.build().toArray());
+        return Objects.hash(
+                getDirectory().getKeyType(),
+                getDirectory().getName(),
+                getDirectory().getValue(),
+                getValue(),
+                parent);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
@@ -201,6 +201,16 @@ public class KeySpacePathWrapper implements KeySpacePath {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        return inner.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return inner.hashCode();
+    }
+
+    @Override
     public String toString() {
         return inner.toString();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayer.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBReverseDirectoryCache;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.subspace.Subspace;
-import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Bytes;
 
@@ -37,7 +36,6 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 
 /**
  * An implementation of {@link LocatableResolver} that uses the FDB directory layer to keep track of the allocation of
@@ -48,13 +46,16 @@ import java.util.function.Supplier;
 public class ScopedDirectoryLayer extends LocatableResolver {
     private static final byte[] RESERVED_CONTENT_SUBSPACE_PREFIX = {(byte) 0xFD};
     private static final int STATE_SUBSPACE_KEY_SUFFIX = -10;
-    private final Subspace baseSubspace;
-    private final Subspace nodeSubspace;
+    @Nonnull
+    private CompletableFuture<Subspace> baseSubspaceFuture;
+    @Nonnull
+    private CompletableFuture<Subspace> nodeSubspaceFuture;
+    @Nonnull
+    private CompletableFuture<Subspace> stateSubspaceFuture;
+    @Nonnull
+    private CompletableFuture<DirectoryLayer> directoryLayerFuture;
+    @Nonnull
     private final Subspace contentSubspace;
-    private final Subspace stateSubspace;
-    private final DirectoryLayer directoryLayer;
-    private final String infoString;
-    private final int hashCode;
 
     /**
      * Creates a scoped directory layer. This constructor invokes blocking calls and must not
@@ -66,7 +67,7 @@ public class ScopedDirectoryLayer extends LocatableResolver {
     @API(API.Status.DEPRECATED)
     @Deprecated
     public ScopedDirectoryLayer(@Nonnull KeySpacePath path) {
-        this(path.getContext().getDatabase(), path);
+        this(path.getContext(), path);
     }
 
     /**
@@ -79,35 +80,25 @@ public class ScopedDirectoryLayer extends LocatableResolver {
      */
     public ScopedDirectoryLayer(@Nonnull FDBRecordContext context,
                                 @Nonnull KeySpacePath path) {
-        this(context.getDatabase(), path, () -> path.toTuple(context));
+        this(context.getDatabase(), context, path);
     }
 
     private ScopedDirectoryLayer(@Nonnull FDBDatabase database,
-                                 @Nonnull KeySpacePath path) {
-        this(database, path, () -> {
-            try (FDBRecordContext context = database.openContext()) {
-                return path.toTuple(context);
-            }
-        });
-    }
-
-    private ScopedDirectoryLayer(@Nonnull FDBDatabase database,
-                                 @Nullable KeySpacePath path,
-                                 @Nonnull Supplier<Tuple> pathTuple) {
+                                 @Nullable FDBRecordContext context,
+                                 @Nullable KeySpacePath path) {
         super(database, path);
         if (path == null) {
-            this.baseSubspace = new Subspace();
+            this.baseSubspaceFuture = CompletableFuture.completedFuture(new Subspace());
             this.contentSubspace = new Subspace();
-            this.infoString = "ScopedDirectoryLayer:GLOBAL";
         } else {
-            this.baseSubspace = new Subspace(pathTuple.get());
+            Objects.requireNonNull(context, "non null path requires non null context");
+            this.baseSubspaceFuture = path.toSubspaceAsync(context);
             this.contentSubspace = new Subspace(RESERVED_CONTENT_SUBSPACE_PREFIX);
-            this.infoString = "ScopedDirectoryLayer:" + path.toString();
         }
-        this.nodeSubspace = new Subspace(Bytes.concat(baseSubspace.getKey(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey()));
-        this.directoryLayer = new DirectoryLayer(nodeSubspace, contentSubspace);
-        this.stateSubspace = nodeSubspace.get(STATE_SUBSPACE_KEY_SUFFIX);
-        this.hashCode = Objects.hash(ScopedDirectoryLayer.class, baseSubspace, database);
+        this.nodeSubspaceFuture = baseSubspaceFuture.thenApply(base ->
+                new Subspace(Bytes.concat(base.getKey(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())));
+        this.stateSubspaceFuture = nodeSubspaceFuture.thenApply(node -> node.get(STATE_SUBSPACE_KEY_SUFFIX));
+        this.directoryLayerFuture = nodeSubspaceFuture.thenApply(node -> new DirectoryLayer(node, contentSubspace));
     }
 
     /**
@@ -117,11 +108,12 @@ public class ScopedDirectoryLayer extends LocatableResolver {
      * @return the global <code>ScopedDirectoryLayer</code> for this database
      */
     public static ScopedDirectoryLayer global(@Nonnull FDBDatabase database) {
-        return new ScopedDirectoryLayer(database, null, () -> null);
+        return new ScopedDirectoryLayer(database, null, null);
     }
 
     private CompletableFuture<Boolean> exists(@Nonnull FDBRecordContext context, String key) {
-        return directoryLayer.exists(context.ensureActive(), Collections.singletonList(key));
+        return directoryLayerFuture
+                .thenCompose(directoryLayer -> directoryLayer.exists(context.ensureActive(), Collections.singletonList(key)));
     }
 
     @Override
@@ -134,9 +126,12 @@ public class ScopedDirectoryLayer extends LocatableResolver {
 
     private CompletableFuture<ResolverResult> createInternal(@Nonnull FDBRecordContext context, String key) {
         FDBReverseDirectoryCache reverseCache = context.getDatabase().getReverseDirectoryCache();
-        return directoryLayer.create(context.ensureActive(), Collections.singletonList(key))
-                .thenApply(serializedValue -> deserializeValue(serializedValue.getKey()))
-                .thenCompose(result -> reverseCache.putIfNotExists(context, wrap(key), result.getValue()).thenApply(ignore -> result));
+        return directoryLayerFuture
+                .thenCompose(directoryLayer ->
+                        directoryLayer.create(context.ensureActive(), Collections.singletonList(key))
+                                .thenApply(serializedValue -> deserializeValue(serializedValue.getKey()))
+                                .thenCompose(result -> reverseCache.putIfNotExists(context, wrap(key), result.getValue())
+                                        .thenApply(ignore -> result)));
     }
 
     @Override
@@ -148,11 +143,13 @@ public class ScopedDirectoryLayer extends LocatableResolver {
         FDBReverseDirectoryCache reverseCache = context.getDatabase().getReverseDirectoryCache();
         return exists(context, key).thenCompose(keyExists ->
                 keyExists ?
-                        directoryLayer.open(context.ensureActive(), Collections.singletonList(key))
-                                .thenApply(serializedValue -> deserializeValue(serializedValue.getKey()))
-                                .thenCompose(result -> reverseCache.putIfNotExists(context, wrap(key), result.getValue()).thenApply(ignore -> result))
-                                .thenApply(Optional::of) :
-                        CompletableFuture.completedFuture(Optional.empty()));
+                directoryLayerFuture
+                        .thenCompose(directoryLayer ->
+                                directoryLayer.open(context.ensureActive(), Collections.singletonList(key))
+                                        .thenApply(serializedValue -> deserializeValue(serializedValue.getKey()))
+                                        .thenCompose(result -> reverseCache.putIfNotExists(context, wrap(key), result.getValue()).thenApply(ignore -> result))
+                                        .thenApply(Optional::of)) :
+                CompletableFuture.completedFuture(Optional.empty()));
     }
 
     @Override
@@ -178,29 +175,31 @@ public class ScopedDirectoryLayer extends LocatableResolver {
 
     @Override
     @Nonnull
-    public Subspace getMappingSubspace() {
-        return nodeSubspace.get(nodeSubspace.getKey()).get(0);
+    public CompletableFuture<Subspace> getMappingSubspaceAsync() {
+        return nodeSubspaceFuture.thenApply(nodeSubspace ->
+                nodeSubspace.get(nodeSubspace.getKey()).get(0));
     }
 
     @Override
-    protected Subspace getStateSubspace() {
-        return stateSubspace;
+    protected CompletableFuture<Subspace> getStateSubspaceAsync() {
+        return stateSubspaceFuture;
     }
 
     @Override
+    @Nonnull
     public ResolverResult deserializeValue(byte[] value) {
         return new ResolverResult(contentSubspace.unpack(value).getLong(0));
     }
 
     @Override
     @Nonnull
-    public Subspace getBaseSubspace() {
-        return baseSubspace;
+    public CompletableFuture<Subspace> getBaseSubspaceAsync() {
+        return baseSubspaceFuture;
     }
 
     @VisibleForTesting
-    public Subspace getNodeSubspace() {
-        return nodeSubspace;
+    public CompletableFuture<Subspace> getNodeSubspace(FDBRecordContext context) {
+        return nodeSubspaceFuture;
     }
 
     @VisibleForTesting
@@ -208,24 +207,4 @@ public class ScopedDirectoryLayer extends LocatableResolver {
         return contentSubspace;
     }
 
-    @Override
-    public String toString() {
-        // pre-computed in constructor
-        return infoString;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj != null && obj instanceof ScopedDirectoryLayer) {
-            ScopedDirectoryLayer that = (ScopedDirectoryLayer) obj;
-            return baseSubspace.equals(that.baseSubspace) && this.database.equals(that.database);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        // pre-computed in constructor
-        return hashCode;
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/StringInterningLayer.java
@@ -91,7 +91,7 @@ public class StringInterningLayer {
     protected CompletableFuture<Optional<ResolverResult>> read(@Nonnull FDBRecordContext context, @Nonnull final String toRead) {
         return context.ensureActive().get(mappingSubspace.pack(toRead))
                 .thenApply(Optional::ofNullable)
-                .thenApply(maybeValue -> maybeValue.map(this::deserializeValue));
+                .thenApply(maybeValue -> maybeValue.map(StringInterningLayer::deserializeValue));
     }
 
 
@@ -190,7 +190,7 @@ public class StringInterningLayer {
         return builder.build().toByteArray();
     }
 
-    protected ResolverResult deserializeValue(byte[] bytes) {
+    protected static ResolverResult deserializeValue(byte[] bytes) {
         try {
             StringInterningProto.Data interned = StringInterningProto.Data.parseFrom(bytes);
             return new ResolverResult(
@@ -198,8 +198,7 @@ public class StringInterningLayer {
                     interned.hasMetadata() ? interned.getMetadata().toByteArray() : null);
         } catch (InvalidProtocolBufferException exception) {
             throw new RecordCoreException("invalid interned value", exception)
-                    .addLogInfo("internedBytes", ByteArrayUtil2.loggable(bytes))
-                    .addLogInfo("mappingSubspace", mappingSubspace);
+                    .addLogInfo("internedBytes", ByteArrayUtil2.loggable(bytes));
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/AsyncLoadingCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/AsyncLoadingCacheTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.async.MoreAsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil.DeadlineExceededException;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
@@ -184,7 +185,8 @@ class AsyncLoadingCacheTest {
             cachedResult.orElseGet("a-key", tooLateSupplier).join();
             fail("should throw CompletionException");
         } catch (CompletionException ex) {
-            assertThat("it is caused by a deadline exception", ex.getCause(), is(instanceOf(RecordCoreException.class)));
+            assertThat("it is caused by a deadline exception", ex.getCause(),
+                    is(instanceOf(DeadlineExceededException.class)));
             assertThat(ex.getCause(), hasMessageContaining("deadline exceeded"));
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -519,7 +519,7 @@ public class FDBReverseDirectoryCacheTest extends FDBTestBase {
         // Create a new directory layer entry, put it in the cache in the same transaction
         try (FDBRecordContext context = openContext()) {
             Transaction transaction = context.ensureActive();
-            DirectoryLayer directoryLayerToUse = new DirectoryLayer(scope.getNodeSubspace(), scope.getContentSubspace());
+            DirectoryLayer directoryLayerToUse = new DirectoryLayer(context.join(scope.getNodeSubspace(context)), scope.getContentSubspace());
             final byte[] rawDirectoryEntry = directoryLayerToUse.createOrOpen(transaction, Collections.singletonList(name)).get().getKey();
             final Long id = Tuple.fromBytes(rawDirectoryEntry).getLong(0);
             rdc.putIfNotExists(context, scopedName, id).get();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
@@ -1302,23 +1302,23 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         KeySpace keySpace = new KeySpace(
                 new KeySpaceDirectory("a", KeyType.STRING)
                         .addSubdirectory(new KeySpaceDirectory("b", KeyType.STRING)
-                                .addSubdirectory(new KeySpaceDirectory("d", KeyType.STRING)))
+                                .addSubdirectory(new KeySpaceDirectory("d", KeyType.STRING, TestWrapper1::new)))
                         .addSubdirectory(new KeySpaceDirectory("c", KeyType.LONG)
-                                .addSubdirectory(new KeySpaceDirectory("d", KeyType.STRING))));
+                                .addSubdirectory(new KeySpaceDirectory("d", KeyType.STRING, TestWrapper1::new))));
 
-        KeySpacePath p1 = keySpace.path("a", "alpha")
+        final KeySpacePath p1 = keySpace.path("a", "alpha")
                 .add("b", "bravo")
                 .add("d", "delta");
 
-        KeySpacePath p2 = keySpace.path("a", "alpha")
+        final KeySpacePath p2 = keySpace.path("a", "alpha")
                 .add("b", "bravo")
                 .add("d", "duck");
 
-        KeySpacePath p3 = keySpace.path("a", "alpha")
+        final KeySpacePath p3 = keySpace.path("a", "alpha")
                 .add("c", 23)
                 .add("d", "delta");
 
-        KeySpacePath sameAsP1 = keySpace.path("a", "alpha")
+        final KeySpacePath sameAsP1 = keySpace.path("a", "alpha")
                 .add("b", "bravo")
                 .add("d", "delta");
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
@@ -46,8 +46,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -78,6 +76,8 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -86,8 +86,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag(Tags.RequiresFDB)
 public class KeySpaceDirectoryTest extends FDBTestBase {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(KeySpaceDirectoryTest.class);
 
     private static class KeyTypeValue {
         KeyType keyType;
@@ -1297,6 +1295,41 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             return null;
         });
         assertThrows(IllegalStateException.class, () -> path.list("c"));
+    }
+
+    @Test
+    public void testPathCompareByValue() {
+        KeySpace keySpace = new KeySpace(
+                new KeySpaceDirectory("a", KeyType.STRING)
+                        .addSubdirectory(new KeySpaceDirectory("b", KeyType.STRING)
+                                .addSubdirectory(new KeySpaceDirectory("d", KeyType.STRING)))
+                        .addSubdirectory(new KeySpaceDirectory("c", KeyType.LONG)
+                                .addSubdirectory(new KeySpaceDirectory("d", KeyType.STRING))));
+
+        KeySpacePath p1 = keySpace.path("a", "alpha")
+                .add("b", "bravo")
+                .add("d", "delta");
+
+        KeySpacePath p2 = keySpace.path("a", "alpha")
+                .add("b", "bravo")
+                .add("d", "duck");
+
+        KeySpacePath p3 = keySpace.path("a", "alpha")
+                .add("c", 23)
+                .add("d", "delta");
+
+        KeySpacePath sameAsP1 = keySpace.path("a", "alpha")
+                .add("b", "bravo")
+                .add("d", "delta");
+
+        assertNotEquals(p1, p2, "paths have different values");
+        assertNotEquals(p1.hashCode(), p2.hashCode(), "they have distinct hash codes");
+        assertNotEquals(p1, p3, "paths have different parents");
+        assertNotEquals(p1.hashCode(), p3.hashCode(), "they have distinct hash codes");
+
+        assertNotSame(p1, sameAsP1, "the paths are not equal by reference");
+        assertEquals(p1, sameAsP1, "they are equal by value");
+        assertEquals(p1.hashCode(), sameAsP1.hashCode(), "they have the same hash code");
     }
 
     private List<Long> resolveBatch(FDBRecordContext context, String... names) {


### PR DESCRIPTION
A lot of refactoring required:

- Resolvers now initialize a set of functions that produce the correct subspaces once they have access to a context from the database
- hash code of resolver should be computed in the constructor still, to do this use the `KeySpacePath` rather than the `Subspace` in the calculation
- Requires changes in `hashCode`/`equals` of `KeySpacePath` so that we can compare separate references by value