### PR TITLE
Fix #251:  Directory layer cache size was accidentally defaulted to zero

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Directory layer cache size was accidentally defaulted to zero [(Issue #251)](https://github.com/FoundationDB/fdb-record-layer/issues/251)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -159,7 +159,7 @@ public class FDBDatabase {
                 .recordStats()
                 .build();
         this.directoryCache = CacheBuilder.newBuilder()
-                .maximumSize(0)
+                .maximumSize(factory.getDirectoryCacheSize())
                 .recordStats()
                 .build();
         this.resolverStateCache = new AsyncLoadingCache<>(factory.getStateRefreshTimeMillis());


### PR DESCRIPTION
Tests were showing an excessive number of read-only commits taking place.
This was due to the fact that the directory layer cache was accidentally
set to a size of zero by default, meaning that every request to look up
an entry required a new transaction.

As a side note: we could buy some efficiencies by doing the initial read
within the existing client transaction and only use a secondary transaction
in the case that the entry needs to be created. I think that this path wasn't
taken in the current code because it makes the semantics of passing a
context into the resolve() call a little confusing.