### PR TITLE
This work is in response to https://github.com/FoundationDB/fdb-record-layer/issues/338. Prior to this work perfor…

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1927,7 +1927,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @Nonnull
     @API(API.Status.INTERNAL)
     protected CompletableFuture<Void> preloadSubspaceAsync() {
-        return subspaceProvider.getSubspaceAsync().thenApply(subspace -> null);
+        return getSubspaceAsync().thenApply(subspace -> null);
     }
 
     /**
@@ -2938,7 +2938,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             if (context == null) {
                 throw new RecordCoreException("The context should be set before setting the key space path.");
             }
-            this.subspaceProvider = keySpacePath == null ? null : new SubspaceProviderByKeySpacePath(keySpacePath, context);
+            this.subspaceProvider = keySpacePath == null ? null : new SubspaceProviderByKeySpacePath(keySpacePath);
             return this;
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
@@ -82,7 +82,12 @@ public abstract class FDBStoreBase {
 
     @Nonnull
     public Subspace getSubspace() {
-        return subspaceProvider.getSubspace();
+        return subspaceProvider.getSubspace(context);
+    }
+
+    @Nonnull
+    public CompletableFuture<Subspace> getSubspaceAsync() {
+        return subspaceProvider.getSubspaceAsync(context);
     }
 
     public void addConflictForSubspace(boolean write) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollector.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollector.java
@@ -351,30 +351,4 @@ public class SizeStatisticsCollector {
     public static SizeStatisticsCollector ofSubspace(@Nonnull Subspace subspace) {
         return new SizeStatisticsCollector(subspace);
     }
-
-    /**
-     * Create a statistics collector of all keys used by index within a given {@link SubspaceProvider}'s subspace.
-     * If the implementation of {@link SubspaceProvider#getSubspace() getSubspace()} is blocking for the
-     * given <code>SubspaceProvide</code>, then this method will also be blocking.
-     *
-     * @param subspaceProvider the provider of the subspace to collect statistics on key and value sizes
-     * @return a statistics collector of the given subspace
-     */
-    @Nonnull
-    public static SizeStatisticsCollector ofSubspaceProvider(@Nonnull SubspaceProvider subspaceProvider) {
-        return new SizeStatisticsCollector(subspaceProvider.getSubspace());
-    }
-
-    /**
-     * Create a statistics collector of all keys used by index within a given {@link SubspaceProvider}'s subspace.
-     * This method is non-blocking, and it returns a future that will contain the statistics collector when
-     * ready.
-     *
-     * @param subspaceProvider the provider of the subspace to collect statistics on key and value sizes
-     * @return a future containing the statistics collector of the given subspace
-     */
-    @Nonnull
-    public static CompletableFuture<SizeStatisticsCollector> ofSubspaceProviderAsync(@Nonnull SubspaceProvider subspaceProvider) {
-        return subspaceProvider.getSubspaceAsync().thenApply(SizeStatisticsCollector::new);
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProvider.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProvider.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.subspace.Subspace;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
@@ -37,14 +38,15 @@ public interface SubspaceProvider {
      * @return Subspace
      */
     @Nonnull
-    Subspace getSubspace();
+    Subspace getSubspace(FDBRecordContext context);
 
     @Nonnull
-    CompletableFuture<Subspace> getSubspaceAsync();
+    CompletableFuture<Subspace> getSubspaceAsync(FDBRecordContext context);
 
     @Nonnull
     LogMessageKeys logKey();
 
+    @NonNull
     @Override
     String toString();
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderByKeySpacePath.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderByKeySpacePath.java
@@ -38,26 +38,22 @@ public class SubspaceProviderByKeySpacePath implements SubspaceProvider {
     @Nonnull
     private final KeySpacePath keySpacePath;
 
-    @Nonnull
-    private final FDBRecordContext context;
-
     @Nullable
     private CompletableFuture<Subspace> subspaceFuture;
 
-    SubspaceProviderByKeySpacePath(@Nonnull KeySpacePath keySpacePath, @Nonnull FDBRecordContext context) {
+    SubspaceProviderByKeySpacePath(@Nonnull KeySpacePath keySpacePath) {
         this.keySpacePath = keySpacePath;
-        this.context = context;
     }
 
     @Nonnull
     @Override
-    public Subspace getSubspace() {
-        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_PATH_RESOLVE, getSubspaceAsync());
+    public Subspace getSubspace(FDBRecordContext context) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_PATH_RESOLVE, getSubspaceAsync(context));
     }
 
     @Nonnull
     @Override
-    public CompletableFuture<Subspace> getSubspaceAsync() {
+    public CompletableFuture<Subspace> getSubspaceAsync(FDBRecordContext context) {
         if (subspaceFuture == null) {
             subspaceFuture = keySpacePath.toSubspaceAsync(context);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderBySubspace.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderBySubspace.java
@@ -42,13 +42,13 @@ public class SubspaceProviderBySubspace implements SubspaceProvider {
 
     @Nonnull
     @Override
-    public Subspace getSubspace() {
+    public Subspace getSubspace(FDBRecordContext context) {
         return subspace;
     }
 
     @Nonnull
     @Override
-    public CompletableFuture<Subspace> getSubspaceAsync() {
+    public CompletableFuture<Subspace> getSubspaceAsync(FDBRecordContext context) {
         return CompletableFuture.completedFuture(subspace);
     }
 


### PR DESCRIPTION
…ming a setKeySpacePath(KeySpacePath)  on FDBRecordStore required that setContext(FDBContext) had previously been performed. This was because the call to setKeySpacePath(KeySpacePath) attempted to create an instance of SubspaceProviderByKeySpace which requires an FDBRecordContext. This work changes the SubspaceProvider interface so that an FDBContext is not needed at at the time and instance is created. The FDBRecordContext is instead passed at the time a SubSpace is actually needed from the provider. I.e. SubSpace.getSubspace and Subspace.getSubspaceAsync were changed to take an FDBRecordContext as input. Note that this interface change also tightens up a potential inconsistency from occurring in an FDBRecordContext construction between its FDBRecordContext and its SubspaceProvider. The FDBRecordContext can be reset directly after and it is turned back into a builder. If the SubspaceProvider is a function of FDBRecordContext it could be out of sync with the new context if it is not re-resolved. Providing the FDBRecordContext when the SubspaceProvider is actually used prevents this issue from occurring. All code changes are related to the implementation and usage of the aforementioned modifications to the SubspaceProvider interface.