### PR TITLE
Resolves #349: Add limit for number of bytes scanned by a cursor.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -53,7 +53,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Tracing diagnostics to detect blocking calls in an asynchronous context [(Issue #262)](https://github.com/FoundationDB/fdb-record-layer/issues/262)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** New limit on the number of bytes scanned while executing a cursor [(Issue #349)](https://github.com/FoundationDB/fdb-record-layer/issues/349)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/AsyncPeekCallbackIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/AsyncPeekCallbackIterator.java
@@ -1,0 +1,73 @@
+/*
+ * AsyncPeekCallbackIterator.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.async;
+
+import javax.annotation.Nonnull;
+import java.util.function.Consumer;
+
+/**
+ * An {@code AsyncPeekCallbackIterator} is an extension of the {@link AsyncPeekIterator} interface that can be given a
+ * callback to call after each time it advances. Note that the {@code AsyncPeekCallbackIterator} is mostly a tag
+ * interface and does not contain any logic for executing the callback after yielding each result; conforming
+ * implementations must implement that logic.
+ *
+ * @param <T> type of elements returned by the scan
+ */
+public interface AsyncPeekCallbackIterator<T> extends AsyncPeekIterator<T> {
+    /**
+     * Wrap an {@link AsyncIterator} with an {@code AsyncPeekCallbackIterator}.
+     * The returned iterator returns the same sequence of elements
+     * as the supplied {@code AsyncIterator} instance in the same order.
+     * The wrapping implementation is free to advance the underlying iterator,
+     * so it is unsafe to modify <code>iterator</code> directly after calling
+     * this method. The returned iterator is also not thread safe, so concurrent
+     * calls to <code>onHasNext</code>, for example, may lead to unexpected behavior.
+     *
+     * @param <T> type of items returned by the scan
+     * @param iterator {@link AsyncIterator} to wrap
+     * @param callback a callback to call when {@link #next()} produces a result
+     * @return an iterator over the same values as <code>iterator</code> that supports peek and callback semantics
+     */
+    static <T> AsyncPeekCallbackIterator<T> wrap(@Nonnull AsyncIterator<T> iterator, @Nonnull Consumer<T> callback) {
+        if (iterator instanceof AsyncPeekCallbackIterator) {
+            final Consumer<T> originalCallback = ((AsyncPeekCallbackIterator<T>)iterator).getCallback();
+            ((AsyncPeekCallbackIterator<T>)iterator).setCallback(t -> {
+                originalCallback.accept(t);
+                callback.accept(t);
+            });
+            return (AsyncPeekCallbackIterator<T>) iterator;
+        }
+        return new WrappingAsyncPeekIterator<>(iterator, callback);
+    }
+
+    /**
+     * Set the callback to the provided {@link Consumer}.
+     * @param callback a consumer to call when a new result is produced by {@link #next()}
+     */
+    void setCallback(@Nonnull Consumer<T> callback);
+
+    /**
+     * Return the callback that this iterator calls before a new result is returned by {@link #next()}.
+     * @return the callback that this iterator calls before a new result is returned by {@link #next()};W
+     */
+    @Nonnull
+    Consumer<T> getCallback();
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteScanLimiter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteScanLimiter.java
@@ -1,0 +1,73 @@
+/*
+ * ByteScanLimiter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.API;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Track the number of bytes scanned up to some limit, after which record scans should not be allowed.
+ *
+ * @see ExecuteState#getByteScanLimiter()
+ */
+@API(API.Status.INTERNAL)
+public class ByteScanLimiter {
+    private final long originalLimit;
+    private final AtomicLong bytesRemaining;
+
+    public ByteScanLimiter(long limit) {
+        originalLimit = limit;
+        bytesRemaining = new AtomicLong(limit);
+    }
+
+    /**
+     * Create a new {@code ByteScanLimiter} with this limiter's original limit, ignoring any calls to
+     * {@link #hasBytesRemaining()} and {@link #registerScannedBytes(long)}.
+     * @return a new {@code ByteScanLimiter} with this limiter's original limit
+     */
+    @Nonnull
+    public ByteScanLimiter reset() {
+        return new ByteScanLimiter(originalLimit);
+    }
+
+    /**
+     * Atomically check whether the number of remaining bytes is at least 0.
+     * @return {@code true} if the remaining count is at least 0 and {@code false} if it is less than 0
+     */
+    public boolean hasBytesRemaining() {
+        return bytesRemaining.get() > 0;
+    }
+
+    /**
+     * Atomically decrement the number of remaining bytes by the given number of bytes.
+     * @param bytes the number of bytes to register
+     */
+    public void registerScannedBytes(long bytes) {
+        bytesRemaining.addAndGet(-bytes);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ByteScanLimiter(%d limit, %d left)", originalLimit, bytesRemaining.get());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
@@ -190,7 +190,17 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
          * @see ExecuteProperties.Builder#setScannedRecordsLimit(int)
          * @see RecordScanLimiter
          */
-        SCAN_LIMIT_REACHED(true);
+        SCAN_LIMIT_REACHED(true),
+
+        /**
+         * The limit on the number of bytes to scan was reached.
+         * {@link #getContinuation()} may return a continuation for resuming the scan.
+         * Note that it is possible for <code>BYTE_LIMIT_REACHED</code> to be returned before any actual records if
+         * a scan retrieves many bytes for records that are discarded, such as by a filter or type filter.
+         * @see ExecuteProperties.Builder#setScannedBytesLimit(long)
+         * @see ByteScanLimiter
+         */
+        BYTE_LIMIT_REACHED(true);
 
         final boolean outOfBand;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteState;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IsolationLevel;
@@ -31,7 +32,6 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
-import com.apple.foundationdb.record.RecordScanLimiter;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
@@ -121,7 +121,7 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
-    public CompletableFuture<FDBStoredRecord<M>> loadRecordInternal(@Nonnull Tuple primaryKey, boolean snapshot) {
+    public CompletableFuture<FDBStoredRecord<M>> loadRecordInternal(@Nonnull Tuple primaryKey, @Nonnull ExecuteState executeState, boolean snapshot) {
         return untypedStore.loadTypedRecord(typedSerializer, primaryKey, snapshot);
     }
 
@@ -151,8 +151,8 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
-    public RecordCursor<IndexEntry> scanIndex(@Nonnull Index index, @Nonnull IndexScanType scanType, @Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties, @Nullable RecordScanLimiter recordScanLimiter) {
-        return untypedStore.scanIndex(index, scanType, range, continuation, scanProperties, recordScanLimiter);
+    public RecordCursor<IndexEntry> scanIndex(@Nonnull Index index, @Nonnull IndexScanType scanType, @Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
+        return untypedStore.scanIndex(index, scanType, range, continuation, scanProperties);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -153,6 +153,7 @@ public class KeyValueCursor implements BaseCursor<KeyValue> {
                         context.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
                         context.increment(FDBStoreTimer.Counts.LOAD_KEY_VALUE);
                     }
+                    limitManager.reportScannedBytes(kv.getKey().length + kv.getValue().length);
                     // Note that this mutates the pointer and NOT the array.
                     // If the value of lastKey is mutated, the Continuation class will break.
                     lastKey = kv.getKey();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -786,7 +786,8 @@ public class SplitHelper {
 
         // Process the next key-value pair from the inner cursor; return whether unsplit complete.
         protected boolean append(@Nonnull RecordCursorResult<KeyValue> resultWithKv) {
-            KeyValue kv = resultWithKv.get();
+            @Nonnull KeyValue kv = resultWithKv.get(); // KeyValue is non-null since we only pass in a result that has one
+            limitManager.reportScannedBytes(kv.getKey().length + kv.getValue().length);
             if (nextPrefix == null) {
                 continuation = resultWithKv.getContinuation();
                 return appendFirst(kv);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithIndex.java
@@ -71,7 +71,7 @@ public interface RecordQueryPlanWithIndex extends RecordQueryPlan {
         final RecordMetaData metaData = store.getRecordMetaData();
         final Index index = metaData.getIndex(getIndexName());
         final RecordCursor<IndexEntry> entryRecordCursor = executeEntries(store, context, continuation, executeProperties);
-        return store.fetchIndexRecords(index, entryRecordCursor, IndexOrphanBehavior.ERROR)
+        return store.fetchIndexRecords(index, entryRecordCursor, IndexOrphanBehavior.ERROR, executeProperties.getState())
                 .map(store::queriedRecord);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/CursorLimitManagerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/CursorLimitManagerTest.java
@@ -58,7 +58,7 @@ public class CursorLimitManagerTest {
     public void testRecordScanLimiter() {
         final int numberOfScans = 12;
         final RecordScanLimiter recordScanLimiter = new RecordScanLimiter(numberOfScans);
-        final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, null);
+        final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, null, null);
 
         for (int i = 0; i < numberOfScans; i++) {
             assertTrue(manager.tryRecordScan());
@@ -75,7 +75,7 @@ public class CursorLimitManagerTest {
     public void testTimeLimiter() {
         final int untilTimeout = 7;
         final FakeTimeLimiter fakeTimeLimiter = new FakeTimeLimiter();
-        final CursorLimitManager manager = new CursorLimitManager(null, false, fakeTimeLimiter);
+        final CursorLimitManager manager = new CursorLimitManager(null, false, null, fakeTimeLimiter);
 
         for (int i = 0; i < untilTimeout; i++) {
             assertTrue(manager.tryRecordScan());
@@ -95,7 +95,7 @@ public class CursorLimitManagerTest {
         final int numberOfScans = 12;
         final RecordScanLimiter recordScanLimiter = new RecordScanLimiter(numberOfScans);
         final FakeTimeLimiter fakeTimeLimiter = new FakeTimeLimiter();
-        final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, fakeTimeLimiter);
+        final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, null, fakeTimeLimiter);
 
         for (int i = 0; i < untilTimeout; i++) {
             assertTrue(manager.tryRecordScan());
@@ -114,7 +114,7 @@ public class CursorLimitManagerTest {
         final int numberOfScans = 12;
         final RecordScanLimiter recordScanLimiter = new RecordScanLimiter(numberOfScans);
         final FakeTimeLimiter fakeTimeLimiter = new FakeTimeLimiter();
-        final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, fakeTimeLimiter);
+        final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, null, fakeTimeLimiter);
 
         for (int i = 0; i < numberOfScans; i++) {
             assertTrue(manager.tryRecordScan());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -165,6 +165,16 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
         createOrOpenRecordStore(context, simpleMetaData(hook));
     }
 
+    public void openSimpleRecordStoreWithSingletonPipeline(FDBRecordContext context) {
+        recordStore = FDBRecordStore.newBuilder()
+                .setContext(context)
+                .setKeySpacePath(path)
+                .setMetaDataProvider(simpleMetaData(NO_HOOK))
+                .setPipelineSizer(operation -> 1)
+                .createOrOpen();
+        setupPlanner(null);
+    }
+
     public void uncheckedOpenSimpleRecordStore(FDBRecordContext context) throws Exception {
         uncheckedOpenSimpleRecordStore(context, NO_HOOK);
     }
@@ -173,7 +183,7 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
         uncheckedOpenRecordStore(context, simpleMetaData(hook));
     }
 
-    private RecordMetaData simpleMetaData(@Nullable RecordMetaDataHook hook) {
+    protected RecordMetaData simpleMetaData(@Nullable RecordMetaDataHook hook) {
         RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         metaData.addUniversalIndex(COUNT_INDEX);
         metaData.addUniversalIndex(COUNT_UPDATES_INDEX);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -285,7 +285,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     }
 
     private ScanProperties forwardScanWithLimiter(RecordScanLimiter limiter) {
-        return new ScanProperties(ExecuteProperties.SERIAL_EXECUTE.setState(new ExecuteState(limiter)));
+        return new ScanProperties(ExecuteProperties.SERIAL_EXECUTE.setState(new ExecuteState(limiter, null)));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -213,10 +213,10 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     protected void openRecordStore(FDBRecordContext context) throws Exception {
-        openRecordStore(context, NO_HOOK);
+        openRecordStore(context, store -> { });
     }
 
-    protected void openRecordStore(FDBRecordContext context, RecordMetaDataHook hook) throws Exception {
+    protected void openRecordStore(FDBRecordContext context, RecordMetaDataHook hook) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
         metaDataBuilder.getRecordType(COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
         hook.apply(metaDataBuilder);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreByteLimitTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreByteLimitTest.java
@@ -1,0 +1,497 @@
+/*
+ * FDBRecordStoreByteLimitTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.limits;
+
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TestRecordsTextProto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.provider.common.TransformedRecordSerializer;
+import com.apple.foundationdb.record.provider.common.text.PrefixTextTokenizer;
+import com.apple.foundationdb.record.provider.common.text.TextSamples;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.SplitHelper;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.test.Tags;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.descendant;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.unorderedUnion;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the byte scan limit on query execution.
+ */
+@Tag(Tags.RequiresFDB)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class FDBRecordStoreByteLimitTest extends FDBRecordStoreLimitTestBase {
+    private static final StoreTimerByteCounter byteCounter = new StoreTimerByteCounter();
+
+    private List<Long> getScannedByteCountsByRecord(@Nonnull FDBRecordContext context, @Nonnull RecordQueryPlan plan) {
+        final List<Long> byteCountsByRecord = new ArrayList<>();
+        byte[] continuation = null;
+        context.getTimer().reset();
+        do {
+            try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan, continuation, ExecuteProperties.SERIAL_EXECUTE)) {
+                RecordCursorResult<FDBQueriedRecord<Message>> result = cursor.onNext().join();
+                if (result.hasNext()) {
+                    byteCountsByRecord.add(byteCounter.getBytesScanned(context));
+                    context.getTimer().reset();
+                }
+                continuation = result.getContinuation().toBytes();
+            }
+        } while (continuation != null);
+
+        return byteCountsByRecord;
+    }
+
+    public Stream<Arguments> plans() {
+        return plans(false);
+    }
+
+    @ParameterizedTest(name = "testPlans() [{index}] {0} {1}")
+    @MethodSource("plans")
+    public void testPlansWithPreciseExecution(String description, boolean notUsed, RecordQueryPlan plan) throws Exception {
+        setupSimpleRecordStore();
+        final List<Long> byteCountsByRecord;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStoreWithSingletonPipeline(context);
+            byteCountsByRecord = getScannedByteCountsByRecord(context, plan);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStoreWithSingletonPipeline(context);
+            assertPlanLimitsWithCorrectExecution(byteCountsByRecord, context, plan);
+        }
+    }
+
+    /**
+     * Make detailed assertions about the number of bytes scanned when the byte scan limit is very close to the number
+     * of records scanned between records.
+     *
+     * This helper method attempts to verify that the number of bytes being scanned during query execution is not too
+     * much higher than the limit specified by {@link ExecuteProperties.Builder#setScannedBytesLimit(long)}. To do this,
+     * it's given a list of the number of bytes scanned between individual records produced by the given plan. Then,
+     * it sets the byte limit to that number of bytes, possibly increased or decreased by 1.
+     *
+     * Suppose that A, B, and C are successive records produced by the plan's cursor. Consider the execution of that
+     * cursor in the absence of any limits. Let the number of bytes scanned between A and B be {@code m} and the number
+     * of bytes scanned between B and C be {@code n}. This test relies on the following claims holding:
+     * a) {@code m} and {@code n} are constant with respect to the asynchronous execution order of the underlying cursors.
+     * b) If the byte scan limit is less than or equal to {@code m}, then at most {@code 2 * m} bytes are scanned between
+     *   A and B, even if we resume the cursor by continuation. The same holds for {@code n}, B and C.
+     * c) If the byte scan limit is {@code m + 1}, then at least {@code m} and at most {@code m + n} bytes are scanned.
+     *
+     * Note that claim (b) requires the factor of two because resuming certain cursors (such as a
+     * {@link com.apple.foundationdb.record.provider.foundationdb.cursors.UnionCursor}) from a continuation requires
+     * rescanning records that have already been deserialized.
+     *
+     * These claims should hold for most query plans. Notably, even claim (a) does not hold for the
+     * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan}.
+     * @param byteCountsByRecord a list of the number of bytes scanned between successive records without any limits
+     * @param context an open record store context
+     * @param plan a query plan to execute
+     */
+    private void assertPlanLimitsWithCorrectExecution(@Nonnull List<Long> byteCountsByRecord,
+                                                      @Nonnull FDBRecordContext context,
+                                                      @Nonnull RecordQueryPlan plan) {
+        byte[] continuation = null;
+        int i = 0;
+        context.getTimer().reset();
+        while (i < byteCountsByRecord.size()) {
+            final int currentIndex = i;
+            // If the limit is slightly too low to scan the next record, we should scan it anyway and then stop.
+            final ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                    .setScannedBytesLimit(byteCountsByRecord.get(currentIndex) - 1)
+                    .build();
+
+            try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan, continuation, executeProperties)) {
+                RecordCursorResult<FDBQueriedRecord<Message>> result = cursor.onNext().join();
+                final long bytesScanned = byteCounter.getBytesScanned(context);
+                if (currentIndex == byteCountsByRecord.size() - 1) { // Final record
+                    // If this is a final record, then there must be enough room to scan everything until the end,
+                    // because of how the byteCountsByRecord are counted.
+                    assertTrue(result.hasNext());
+                }
+                // If the execution order is a little bit different this time (especially for union/intersection
+                // cursors) then we might not have a result when we expect to.
+                if (result.hasNext()) {
+                    i++;
+                    context.getTimer().reset();
+                } else {
+                    // Check that we stopped because of the byte scan limit.
+                    assertEquals(RecordCursor.NoNextReason.BYTE_LIMIT_REACHED, result.getNoNextReason());
+                }
+                // Assertion of claim (b)
+                assertThat(bytesScanned, lessThanOrEqualTo(2 * byteCountsByRecord.get(currentIndex)));
+                continuation = result.getContinuation().toBytes();
+            }
+        }
+
+        continuation = null;
+        i = 0;
+        while (i < byteCountsByRecord.size()) {
+            final int currentIndex = i;
+            // If the limit is exactly right we should scan the record and then stop.
+            final ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                    .setScannedBytesLimit(byteCountsByRecord.get(currentIndex))
+                    .build();
+            try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan, continuation, executeProperties)) {
+                RecordCursorResult<FDBQueriedRecord<Message>> result = cursor.onNext().join();
+                final long bytesScanned = byteCounter.getBytesScanned(context);
+                // If the execution order is a little bit different this time (especially for union/intersection
+                // cursors) then we might not have a result when we expect to.
+                if (result.hasNext()) {
+                    i++;
+                    context.getTimer().reset();
+                } else if (currentIndex < byteCountsByRecord.size() - 1) { // not the final record yet
+                    // Check that we stopped because of the byte scan limit.
+                    assertEquals(RecordCursor.NoNextReason.BYTE_LIMIT_REACHED, result.getNoNextReason());
+                }
+                // Assertion of claim (b)
+                assertThat(bytesScanned, lessThanOrEqualTo(2 * byteCountsByRecord.get(currentIndex)));
+                continuation = result.getContinuation().toBytes();
+            }
+        }
+
+        continuation = null;
+        i = 0;
+        while (i < byteCountsByRecord.size()) {
+            // If the limit is slightly too high we should scan the record, proceed to the next one (if it exists), and then stop.
+            final ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                    .setScannedBytesLimit(byteCountsByRecord.get(i) + 1)
+                    .build();
+            try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan, continuation, executeProperties)) {
+                RecordCursorResult<FDBQueriedRecord<Message>> result = cursor.onNext().join();
+                assertTrue(result.hasNext());
+                continuation = result.getContinuation().toBytes();
+                result = cursor.onNext().join();
+
+                long bytesScanned = byteCounter.getBytesScanned(context);
+                // Assertion of claim (c)
+                assertThat(bytesScanned, greaterThanOrEqualTo(byteCountsByRecord.get(i)));
+                if (i < byteCountsByRecord.size() - 1) {
+                    // Assertion of claim (c)
+                    assertThat(bytesScanned, lessThanOrEqualTo(byteCountsByRecord.get(i) + byteCountsByRecord.get(i + 1)));
+                }
+
+                i++;
+                if (result.hasNext()) {
+                    result = cursor.onNext().join();
+                    assertFalse(result.hasNext());
+                }
+                context.getTimer().reset();
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "plansByContinuation() [{index}] {0}")
+    @MethodSource("plans")
+    public void testPlansReturnSameRecordsRegardlessOfLimit(String description, boolean notUsed, RecordQueryPlan plan) throws Exception {
+        setupSimpleRecordStore();
+        final Function<FDBQueriedRecord<Message>, Long> getRecNo = r -> {
+            TestRecords1Proto.MySimpleRecord.Builder record = TestRecords1Proto.MySimpleRecord.newBuilder();
+            record.mergeFrom(r.getRecord());
+            return record.getRecNo();
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final List<Long> allAtOnce;
+            try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan)) {
+                allAtOnce = cursor.map(getRecNo).asList().get();
+            }
+
+            for (long byteLimit = 0; byteLimit < 1000; byteLimit += 100) {
+                final ExecuteProperties executeProperties = ExecuteProperties.newBuilder().setScannedBytesLimit(byteLimit).build();
+                final List<Long> byContinuation = new ArrayList<>(allAtOnce.size());
+                byte[] continuation = null;
+                do {
+                    try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan, continuation, executeProperties)) {
+                        RecordCursorResult<Long> result;
+                        do {
+                            result = cursor.onNext().get().map(getRecNo);
+                            if (result.hasNext()) {
+                                byContinuation.add(result.get());
+                            }
+                        } while (result.hasNext());
+                        continuation = result.getContinuation().toBytes();
+                    }
+                } while (continuation != null);
+                assertEquals(allAtOnce, byContinuation);
+            }
+        }
+    }
+
+    private void deleteSimpleRecords() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, TEST_SPLIT_HOOK);
+            recordStore.deleteAllRecords(); // Undo setupRecordStore().
+            commit(context);
+        }
+    }
+
+    @Test
+    public void testSplitContinuation() throws Exception {
+        deleteSimpleRecords();
+
+        final String bigValue = Strings.repeat("X", SplitHelper.SPLIT_RECORD_SIZE + 10);
+        final String smallValue = Strings.repeat("Y", 5);
+
+        final List<FDBStoredRecord<Message>> createdRecords = new ArrayList<>();
+        createdRecords.add(saveAndSplitSimpleRecord(1L, smallValue, 1));
+        createdRecords.add(saveAndSplitSimpleRecord(2L, smallValue, 2));
+        createdRecords.add(saveAndSplitSimpleRecord(3L, bigValue, 3));
+        createdRecords.add(saveAndSplitSimpleRecord(4L, smallValue, 4));
+        createdRecords.add(saveAndSplitSimpleRecord(5L, bigValue, 5));
+        createdRecords.add(saveAndSplitSimpleRecord(6L, bigValue, 6));
+        createdRecords.add(saveAndSplitSimpleRecord(7L, smallValue, 7));
+        createdRecords.add(saveAndSplitSimpleRecord(8L, smallValue, 8));
+        createdRecords.add(saveAndSplitSimpleRecord(9L, smallValue, 9));
+
+        // Scan one record at a time using continuations
+        final List<FDBStoredRecord<Message>> scannedRecords = new ArrayList<>();
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, TEST_SPLIT_HOOK);
+
+            Supplier<ScanProperties> props = () -> new ScanProperties(ExecuteProperties.newBuilder()
+                    .setScannedBytesLimit(0)
+                    .setIsolationLevel(IsolationLevel.SERIALIZABLE)
+                    .build());
+            RecordCursor<FDBStoredRecord<Message>> messageCursor = recordStore.scanRecords(null, props.get());
+            while (messageCursor.hasNext()) {
+                scannedRecords.add(messageCursor.next());
+                messageCursor = recordStore.scanRecords(messageCursor.getContinuation(), props.get());
+            }
+            commit(context);
+        }
+        assertEquals(createdRecords, scannedRecords);
+    }
+
+    private static final String SIMPLE_DOC = "SimpleDocument";
+    private static final String COMPLEX_DOC = "ComplexDocument";
+    private static final Index SIMPLE_TEXT_PREFIX = new Index("Simple$text_prefix", field("text"), IndexTypes.TEXT,
+            ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, PrefixTextTokenizer.NAME, IndexOptions.TEXT_TOKENIZER_VERSION_OPTION, "1"));
+    private static final TransformedRecordSerializer<Message> COMPRESSING_SERIALIZER = TransformedRecordSerializer.newDefaultBuilder()
+            .setCompressWhenSerializing(true)
+            .build();
+
+    private void openTextRecordStore(FDBRecordContext context) {
+        openTextRecordStore(context, NO_HOOK);
+    }
+
+    private void openTextRecordStore(FDBRecordContext context, RecordMetaDataHook hook) {
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
+        metaDataBuilder.getRecordType(COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
+        hook.apply(metaDataBuilder);
+        uncheckedOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
+        recordStore = recordStore.asBuilder()
+                .setSerializer(COMPRESSING_SERIALIZER)
+                .setPipelineSizer(pipelineOperation -> 1)
+                .build();
+    }
+
+    @Test
+    public void simpleFullTextContainsQuery() throws Exception {
+        // Load a big (ish) data set
+        final int recordCount = 100;
+        final int batchSize = 10;
+
+        for (int i = 0; i < recordCount; i += batchSize) {
+            try (FDBRecordContext context = openContext()) {
+                openTextRecordStore(context);
+                for (int j = 0; j < batchSize; j++) {
+                    TestRecordsTextProto.SimpleDocument document = TestRecordsTextProto.SimpleDocument.newBuilder()
+                            .setDocId(i + j)
+                            .setText((i + j) % 2 == 0 ? "some" : "text")
+                            .build();
+                    recordStore.saveRecord(document);
+                }
+                commit(context);
+            }
+        }
+
+        setupPlanner(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType(SIMPLE_DOC)
+                .setFilter(Query.field("text").text().containsAll("some text"))
+                .build();
+        RecordQueryPlan plan = planner.plan(query);
+
+        final List<Long> byteCountsByRecord;
+        try (FDBRecordContext context = openContext()) {
+            openTextRecordStore(context);
+            byteCountsByRecord = getScannedByteCountsByRecord(context, plan);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openTextRecordStore(context);
+            assertPlanLimitsWithCorrectExecution(byteCountsByRecord, context, plan);
+        }
+    }
+
+    public Stream<Arguments> complexTextQueries() {
+        return Stream.of(
+                Arguments.of(RecordQuery.newBuilder()
+                        .setRecordType(SIMPLE_DOC)
+                        .setFilter(Query.or(
+                                Query.field("text").text().containsPrefix("ang"),
+                                Query.field("text").text().containsPrefix("un")))
+                        .setRemoveDuplicates(true)
+                        .build(), 2),
+                Arguments.of(RecordQuery.newBuilder()
+                        .setRecordType(SIMPLE_DOC)
+                        .setFilter(Query.or(
+                                Query.field("text").text().containsPrefix("ang"),
+                                Query.field("text").text().containsPrefix("un"),
+                                Query.field("text").text().containsPrefix("tw"),
+                                Query.field("text").text().containsPrefix("thie")))
+                        .setRemoveDuplicates(true)
+                        .build(), 4));
+    }
+
+    /**
+     * Queries with an OR of {@link com.apple.foundationdb.record.query.expressions.Text#containsPrefix(String)}
+     * predicates get planned as {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan}s,
+     * which have unusual semantics where results are returned in an undefined order as soon as any child has one.
+     * Therefore, the assertions made in {@link #assertPlanLimitsWithCorrectExecution(List, FDBRecordContext, RecordQueryPlan)}
+     * are far too strong for plans like this. Instead, we make very weak assertions that the byte scan limit does
+     * <em>something</em>.
+     */
+    @ParameterizedTest
+    @MethodSource("complexTextQueries")
+    public void queryWithWideOrOfFullTextPrefixPredicates(@Nonnull RecordQuery query, int numPredicates) throws Exception {
+        deleteSimpleRecords();
+        final List<String> textSamples = ImmutableList.of(
+                TextSamples.ANGSTROM,
+                TextSamples.ROMEO_AND_JULIET_PROLOGUE,
+                TextSamples.AETHELRED,
+                TextSamples.FRENCH,
+                TextSamples.KOREAN
+        );
+
+        RecordMetaDataHook indexHook = metaDataBuilder ->
+                    metaDataBuilder.addIndex(metaDataBuilder.getRecordType(SIMPLE_DOC), SIMPLE_TEXT_PREFIX);
+        try (FDBRecordContext context = openContext()) {
+            openTextRecordStore(context, indexHook);
+            for (int i = 0; i < textSamples.size(); i++) {
+                recordStore.saveRecord(TestRecordsTextProto.SimpleDocument.newBuilder()
+                        .setDocId(i)
+                        .setGroup(i % 2)
+                        .setText(textSamples.get(i))
+                        .build());
+            }
+            commit(context);
+        }
+
+        setupPlanner(null);
+        RecordQueryPlan plan = planner.plan(query);
+        assertThat(plan, descendant(unorderedUnion(Collections.nCopies(numPredicates, any(RecordQueryPlan.class)))));
+
+        long totalBytes;
+        Set<Long> noLimitRecordIds = new HashSet<>();
+        try (FDBRecordContext context = openContext()) {
+            openTextRecordStore(context, indexHook);
+            context.getTimer().reset();
+            RecordCursor<FDBQueriedRecord<Message>> cursor =
+                    recordStore.executeQuery(query, null, ExecuteProperties.SERIAL_EXECUTE);
+            RecordCursorResult<FDBQueriedRecord<Message>> result;
+            do {
+                result = cursor.onNext().get();
+                if (result.hasNext()) {
+                    TestRecordsTextProto.SimpleDocument.Builder record = TestRecordsTextProto.SimpleDocument.newBuilder();
+                    record.mergeFrom(result.get().getRecord());
+                    noLimitRecordIds.add(record.getDocId());
+                }
+            } while (result.hasNext());
+            totalBytes = byteCounter.getBytesScanned(context);
+        }
+
+        Set<Long> limitRecordIds = new HashSet<>();
+        try (FDBRecordContext context = openContext()) {
+            openTextRecordStore(context);
+
+
+            ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder()
+                    .setScannedBytesLimit(0);
+            byte[] continuation = null;
+            do {
+                context.getTimer().reset();
+                RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(query, continuation, executeProperties.build());
+                RecordCursorResult<FDBQueriedRecord<Message>> result;
+                do {
+                    result = cursor.onNext().get();
+                    if (result.hasNext()) {
+                        TestRecordsTextProto.SimpleDocument.Builder record = TestRecordsTextProto.SimpleDocument.newBuilder();
+                        record.mergeFrom(result.get().getRecord());
+                        limitRecordIds.add(record.getDocId());
+                    }
+                } while (result.hasNext());
+                assertThat(byteCounter.getBytesScanned(context), lessThan(totalBytes));
+                continuation = result.getContinuation().toBytes();
+                if (continuation != null) {
+                    assertEquals(RecordCursor.NoNextReason.BYTE_LIMIT_REACHED, result.getNoNextReason());
+                }
+            } while (continuation != null);
+            assertEquals(noLimitRecordIds, limitRecordIds);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreLimitTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreLimitTestBase.java
@@ -1,0 +1,132 @@
+/*
+ * FDBRecordStoreLimitTestBase.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.limits;
+
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+
+/**
+ * Base class for tests of various scan limits.
+ */
+@Tag(Tags.RequiresFDB)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class FDBRecordStoreLimitTestBase extends FDBRecordStoreTestBase {
+    @BeforeAll
+    public void init() {
+        clearAndInitialize();
+    }
+
+    @BeforeEach
+    public void setupSimpleRecordStore() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            recordStore.deleteAllRecords();
+
+            for (int i = 0; i < 100; i++) {
+                TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
+                recBuilder.setRecNo(i);
+                recBuilder.setStrValueIndexed((i & 1) == 1 ? "odd" : "even");
+                recBuilder.setNumValueUnique(i + 1000);
+                recBuilder.setNumValue3Indexed(i % 3);
+                recordStore.saveRecord(recBuilder.build());
+            }
+            commit(context);
+        }
+    }
+
+    private RecordQueryPlan indexPlanEquals(String indexName, Object value) {
+        return new RecordQueryIndexPlan(indexName, IndexScanType.BY_VALUE,
+                new ScanComparisons(Arrays.asList(new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, value)),
+                        Collections.emptyList()),
+                false);
+    }
+
+    private KeyExpression primaryKey() {
+        return field("rec_no");
+    }
+
+    public Stream<Arguments> plans(boolean fail) {
+        RecordQueryPlan scanPlan = new RecordQueryScanPlan(ScanComparisons.EMPTY, false);
+        RecordQueryPlan indexPlan = new RecordQueryIndexPlan("MySimpleRecord$str_value_indexed",
+                IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false);
+        QueryComponent filter = Query.field("str_value_indexed").equalsValue("odd");
+        QueryComponent middleFilter = Query.and(
+                Query.field("rec_no").greaterThan(24L),
+                Query.field("rec_no").lessThan(60L));
+        RecordQueryPlan firstChild = indexPlanEquals("MySimpleRecord$str_value_indexed", "even");
+        RecordQueryPlan secondChild = indexPlanEquals("MySimpleRecord$num_value_3_indexed", 0);
+        return Stream.of(
+                Arguments.of("full record scan", fail, scanPlan),
+                Arguments.of("simple index scan", fail, indexPlan),
+                Arguments.of("reverse index scan", fail, new RecordQueryIndexPlan("MySimpleRecord$str_value_indexed",
+                        IndexScanType.BY_VALUE, ScanComparisons.EMPTY, true)),
+                Arguments.of("filter on scan plan", fail, new RecordQueryFilterPlan(scanPlan, filter)),
+                Arguments.of("filter on index plan", fail, new RecordQueryFilterPlan(indexPlan, filter)),
+                Arguments.of("type filter on scan plan", fail, new RecordQueryTypeFilterPlan(scanPlan, Collections.singletonList("MySimpleRecord"))),
+                Arguments.of("type filter on index plan", fail, new RecordQueryTypeFilterPlan(indexPlan, Collections.singletonList("MySimpleRecord"))),
+                Arguments.of("disjoint union", fail, new RecordQueryUnionPlan(
+                        indexPlanEquals("MySimpleRecord$str_value_indexed", "odd"),
+                        indexPlanEquals("MySimpleRecord$str_value_indexed", "even"),
+                        primaryKey(), false, false)),
+                Arguments.of("overlapping union", fail, new RecordQueryUnionPlan(firstChild, secondChild, primaryKey(), false, false)),
+                Arguments.of("overlapping union (swapped args)", fail, new RecordQueryUnionPlan(secondChild, firstChild, primaryKey(), false, false)),
+                Arguments.of("overlapping intersection", fail, new RecordQueryIntersectionPlan(firstChild, secondChild, primaryKey(), false)),
+                Arguments.of("overlapping intersection", fail, new RecordQueryIntersectionPlan(secondChild, firstChild, primaryKey(), false)),
+                Arguments.of("union with inner filter", fail, new RecordQueryUnionPlan(
+                        new RecordQueryFilterPlan(firstChild, middleFilter), secondChild, primaryKey(), false, false)),
+                Arguments.of("union with two inner filters", fail, new RecordQueryUnionPlan(
+                        new RecordQueryFilterPlan(firstChild, middleFilter),
+                        new RecordQueryFilterPlan(secondChild, Query.field("rec_no").lessThan(55L)),
+                        primaryKey(), false, false)),
+                Arguments.of("intersection with inner filter", fail, new RecordQueryIntersectionPlan(
+                        new RecordQueryFilterPlan(firstChild, middleFilter), secondChild, primaryKey(), false)),
+                Arguments.of("intersection with two inner filters", fail, new RecordQueryIntersectionPlan(
+                        new RecordQueryFilterPlan(firstChild, middleFilter),
+                        new RecordQueryFilterPlan(secondChild, Query.field("rec_no").lessThan(55L)),
+                        primaryKey(), false)));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/StoreTimerByteCounter.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/StoreTimerByteCounter.java
@@ -1,0 +1,71 @@
+/*
+ * StoreTimerByteCounter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.limits;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * A utility class for counting the total number of bytes scanned (as defined by the
+ * {@link com.apple.foundationdb.record.ByteScanLimiter}) during the execution of a
+ * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan} by combining several counters from the
+ * {@link com.apple.foundationdb.record.provider.common.StoreTimer}. This provides a means for verifying that the
+ * number of bytes scanned is actually being limited by the {@code ByteScanLimiter}.
+ */
+public class StoreTimerByteCounter {
+    private static final List<FDBStoreTimer.Counts> DEFAULT_COUNTS = ImmutableList.of(
+            FDBStoreTimer.Counts.LOAD_RECORD_KEY_BYTES,
+            FDBStoreTimer.Counts.LOAD_RECORD_VALUE_BYTES,
+            FDBStoreTimer.Counts.LOAD_INDEX_KEY_BYTES,
+            FDBStoreTimer.Counts.LOAD_INDEX_VALUE_BYTES);
+
+    private final List<FDBStoreTimer.Counts> countsWithScannedBytes;
+
+    public StoreTimerByteCounter() {
+        this(DEFAULT_COUNTS);
+    }
+
+    public StoreTimerByteCounter(List<FDBStoreTimer.Counts> countsWithScannedBytes) {
+        this.countsWithScannedBytes = countsWithScannedBytes;
+    }
+
+    public long getBytesScanned(@Nonnull final StoreTimer timer) {
+        long total = 0L;
+        for (FDBStoreTimer.Counts count : countsWithScannedBytes) {
+            total += timer.getCount(count);
+        }
+        return total;
+    }
+
+    public long getBytesScanned(@Nonnull FDBRecordContext context) {
+        final FDBStoreTimer timer = context.getTimer();
+        if (timer == null) {
+            throw new RecordCoreException("context must have a timer to test byte scan limit");
+        }
+        return getBytesScanned(timer);
+    }
+}


### PR DESCRIPTION
This adds a new limit ("the byte scan limit") that's broadly similar to the record scan limit but that counts the number of bytes being scanned instead of the number of key-value pairs. The semantics of the implementation are pretty weak because we can't in general know the number of bytes that a cursor will scan when it asks for permission to continue. However, the implemented limit should still provide some kind of protection against queries that scan a lot of big records.

The implementation itself is pretty straightforward. In reviewing, I think the most important question is whether the tests are strong and comprehensive enough for something that's pretty delicate.