### PR TITLE
Fixes #369: Fix typo and type error in example query

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -252,10 +252,10 @@ and output sort order, for example:
 ```java
     RecordQuery query = RecordQuery.newBuilder()
         .setRecordType("myRecord")
-        .setFiler(Query.and(
+        .setFilter(Query.and(
             Query.field("str_field").equalsValue("hello!"),
             Query.field("num_field").greaterThan(10)))
-        .setSort(Query.field("rec_no"))
+        .setSort(Key.Expressions.field("rec_no"))
         .build();
 ```
 


### PR DESCRIPTION
This uses a `Key.Expressions.field` in the sort instead of the erroneous `Query.field` and fixes the method name.