### PR TITLE
Resolves #336: Add an unordered variant of the IntersectionCursor

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -56,7 +56,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Validation checks now reject a `RecordMetaData` object that defines no record types [(Issue #354)](https://github.com/FoundationDB/fdb-record-layer/issues/354)
 * **Feature** A new cursor type allows for intersecting cursors with incompatible orderings [(Issue #336)](https://github.com/FoundationDB/fdb-record-layer/issues/336)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The text search query API now exposes `containsAllPrefixes` and `containsAnyPrefix` predicates [(Issue #343)](https://github.com/FoundationDB/fdb-record-layer/issues/343)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -55,7 +55,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Validation checks now reject a `RecordMetaData` object that defines no record types [(Issue #354)](https://github.com/FoundationDB/fdb-record-layer/issues/354)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** A new cursor type allows for intersecting cursors with incompatible orderings [(Issue #336)](https://github.com/FoundationDB/fdb-record-layer/issues/336)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/BloomFilterCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/BloomFilterCursorContinuation.java
@@ -1,0 +1,94 @@
+/*
+ * BloomFilterCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.google.protobuf.ByteString;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static com.apple.foundationdb.record.RecordCursorProto.ProbableIntersectionContinuation;
+
+class BloomFilterCursorContinuation implements RecordCursorContinuation {
+    @Nonnull
+    private final RecordCursorContinuation childContinuation;
+    @Nullable
+    private final ByteString bloomBytes;
+    @Nullable
+    private ProbableIntersectionContinuation.CursorState cachedProto;
+    @Nullable
+    private byte[] cachedBytes;
+
+    BloomFilterCursorContinuation(@Nonnull RecordCursorContinuation childContinuation, @Nullable ByteString bloomBytes) {
+        this.childContinuation = childContinuation;
+        this.bloomBytes = bloomBytes;
+    }
+
+    @Nonnull
+    ProbableIntersectionContinuation.CursorState toProto() {
+        if (cachedProto == null) {
+            ProbableIntersectionContinuation.CursorState.Builder builder = ProbableIntersectionContinuation.CursorState.newBuilder();
+            if (childContinuation.isEnd()) {
+                builder.setExhausted(true);
+            } else {
+                byte[] childBytes = childContinuation.toBytes();
+                if (childBytes != null) {
+                    builder.setContinuation(ByteString.copyFrom(childBytes));
+                }
+            }
+            if (bloomBytes != null) {
+                builder.setBloomFilter(bloomBytes);
+            }
+            cachedProto = builder.build();
+        }
+        return cachedProto;
+    }
+
+    @Override
+    @Nullable
+    public byte[] toBytes() {
+        if (cachedBytes == null) {
+            cachedBytes = toProto().toByteArray();
+        }
+        return cachedBytes;
+    }
+
+    @Nonnull
+    RecordCursorContinuation getChild() {
+        return childContinuation;
+    }
+
+    @Nullable
+    ByteString getBloomBytes() {
+        return bloomBytes;
+    }
+
+    // Bloom continuations can never themselves be end continuations, though their children might be.
+    @Override
+    public boolean isEnd() {
+        return false;
+    }
+
+    boolean isChildEnd() {
+        return childContinuation.isEnd();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
@@ -46,13 +46,13 @@ import java.util.function.Function;
 public class IntersectionCursor<T> extends IntersectionCursorBase<T, T> {
 
     private IntersectionCursor(@Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
-                               boolean reverse, @Nonnull List<CursorState<T>> cursorStates,
+                               boolean reverse, @Nonnull List<KeyedMergeCursorState<T>> cursorStates,
                                @Nullable FDBStoreTimer timer) {
         super(comparisonKeyFunction, reverse, cursorStates, timer);
     }
 
     @Override
-    T getNextResult(@Nonnull List<CursorState<T>> cursorStates) {
+    T getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
         return cursorStates.get(0).getResult().get();
     }
 
@@ -110,7 +110,7 @@ public class IntersectionCursor<T> extends IntersectionCursorBase<T, T> {
             @Nonnull Function<byte[], RecordCursor<T>> right,
             @Nullable byte[] continuation,
             @Nullable FDBStoreTimer timer) {
-        return new IntersectionCursor<>(comparisonKeyFunction, reverse, createCursorStates(left, right, continuation), timer);
+        return new IntersectionCursor<>(comparisonKeyFunction, reverse, createCursorStates(left, right, continuation, comparisonKeyFunction), timer);
     }
 
     /**
@@ -179,6 +179,6 @@ public class IntersectionCursor<T> extends IntersectionCursorBase<T, T> {
             @Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
             @Nullable byte[] continuation,
             @Nullable FDBStoreTimer timer) {
-        return new IntersectionCursor<>(comparisonKeyFunction, reverse, createCursorStates(cursorFunctions, continuation), timer);
+        return new IntersectionCursor<>(comparisonKeyFunction, reverse, createCursorStates(cursorFunctions, continuation, comparisonKeyFunction), timer);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorBase.java
@@ -21,62 +21,35 @@
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
 import com.apple.foundationdb.async.AsyncUtil;
-import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.RecordCursorContinuation;
-import com.apple.foundationdb.record.RecordCursorEndContinuation;
-import com.apple.foundationdb.record.RecordCursorProto;
-import com.apple.foundationdb.record.RecordCursorResult;
-import com.apple.foundationdb.record.RecordCursorStartContinuation;
-import com.apple.foundationdb.record.RecordCursorVisitor;
-import com.apple.foundationdb.record.cursors.IllegalContinuationAccessChecker;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
-import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Common implementation code for performing an intersection shared between
  * the different intersection cursors. In particular, this base cursor
- * is agnostic to the type of result it returns to the users
+ * is agnostic to the type of result it returns to the users.
  *
  * @param <T> the type of elements returned by each child cursor
  * @param <U> the type of elements returned by this cursor
  */
-abstract class IntersectionCursorBase<T, U> implements RecordCursor<U> {
+abstract class IntersectionCursorBase<T, U> extends MergeCursor<T, U, KeyedMergeCursorState<T>> {
     @Nonnull
     private final Function<? super T, ? extends List<Object>> comparisonKeyFunction;
     private final boolean reverse;
-    @Nonnull
-    private final List<CursorState<T>> cursorStates;
-    @Nullable
-    private final FDBStoreTimer timer;
-    @Nullable
-    private CompletableFuture<Boolean> hasNextFuture;
-    @Nullable
-    private RecordCursorResult<U> nextResult;
-
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
 
     @Nonnull
     private static final Set<StoreTimer.Event> duringEvents = Collections.singleton(FDBStoreTimer.Events.QUERY_INTERSECTION);
@@ -86,77 +59,21 @@ abstract class IntersectionCursorBase<T, U> implements RecordCursor<U> {
     private static final Set<StoreTimer.Count> nonmatchesCounts =
             ImmutableSet.of(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_NONMATCHES, FDBStoreTimer.Counts.QUERY_DISCARDED);
 
-    protected static class CursorState<T> {
-        @Nonnull
-        private final RecordCursor<T> cursor;
-        @Nullable
-        private CompletableFuture<RecordCursorResult<T>> onNextFuture;
-        private List<Object> key;
-        @Nonnull
-        private RecordCursorContinuation continuation;
-        @Nullable
-        private RecordCursorResult<T> result;
-
-        CursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuation) {
-            this.cursor = cursor;
-            this.continuation = continuation;
-        }
-
-        @Nonnull
-        public CompletableFuture<RecordCursorResult<T>> getOnNextFuture(@Nonnull Function<? super T, ? extends List<Object>> keyFunction) {
-            if (onNextFuture == null) {
-                onNextFuture = cursor.onNext().thenApply(cursorResult -> {
-                    result = cursorResult;
-                    if (result.hasNext()) {
-                        key = keyFunction.apply(result.get());
-                    } else {
-                        continuation = result.getContinuation(); // no result, so we advanced the cached continuation
-                    }
-                    return cursorResult;
-                });
-            }
-            return onNextFuture;
-        }
-
-        public void consume() {
-            // after consuming a element from a cursor, we should never need to query it again,
-            // so we update its continuation information now
-            onNextFuture = null;
-            continuation = result.getContinuation();
-        }
-
-        @Nonnull
-        public static <T> CursorState<T> from(
-                @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
-                @Nonnull RecordCursorContinuation continuation) {
-            if (continuation.isEnd()) {
-                return new CursorState<>(RecordCursor.empty(), RecordCursorEndContinuation.END);
-            } else {
-                return new CursorState<>(cursorFunction.apply(continuation.toBytes()), continuation);
-            }
-        }
-
-        @Nullable
-        public RecordCursorResult<T> getResult() {
-            return result;
-        }
-    }
-
     protected IntersectionCursorBase(@Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
-                                     boolean reverse, @Nonnull List<CursorState<T>> cursorStates,
+                                     boolean reverse, @Nonnull List<KeyedMergeCursorState<T>> cursorStates,
                                      @Nullable FDBStoreTimer timer) {
+        super(cursorStates, timer);
         this.comparisonKeyFunction = comparisonKeyFunction;
         this.reverse = reverse;
-        this.cursorStates = cursorStates;
-        this.timer = timer;
     }
 
     // Identify the list of maximal (and non-maximal) elements from the list of cursor states.
-    private void mergeStates(@Nonnull List<CursorState<T>> maxStates, @Nonnull List<CursorState<T>> nonMaxCursors, long startTime) {
+    private void findMaxStates(@Nonnull List<KeyedMergeCursorState<T>> maxStates, @Nonnull List<KeyedMergeCursorState<T>> nonMaxCursors) {
+        final List<KeyedMergeCursorState<T>> cursorStates = getCursorStates();
         maxStates.add(cursorStates.get(0));
-        List<Object> maxKey = cursorStates.get(0).key;
-        for (CursorState<T> cursorState : cursorStates.subList(1, cursorStates.size())) {
-            int compare = KeyComparisons.KEY_COMPARATOR.compare(cursorState.key, maxKey) * (reverse ? -1 : 1);
+        List<Object> maxKey = cursorStates.get(0).getComparisonKey();
+        for (KeyedMergeCursorState<T> cursorState : cursorStates.subList(1, cursorStates.size())) {
+            int compare = KeyComparisons.KEY_COMPARATOR.compare(cursorState.getComparisonKey(), maxKey) * (reverse ? -1 : 1);
             if (compare == 0) {
                 maxStates.add(cursorState);
             } else if (compare < 0) {
@@ -167,140 +84,83 @@ abstract class IntersectionCursorBase<T, U> implements RecordCursor<U> {
                 // this new cursor is now the only max cursor
                 nonMaxCursors.addAll(maxStates);
                 maxStates.clear();
-                maxKey = cursorState.key;
+                maxKey = cursorState.getComparisonKey();
                 maxStates.add(cursorState);
             }
         }
+    }
 
-        if (!nonMaxCursors.isEmpty()) {
-            // Any non-maximal cursor is definitely not in the intersection,
-            // so we can consume those records (which updates their continuations).
-            nonMaxCursors.forEach(CursorState::consume);
-        }
+    /**
+     * Compute the next result states for the cursor based on the status of the existing states.
+     * This should return a (not necessarily proper) sublist of this cursors cursor states.
+     * By default, this assumes the cursors return results in a compatible order based on their
+     * comparison key and loops until they all have matching values. Extenders of this class may
+     * choose an alternative approach depending on the semantics of that cursor.
+     *
+     * <p>
+     * To indicate that the intersection cursor should stop, this function should either return
+     * an empty list of states or a list containing at least one state that does not have a next
+     * item.
+     * </p>
+     *
+     * @return the list of states included in the next result
+     */
+    @Override
+    @Nonnull
+    protected CompletableFuture<List<KeyedMergeCursorState<T>>> computeNextResultStates() {
+        final List<KeyedMergeCursorState<T>> cursorStates = getCursorStates();
+        return AsyncUtil.whileTrue(() -> whenAll(cursorStates).thenApply(vignore -> {
+            // If any of the cursors do not have a next element, then we are done.
+            if (cursorStates.stream().anyMatch(cursorState -> !cursorState.getResult().hasNext())) {
+                return false;
+            }
 
-        if (timer != null) {
-            if (nonMaxCursors.isEmpty()) {
-                // All of the cursors are in the intersection, so return a match.
+            // If everything compares equally, then we have a match and should return it.
+            // Otherwise, everything except for the maximum iterator values is guaranteed
+            // not to match, so null those values out and then move on.
+            final long startTime = System.nanoTime();
+            List<KeyedMergeCursorState<T>> maxCursors = new ArrayList<>(cursorStates.size());
+            List<KeyedMergeCursorState<T>> nonMaxCursors = new ArrayList<>(cursorStates.size());
+            findMaxStates(maxCursors, nonMaxCursors);
+            logDuplicates(maxCursors, nonMaxCursors, startTime);
+            if (!nonMaxCursors.isEmpty()) {
+                // Any non-maximal cursor is definitely not in the intersection,
+                // so we can consume those records (which updates their continuations).
+                // Then we loop again to see if we pick any up the next go around.
+                nonMaxCursors.forEach(KeyedMergeCursorState::consume);
+            }
+            return !nonMaxCursors.isEmpty();
+        }), getExecutor()).thenApply(vignore -> {
+            // This waits for all cursor states to return some result, so getResult will return
+            // something non-null.
+            if (cursorStates.stream().anyMatch(cursorState -> !cursorState.getResult().hasNext())) {
+                return Collections.emptyList();
+            } else {
+                return cursorStates;
+            }
+        });
+    }
+
+    private void logDuplicates(@Nonnull List<?> maxStates, @Nonnull List<?> nonMaxStates, long startTime) {
+        if (getTimer() != null) {
+            if (nonMaxStates.isEmpty()) {
+                // All of the cursors are in the intersection, so this will return a match.
                 // Subtract one from the number of cursors in the matching set in
                 // order to make it so that the metric represents the number of
                 // records *not* returned because they have been matched away in
                 // an intersection.
-                timer.record(duringEvents, System.nanoTime() - startTime);
-                timer.increment(matchesCounts, maxStates.size() - 1);
+                getTimer().record(duringEvents, System.nanoTime() - startTime);
+                getTimer().increment(matchesCounts, maxStates.size() - 1);
             } else {
-                timer.record(duringEvents, System.nanoTime() - startTime);
-                timer.increment(nonmatchesCounts, nonMaxCursors.size());
+                getTimer().record(duringEvents, System.nanoTime() - startTime);
+                getTimer().increment(nonmatchesCounts, nonMaxStates.size());
             }
         }
     }
 
     @Nonnull
-    @Override
-    public CompletableFuture<RecordCursorResult<U>> onNext() {
-        mayGetContinuation = false;
-        return AsyncUtil.whileTrue(() -> {
-            CompletableFuture<?>[] onNextFutures = new CompletableFuture<?>[cursorStates.size()];
-            int i = 0;
-            for (CursorState<T> cursorState : cursorStates) {
-                onNextFutures[i] = cursorState.getOnNextFuture(comparisonKeyFunction);
-                i++;
-            }
-            return CompletableFuture.allOf(onNextFutures).thenApply(vignore -> {
-                // If any of the cursors do not have a next element, then we are done.
-                if (cursorStates.stream().anyMatch(cursorState -> !cursorState.result.hasNext())) {
-                    return false;
-                }
-
-                long startTime = System.nanoTime();
-                // If everything compares equally, then we have a match and should return it.
-                // Otherwise, everything except for the maximum iterator values is guaranteed
-                // not to match, so null those values out and then move on.
-                List<CursorState<T>> maxCursors = new ArrayList<>(cursorStates.size());
-                List<CursorState<T>> nonMaxCursors = new ArrayList<>(cursorStates.size());
-                mergeStates(maxCursors, nonMaxCursors, startTime);
-                return !nonMaxCursors.isEmpty();
-            });
-        }, getExecutor()).thenApply(vignore -> {
-            boolean hasNext = cursorStates.stream().allMatch(cursorState -> cursorState.result.hasNext());
-            mayGetContinuation = !hasNext;
-            if (!hasNext) {
-                nextResult = RecordCursorResult.withoutNextValue(IntersectionContinuation.from(this), mergeNoNextReasons());
-            } else {
-                final U result = getNextResult(cursorStates);
-                cursorStates.forEach(CursorState::consume);
-                nextResult = RecordCursorResult.withNextValue(result, IntersectionContinuation.from(this));
-            }
-            return nextResult;
-        });
-    }
-
-    @Nonnull
-    @Override
-    public CompletableFuture<Boolean> onHasNext() {
-        if (hasNextFuture == null) {
-            mayGetContinuation = false;
-            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return hasNextFuture;
-    }
-
-    /**
-     * Given a list of cursor states, return a value based on the states of
-     * an appropriate type. This will only be called when all of the cursor states
-     * already all match, so this does not need to check for an intersection. The result
-     * of this method then determines the value that the cursor actually omits having
-     * found a match.
-     *
-     * @param cursorStates a list of cursor states with all cursors already having found a match
-     * @return the result to return given an intersection
-     */
-    abstract U getNextResult(@Nonnull List<CursorState<T>> cursorStates);
-
-    @Nullable
-    @Override
-    public U next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        mayGetContinuation = true;
-        hasNextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Override
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
-    }
-
-    @Override
-    public void close() {
-        cursorStates.forEach(cursorState -> cursorState.cursor.close());
-    }
-
-    @Nonnull
-    @Override
-    public Executor getExecutor() {
-        return cursorStates.get(0).cursor.getExecutor();
-    }
-
-    @Override
-    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
-        if (visitor.visitEnter(this)) {
-            for (CursorState<T> cursorState : cursorStates) {
-                if (!cursorState.cursor.accept(visitor)) {
-                    break;
-                }
-            }
-        }
-        return visitor.visitLeave(this);
+    protected Function<? super T, ? extends List<Object>> getComparisonKeyFunction() {
+        return comparisonKeyFunction;
     }
 
     /**
@@ -315,200 +175,42 @@ abstract class IntersectionCursorBase<T, U> implements RecordCursor<U> {
      * by the element scan limiter).
      * @return the weakest reason for stopping
      */
-    private NoNextReason mergeNoNextReasons() {
-        if (cursorStates.stream().allMatch(cursorState -> cursorState.result.hasNext())) {
-            throw new RecordCoreException("mergeNoNextReason should not be called when all sides have next");
-        }
-
-        NoNextReason reason = null;
-        for (CursorState<T> cursorState : cursorStates) {
-            if (!cursorState.result.hasNext()) {
-                NoNextReason cursorReason = cursorState.cursor.getNoNextReason();
-                if (cursorReason.isSourceExhausted()) {
-                    // one of the cursors is exhausted, so regardless of the other cursors'
-                    // reasons, the intersection cursor is also definitely exhausted
-                    return cursorReason;
-                } else if (reason == null || (reason.isOutOfBand() && !cursorReason.isOutOfBand())) {
-                    // if either we haven't chosen a reason yet (which is the case if reason is null)
-                    // or if we have found an in-band reason to stop that supersedes a previous out-of-band
-                    // reason, then update the current reason to that one
-                    reason = cursorReason;
-                }
-            }
-        }
-
-        return reason;
+    @Override
+    @Nonnull
+    protected NoNextReason mergeNoNextReasons() {
+        return getWeakestNoNextReason(getCursorStates());
     }
 
-    private static class IntersectionContinuation implements RecordCursorContinuation {
-        private static final RecordCursorProto.IntersectionContinuation.CursorState EXHAUSTED_PROTO = RecordCursorProto.IntersectionContinuation.CursorState.newBuilder()
-                .setStarted(true)
-                .build();
-        private static final RecordCursorProto.IntersectionContinuation.CursorState START_PROTO = RecordCursorProto.IntersectionContinuation.CursorState.newBuilder()
-                .setStarted(false)
-                .build();
-
-        @Nonnull
-        private final List<RecordCursorContinuation> continuations; // all continuations must themselves be immutable
-        @Nullable
-        private RecordCursorProto.IntersectionContinuation cachedProto;
-
-        private IntersectionContinuation(@Nonnull List<RecordCursorContinuation> continuations) {
-            this(continuations, null);
-        }
-
-        private IntersectionContinuation(@Nonnull List<RecordCursorContinuation> continuations, @Nullable RecordCursorProto.IntersectionContinuation proto) {
-            this.continuations = continuations;
-            this.cachedProto = proto;
-        }
-
-        public static IntersectionContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
-            if (bytes == null) {
-                return new IntersectionContinuation(Collections.nCopies(numberOfChildren, RecordCursorStartContinuation.START));
-            }
-            try {
-                return IntersectionContinuation.from(RecordCursorProto.IntersectionContinuation.parseFrom(bytes), numberOfChildren);
-            } catch (InvalidProtocolBufferException ex) {
-                throw new RecordCoreException("invalid continuation", ex)
-                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
-            }
-        }
-
-        public static IntersectionContinuation from(@Nonnull RecordCursorProto.IntersectionContinuation parsed, int numberOfChildren) {
-            ImmutableList.Builder<RecordCursorContinuation> builder = ImmutableList.builder();
-            if (!parsed.getFirstStarted()) {
-                builder.add(RecordCursorStartContinuation.START);
-            } else if (parsed.hasFirstContinuation()) {
-                builder.add(ByteArrayContinuation.fromNullable(parsed.getFirstContinuation().toByteArray()));
-            } else {
-                builder.add(RecordCursorEndContinuation.END);
-            }
-            if (!parsed.getSecondStarted()) {
-                builder.add(RecordCursorStartContinuation.START);
-            } else if (parsed.hasSecondContinuation()) {
-                builder.add(ByteArrayContinuation.fromNullable(parsed.getSecondContinuation().toByteArray()));
-            } else {
-                builder.add(RecordCursorEndContinuation.END);
-            }
-            for (RecordCursorProto.IntersectionContinuation.CursorState state : parsed.getOtherChildStateList()) {
-                if (!state.getStarted()) {
-                    builder.add(RecordCursorStartContinuation.START);
-                } else if (state.hasContinuation()) {
-                    builder.add(ByteArrayContinuation.fromNullable(state.getContinuation().toByteArray()));
-                } else {
-                    builder.add(RecordCursorEndContinuation.END);
-                }
-            }
-            ImmutableList<RecordCursorContinuation> children = builder.build();
-            if (children.size() != numberOfChildren) {
-                throw new RecordCoreArgumentException("invalid continuation (extraneous child state information present)")
-                        .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, numberOfChildren - 2)
-                        .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, parsed.getOtherChildStateCount());
-            }
-            return new IntersectionContinuation(children, parsed);
-        }
-
-        public static <U, T> IntersectionContinuation from(@Nonnull IntersectionCursorBase<U, T> cursor) {
-            return new IntersectionContinuation(cursor.cursorStates.stream().map(cursorState -> cursorState.continuation).collect(Collectors.toList()));
-        }
-
-        public RecordCursorProto.IntersectionContinuation toProto() {
-            if (cachedProto == null) {
-                final RecordCursorProto.IntersectionContinuation.Builder builder = RecordCursorProto.IntersectionContinuation.newBuilder();
-                final Iterator<RecordCursorContinuation> continuationIterator = continuations.iterator();
-
-                // A CursorState can have a null continuation for one of two reasons:
-                //
-                // 1. Its cursor has been exhausted.
-                // 2. The intersection cursor has not "consumed" that cursor yet.
-                //
-                // If any child has been exhausted, then the intersection cursor should return a null (i.e., exhausted)
-                // continuation as it will never return any more results. If the cursor state hasn't been consumed yet
-                // (which can happen if the first element of that cursor compares greater than all elements seen from
-                // other cursors), then the correct behavior is to restart that child from the beginning on subsequent
-                // runs of this intersection cursor, so the corresponding entry in the continuation proto is marked as
-                // not "started" for that child.
-
-                // First two cursors are handled differently (essentially for compatibility reasons)
-                final RecordCursorContinuation firstContinuation = continuationIterator.next();
-                byte[] asBytes = firstContinuation.toBytes();
-                if (asBytes == null && !firstContinuation.isEnd()) { // first cursor has not started
-                    builder.setFirstStarted(false);
-                } else {
-                    builder.setFirstStarted(true);
-                    if (asBytes != null) {
-                        builder.setFirstContinuation(ByteString.copyFrom(asBytes));
-                    }
-                }
-                final RecordCursorContinuation secondContinuation = continuationIterator.next();
-                asBytes = secondContinuation.toBytes();
-                if (asBytes == null && !secondContinuation.isEnd()) { // second cursor not started
-                    builder.setSecondStarted(false);
-                } else {
-                    builder.setSecondStarted(true);
-                    if (asBytes != null) {
-                        builder.setSecondContinuation(ByteString.copyFrom(asBytes));
-                    }
-                }
-
-                // The rest of the cursor states get written as elements in a repeated message field
-                while (continuationIterator.hasNext()) {
-                    final RecordCursorProto.IntersectionContinuation.CursorState cursorState;
-                    final RecordCursorContinuation continuation = continuationIterator.next();
-                    if (continuation.isEnd()) {
-                        cursorState = EXHAUSTED_PROTO;
-                    } else {
-                        asBytes = continuation.toBytes();
-                        if (asBytes == null && !continuation.isEnd()) {
-                            cursorState = START_PROTO;
-                        } else {
-                            cursorState = RecordCursorProto.IntersectionContinuation.CursorState.newBuilder()
-                                    .setStarted(true)
-                                    .setContinuation(ByteString.copyFrom(asBytes))
-                                    .build();
-                        }
-                    }
-                    builder.addOtherChildState(cursorState);
-                }
-                cachedProto = builder.build();
-            }
-            return cachedProto;
-        }
-
-        @Nullable
-        @Override
-        public byte[] toBytes() {
-            if (isEnd()) {
-                return null;
-            }
-            return toProto().toByteArray();
-        }
-
-        @Override
-        public boolean isEnd() {
-            // one of the children have actually stopped, so the intersection will have no more records
-            return continuations.stream().anyMatch(RecordCursorContinuation::isEnd);
-        }
+    @Override
+    @Nonnull
+    public IntersectionCursorContinuation getContinuationObject() {
+        return IntersectionCursorContinuation.from(this);
     }
 
-    protected static <T> List<CursorState<T>> createCursorStates(@Nonnull Function<byte[], RecordCursor<T>> left, @Nonnull Function<byte[], RecordCursor<T>> right,
-                                                                 @Nullable byte[] byteContinuation) {
-        final IntersectionContinuation continuation = IntersectionContinuation.from(byteContinuation, 2);
+    @Nonnull
+    protected static <T> List<KeyedMergeCursorState<T>> createCursorStates(@Nonnull Function<byte[], RecordCursor<T>> left,
+                                                                           @Nonnull Function<byte[], RecordCursor<T>> right,
+                                                                           @Nullable byte[] byteContinuation,
+                                                                           @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction) {
+        final IntersectionCursorContinuation continuation = IntersectionCursorContinuation.from(byteContinuation, 2);
         return ImmutableList.of(
-                CursorState.from(left, continuation.continuations.get(0)),
-                CursorState.from(right, continuation.continuations.get(1)));
+                KeyedMergeCursorState.from(left, continuation.getContinuations().get(0), comparisonKeyFunction),
+                KeyedMergeCursorState.from(right, continuation.getContinuations().get(1), comparisonKeyFunction));
     }
 
-    protected static <T> List<CursorState<T>> createCursorStates(@Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions, @Nullable byte[] byteContinuation) {
+    @Nonnull
+    protected static <T> List<KeyedMergeCursorState<T>> createCursorStates(@Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
+                                                                           @Nullable byte[] byteContinuation,
+                                                                           @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction) {
         if (cursorFunctions.size() < 2) {
             throw new RecordCoreArgumentException("not enough child cursors provided to IntersectionCursor")
                     .addLogInfo(LogMessageKeys.CHILD_COUNT, cursorFunctions.size());
         }
-        final List<CursorState<T>> cursorStates = new ArrayList<>(cursorFunctions.size());
-        final IntersectionContinuation continuation = IntersectionContinuation.from(byteContinuation, cursorFunctions.size());
+        final List<KeyedMergeCursorState<T>> cursorStates = new ArrayList<>(cursorFunctions.size());
+        final IntersectionCursorContinuation continuation = IntersectionCursorContinuation.from(byteContinuation, cursorFunctions.size());
         int i = 0;
         for (Function<byte[], RecordCursor<T>> cursorFunction : cursorFunctions) {
-            cursorStates.add(CursorState.from(cursorFunction, continuation.continuations.get(i)));
+            cursorStates.add(KeyedMergeCursorState.from(cursorFunction, continuation.getContinuations().get(i), comparisonKeyFunction));
             i++;
         }
         return cursorStates;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorBase.java
@@ -92,7 +92,7 @@ abstract class IntersectionCursorBase<T, U> extends MergeCursor<T, U, KeyedMerge
 
     /**
      * Compute the next result states for the cursor based on the status of the existing states.
-     * This should return a (not necessarily proper) sublist of this cursors cursor states.
+     * This should return a (not necessarily proper) sublist of this cursor's cursor states.
      * By default, this assumes the cursors return results in a compatible order based on their
      * comparison key and loops until they all have matching values. Extenders of this class may
      * choose an alternative approach depending on the semantics of that cursor.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
@@ -1,0 +1,170 @@
+/*
+ * IntersectionCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.ByteArrayContinuation;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorEndContinuation;
+import com.apple.foundationdb.record.RecordCursorProto;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.IntersectionContinuation.Builder, RecordCursorContinuation> {
+    @Nonnull
+    private static final RecordCursorProto.IntersectionContinuation.CursorState EXHAUSTED_PROTO = RecordCursorProto.IntersectionContinuation.CursorState.newBuilder()
+            .setStarted(true)
+            .build();
+    @Nonnull
+    private static final RecordCursorProto.IntersectionContinuation.CursorState START_PROTO = RecordCursorProto.IntersectionContinuation.CursorState.newBuilder()
+            .setStarted(false)
+            .build();
+
+    private IntersectionCursorContinuation(@Nonnull List<RecordCursorContinuation> continuations,
+                                           @Nullable RecordCursorProto.IntersectionContinuation originalProto) {
+        super(continuations, originalProto);
+    }
+
+    private IntersectionCursorContinuation(@Nonnull List<RecordCursorContinuation> continuations) {
+        this(continuations, null);
+    }
+
+    @Override
+    void setFirstChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        byte[] asBytes = continuation.toBytes();
+        if (asBytes == null && !continuation.isEnd()) { // first cursor has not started
+            builder.setFirstStarted(false);
+        } else {
+            builder.setFirstStarted(true);
+            if (asBytes != null) {
+                builder.setFirstContinuation(ByteString.copyFrom(asBytes));
+            }
+        }
+    }
+
+    @Override
+    void setSecondChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        byte[] asBytes = continuation.toBytes();
+        if (asBytes == null && !continuation.isEnd()) { // second cursor not started
+            builder.setSecondStarted(false);
+        } else {
+            builder.setSecondStarted(true);
+            if (asBytes != null) {
+                builder.setSecondContinuation(ByteString.copyFrom(asBytes));
+            }
+        }
+    }
+
+    @Override
+    void addOtherChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        final RecordCursorProto.IntersectionContinuation.CursorState cursorState;
+        if (continuation.isEnd()) {
+            cursorState = EXHAUSTED_PROTO;
+        } else {
+            byte[] asBytes = continuation.toBytes();
+            if (asBytes == null && !continuation.isEnd()) {
+                cursorState = START_PROTO;
+            } else {
+                cursorState = RecordCursorProto.IntersectionContinuation.CursorState.newBuilder()
+                        .setStarted(true)
+                        .setContinuation(ByteString.copyFrom(asBytes))
+                        .build();
+            }
+        }
+        builder.addOtherChildState(cursorState);
+    }
+
+    @Override
+    @Nonnull
+    RecordCursorProto.IntersectionContinuation.Builder newProtoBuilder() {
+        return RecordCursorProto.IntersectionContinuation.newBuilder();
+    }
+
+    @Override
+    public boolean isEnd() {
+        // one of the children have actually stopped, so the intersection will have no more records
+        return getContinuations().stream().anyMatch(RecordCursorContinuation::isEnd);
+    }
+
+    @Nonnull
+    static IntersectionCursorContinuation from(@Nonnull IntersectionCursorBase<?, ?> cursor) {
+        return new IntersectionCursorContinuation(cursor.getChildContinuations());
+    }
+
+    @Nonnull
+    static IntersectionCursorContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
+        if (bytes == null) {
+            return new IntersectionCursorContinuation(Collections.nCopies(numberOfChildren, RecordCursorStartContinuation.START));
+        }
+        try {
+            return IntersectionCursorContinuation.from(RecordCursorProto.IntersectionContinuation.parseFrom(bytes), numberOfChildren);
+        } catch (InvalidProtocolBufferException ex) {
+            throw new RecordCoreException("invalid continuation", ex)
+                    .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
+        }
+    }
+
+    @Nonnull
+    static IntersectionCursorContinuation from(@Nonnull RecordCursorProto.IntersectionContinuation parsed, int numberOfChildren) {
+        ImmutableList.Builder<RecordCursorContinuation> builder = ImmutableList.builder();
+        if (!parsed.getFirstStarted()) {
+            builder.add(RecordCursorStartContinuation.START);
+        } else if (parsed.hasFirstContinuation()) {
+            builder.add(ByteArrayContinuation.fromNullable(parsed.getFirstContinuation().toByteArray()));
+        } else {
+            builder.add(RecordCursorEndContinuation.END);
+        }
+        if (!parsed.getSecondStarted()) {
+            builder.add(RecordCursorStartContinuation.START);
+        } else if (parsed.hasSecondContinuation()) {
+            builder.add(ByteArrayContinuation.fromNullable(parsed.getSecondContinuation().toByteArray()));
+        } else {
+            builder.add(RecordCursorEndContinuation.END);
+        }
+        for (RecordCursorProto.IntersectionContinuation.CursorState state : parsed.getOtherChildStateList()) {
+            if (!state.getStarted()) {
+                builder.add(RecordCursorStartContinuation.START);
+            } else if (state.hasContinuation()) {
+                builder.add(ByteArrayContinuation.fromNullable(state.getContinuation().toByteArray()));
+            } else {
+                builder.add(RecordCursorEndContinuation.END);
+            }
+        }
+        ImmutableList<RecordCursorContinuation> children = builder.build();
+        if (children.size() != numberOfChildren) {
+            throw new RecordCoreArgumentException("invalid continuation (extraneous child state information present)")
+                    .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, numberOfChildren - 2)
+                    .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, parsed.getOtherChildStateCount());
+        }
+        return new IntersectionCursorContinuation(children, parsed);
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
@@ -42,14 +42,15 @@ import java.util.function.Function;
 public class IntersectionMultiCursor<T> extends IntersectionCursorBase<T, List<T>> {
 
     private IntersectionMultiCursor(@Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
-                                    boolean reverse, @Nonnull List<CursorState<T>> cursorStates,
+                                    boolean reverse, @Nonnull List<KeyedMergeCursorState<T>> cursorStates,
                                     @Nullable FDBStoreTimer timer) {
         super(comparisonKeyFunction, reverse, cursorStates, timer);
+
     }
 
     @Override
     @Nonnull
-    List<T> getNextResult(@Nonnull List<CursorState<T>> cursorStates) {
+    List<T> getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
         List<T> result = new ArrayList<>(cursorStates.size());
         cursorStates.forEach(cursorState -> result.add(cursorState.getResult().get()));
         return result;
@@ -88,6 +89,7 @@ public class IntersectionMultiCursor<T> extends IntersectionCursorBase<T, List<T
             @Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
             @Nullable byte[] continuation,
             @Nullable FDBStoreTimer timer) {
-        return new IntersectionMultiCursor<>(comparisonKeyFunction, reverse, createCursorStates(cursorFunctions, continuation), timer);
+        return new IntersectionMultiCursor<>(comparisonKeyFunction, reverse,
+                createCursorStates(cursorFunctions, continuation, comparisonKeyFunction), timer);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/KeyedMergeCursorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/KeyedMergeCursorState.java
@@ -1,0 +1,79 @@
+/*
+ * KeyedMergeCursorState.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorEndContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Adds a comparison key and a comparison function to the {@link MergeCursorState} class.
+ * @param <T> the type of element returned by the underlying cursor
+ */
+class KeyedMergeCursorState<T> extends MergeCursorState<T> {
+    @Nonnull
+    private final Function<? super T, ? extends List<Object>> comparisonKeyFunction;
+    @Nullable
+    private List<Object> comparisonKey;
+
+    KeyedMergeCursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuation,
+                          @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction) {
+        super(cursor, continuation);
+        this.comparisonKeyFunction = comparisonKeyFunction;
+    }
+
+    @Override
+    protected void handleNextCursorResult(@Nonnull RecordCursorResult<T> cursorResult) {
+        super.handleNextCursorResult(cursorResult);
+        if (cursorResult.hasNext()) {
+            comparisonKey = comparisonKeyFunction.apply(cursorResult.get());
+        }
+    }
+
+    @Nullable
+    public List<Object> getComparisonKey() {
+        return comparisonKey;
+    }
+
+    @Override
+    public void consume() {
+        super.consume();
+        this.comparisonKey = null;
+    }
+
+    @Nonnull
+    public static <T> KeyedMergeCursorState<T> from(
+            @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
+            @Nonnull RecordCursorContinuation continuation,
+            @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction) {
+        if (continuation.isEnd()) {
+            return new KeyedMergeCursorState<>(RecordCursor.empty(), RecordCursorEndContinuation.END, comparisonKeyFunction);
+        } else {
+            return new KeyedMergeCursorState<>(cursorFunction.apply(continuation.toBytes()), continuation, comparisonKeyFunction);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
@@ -1,0 +1,338 @@
+/*
+ * MergeCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.cursors.EmptyCursor;
+import com.apple.foundationdb.record.cursors.IllegalContinuationAccessChecker;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+/**
+ * An abstract class that corresponds to some kind of cursor merging multiple children together.
+ * It forms a common basis for various union and intersection cursors. Extenders should also extend:
+ *
+ * <ul>
+ *     <li>{@link MergeCursorContinuation} with an implementation that constructs an appropriate Protobuf message.</li>
+ *     <li>{@link MergeCursorState} if additional state is needed to accompany each cursor.</li>
+ * </ul>
+ */
+abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implements RecordCursor<U> {
+    @Nonnull
+    private final List<S> cursorStates;
+    @Nullable
+    private final FDBStoreTimer timer;
+    @Nonnull
+    private final Executor executor;
+    @Nullable
+    private CompletableFuture<Boolean> hasNextFuture;
+    @Nullable
+    private RecordCursorResult<U> nextResult;
+
+    // for detecting incorrect cursor usage
+    private boolean mayGetContinuation = false;
+
+    MergeCursor(@Nonnull List<S> cursorStates, @Nullable FDBStoreTimer timer) {
+        this.cursorStates = cursorStates;
+        this.timer = timer;
+        // Choose the executor from the first non-empty cursor. The executors for empty cursors are just
+        // the default one, whereas non-empty cursors may have an executor set by the user.
+        Executor cursorExecutor = null;
+        for (S cursorState : cursorStates) {
+            if (!(cursorState.getCursor() instanceof EmptyCursor)) {
+                cursorExecutor = cursorState.getExecutor();
+                break;
+            }
+        }
+        this.executor = cursorExecutor != null ? cursorExecutor : cursorStates.get(0).getExecutor();
+    }
+
+    private static <T, S extends MergeCursorState<T>> CompletableFuture<?>[] getOnNextFutures(@Nonnull List<S> cursorStates) {
+        CompletableFuture<?>[] futures = new CompletableFuture<?>[cursorStates.size()];
+        int i = 0;
+        for (S cursorState : cursorStates) {
+            futures[i] = cursorState.getOnNextFuture();
+            i++;
+        }
+        return futures;
+    }
+
+    @Nonnull
+    static <T, S extends MergeCursorState<T>> CompletableFuture<Void> whenAll(@Nonnull List<S> cursorStates) {
+        return CompletableFuture.allOf(getOnNextFutures(cursorStates));
+    }
+
+    // This returns a "wildcard" to handle the fact that the signature of AsyncUtil.DONE is
+    // CompletableFuture<Void> whereas CompletableFuture.anyOf returns a CompletableFuture<Object>.
+    // The caller always ignores the result anyway and just uses this as a signal, so it's not
+    // a big loss.
+    @SuppressWarnings("squid:S1452")
+    @Nonnull
+    static <T, S extends MergeCursorState<T>> CompletableFuture<?> whenAny(@Nonnull List<S> cursorStates) {
+        List<S> nonExhausted = new ArrayList<>(cursorStates.size());
+        for (S cursorState : cursorStates) {
+            if (!cursorState.isExhausted()) {
+                if (cursorState.getOnNextFuture().isDone()) {
+                    // Short-circuit and return immediately if we find a state that is already done.
+                    return AsyncUtil.DONE;
+                } else {
+                    nonExhausted.add(cursorState);
+                }
+            }
+        }
+        if (nonExhausted.isEmpty()) {
+            // Everything is exhausted. Can return immediately.
+            return AsyncUtil.DONE;
+        } else {
+            return CompletableFuture.anyOf(getOnNextFutures(nonExhausted));
+        }
+    }
+
+    /**
+     * Gets the strongest reason for stopping of all cursor states. An out-of-band reason is stronger
+     * than an in-band limit, and an in-band limit is stronger than {@link com.apple.foundationdb.record.RecordCursor.NoNextReason#SOURCE_EXHAUSTED}.
+     * Cursors that have not been stopped are ignored, but if no cursor has stopped, this throws an error.
+     *
+     * @param cursorStates the list of cursor states to consider
+     * @param <T> the type of elements returned by this cursor
+     * @param <S> the type of cursor state in the list of cursors
+     * @return the strongest reason to stop from the list of all cursors
+     */
+    @Nonnull
+    static <T, S extends MergeCursorState<T>> NoNextReason getStrongestNoNextReason(@Nonnull List<S> cursorStates) {
+        NoNextReason reason = null;
+        for (S cursorState : cursorStates) {
+            final RecordCursorResult<T> childResult = cursorState.getResult();
+            if (childResult != null && !childResult.hasNext()) {
+                // Combine the current reason so far with this child's reason.
+                // In particular, choose the child reason if it is at least as strong
+                // as the current one. This guarantees that it will choose an
+                // out of band reason if there is one and will only return
+                // SOURCE_EXHAUSTED if every child ended with SOURCE_EXHAUSTED.
+                NoNextReason childReason = cursorState.getResult().getNoNextReason();
+                if (reason == null || childReason.isOutOfBand() || reason.isSourceExhausted()) {
+                    reason = childReason;
+                }
+            }
+        }
+        if (reason == null) {
+            throw new RecordCoreException("mergeNoNextReason should not be called when all children have next");
+        }
+        return reason;
+    }
+
+    /**
+     * Gets the weakest reason for stopping of all cursor states. The weakest reason is
+     * {@link com.apple.foundationdb.record.RecordCursor.NoNextReason#SOURCE_EXHAUSTED}, followed by an
+     * in-band limit, then an out of band limit.
+     *
+     * @param cursorStates the list of cursor states to consider
+     * @param <T> the type of elements returned by this cursor
+     * @param <S> the type of cursor state in the list of cursors
+     * @return the strongest reason to stop from the list of all cursors
+     */
+    @Nonnull
+    static <T, S extends MergeCursorState<T>> NoNextReason getWeakestNoNextReason(@Nonnull List<S> cursorStates) {
+        NoNextReason reason = null;
+        for (S cursorState : cursorStates) {
+            final RecordCursorResult<T> childResult = cursorState.getResult();
+            if (childResult != null && !childResult.hasNext()) {
+                NoNextReason childReason = childResult.getNoNextReason();
+                if (childReason.isSourceExhausted()) {
+                    // one of the cursors is exhausted, so regardless of the other cursors'
+                    // reasons, the cursor has stopped due to source exhaustion
+                    return childReason;
+                } else if (reason == null || (reason.isOutOfBand() && !childReason.isOutOfBand())) {
+                    // if either we haven't chosen a reason yet (which is the case if reason is null)
+                    // or if we have found an in-band reason to stop that supersedes a previous out-of-band
+                    // reason, then update the current reason to that one
+                    reason = childReason;
+                }
+            }
+        }
+        if (reason == null) {
+            throw new RecordCoreException("mergeNoNextReason should not be called when all children have next");
+        }
+        return reason;
+    }
+
+    /**
+     * Get the child cursors along with associated mutable state.
+     *
+     * @return the child cursors of this cursor
+     */
+    @Nonnull
+    List<S> getCursorStates() {
+        return cursorStates;
+    }
+
+    /**
+     * Determine which cursors should have their values included in the next iteration.
+     * This list should include the state associated with each cursor, and the returned value should
+     * be a (not necessarily proper) sublist of the result states of this cursor. (This
+     * list can be retrieved by calling {@link #getCursorStates()}.) To indicate that this cursor
+     * is done returning elements, this function should return the empty list.
+     *
+     * @return the list of cursors to include in the next iteration
+     */
+    @Nonnull
+    abstract CompletableFuture<List<S>> computeNextResultStates();
+
+    /**
+     * Determine the next result to return based on the results of the child cursors. This will
+     * be called with the return value of {@link #computeNextResultStates()}.
+     *
+     * @param resultStates the list of cursors to be included in the result
+     * @return a result somehow combining the results of the input cursors
+     */
+    @Nonnull
+    abstract U getNextResult(@Nonnull List<S> resultStates);
+
+    /**
+     * Merge the {@link NoNextReason}s for child cursors. This will only be called after it is
+     * determined that the merge cursor itself will not return a {@code NoNextReason}. Note that
+     * this may (or may) not imply that all child cursors are done (depending on the implementation
+     * of the extending cursor). This {@code NoNextReason} will be the reason returned by the
+     * merge cursor.
+     *
+     * @return a {@link NoNextReason} based on the child cursors' {@code NoNextReason}s
+     */
+    @Nonnull
+    abstract NoNextReason mergeNoNextReasons();
+
+    /**
+     * Produce a {@link RecordCursorContinuation} for this cursor. The super-class itself handles
+     * constructing the byte array continuation from this continuation. Most continuations will
+     * be based on the continuations of this cursors child cursors. These can be retrieved by
+     * calling {@link #getChildContinuations()}. This will only be called after {@link #computeNextResultStates()}
+     * has completed.
+     *
+     * @return a {@link RecordCursorContinuation} for this cursor based on the state of its child cursors
+     */
+    @Nonnull
+    abstract RecordCursorContinuation getContinuationObject();
+
+    @Override
+    @Nonnull
+    public CompletableFuture<RecordCursorResult<U>> onNext() {
+        mayGetContinuation = false;
+        return computeNextResultStates().thenApply(resultStates -> {
+            boolean hasNext = !resultStates.isEmpty();
+            mayGetContinuation = !hasNext;
+            if (!hasNext) {
+                nextResult = RecordCursorResult.withoutNextValue(getContinuationObject(), mergeNoNextReasons());
+            } else {
+                final U result = getNextResult(resultStates);
+                resultStates.forEach(S::consume);
+                nextResult = RecordCursorResult.withNextValue(result, getContinuationObject());
+            }
+            return nextResult;
+        });
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<Boolean> onHasNext() {
+        if (hasNextFuture == null) {
+            mayGetContinuation = false;
+            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
+        }
+        return hasNextFuture;
+    }
+
+    @Override
+    @Nullable
+    public U next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        mayGetContinuation = true;
+        hasNextFuture = null;
+        return nextResult.get();
+    }
+
+    @Override
+    @Nullable
+    public byte[] getContinuation() {
+        IllegalContinuationAccessChecker.check(mayGetContinuation);
+        return nextResult.getContinuation().toBytes();
+    }
+
+    @Override
+    @Nonnull
+    public NoNextReason getNoNextReason() {
+        return nextResult.getNoNextReason();
+    }
+
+    @Nonnull
+    List<RecordCursorContinuation> getChildContinuations() {
+        return cursorStates.stream().map(S::getContinuation).collect(Collectors.toList());
+    }
+
+    @Override
+    public void close() {
+        cursorStates.forEach(S::close);
+        if (hasNextFuture != null) {
+            hasNextFuture.cancel(false);
+        }
+    }
+
+    @Override
+    @Nonnull
+    public Executor getExecutor() {
+        return executor;
+    }
+
+    /**
+     * Get the {@link FDBStoreTimer} used to instrument events of this cursor.
+     *
+     * @return the timer used to instrument this cursor
+     */
+    @Nullable
+    public FDBStoreTimer getTimer() {
+        return timer;
+    }
+
+    @Override
+    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+        if (visitor.visitEnter(this)) {
+            for (S cursorState : getCursorStates()) {
+                if (!cursorState.getCursor().accept(visitor)) {
+                    break;
+                }
+            }
+        }
+        return visitor.visitLeave(this);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorContinuation.java
@@ -1,0 +1,124 @@
+/*
+ * MergeCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Common code for handling the continuations of {@link MergeCursor}s. The continuations for these cursors are constructed
+ * from a Protobuf message containing information on the state of each child cursor. This class handles caching
+ * that Protobuf message and its byte representation so that subsequent calls to get the continuation are fast. It also
+ * abstracts away some of the logic for converting a list of continuations into a single Protobuf message, but this is
+ * still somewhat clunky because Protobuf does not support {@link Message} inheritance (which limits the opportunity for
+ * polymorphism).
+ *
+ * @param <B> the builder for message type of the continuation proto message
+ */
+abstract class MergeCursorContinuation<B extends Message.Builder, C extends RecordCursorContinuation> implements RecordCursorContinuation {
+    @Nonnull
+    private final List<C> continuations; // all continuations must themselves be immutable
+    @Nullable
+    private Message cachedProto;
+    @Nullable
+    private byte[] cachedBytes;
+
+    protected MergeCursorContinuation(@Nonnull List<C> continuations, @Nullable Message originalProto) {
+        this.continuations = continuations;
+        this.cachedProto = originalProto;
+    }
+
+    /**
+     * Fill in the Protobuf builder with the information from the first child. For backwards-compatibility reasons,
+     * cursors may handle this differently than the other children. This method will be called before
+     * {@link #setSecondChild(B, C)} and all calls to {@link #addOtherChild(B, C)}.
+     *
+     * @param builder a builder for the Protobuf continuation
+     * @param continuation the first child's continuation
+     */
+    abstract void setFirstChild(@Nonnull B builder, @Nonnull C continuation);
+
+    /**
+     * Fill in the Protobuf builder with the information from the second child. For backwards-compatibility reasons,
+     * cursors may handle this differently than the other children. This method will be called after
+     * {@link #setFirstChild(B, C)} and before all calls to {@link #addOtherChild(B, C)}.
+     *
+     * @param builder a builder for the Protobuf continuation
+     * @param continuation the second child's continuation
+     */
+    abstract void setSecondChild(@Nonnull B builder, @Nonnull C continuation);
+
+    /**
+     * Fill in the Protobuf builder with the information for a child other than the first or second child. For
+     * backwards-compatibility reasons, cursors may handle those two children differently than the other children.
+     * This method will be called in the same order as the continuations in {@link #getContinuations()}.
+     *
+     * @param builder a builder for the Protobuf continuation
+     * @param continuation a child other than the first or second child
+     */
+    abstract void addOtherChild(@Nonnull B builder, @Nonnull C continuation);
+
+    /**
+     * Get a new builder instance for the Protobuf message associated with this continuation. This should typically
+     * be implemented by calling the {@code newBuilder()} method on the appropriate message type.
+     *
+     * @return a new builder for the underlying Protobuf message type
+     */
+    @Nonnull
+    abstract B newProtoBuilder();
+
+    @Nonnull
+    Message toProto() {
+        if (cachedProto == null) {
+            B builder = newProtoBuilder();
+            final Iterator<C> continuationIterator = continuations.iterator();
+            setFirstChild(builder, continuationIterator.next());
+            setSecondChild(builder, continuationIterator.next());
+            while (continuationIterator.hasNext()) {
+                addOtherChild(builder, continuationIterator.next());
+            }
+            cachedProto = builder.build();
+        }
+        return cachedProto;
+    }
+
+    @Nullable
+    @Override
+    public byte[] toBytes() {
+        if (isEnd()) {
+            return null;
+        }
+        if (cachedBytes == null) {
+            cachedBytes = toProto().toByteArray();
+        }
+        return cachedBytes;
+    }
+
+    @Nonnull
+    protected List<C> getContinuations() {
+        return continuations;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
@@ -1,0 +1,120 @@
+/*
+ * MergeCursorState.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorEndContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+/**
+ * A holder for mutable state needed to track one of the children cursors of some merge operation. This includes
+ * the cursor itself as well as information tracking the progress including continuation information. Subclasses
+ * may add additional information such as a comparison key or value (for ordered cursors).
+ *
+ * @param <T> the type of elements returned by the underlying cursor
+ */
+class MergeCursorState<T> implements AutoCloseable {
+    @Nonnull
+    private final RecordCursor<T> cursor;
+    @Nullable
+    private CompletableFuture<RecordCursorResult<T>> onNextFuture;
+    @Nonnull
+    private RecordCursorContinuation continuation;
+    @Nullable
+    private RecordCursorResult<T> result;
+
+    MergeCursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuation) {
+        this.cursor = cursor;
+        this.continuation = continuation;
+    }
+
+    protected void handleNextCursorResult(@Nonnull RecordCursorResult<T> cursorResult) {
+        result = cursorResult;
+        if (!result.hasNext()) {
+            continuation = result.getContinuation(); // no result, so we advanced the cached continuation
+        }
+    }
+
+    @Nonnull
+    public CompletableFuture<RecordCursorResult<T>> getOnNextFuture() {
+        if (onNextFuture == null) {
+            onNextFuture = cursor.onNext().thenApply(cursorResult -> {
+                handleNextCursorResult(cursorResult);
+                return cursorResult;
+            });
+        }
+        return onNextFuture;
+    }
+
+    public void consume() {
+        // after consuming a element from a cursor, we should never need to query it again,
+        // so we update its continuation information now
+        onNextFuture = null;
+        continuation = result.getContinuation();
+    }
+
+    public boolean isExhausted() {
+        return result != null && !result.hasNext() && result.getNoNextReason().isSourceExhausted();
+    }
+
+    @Nullable
+    public RecordCursorResult<T> getResult() {
+        return result;
+    }
+
+    @Override
+    public void close() {
+        cursor.close();
+    }
+
+    @Nonnull
+    public Executor getExecutor() {
+        return cursor.getExecutor();
+    }
+
+    @Nonnull
+    public RecordCursor<T> getCursor() {
+        return cursor;
+    }
+
+    @Nonnull
+    public RecordCursorContinuation getContinuation() {
+        return continuation;
+    }
+
+    @Nonnull
+    public static <T> MergeCursorState<T> from(
+            @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
+            @Nonnull RecordCursorContinuation continuation) {
+        if (continuation.isEnd()) {
+            return new MergeCursorState<>(RecordCursor.empty(), RecordCursorEndContinuation.END);
+        } else {
+            return new MergeCursorState<>(cursorFunction.apply(continuation.toBytes()), continuation);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
@@ -1,0 +1,259 @@
+/*
+ * ProbableIntersectionCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * A cursor that returns all results that are probably in all of its children. This differs from the
+ * {@link IntersectionCursor} in that it does not require that its children produce results in a compatible order.
+ * Just like the {@code IntersectionCursor}, this cursor does require a comparison key function for each entry, but it
+ * only uses this comparison key for determining whether two results returned by child cursors are equal.
+ *
+ * <p>
+ * This cursor makes very few guarantees about its results. In particular, just as with the {@link UnorderedUnionCursor},
+ * results are returned as they come, so the exact ordering of returned results is determined only at runtime.
+ * It also can produce duplicates if the same result appears multiple times in its child cursors.
+ * Additionally, in order to support resuming this cursor using a continuation, Bloom filters are used internally
+ * to remember which results the cursors have already seen. However, as Bloom filters can report false positives,
+ * it is possible that this cursor can return a result that only appears in a proper subset of the child cursors'
+ * result sets. The selectivity of the Bloom filter can be adjusted by setting the {@code expectedResults}
+ * and {@code falsePositivePercentage} parameters at cursor creation time. These parameters are fed through to the
+ * underlying Guava {@link com.google.common.hash.BloomFilter} initializer.
+ * </p>
+ *
+ * <p>
+ * However, this cursor does make the following guarantees:
+ * </p>
+ *
+ * <ul>
+ *     <li>All results that are actually in the intersection will be in this cursor's result set.</li>
+ *     <li>Any result of this cursor is the result of at least one child cursor.</li>
+ * </ul>
+ *
+ * <p>
+ * This cursor can therefore be used to select a narrow candidate set of "probable" elements of the intersection
+ * and then perform a (possibly more expensive) alternative filter to verify each result. For example, if each
+ * child corresponds to satisfying some conjunct of an {@link com.apple.foundationdb.record.query.expressions.AndComponent "and"}
+ * predicate by scanning an index, then one could intersect the results with this cursor and then evaluate
+ * the predicate on each returned record as a residual filter.
+ * </p>
+ *
+ * @param <T> the type of element returned by this cursor
+ * @see com.google.common.hash.BloomFilter
+ */
+@API(API.Status.EXPERIMENTAL)
+public class ProbableIntersectionCursor<T> extends MergeCursor<T, T, ProbableIntersectionCursorState<T>> {
+    /**
+     * The default number of results to expect to be read from each child cursor of this cursor.
+     */
+    public static final long DEFAULT_EXPECTED_RESULTS = 500L;
+    /**
+     * The default acceptable false positive percentage when evaluating whether an element is contained with a given cursor's result set.
+     */
+    public static final double DEFAULT_FALSE_POSITIVE_PERCENTAGE = 0.01;
+
+    @Nonnull
+    private static final Set<StoreTimer.Event> duringEvents = Collections.singleton(FDBStoreTimer.Events.QUERY_INTERSECTION);
+    @Nonnull
+    private static final Set<StoreTimer.Count> matchesCounts = Collections.singleton(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_MATCHES);
+    @Nonnull
+    private static final Set<StoreTimer.Count> nonmatchesCounts =
+            ImmutableSet.of(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_NONMATCHES, FDBStoreTimer.Counts.QUERY_DISCARDED);
+
+    ProbableIntersectionCursor(@Nonnull List<ProbableIntersectionCursorState<T>> cursorStates, @Nullable FDBStoreTimer timer) {
+        super(cursorStates, timer);
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private boolean checkIfInRest(@Nonnull ProbableIntersectionCursorState<T> cursorState) {
+        final List<ProbableIntersectionCursorState<T>> cursorStates = getCursorStates();
+        final List<Object> key = cursorState.getComparisonKey();
+        boolean allContain = true;
+        for (ProbableIntersectionCursorState<T> otherCursorState : cursorStates) {
+            // Check if all states (beside the source state) contain the element (at least according
+            // to the Bloom filter)
+            if (otherCursorState != cursorState && !otherCursorState.mightContain(key)) {
+                allContain = false;
+                break;
+            }
+        }
+        return allContain;
+    }
+
+    @Override
+    @Nonnull
+    CompletableFuture<List<ProbableIntersectionCursorState<T>>> computeNextResultStates() {
+        final AtomicReference<ProbableIntersectionCursorState<T>> resultStateRef = new AtomicReference<>();
+        return AsyncUtil.whileTrue(() -> whenAny(getCursorStates()).thenApply(vignore -> {
+            final long startTime = System.nanoTime();
+            final List<ProbableIntersectionCursorState<T>> cursorStates = getCursorStates();
+            boolean allDone = true;
+            for (ProbableIntersectionCursorState<T> cursorState : cursorStates) {
+                final CompletableFuture<RecordCursorResult<T>> onNextFuture = cursorState.getOnNextFuture();
+                if (!onNextFuture.isDone()) {
+                    allDone = false;
+                    continue;
+                }
+                final RecordCursorResult<T> resultState = onNextFuture.join();
+                if (resultState.hasNext()) {
+                    allDone = false;
+                    if (!cursorState.isDefiniteDuplicate() && checkIfInRest(cursorState)) {
+                        // We've found an element that is in all of the other states.
+                        // Exit immediately with "false" to indicate that the loop can stop.
+                        resultStateRef.set(cursorState);
+                        if (getTimer() != null) {
+                            getTimer().increment(matchesCounts);
+                            getTimer().record(duringEvents, System.nanoTime() - startTime);
+                        }
+                        return false;
+                    } else {
+                        // This element is missing from at least one child so will not be in the
+                        // result set (at least not yet).
+                        cursorState.consume();
+                        if (getTimer() != null) {
+                            getTimer().increment(nonmatchesCounts);
+                        }
+                    }
+                }
+            }
+            if (getTimer() != null) {
+                getTimer().record(duringEvents, System.nanoTime() - startTime);
+            }
+            return !allDone;
+        }), getExecutor()).thenApply(vignore -> {
+            if (resultStateRef.get() == null) {
+                // All cursors have stopped. Signal this with the empty list.
+                return Collections.emptyList();
+            } else {
+                // At least one cursor still has elements.
+                return Collections.singletonList(resultStateRef.get());
+            }
+        });
+    }
+
+    @Override
+    @Nonnull
+    T getNextResult(@Nonnull List<ProbableIntersectionCursorState<T>> resultStates) {
+        return resultStates.get(0).getResult().get();
+    }
+
+    @Override
+    @Nonnull
+    NoNextReason mergeNoNextReasons() {
+        return getStrongestNoNextReason(getCursorStates());
+    }
+
+    @Override
+    @Nonnull
+    ProbableIntersectionCursorContinuation getContinuationObject() {
+        return ProbableIntersectionCursorContinuation.from(this);
+    }
+
+    @Nonnull
+    static <T> List<ProbableIntersectionCursorState<T>> createCursorStates(@Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
+                                                                           @Nullable byte[] byteContinuation,
+                                                                           @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
+                                                                           long expectedInsertions, double falsePositiveRate) {
+        final List<ProbableIntersectionCursorState<T>> cursorStates = new ArrayList<>(cursorFunctions.size());
+        final ProbableIntersectionCursorContinuation continuation = ProbableIntersectionCursorContinuation.from(byteContinuation, cursorFunctions.size());
+        int i = 0;
+        for (Function<byte[], RecordCursor<T>> cursorFunction : cursorFunctions) {
+            cursorStates.add(ProbableIntersectionCursorState.from(cursorFunction, continuation.getContinuations().get(i),
+                    comparisonKeyFunction, expectedInsertions, falsePositiveRate));
+            i++;
+        }
+        return cursorStates;
+    }
+
+    /**
+     * Create a cursor merging the results of two or more cursors. This uses the default values for
+     * <code>expectedResults</code> and <code>falsePositivePercentage</code>.
+     *
+     * @param comparisonKeyFunction the function evaluated to compare elements from different cursors
+     * @param cursorFunctions a list of functions to produce {@link RecordCursor}s from a continuation
+     * @param continuation any continuation from a previous scan
+     * @param timer the timer used to instrument events
+     * @param <T> the type of elements returned by this cursor
+     * @return a cursor containing any records from any child cursor
+     * @see #create(Function, List, long, double, byte[], FDBStoreTimer)
+     */
+    @Nonnull
+    public static <T> ProbableIntersectionCursor<T> create(
+            @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
+            @Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
+            @Nullable byte[] continuation,
+            @Nullable FDBStoreTimer timer) {
+        return create(comparisonKeyFunction, cursorFunctions, DEFAULT_EXPECTED_RESULTS, DEFAULT_FALSE_POSITIVE_PERCENTAGE, continuation, timer);
+    }
+
+    /**
+     * Create a cursor merging the results of two or more cursors. The resulting cursor will return all children
+     * that are <i>probably</i> in all of the child cursors. Unlike the {@link IntersectionCursor}, this does not require
+     * that results be returned in the same order as their values from the comparison key function. However, it
+     * does require that if two elements evaluate to the same comparison key that they are equal.
+     *
+     * <p>
+     * Every result from this cursor is guaranteed to be in at least one child, but some results may appear in only
+     * a proper subset of the given cursors. This is because a probabilistic data structure is used internally to
+     * allow for the cursor to be resumed across continuation boundaries. The caller can adjust the memory usage
+     * as well as the false positive rate by tweaking the values of the {@code expectedResults} and
+     * {@code falsePositivePercentage} parameters. Note that those parameters only matter if the continuation is <code>null</code>.
+     * A non-null continuation will read those parameters based on serialized versions of the data structure that are
+     * included as part of the continuation.
+     * </p>
+     *
+     * @param comparisonKeyFunction the function evaluated to compare elements from different cursors
+     * @param cursorFunctions a list of functions to produce {@link RecordCursor}s from a continuation
+     * @param expectedResults the expected number of results from each child cursor
+     * @param falsePositivePercentage an acceptable false positive percentage for each cursor
+     * @param continuation any continuation from a previous scan
+     * @param timer the timer used to instrument events
+     * @param <T> the type of elements returned by this cursor
+     * @return a cursor containing any records from any child cursor
+     */
+    @Nonnull
+    public static <T> ProbableIntersectionCursor<T> create(
+            @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
+            @Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
+            long expectedResults,
+            double falsePositivePercentage,
+            @Nullable byte[] continuation,
+            @Nullable FDBStoreTimer timer) {
+        return new ProbableIntersectionCursor<>(createCursorStates(cursorFunctions, continuation, comparisonKeyFunction, expectedResults, falsePositivePercentage), timer);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorContinuation.java
@@ -1,0 +1,128 @@
+/*
+ * ProbableIntersectionCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.ByteArrayContinuation;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursorEndContinuation;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.RecordCursorProto.ProbableIntersectionContinuation;
+
+class ProbableIntersectionCursorContinuation extends MergeCursorContinuation<ProbableIntersectionContinuation.Builder, BloomFilterCursorContinuation> {
+    protected ProbableIntersectionCursorContinuation(@Nonnull List<BloomFilterCursorContinuation> continuations, @Nullable Message originalProto) {
+        super(continuations, originalProto);
+    }
+
+    protected ProbableIntersectionCursorContinuation(@Nonnull List<BloomFilterCursorContinuation> continuations) {
+        this(continuations, null);
+    }
+
+    private void addChild(@Nonnull ProbableIntersectionContinuation.Builder builder,
+                          @Nonnull BloomFilterCursorContinuation continuation) {
+        builder.addChildState(continuation.toProto());
+    }
+
+    @Override
+    void setFirstChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+        addChild(builder, continuation);
+    }
+
+    @Override
+    void setSecondChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+        addChild(builder, continuation);
+    }
+
+    @Override
+    void addOtherChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+        addChild(builder, continuation);
+    }
+
+    @Nonnull
+    @Override
+    ProbableIntersectionContinuation.Builder newProtoBuilder() {
+        return ProbableIntersectionContinuation.newBuilder();
+    }
+
+    @Override
+    public boolean isEnd() {
+        // A bloom cursor continuation is never an "end cursor" as it will never return "null" (because the BloomFilter
+        // at least is always serialized). However, if the *child* of each cursor is done, then the whole cursor
+        // is at an end.
+        return getContinuations().stream().allMatch(BloomFilterCursorContinuation::isChildEnd);
+    }
+
+    @Nonnull
+    static ProbableIntersectionCursorContinuation from(@Nonnull ProbableIntersectionCursor<?> cursor) {
+        // This can't use getChildContinuations() because of the way the type system works
+        List<BloomFilterCursorContinuation> childContinuations = cursor.getCursorStates().stream()
+                .map(ProbableIntersectionCursorState::getContinuation)
+                .collect(Collectors.toList());
+        return new ProbableIntersectionCursorContinuation(childContinuations);
+    }
+
+    @Nonnull
+    static ProbableIntersectionCursorContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
+        if (bytes == null) {
+            return new ProbableIntersectionCursorContinuation(Collections.nCopies(numberOfChildren,
+                    new BloomFilterCursorContinuation(RecordCursorStartContinuation.START, null)));
+        }
+        try {
+            return ProbableIntersectionCursorContinuation.from(ProbableIntersectionContinuation.parseFrom(bytes), numberOfChildren);
+        } catch (InvalidProtocolBufferException ex) {
+            throw new RecordCoreException("invalid continuation", ex)
+                    .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
+        }
+    }
+
+    @Nonnull
+    static ProbableIntersectionCursorContinuation from(@Nonnull ProbableIntersectionContinuation parsed, int numberOfChildren) {
+        ImmutableList.Builder<BloomFilterCursorContinuation> builder = ImmutableList.builder();
+        for (ProbableIntersectionContinuation.CursorState state : parsed.getChildStateList()) {
+            if (state.getExhausted()) {
+                builder.add(new BloomFilterCursorContinuation(RecordCursorEndContinuation.END, state.getBloomFilter()));
+            } else if (state.hasContinuation()) {
+                builder.add(new BloomFilterCursorContinuation(ByteArrayContinuation.fromNullable(state.getContinuation().toByteArray()), state.getBloomFilter()));
+            } else {
+                builder.add(new BloomFilterCursorContinuation(RecordCursorStartContinuation.START, state.getBloomFilter()));
+            }
+        }
+        ImmutableList<BloomFilterCursorContinuation> children = builder.build();
+        if (children.size() != numberOfChildren) {
+            throw new RecordCoreArgumentException("invalid continuation (extraneous child state information present)")
+                    .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, numberOfChildren)
+                    .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, parsed.getChildStateCount());
+        }
+        return new ProbableIntersectionCursorContinuation(children, parsed);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorState.java
@@ -1,0 +1,181 @@
+/*
+ * ProbableIntersectionCursorState.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnel;
+import com.google.common.hash.PrimitiveSink;
+import com.google.protobuf.ByteString;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * A cursor state for merge cursors that also remembers information about which comparison key values it has seen.
+ * In particular, it maintains a Bloom filter computed from all of the results that have been processed by the
+ * cursor so far. This Bloom filter is then included as part of this cursor's continuation so that the cursor
+ * can be resumed only from its continuation. It also maintains a hash set of all results it has seen since it was
+ * last resumed from its continuation, but this set is <em>not</em> included in the continuation and only serves to
+ * lessen the number of false positives.
+ *
+ * <p>
+ * This currently uses the Guava {@link BloomFilter} implementation internally. This could be changed in the future,
+ * but if it is, care should be taken to make sure the serialized continuation is either compatible with that
+ * implementation's serialization logic or is versioned in some way to prevent unpredictable behavior during
+ * upgrades.
+ * </p>
+ *
+ * @param <T> the type of elements returned by the wrapping cursor
+ */
+class ProbableIntersectionCursorState<T> extends KeyedMergeCursorState<T> {
+    @Nonnull
+    private final BloomFilter<List<Object>> bloomFilter;
+    @Nonnull
+    private final Set<List<Object>> seenSet;
+    private final boolean firstIteration;
+
+    private ProbableIntersectionCursorState(@Nonnull RecordCursor<T> cursor, @Nonnull BloomFilterCursorContinuation continuation,
+                                    @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
+                                    @Nonnull BloomFilter<List<Object>> bloomFilter,
+                                    @Nonnull Set<List<Object>> seenSet, boolean firstIteration) {
+        super(cursor, continuation.getChild(), comparisonKeyFunction);
+        this.bloomFilter = bloomFilter;
+        this.seenSet = seenSet;
+        this.firstIteration = firstIteration;
+    }
+
+    @Override
+    public void consume() {
+        // When consuming, insert the key of the most recent thing returned by this cursor.
+        bloomFilter.put(getComparisonKey());
+        seenSet.add(getComparisonKey());
+        super.consume();
+    }
+
+    @Override
+    @Nonnull
+    public BloomFilterCursorContinuation getContinuation() {
+        ByteString.Output bloomOutput = ByteString.newOutput();
+        try {
+            bloomFilter.writeTo(bloomOutput);
+        } catch (IOException e) {
+            throw new RecordCoreException("unable to serialize bloom filter", e);
+        }
+        return new BloomFilterCursorContinuation(super.getContinuation(), bloomOutput.toByteString());
+    }
+
+    @VisibleForTesting
+    BloomFilter<List<Object>> getBloomFilter() {
+        return bloomFilter;
+    }
+
+    /**
+     * Return whether this cursor state might have seen the given comparison key. If the
+     * key has been seen before, this will return {@code true}. If the key has <em>not</em>
+     * seen the key before, then this will <em>probably</em> return {@code false}, but
+     * it might return {@code true}.
+     *
+     * @param otherComparisonKey comparison key from another cursor
+     * @return whether this key might have seen that comparison key before
+     */
+    boolean mightContain(@Nonnull List<Object> otherComparisonKey) {
+        // If the comparison key is in this state's list of seen elements, then
+        // it is definitely contained. If this is the first iteration (i.e., this
+        // cursor has not been resumed after a continuation), then it might be
+        // necessary to consult the bloom filter.
+        return seenSet.contains(otherComparisonKey) || (!firstIteration && bloomFilter.mightContain(otherComparisonKey));
+    }
+
+    boolean isDefiniteDuplicate() {
+        return seenSet.contains(getComparisonKey());
+    }
+
+    // This is an enum as is the suggestion of the BloomFilter documentation
+    private enum KeyFunnel implements Funnel<List<Object>> {
+        VERSION_0, // For backwards compatibility reasons.
+        ;
+
+        @Override
+        public void funnel(List<Object> objects, PrimitiveSink primitiveSink) {
+            for (Object o : objects) {
+                if (o == null) {
+                    primitiveSink.putByte((byte)0x00);
+                } else if (o instanceof byte[]) {
+                    primitiveSink.putBytes((byte[])o);
+                } else if (o instanceof ByteString) {
+                    primitiveSink.putBytes(((ByteString)o).toByteArray());
+                } else if (o instanceof ByteBuffer) {
+                    primitiveSink.putBytes((ByteBuffer) o);
+                } else if (o instanceof String) {
+                    primitiveSink.putString((String)o, Charsets.UTF_8);
+                } else if (o instanceof Float) {
+                    primitiveSink.putFloat((float)o);
+                } else if (o instanceof Double) {
+                    primitiveSink.putDouble((double)o);
+                } else if (o instanceof Integer) {
+                    primitiveSink.putInt((int)o);
+                } else if (o instanceof Long) {
+                    primitiveSink.putLong((long) o);
+                } else if (o instanceof Boolean) {
+                    primitiveSink.putBoolean((boolean)o);
+                } else if (o instanceof Enum) {
+                    primitiveSink.putInt(((Enum)o).ordinal());
+                } else {
+                    primitiveSink.putBytes(Tuple.from(o).pack());
+                }
+            }
+        }
+    }
+
+    @Nonnull
+    static <T> ProbableIntersectionCursorState<T> from(
+            @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
+            @Nonnull BloomFilterCursorContinuation continuation,
+            @Nonnull Function<? super T, ? extends List<Object>> comparisonKeyFunction,
+            long expectedInsertions, double falsePositiveRate) {
+        BloomFilter<List<Object>> bloomFilter;
+        if (continuation.getBloomBytes() == null) {
+            bloomFilter = BloomFilter.create(KeyFunnel.VERSION_0, expectedInsertions, falsePositiveRate);
+        } else {
+            try {
+                bloomFilter = BloomFilter.readFrom(continuation.getBloomBytes().newInput(), KeyFunnel.VERSION_0);
+            } catch (IOException e) {
+                throw new RecordCoreException("unable to deserialize bloom filter", e);
+            }
+        }
+        if (continuation.isChildEnd()) {
+            return new ProbableIntersectionCursorState<>(RecordCursor.empty(), continuation, comparisonKeyFunction, bloomFilter, Collections.emptySet(), false);
+        } else {
+            return new ProbableIntersectionCursorState<>(cursorFunction.apply(continuation.getChild().toBytes()), continuation, comparisonKeyFunction, bloomFilter, new HashSet<>(), continuation.getBloomBytes() == null);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
@@ -20,40 +20,15 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
-import com.apple.foundationdb.async.AsyncUtil;
-import com.apple.foundationdb.record.ByteArrayContinuation;
-import com.apple.foundationdb.record.RecordCoreArgumentException;
-import com.apple.foundationdb.record.RecordCoreException;
-import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.RecordCursorContinuation;
-import com.apple.foundationdb.record.RecordCursorEndContinuation;
-import com.apple.foundationdb.record.RecordCursorProto;
-import com.apple.foundationdb.record.RecordCursorResult;
-import com.apple.foundationdb.record.RecordCursorStartContinuation;
-import com.apple.foundationdb.record.RecordCursorVisitor;
-import com.apple.foundationdb.record.cursors.EmptyCursor;
-import com.apple.foundationdb.record.cursors.IllegalContinuationAccessChecker;
-import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
-import com.apple.foundationdb.tuple.ByteArrayUtil2;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Common implementation code for performing a union shared between
@@ -62,211 +37,24 @@ import java.util.stream.Collectors;
  *
  * @param <T> the type of elements returned by each child cursor
  */
-abstract class UnionCursorBase<T> implements RecordCursor<T> {
+abstract class UnionCursorBase<T, S extends MergeCursorState<T>> extends MergeCursor<T, T, S> {
     @Nonnull
-    private final List<CursorState<T>> cursorStates;
-    @Nullable
-    private CompletableFuture<Boolean> hasNextFuture;
-    @Nullable
-    private RecordCursorResult<T> nextResult;
-
+    static final Set<StoreTimer.Event> duringEvents = Collections.singleton(FDBStoreTimer.Events.QUERY_UNION);
     @Nonnull
-    private final Executor executor;
-    @Nullable
-    private final FDBStoreTimer timer;
-
+    static final Set<StoreTimer.Count> uniqueCounts = Collections.singleton(FDBStoreTimer.Counts.QUERY_UNION_PLAN_UNIQUES);
     @Nonnull
-    private static final Set<StoreTimer.Event> duringEvents = Collections.singleton(FDBStoreTimer.Events.QUERY_UNION);
-    @Nonnull
-    private static final Set<StoreTimer.Count> uniqueCounts = Collections.singleton(FDBStoreTimer.Counts.QUERY_UNION_PLAN_UNIQUES);
-    @Nonnull
-    private static final Set<StoreTimer.Count> duplicateCounts =
+    static final Set<StoreTimer.Count> duplicateCounts =
             ImmutableSet.of(FDBStoreTimer.Counts.QUERY_UNION_PLAN_DUPLICATES, FDBStoreTimer.Counts.QUERY_DISCARDED);
 
-    // for detecting incorrect cursor usage
-    protected boolean mayGetContinuation = false;
-
-    protected static class CursorState<T> {
-        @Nonnull
-        private final RecordCursor<T> cursor;
-        @Nullable
-        private CompletableFuture<RecordCursorResult<T>> onNextFuture;
-        @Nonnull
-        private RecordCursorContinuation continuation;
-        @Nullable
-        private RecordCursorResult<T> result;
-
-        public CursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuationStart) {
-            this.cursor = cursor;
-            this.continuation = continuationStart;
-        }
-
-        @Nonnull
-        public CompletableFuture<RecordCursorResult<T>> getOnNextFuture() {
-            if (onNextFuture == null) {
-                onNextFuture = cursor.onNext().thenApply(cursorResult -> {
-                    result = cursorResult;
-                    if (!result.hasNext()) {
-                        continuation = result.getContinuation(); // no result, so we can advance the cached continuation
-                    }
-                    return cursorResult;
-                });
-            }
-            return onNextFuture;
-        }
-
-        public void consume() {
-            onNextFuture = null;
-            continuation = result.getContinuation();
-        }
-
-        public boolean isExhausted() {
-            return result != null && !result.hasNext() && result.getNoNextReason().isSourceExhausted();
-        }
-
-        @Nonnull
-        public RecordCursorResult<T> getResult() {
-            if (result == null) {
-                throw new RecordCoreException("tried to get result before any result was ready");
-            }
-            return result;
-        }
-
-        @Nonnull
-        public static <T> CursorState<T> from(
-                @Nonnull Function<byte[], RecordCursor<T>> cursorFunction,
-                @Nonnull RecordCursorContinuation continuation) {
-            if (continuation.isEnd()) {
-                return new CursorState<>(RecordCursor.empty(), RecordCursorEndContinuation.END);
-            } else {
-                return new CursorState<>(cursorFunction.apply(continuation.toBytes()), continuation);
-            }
-        }
+    UnionCursorBase(@Nonnull List<S> cursorStates, @Nullable FDBStoreTimer timer) {
+        super(cursorStates, timer);
     }
 
-    private static <T> CompletableFuture<?>[] getOnNextFutures(@Nonnull List<CursorState<T>> cursorStates) {
-        CompletableFuture<?>[] futures = new CompletableFuture<?>[cursorStates.size()];
-        int i = 0;
-        for (CursorState<T> cursorState : cursorStates) {
-            futures[i] = cursorState.getOnNextFuture();
-            i++;
-        }
-        return futures;
-    }
-
-    // This returns a "wildcard" to handle the fact that the signature of AsyncUtil.DONE is
-    // CompletableFuture<Void> whereas CompletableFuture.anyOf returns a CompletableFuture<Object>.
-    // The caller always ignores the result anyway and just uses this as a signal, so it's not
-    // a big loss.
-    @SuppressWarnings("squid:S1452")
-    @Nonnull
-    protected static <T> CompletableFuture<?> whenAny(@Nonnull List<CursorState<T>> cursorStates) {
-        List<CursorState<T>> nonExhausted = new ArrayList<>(cursorStates.size());
-        for (CursorState<T> cursorState : cursorStates) {
-            if (!cursorState.isExhausted()) {
-                if (cursorState.getOnNextFuture().isDone()) {
-                    // Short-circuit and return immediately if we find a state that is already done.
-                    return AsyncUtil.DONE;
-                } else {
-                    nonExhausted.add(cursorState);
-                }
-            }
-        }
-        if (nonExhausted.isEmpty()) {
-            // Everything is exhausted. Can return immediately.
-            return AsyncUtil.DONE;
-        } else {
-            return CompletableFuture.anyOf(getOnNextFutures(nonExhausted));
-        }
-    }
-
-    @Nonnull
-    protected static <T> CompletableFuture<Void> whenAll(@Nonnull List<CursorState<T>> cursorStates) {
-        return CompletableFuture.allOf(getOnNextFutures(cursorStates));
-    }
-
-    protected UnionCursorBase(@Nonnull List<CursorState<T>> cursorStates, @Nullable FDBStoreTimer timer) {
-        this.cursorStates = cursorStates;
-        this.timer = timer;
-
-        // Choose the executor from the first non-empty cursor. The executors for empty cursors are just
-        // the default one, whereas non-empty cursors may have an executor set by the user.
-        Executor cursorExecutor = null;
-        for (CursorState<T> cursorState : cursorStates) {
-            if (!(cursorState.cursor instanceof EmptyCursor)) {
-                cursorExecutor = cursorState.cursor.getExecutor();
-                break;
-            }
-        }
-        this.executor = cursorExecutor != null ? cursorExecutor : cursorStates.get(0).cursor.getExecutor();
-    }
-
-    /**
-     * Determine if there is a next element to be returned by looking at the
-     * current cursor states.
-     *
-     * @param cursorStates the list of states of all child cursors
-     */
-    @Nonnull
-    abstract CompletableFuture<Boolean> getIfAnyHaveNext(@Nonnull List<CursorState<T>> cursorStates);
-
-    @Nonnull
     @Override
-    public CompletableFuture<RecordCursorResult<T>> onNext() {
-        return getIfAnyHaveNext(cursorStates).thenApply(hasNext -> {
-            if (hasNext) {
-                final long startTime = System.nanoTime();
-                List<CursorState<T>> chosenStates = new ArrayList<>(cursorStates.size());
-                List<CursorState<T>> otherStates = new ArrayList<>(cursorStates.size());
-                chooseStates(cursorStates, chosenStates, otherStates);
-                logDuplicates(chosenStates);
-                // Advance each chosen state
-                chosenStates.forEach(CursorState::consume);
-                final T result = getNextResult(chosenStates);
-                if (result == null) {
-                    throw new RecordCoreException("minimum element had null result");
-                }
-                nextResult = RecordCursorResult.withNextValue(result, UnionContinuation.from(this));
-                if (timer != null) {
-                    timer.record(duringEvents, System.nanoTime() - startTime);
-                }
-            } else {
-                mayGetContinuation = true;
-                nextResult = RecordCursorResult.withoutNextValue(UnionContinuation.from(this), mergeNoNextReasons());
-            }
-            return nextResult;
-        });
+    @Nonnull
+    UnionCursorContinuation getContinuationObject() {
+        return UnionCursorContinuation.from(this);
     }
-
-    private void logDuplicates(List<?> chosenStates) {
-        if (chosenStates.isEmpty()) {
-            throw new RecordCoreException("union with additional items had no next states");
-        }
-        if (timer != null) {
-            if (chosenStates.size() == 1) {
-                timer.increment(uniqueCounts);
-            } else {
-                // The number of duplicates is the number of minimum states
-                // for this value except for the first one (hence the "- 1").
-                timer.increment(duplicateCounts, chosenStates.size() - 1);
-            }
-        }
-    }
-
-    /**
-     * Choose which states should be returned by the union cursor as the next element. If this
-     * method adds more than one state to the <code>chosenStates</code> list, then all results
-     * from those cursors should be considered equivalent, and every cursor in that list
-     * of states will be consumed when the {@link #next()} method of this cursor is called. If the
-     * extender wishes to combine all duplicates for a given step in some way, they can control how the elements
-     * are combined by overriding the {@link #getNextResult(List)} method.
-     *
-     * @param allStates all states of all children of this cursor
-     * @param chosenStates the list to populate with states to choose as part of the union
-     * @param otherStates the list to populate with all other states
-     */
-    abstract void chooseStates(@Nonnull List<CursorState<T>> allStates, @Nonnull List<CursorState<T>> chosenStates,
-                               @Nonnull List<CursorState<T>> otherStates);
 
     /**
      * Get the result from the list of chosen states. These states have all been identified
@@ -277,41 +65,10 @@ abstract class UnionCursorBase<T> implements RecordCursor<T> {
      * @param chosenStates the states that contain the next value to return
      * @return the result to return from this cursor given these elements appear in the union
      */
-    T getNextResult(@Nonnull List<CursorState<T>> chosenStates) {
-        return chosenStates.get(0).result.get();
-    }
-
+    @Override
     @Nonnull
-    @Override
-    public CompletableFuture<Boolean> onHasNext() {
-        if (hasNextFuture == null) {
-            mayGetContinuation = false;
-            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return hasNextFuture;
-    }
-
-    @Nonnull
-    @Override
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        mayGetContinuation = true;
-        hasNextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Override
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
+    T getNextResult(@Nonnull List<S> chosenStates) {
+        return chosenStates.get(0).getResult().get();
     }
 
     /**
@@ -320,212 +77,9 @@ abstract class UnionCursorBase<T> implements RecordCursor<T> {
      * only return {@link NoNextReason#SOURCE_EXHAUSTED SOURCE_EXHAUSTED} if all of the cursors are exhausted.
      * @return the strongest reason for stopping
      */
-    private NoNextReason mergeNoNextReasons() {
-        if (cursorStates.stream().allMatch(cursorState -> cursorState.result.hasNext())) {
-            throw new RecordCoreException("mergeNoNextReason should not be called when all children have next");
-        }
-        NoNextReason reason = null;
-        for (CursorState<T> cursorState : cursorStates) {
-            if (!cursorState.getOnNextFuture().isDone()) {
-                continue;
-            }
-            if (!cursorState.result.hasNext()) {
-                // Combine the current reason so far with this child's reason.
-                // In particular, choose the child reason if it is at least as strong
-                // as the current one. This guarantees that it will choose an
-                // out of band reason if there is one and will only return
-                // SOURCE_EXHAUSTED if every child ended with SOURCE_EXHAUSTED.
-                NoNextReason childReason = cursorState.cursor.getNoNextReason();
-                if (reason == null || childReason.isOutOfBand() || reason.isSourceExhausted()) {
-                    reason = childReason;
-                }
-            }
-        }
-        return reason;
-    }
-
     @Override
-    public void close() {
-        cursorStates.forEach(cursorState -> cursorState.cursor.close());
-        if (hasNextFuture != null) {
-            hasNextFuture.cancel(false);
-        }
-    }
-
     @Nonnull
-    @Override
-    public Executor getExecutor() {
-        return executor;
-    }
-
-    @Override
-    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
-        if (visitor.visitEnter(this)) {
-            for (CursorState<T> cursorState : cursorStates) {
-                if (!cursorState.cursor.accept(visitor)) {
-                    break;
-                }
-            }
-        }
-        return visitor.visitLeave(this);
-    }
-
-
-    private static class UnionContinuation implements RecordCursorContinuation {
-        private static final RecordCursorProto.UnionContinuation.CursorState EXHAUSTED_PROTO = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
-                .setExhausted(true)
-                .build();
-        private static final RecordCursorProto.UnionContinuation.CursorState START_PROTO = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
-                .setExhausted(false)
-                .build();
-
-        @Nonnull
-        private final List<RecordCursorContinuation> continuations; // all continuations must themselves be immutable
-        @Nullable
-        private RecordCursorProto.UnionContinuation cachedProto;
-
-        private UnionContinuation(@Nonnull List<RecordCursorContinuation> continuations) {
-            this(continuations, null);
-        }
-
-        private UnionContinuation(@Nonnull List<RecordCursorContinuation> continuations, @Nullable RecordCursorProto.UnionContinuation proto) {
-            this.continuations = continuations;
-            this.cachedProto = proto;
-        }
-
-        @SuppressWarnings("PMD.PreserveStackTrace")
-        public static UnionContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
-            if (bytes == null) {
-                return new UnionContinuation(Collections.nCopies(numberOfChildren, RecordCursorStartContinuation.START));
-            }
-            try {
-                return UnionContinuation.from(RecordCursorProto.UnionContinuation.parseFrom(bytes), numberOfChildren);
-            } catch (InvalidProtocolBufferException ex) {
-                throw new RecordCoreException("invalid continuation", ex)
-                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
-            } catch (RecordCoreArgumentException ex) {
-                throw ex.addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
-            }
-        }
-
-        public static UnionContinuation from(@Nonnull RecordCursorProto.UnionContinuation parsed, int numberOfChildren) {
-            ImmutableList.Builder<RecordCursorContinuation> builder = ImmutableList.builder();
-            if (parsed.hasFirstContinuation()) {
-                builder.add(ByteArrayContinuation.fromNullable(parsed.getFirstContinuation().toByteArray()));
-            } else if (parsed.getFirstExhausted()) {
-                builder.add(RecordCursorEndContinuation.END);
-            } else {
-                builder.add(RecordCursorStartContinuation.START);
-            }
-            if (parsed.hasSecondContinuation()) {
-                builder.add(ByteArrayContinuation.fromNullable(parsed.getSecondContinuation().toByteArray()));
-            } else if (parsed.getSecondExhausted()) {
-                builder.add(RecordCursorEndContinuation.END);
-            } else {
-                builder.add(RecordCursorStartContinuation.START);
-            }
-            for (RecordCursorProto.UnionContinuation.CursorState state : parsed.getOtherChildStateList()) {
-                if (state.hasContinuation()) {
-                    builder.add(ByteArrayContinuation.fromNullable(state.getContinuation().toByteArray()));
-                } else if (state.getExhausted()) {
-                    builder.add(RecordCursorEndContinuation.END);
-                } else {
-                    builder.add(RecordCursorStartContinuation.START);
-                }
-            }
-            ImmutableList<RecordCursorContinuation> children = builder.build();
-            if (children.size() != numberOfChildren) {
-                throw new RecordCoreArgumentException("invalid continuation (expected continuation count does not match read)")
-                        .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, numberOfChildren)
-                        .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, children.size());
-            }
-            return new UnionContinuation(children, parsed);
-        }
-
-        public static <T> UnionContinuation from(@Nonnull UnionCursorBase<T> cursor) {
-            return new UnionContinuation(cursor.cursorStates.stream().map(cursorState -> cursorState.continuation).collect(Collectors.toList()));
-        }
-
-        public RecordCursorProto.UnionContinuation toProto() {
-            if (cachedProto == null) {
-                final RecordCursorProto.UnionContinuation.Builder builder = RecordCursorProto.UnionContinuation.newBuilder();
-                final Iterator<RecordCursorContinuation> continuationIterator = continuations.iterator();
-                // The first two continuations are special (essentially for compatibility reasons)
-                final RecordCursorContinuation firstContinuation = continuationIterator.next();
-                if (firstContinuation.isEnd()) {
-                    builder.setFirstExhausted(true);
-                } else {
-                    final byte[] asBytes = firstContinuation.toBytes();
-                    if (asBytes != null) {
-                        builder.setFirstContinuation(ByteString.copyFrom(asBytes));
-                    }
-                }
-                final RecordCursorContinuation secondContinuation = continuationIterator.next();
-                if (secondContinuation.isEnd()) {
-                    builder.setSecondExhausted(true);
-                } else {
-                    final byte[] asBytes = secondContinuation.toBytes();
-                    if (asBytes != null) {
-                        builder.setSecondContinuation(ByteString.copyFrom(asBytes));
-                    }
-                }
-                // The rest of the cursor states get written as elements in a repeated message field
-                while (continuationIterator.hasNext()) {
-                    RecordCursorProto.UnionContinuation.CursorState cursorState;
-                    RecordCursorContinuation continuation = continuationIterator.next();
-                    if (continuation.isEnd()) {
-                        cursorState = EXHAUSTED_PROTO;
-                    } else {
-                        final byte[] asBytes = continuation.toBytes();
-                        if (asBytes == null) {
-                            cursorState = START_PROTO;
-                        } else {
-                            cursorState = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
-                                    .setContinuation(ByteString.copyFrom(asBytes))
-                                    .build();
-                        }
-                    }
-                    builder.addOtherChildState(cursorState);
-                }
-                cachedProto = builder.build();
-            }
-            return cachedProto;
-        }
-
-        @Nullable
-        @Override
-        public byte[] toBytes() {
-            if (isEnd()) {
-                return null;
-            }
-            return toProto().toByteArray();
-        }
-
-        @Override
-        public boolean isEnd() {
-            return continuations.stream().allMatch(RecordCursorContinuation::isEnd);
-        }
-    }
-
-    @Nonnull
-    protected static <T> List<CursorState<T>> createCursorStates(@Nonnull Function<byte[], RecordCursor<T>> left, @Nonnull Function<byte[], RecordCursor<T>> right,
-                                                                 @Nullable byte[] byteContinuation) {
-        final UnionContinuation continuation = UnionContinuation.from(byteContinuation, 2);
-        return ImmutableList.of(
-                CursorState.from(left, continuation.continuations.get(0)),
-                CursorState.from(right, continuation.continuations.get(1)));
-    }
-
-    @Nonnull
-    protected static <T> List<CursorState<T>> createCursorStates(@Nonnull List<Function<byte[], RecordCursor<T>>> cursorFunctions,
-                                                                 @Nullable byte[] byteContinuation) {
-        final List<CursorState<T>> cursorStates = new ArrayList<>(cursorFunctions.size());
-        final UnionContinuation continuation = UnionContinuation.from(byteContinuation, cursorFunctions.size());
-        int i = 0;
-        for (Function<byte[], RecordCursor<T>> cursorFunction : cursorFunctions) {
-            cursorStates.add(CursorState.from(cursorFunction, continuation.continuations.get(i)));
-            i++;
-        }
-        return cursorStates;
+    protected NoNextReason mergeNoNextReasons() {
+        return getStrongestNoNextReason(getCursorStates());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
@@ -1,0 +1,168 @@
+/*
+ * UnionCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.ByteArrayContinuation;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorEndContinuation;
+import com.apple.foundationdb.record.RecordCursorProto;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.UnionContinuation.Builder, RecordCursorContinuation> {
+    @Nonnull
+    private static final RecordCursorProto.UnionContinuation.CursorState EXHAUSTED_PROTO = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
+            .setExhausted(true)
+            .build();
+    @Nonnull
+    private static final RecordCursorProto.UnionContinuation.CursorState START_PROTO = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
+            .setExhausted(false)
+            .build();
+
+    protected UnionCursorContinuation(@Nonnull List<RecordCursorContinuation> continuations, @Nullable RecordCursorProto.UnionContinuation originalProto) {
+        super(continuations, originalProto);
+    }
+
+    protected UnionCursorContinuation(@Nonnull List<RecordCursorContinuation> continuations) {
+        this(continuations, null);
+    }
+
+    @Override
+    void setFirstChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        if (continuation.isEnd()) {
+            builder.setFirstExhausted(true);
+        } else {
+            final byte[] asBytes = continuation.toBytes();
+            if (asBytes != null) {
+                builder.setFirstContinuation(ByteString.copyFrom(asBytes));
+            }
+        }
+    }
+
+    @Override
+    void setSecondChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        if (continuation.isEnd()) {
+            builder.setSecondExhausted(true);
+        } else {
+            final byte[] asBytes = continuation.toBytes();
+            if (asBytes != null) {
+                builder.setSecondContinuation(ByteString.copyFrom(asBytes));
+            }
+        }
+    }
+
+    @Override
+    void addOtherChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        RecordCursorProto.UnionContinuation.CursorState cursorState;
+        if (continuation.isEnd()) {
+            cursorState = EXHAUSTED_PROTO;
+        } else {
+            final byte[] asBytes = continuation.toBytes();
+            if (asBytes == null) {
+                cursorState = START_PROTO;
+            } else {
+                cursorState = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
+                        .setContinuation(ByteString.copyFrom(asBytes))
+                        .build();
+            }
+        }
+        builder.addOtherChildState(cursorState);
+    }
+
+    @Override
+    @Nonnull
+    RecordCursorProto.UnionContinuation.Builder newProtoBuilder() {
+        return RecordCursorProto.UnionContinuation.newBuilder();
+    }
+
+    @Override
+    public boolean isEnd() {
+        // As long as at least one child has data, this should not be an end continuation.
+        return getContinuations().stream().allMatch(RecordCursorContinuation::isEnd);
+    }
+
+    @Nonnull
+    static UnionCursorContinuation from(@Nonnull UnionCursorBase<?, ?> cursor) {
+        return new UnionCursorContinuation(cursor.getChildContinuations());
+    }
+
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    @Nonnull
+    static UnionCursorContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
+        if (bytes == null) {
+            return new UnionCursorContinuation(Collections.nCopies(numberOfChildren, RecordCursorStartContinuation.START));
+        }
+        try {
+            return UnionCursorContinuation.from(RecordCursorProto.UnionContinuation.parseFrom(bytes), numberOfChildren);
+        } catch (InvalidProtocolBufferException ex) {
+            throw new RecordCoreException("invalid continuation", ex)
+                    .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
+        } catch (RecordCoreArgumentException ex) {
+            throw ex.addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
+        }
+    }
+
+    @Nonnull
+    static UnionCursorContinuation from(@Nonnull RecordCursorProto.UnionContinuation parsed, int numberOfChildren) {
+        ImmutableList.Builder<RecordCursorContinuation> builder = ImmutableList.builder();
+        if (parsed.hasFirstContinuation()) {
+            builder.add(ByteArrayContinuation.fromNullable(parsed.getFirstContinuation().toByteArray()));
+        } else if (parsed.getFirstExhausted()) {
+            builder.add(RecordCursorEndContinuation.END);
+        } else {
+            builder.add(RecordCursorStartContinuation.START);
+        }
+        if (parsed.hasSecondContinuation()) {
+            builder.add(ByteArrayContinuation.fromNullable(parsed.getSecondContinuation().toByteArray()));
+        } else if (parsed.getSecondExhausted()) {
+            builder.add(RecordCursorEndContinuation.END);
+        } else {
+            builder.add(RecordCursorStartContinuation.START);
+        }
+        for (RecordCursorProto.UnionContinuation.CursorState state : parsed.getOtherChildStateList()) {
+            if (state.hasContinuation()) {
+                builder.add(ByteArrayContinuation.fromNullable(state.getContinuation().toByteArray()));
+            } else if (state.getExhausted()) {
+                builder.add(RecordCursorEndContinuation.END);
+            } else {
+                builder.add(RecordCursorStartContinuation.START);
+            }
+        }
+        ImmutableList<RecordCursorContinuation> children = builder.build();
+        if (children.size() != numberOfChildren) {
+            throw new RecordCoreArgumentException("invalid continuation (expected continuation count does not match read)")
+                    .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, numberOfChildren)
+                    .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, children.size());
+        }
+        return new UnionCursorContinuation(children, parsed);
+    }
+}

--- a/fdb-record-layer-core/src/main/proto/record_cursor.proto
+++ b/fdb-record-layer-core/src/main/proto/record_cursor.proto
@@ -30,6 +30,9 @@ message FlatMapContinuation {
     optional bytes check_value = 3;
 }
 
+// For backwards compatibility reasons, the union and intersection continuations differentiate
+// between the first two children and all other children.
+
 message IntersectionContinuation {
     message CursorState {
         optional bytes continuation = 1;
@@ -52,4 +55,13 @@ message UnionContinuation {
     optional bool first_exhausted = 3;
     optional bool second_exhausted = 4;
     repeated CursorState other_child_state = 5;
+}
+
+message ProbableIntersectionContinuation {
+    message CursorState {
+        optional bytes continuation = 1;
+        optional bool exhausted = 2;
+        optional bytes bloom_filter = 3;
+    }
+    repeated CursorState child_state = 1;
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
@@ -1,0 +1,326 @@
+/*
+ * ProbableIntersectionCursorTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorProto;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorTest;
+import com.apple.foundationdb.record.cursors.FirableCursor;
+import com.apple.foundationdb.record.cursors.RowLimitedCursor;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.google.common.collect.Iterators;
+import com.google.common.hash.BloomFilter;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests of the {@link ProbableIntersectionCursor} class. This class is somewhat difficult to test because of its
+ * relatively weak contract. In particular, because it is allowed to return values even if they aren't actually
+ * in all child cursors, the result set is a little hard to predict.
+ */
+public class ProbableIntersectionCursorTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProbableIntersectionCursorTest.class);
+
+    @Nonnull
+    private <T, C extends RecordCursor<T>> List<Function<byte[], RecordCursor<T>>> cursorsToFunctions(@Nonnull List<C> cursors) {
+        return cursors.stream()
+                .map(cursor -> (Function<byte[], RecordCursor<T>>)(bignore -> cursor))
+                .collect(Collectors.toList());
+    }
+
+    @Nonnull
+    private <T, L extends List<T>> List<Function<byte[], RecordCursor<T>>> listsToFunctions(@Nonnull List<L> lists) {
+        return lists.stream()
+                .map(list -> (Function<byte[], RecordCursor<T>>)(continuation -> RecordCursor.fromList(list, continuation)))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Show that a basic intersection succeeds.
+     */
+    @Test
+    public void basicIntersection() {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        final Iterator<Integer> iterator1 = IntStream.iterate(0, x -> x + 2).limit(150).iterator();
+        final Iterator<Integer> iterator2 = IntStream.iterate(0, x -> x + 3).limit(100).iterator();
+
+        final FirableCursor<Integer> cursor1 = new FirableCursor<>(RecordCursor.fromIterator(iterator1));
+        final FirableCursor<Integer> cursor2 = new FirableCursor<>(RecordCursor.fromIterator(iterator2));
+        final RecordCursor<Integer> intersectionCursor = ProbableIntersectionCursor.create(
+                Collections::singletonList,
+                Arrays.asList(bignore -> cursor1, bignore -> cursor2),
+                null,
+                timer
+        );
+
+        cursor1.fireAll(); // Intersection consumes first cursor
+        CompletableFuture<RecordCursorResult<Integer>> firstFuture = intersectionCursor.onNext();
+        cursor2.fire();
+        RecordCursorResult<Integer> firstResult = firstFuture.join();
+        assertEquals(0, (int)firstResult.get());
+        assertThat(firstResult.hasNext(), is(true));
+        assertEquals(cursor1.getNoNextReason(), RecordCursor.NoNextReason.SOURCE_EXHAUSTED);
+        cursor2.fireAll(); // Intersection consumes second cursor as they come
+
+        AtomicInteger falsePositives = new AtomicInteger();
+        AsyncUtil.whileTrue(() -> intersectionCursor.onNext().thenApply(result -> {
+            if (result.hasNext()) {
+                int value = result.get();
+                assertEquals(0, value % 3); // every result *must* be divisible by 3
+                if (value % 2 != 0) {
+                    falsePositives.incrementAndGet(); // most results should be divisible by 2
+                }
+                assertThat(result.getContinuation().isEnd(), is(false));
+                assertNotNull(result.getContinuation().toBytes());
+                try {
+                    RecordCursorProto.ProbableIntersectionContinuation protoContinuation = RecordCursorProto.ProbableIntersectionContinuation.parseFrom(result.getContinuation().toBytes());
+                    assertEquals(2, protoContinuation.getChildStateCount());
+                    assertThat(protoContinuation.getChildState(0).getExhausted(), is(true));
+                    assertThat(protoContinuation.getChildState(0).hasContinuation(), is(false));
+                    assertThat(protoContinuation.getChildState(1).getExhausted(), is(false));
+                    assertThat(protoContinuation.getChildState(1).hasContinuation(), is(true));
+                } catch (InvalidProtocolBufferException e) {
+                    throw new RecordCoreException("error parsing proto continuation", e);
+                }
+            } else {
+                assertThat(result.getNoNextReason().isSourceExhausted(), is(true));
+                assertThat(result.getContinuation().isEnd(), is(true));
+                assertNull(result.getContinuation().toBytes());
+            }
+            return result.hasNext();
+        })).join();
+
+        assertThat(falsePositives.get(), lessThan(5));
+        assertEquals(50 + falsePositives.get(), timer.getCount(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_MATCHES));
+        assertEquals(200 - falsePositives.get(), timer.getCount(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_NONMATCHES));
+    }
+
+    /**
+     * Test that the cursor can be resumed by deserializing its state from the continuation object.
+     */
+    @Test
+    public void resumeFromContinuation() {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        final List<Integer> list1 = Arrays.asList(10, 2, 5, 6, 8, 19, 0);
+        final List<Integer> list2 = Arrays.asList( 9, 1, 3, 5, 2, 4, 8);
+        final List<Function<byte[], RecordCursor<Integer>>> cursorFuncs = listsToFunctions(Arrays.asList(list1, list2));
+        final Function<byte[], ProbableIntersectionCursor<Integer>> intersectionCursorFunction = continuation ->
+                ProbableIntersectionCursor.create(Collections::singletonList, cursorFuncs, continuation, timer);
+
+        final Iterator<Integer> resultIterator = Iterators.forArray(5, 2, 8);
+        byte[] continuation = null;
+        boolean done = false;
+        List<BloomFilter<List<Object>>> lastBloomFilters = null;
+        while (!done) {
+            ProbableIntersectionCursor<Integer> intersectionCursor = intersectionCursorFunction.apply(continuation);
+            List<BloomFilter<List<Object>>> bloomFilters = intersectionCursor.getCursorStates().stream()
+                    .map(ProbableIntersectionCursorState::getBloomFilter)
+                    .collect(Collectors.toList());
+            if (lastBloomFilters != null) {
+                assertEquals(lastBloomFilters, bloomFilters);
+            }
+            lastBloomFilters = bloomFilters;
+
+            RecordCursorResult<Integer> result = intersectionCursor.onNext().join();
+            if (resultIterator.hasNext()) {
+                assertThat(result.hasNext(), is(true));
+                assertEquals(resultIterator.next(), result.get());
+                assertThat(result.getContinuation().isEnd(), is(false));
+                assertNotNull(result.getContinuation().toBytes());
+            } else {
+                assertThat(result.hasNext(), is(false));
+                assertEquals(RecordCursor.NoNextReason.SOURCE_EXHAUSTED, result.getNoNextReason());
+                assertThat(result.getContinuation().isEnd(), is(true));
+                assertNull(result.getContinuation().toBytes());
+                done = true;
+            }
+            continuation = result.getContinuation().toBytes();
+        }
+        assertEquals(3, timer.getCount(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_MATCHES));
+        assertEquals(list1.size() + list2.size() - 3, timer.getCount(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_NONMATCHES));
+    }
+
+    @Test
+    public void longLists() {
+        final Random r = new Random(0xba5eba11);
+
+        for (int itr = 0; itr < 50; itr++) {
+            long seed = r.nextLong();
+            LOGGER.info(KeyValueLogMessage.of("running intersection with large lists", "seed", seed, "iteration", itr));
+            r.setSeed(seed);
+
+            final List<List<Integer>> lists = Stream.generate(
+                    () -> IntStream.generate(() -> r.nextInt(500)).limit(1000).boxed().collect(Collectors.toList())
+            ).limit(5).collect(Collectors.toList());
+            final List<Function<byte[], RecordCursor<Integer>>> cursorFuncs = lists.stream()
+                    .map(list -> (Function<byte[], RecordCursor<Integer>>)((byte[] continuation) -> new RowLimitedCursor<>(RecordCursor.fromList(list, continuation), r.nextInt(50) + 10)))
+                    .collect(Collectors.toList());
+            final List<Set<Integer>> sets = lists.stream().map(HashSet::new).collect(Collectors.toList());
+            final Set<Integer> actualIntersection = new HashSet<>(sets.get(0));
+            sets.forEach(actualIntersection::retainAll);
+
+            Set<Integer> found = new HashSet<>();
+            AtomicInteger falsePositives = new AtomicInteger();
+            boolean done = false;
+            byte[] continuation = null;
+            while (!done) {
+                RecordCursor<Integer> intersectionCursor = ProbableIntersectionCursor.create(Collections::singletonList, cursorFuncs, continuation, null);
+                AsyncUtil.whileTrue(() -> intersectionCursor.onNext().thenApply(result -> {
+                    if (result.hasNext()) {
+                        // Each value should be in at least one set and hopefully all
+                        int value = result.get();
+                        assertThat(sets.stream().anyMatch(set -> set.contains(value)), is(true));
+                        if (!actualIntersection.contains(value)) {
+                            falsePositives.incrementAndGet();
+                        }
+                        found.add(value);
+                    }
+                    return result.hasNext();
+                })).join();
+                RecordCursorResult<Integer> result = intersectionCursor.onNext().join();
+                assertThat(result.hasNext(), is(false));
+                if (result.getNoNextReason().isSourceExhausted()) {
+                    done = true;
+                } else {
+                    assertEquals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, result.getNoNextReason());
+                }
+                continuation = result.getContinuation().toBytes();
+            }
+
+            assertThat(found.containsAll(actualIntersection), is(true));
+            LOGGER.info(KeyValueLogMessage.of("intersection false positives",
+                    "false_positives", falsePositives.get(),
+                    "actual_intersection_size", actualIntersection.size(),
+                    "iteration", itr));
+            assertThat(falsePositives.get(), lessThan(20));
+        }
+    }
+
+    private void verifyResults(@Nonnull RecordCursor<Integer> cursor, @Nonnull RecordCursor.NoNextReason expectedReason, int...expectedResults) {
+        for (int expectedResult : expectedResults) {
+            RecordCursorResult<Integer> result = cursor.onNext().join();
+            assertThat(result.hasNext(), is(true));
+            assertEquals(expectedResult, (int)result.get());
+            assertThat(result.getContinuation().isEnd(), is(false));
+            assertNotNull(result.getContinuation().toBytes());
+        }
+        RecordCursorResult<Integer> result = cursor.onNext().join();
+        assertThat(result.hasNext(), is(false));
+        assertEquals(expectedReason, result.getNoNextReason());
+        assertThat(result.getContinuation().isEnd(), is(expectedReason.isSourceExhausted()));
+        if (expectedReason.isSourceExhausted()) {
+            assertNull(result.getContinuation().toBytes());
+        } else {
+            assertNotNull(result.getContinuation().toBytes());
+        }
+    }
+
+    @Test
+    public void noNextReasons() {
+        // Both one out of band limit reached
+        RecordCursor<Integer> cursor = ProbableIntersectionCursor.create(Collections::singletonList,
+                cursorsToFunctions(Arrays.asList(
+                        new RecordCursorTest.FakeOutOfBandCursor<>(RecordCursor.fromList(Arrays.asList(1, 4, 3, 7, 9)), 3),
+                        new RecordCursorTest.FakeOutOfBandCursor<>(RecordCursor.fromList(Arrays.asList(3, 7, 8, 4, 1)), 2)
+                )),
+                null,
+                null);
+        verifyResults(cursor, RecordCursor.NoNextReason.TIME_LIMIT_REACHED, 3);
+
+        // One in-band limit reached, one out of band
+        cursor = ProbableIntersectionCursor.create(Collections::singletonList,
+                cursorsToFunctions(Arrays.asList(
+                        new RecordCursorTest.FakeOutOfBandCursor<>(RecordCursor.fromList(Arrays.asList(1, 4, 3, 7, 9)), 3),
+                        RecordCursor.fromList(Arrays.asList(3, 7, 8, 4, 1)).limitRowsTo(2)
+                )),
+                null,
+                null);
+        verifyResults(cursor, RecordCursor.NoNextReason.TIME_LIMIT_REACHED, 3);
+
+        // Both in-band limit reached
+        cursor = ProbableIntersectionCursor.create(Collections::singletonList,
+                cursorsToFunctions(Arrays.asList(
+                        RecordCursor.fromList(Arrays.asList(1, 4, 3, 7, 9)).limitRowsTo(3),
+                        RecordCursor.fromList(Arrays.asList(3, 7, 8, 4, 1)).limitRowsTo(2)
+                )),
+                null,
+                null);
+        verifyResults(cursor, RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, 3);
+
+        // One out-of-band limit reached, one exhausted
+        cursor = ProbableIntersectionCursor.create(Collections::singletonList,
+                cursorsToFunctions(Arrays.asList(
+                        new RecordCursorTest.FakeOutOfBandCursor<>(RecordCursor.fromList(Arrays.asList(1, 4, 3, 7, 9)), 3),
+                        RecordCursor.fromList(Arrays.asList(3, 7, 8, 4, 1))
+                )),
+                null,
+                null);
+        verifyResults(cursor, RecordCursor.NoNextReason.TIME_LIMIT_REACHED, 3, 4, 1);
+
+        // One in band limit reached, one exhausted
+        cursor = ProbableIntersectionCursor.create(Collections::singletonList,
+                cursorsToFunctions(Arrays.asList(
+                        RecordCursor.fromList(Arrays.asList(1, 4, 3, 7, 9)).limitRowsTo(3),
+                        RecordCursor.fromList(Arrays.asList(3, 7, 8, 4, 1))
+                )),
+                null,
+                null);
+        verifyResults(cursor, RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, 3, 4, 1);
+
+        // Both exhausted
+        cursor = ProbableIntersectionCursor.create(Collections::singletonList,
+                cursorsToFunctions(Arrays.asList(
+                        RecordCursor.fromList(Arrays.asList(1, 4, 3, 7, 9)),
+                        RecordCursor.fromList(Arrays.asList(3, 7, 8, 4, 1))
+                )),
+                null,
+                null);
+        verifyResults(cursor, RecordCursor.NoNextReason.SOURCE_EXHAUSTED, 3, 7, 4, 1);
+    }
+}


### PR DESCRIPTION
The work here is separated into three commits that are all related. In particular, each one depends on the next, though in theory, they all do separate things. I think it's easier to review each one separately, though I could be wrong.

This first is a "simple" refactoring of the intersection and union cursors so that their common code can be shared. In particular, I was upset that both cursors had essentially identical `CursorState` classes but one couldn't write functions that operated on either one of them (because Java doesn't support that type of polymorphism). This refactors their common code and I think is easier to manage (it was easier for me to make a new kind of cursor once this was done, at least), though there's kind of a fine line here between "good OO design" and "spaghetti inheritance".

The second adds the unordered intersection cursor (called `ProbableIntersectionCursor` because it returns a "probable intersection" of its children) and doesn't do anything with it other than run some tests. This resolves #336.

The third adds some text predicates that evaluate whether a record's indexed field contains any of the given prefixes or all of them. The "any" predicate makes use of the `UnorderedUnionCursor` that was added with #148 in the straightforward way. The "all" predicate is somewhat more involved as it also contains parameters for tweaking behavior of the underlying bloom filter. It also has a "strict" and "non-strict" mode. In the "strict" mode, all records identified as being in the intersection are also subject to a filter that actually determines if the record contains all of the prefixes. (In other words, it guarantees no false positives.) The "non-strict" mode does not double check, but it allows for the user to use covering indexes right out of the box. It might be acceptable in some situations such as when one just wants to perform a rough search of records and is okay with getting back somewhat fuzzy results. This resolves #343.