### PR TITLE
Fixes #358: ChainedCursor does not obey byte/record/time scan limits

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** ChainedCursor does not obey byte/record/time scan limits [(Issue #358)](https://github.com/FoundationDB/fdb-record-layer/issues/358)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
@@ -334,10 +334,10 @@ public class ExecuteProperties {
             components.add(String.format("rowLimit %d", rowLimit));
         }
         if (timeLimit != UNLIMITED_TIME) {
-            components.add(String.format("timeLimit %d ms,", timeLimit));
+            components.add(String.format("timeLimit %d ms", timeLimit));
         }
         if (failOnScanLimitReached) {
-            components.add("fail on scan limit,");
+            components.add("fail on scan limit");
         }
         components.add(state.toString());
         return String.format("ExecuteProperties(%s)", String.join(", ", components));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ScanProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ScanProperties.java
@@ -141,4 +141,10 @@ public class ScanProperties {
         }
         return new ScanProperties(executeProperties, reverse, cursorStreamingMode);
     }
+
+    @Override
+    public String toString() {
+        return String.format("ScanProperties(%s, direction: %s, streaming mode: %s)",
+                executeProperties, reverse ? "reverse" : "forward", cursorStreamingMode);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
@@ -21,10 +21,11 @@
 package com.apple.foundationdb.record.cursors;
 
 import com.apple.foundationdb.API;
-import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,15 +36,68 @@ import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 /**
- * A cursor that produces items by applying a given function to the previous item.
+ * A cursor that iterates over a set of data that is dynamically generated a single value at a time. The cursor is
+ * driven by a value generation function.  The function initially takes an <code>Optional.empty()</code> as
+ * input, and from that produces an initial value.  Upon subsequent iterations the function is given the
+ * value it previously returned and the next value is computed.  For example, the following generator would
+ * produce the values from 1 to 10:
+ * <pre>
+ *     maybePreviousValue -&gt; {
+ *         if (maybePreviousValue.isPresent()) {
+ *             if (maybePreviousValue.get() &lt; 10) {
+ *                 return Optional.of(maybePreviousValue.get() + 1);
+ *             } else {
+ *                 return Optional.empty();
+ *             }
+ *             return Optional.of(1);
+ *         }
+ *     }
+ * </pre>
+ * Given this function, the <code>ChainedCursor</code> would iteratively generate the value from 1 to 10.
+ *
+ * <p>In order to support continuations, the cursor must additionally be provided a functions that can
+ * encode and decode the values it produces into binary continuation form.  So the fully defined cursor
+ * to perform our iteration from 1 to 10, would look like:
+ * <pre>
+ *     new ChainedCursor(
+ *         // Value generator
+ *         maybePreviousValue -&gt; {
+ *             if (maybePreviousValue.isPresent()) {
+ *                 if (maybePreviousValue.get() &lt; 10) {
+ *                     return Optional.of(maybePreviousValue.get() + 1);
+ *                 } else {
+ *                     return Optional.empty();
+ *                 }
+ *                 return Optional.of(1);
+ *             }
+ *             return Optional.of(1);
+ *         },
+ *         // Continuation encoder
+ *         previousValue -&gt; Tuple.from(previousValue).pack(),
+ *         // Continuation decoder
+ *         encodedContinuation -&gt; Tuple.fromBytes(encodedContinuation).getLong(0)
+ *         executor
+ *     )
+ * </pre>
+ *
+ * <h2>Resource Governing</h2>
+ *
+ * When the <code>ChainedCursor</code> is created with a set of {@link ScanProperties} it will attempt to count each
+ * iteration of the cursor against the limits that are indicated by the properties.  This can lead to an interesting
+ * behavior if the same set of <code>ScanProperties</code> are also used by cursors that are present in the <code>nextGenerator</code>
+ * that is provided and can lead to double-counting.  For example, if the <code>nextGenerator</code> is driven
+ * by the read of a row key via the <code>KeyValueCursor</code>, the cursor could end up counting that read, and the
+ * <code>ChainedCursor</code> would then, again, count that read. As such, the caller should take care on
+ * specifying the <code>ScanProperties</code> to the cursor and within the <code>nextGenerator</code>
+ *
  * @param <T> the type of elements of the cursor
  */
 @API(API.Status.MAINTAINED)
-public class ChainedCursor<T> implements RecordCursor<T> {
+public class ChainedCursor<T> implements BaseCursor<T> {
     @Nonnull
     private final Function<Optional<T>, CompletableFuture<Optional<T>>> nextGenerator;
     @Nonnull
-    private final Function<T, byte[]> getContinuation;
+    private final Function<T, byte[]> continuationEncoder;
     @Nonnull
     private final Executor executor;
     @Nullable
@@ -53,33 +107,111 @@ public class ChainedCursor<T> implements RecordCursor<T> {
     @Nullable
     private RecordCursorResult<T> lastResult;
 
+    @Nonnull
+    private final CursorLimitManager limitManager;
+    private final long maxReturnedRows;
+    private long returnedRowCount;
+
     // for detecting incorrect cursor usage
     private boolean mayGetContinuation = false;
 
+    /**
+     * Creates a new <code>ChainedCursor</code>.  When created in this fashion any resource limits that may be
+     * specified in cursors that are used within the <code>nextGenerator</code> will be honored.
+     *
+     * @param nextGenerator a function that that is called to perform iteration
+     * @param continuationEncoder a function that takes a value that was returned by <code>nextGenerator</code> and
+     *     encodes it as a continuation value
+     * @param continuationDecoder a function that takes a continuation that was produced by <code>continuationEncoder</code>
+     *     and decodes it back to its original value as returned by <code>nextGenerator</code>
+     * @param continuation the initial continuation for the iteration
+     * @param executor executor that will be returned by {@link #getExecutor()}
+     */
     public ChainedCursor(
             @Nonnull Function<Optional<T>, CompletableFuture<Optional<T>>> nextGenerator,
-            @Nonnull Function<T, byte[]> getContinuation,
-            @Nonnull Function<byte[], T> getContinueValue,
+            @Nonnull Function<T, byte[]> continuationEncoder,
+            @Nonnull Function<byte[], T> continuationDecoder,
             @Nullable byte[] continuation,
             @Nonnull Executor executor) {
+        this(null, nextGenerator, continuationEncoder, continuationDecoder, continuation, null, executor);
+    }
+
+    /**
+     * Creates a <code>ChainedCursor</code>.
+     *
+     * <p>The {@link ScanProperties#isReverse()}} cannot be honored by the <code>ChainedCursor</code> as the
+     * direction of iteration is strictly controlled by the <code>nextGenerator</code>.
+     *
+     * @param context a record context
+     * @param nextGenerator a function that that is called to perform iteration
+     * @param continuationEncoder a function that takes a value that was returned by <code>nextGenerator</code> and
+     *     encodes it as a continuation value
+     * @param continuationDecoder a function that takes a continuation that was produced by <code>continuationEncoder</code>
+     *     and decodes it back to its original value as returned by <code>nextGenerator</code>
+     * @param continuation the initial continuation for the iteration
+     * @param scanProperties properties used to control the scanning behavior
+     */
+    public ChainedCursor(
+            @Nonnull FDBRecordContext context,
+            @Nonnull Function<Optional<T>, CompletableFuture<Optional<T>>> nextGenerator,
+            @Nonnull Function<T, byte[]> continuationEncoder,
+            @Nonnull Function<byte[], T> continuationDecoder,
+            @Nullable byte[] continuation,
+            @Nonnull ScanProperties scanProperties) {
+        this(context, nextGenerator, continuationEncoder, continuationDecoder, continuation, scanProperties, context.getExecutor());
+    }
+
+    private ChainedCursor(
+            @Nullable FDBRecordContext context,
+            @Nonnull Function<Optional<T>, CompletableFuture<Optional<T>>> nextGenerator,
+            @Nonnull Function<T, byte[]> continuationEncoder,
+            @Nonnull Function<byte[], T> continuationDecoder,
+            @Nullable byte[] continuation,
+            @Nullable ScanProperties scanProperties,
+            @Nonnull Executor executor) {
         this.nextGenerator = nextGenerator;
-        this.getContinuation = getContinuation;
+        this.continuationEncoder = continuationEncoder;
         this.executor = executor;
         if (continuation != null) {
-            this.lastValue = Optional.of(getContinueValue.apply(continuation));
+            this.lastValue = Optional.of(continuationDecoder.apply(continuation));
         } else {
             lastValue = Optional.empty();
         }
+
+        // If we didn't have a context, then we couldn't have any passed in limits, so create a
+        // manager in which it will impose no limits.
+        if (context == null) {
+            limitManager = new CursorLimitManager(ScanProperties.FORWARD_SCAN);
+        } else {
+            limitManager = new CursorLimitManager(context, scanProperties);
+        }
+
+        this.maxReturnedRows = scanProperties == null
+                               ? Integer.MAX_VALUE
+                               : scanProperties.getExecuteProperties().getReturnedRowLimitOrMax();
     }
 
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
     public CompletableFuture<RecordCursorResult<T>> onNext() {
+        if (returnedRowCount == maxReturnedRows) {
+            lastResult = RecordCursorResult.withoutNextValue(
+                    new Continuation<>(lastValue, continuationEncoder), NoNextReason.RETURN_LIMIT_REACHED);
+            return CompletableFuture.completedFuture(lastResult);
+        }
+
+        if (!limitManager.tryRecordScan()) {
+            lastResult = RecordCursorResult.withoutNextValue(
+                    new Continuation<>(lastValue, continuationEncoder), limitManager.getStoppedReason().get());
+            return CompletableFuture.completedFuture(lastResult);
+        }
+
         return nextGenerator.apply(lastValue).thenApply(nextValue -> {
             if (nextValue.isPresent()) {
+                ++returnedRowCount;
                 lastValue = nextValue;
-                lastResult = RecordCursorResult.withNextValue(nextValue.get(), new Continuation<>(nextValue, getContinuation));
+                lastResult = RecordCursorResult.withNextValue(nextValue.get(), new Continuation<>(nextValue, continuationEncoder));
             } else {
                 lastValue = nextValue;
                 lastResult = RecordCursorResult.exhausted();
@@ -146,20 +278,20 @@ public class ChainedCursor<T> implements RecordCursor<T> {
         @Nonnull
         private final Optional<T> lastValue;
         @Nonnull
-        private final Function<T, byte[]> getContinuation;
+        private final Function<T, byte[]> continuationEncoder;
         @Nullable
         private byte[] cachedBytes;
 
-        public Continuation(@Nonnull Optional<T> lastValue, @Nonnull Function<T, byte[]> getContinuation) {
+        public Continuation(@Nonnull Optional<T> lastValue, @Nonnull Function<T, byte[]> continuationEncoder) {
             this.lastValue = lastValue;
-            this.getContinuation = getContinuation;
+            this.continuationEncoder = continuationEncoder;
         }
 
         @Nullable
         @Override
         public byte[] toBytes() {
             if (cachedBytes == null) {
-                cachedBytes = lastValue.map(getContinuation).orElse(null);
+                cachedBytes = lastValue.map(continuationEncoder).orElse(null);
             }
             return cachedBytes;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -38,6 +38,7 @@ public enum LogMessageKeys {
     CALLING_METHOD("calling_method"),
     CALLING_LINE("calling_line"),
     FUTURE_COMPLETED("future_completed"),
+    SCAN_PROPERTIES("scan_properties"),
     // record splitting/unsplitting
     KEY("key"),
     KEY_TUPLE("key_tuple"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
@@ -413,29 +413,38 @@ public class KeySpaceDirectory {
                 ? CompletableFuture.completedFuture(new Subspace())
                 : listFrom.toSubspaceAsync(context);
 
+        // The chained cursor cannot implement reverse scan, so we implement it by having the
+        // inner key value cursor do the reversing but telling the chained cursor we are moving
+        // forward.
+        final ScanProperties chainedCursorScanProperties;
+        if (scanProperties.isReverse()) {
+            chainedCursorScanProperties = scanProperties.setReverse(false);
+        } else {
+            chainedCursorScanProperties = scanProperties;
+        }
+
+        // For the read of the individual row keys, we only want to read a single key. In addition,
+        // the ChainedCursor is going to do counting of our reads to apply any limits that were specified
+        // on the ScanProperties.  We don't want the inner KeyValueCursor in nextTuple() to ALSO count those
+        // same reads so we clear out its limits.
+        final ScanProperties keyReadScanProperties = scanProperties.with(
+                props -> props.clearState().setReturnedRowLimit(1));
+
         return new LazyCursor<>(
                 fromSubspaceFuture.thenCompose(subspace ->
                         subdir.getValueRange(context, valueRange, subspace).thenApply(range -> {
-                            // The ChainedCursor is going to do counting of our reads to apply any limits
-                            // that were specified on the ScanProperties.  We don't want the inner
-                            // KeyValueCursor in nextTuple() to ALSO count those same reads so we clear
-                            // out its limits.
-                            final ScanProperties singleRowScan = scanProperties.with(
-                                    props -> props.clearState().setReturnedRowLimit(1));
-
                             final RecordCursor<Tuple> cursor = new ChainedCursor<>(
                                     context,
-                                    lastKey -> nextTuple(context, subspace, range, lastKey, singleRowScan),
+                                    lastKey -> nextTuple(context, subspace, range, lastKey, keyReadScanProperties),
                                     Tuple::pack,
                                     Tuple::fromBytes,
                                     continuation,
-                                    scanProperties);
+                                    chainedCursorScanProperties);
 
-                            return cursor.limitRowsTo(scanProperties.getExecuteProperties().getReturnedRowLimit())
-                                    .mapPipelined(tuple -> {
-                                        final Tuple key = Tuple.fromList(tuple.getItems());
-                                        return findChildForKey(context, listFrom, key, 1, 0);
-                                    }, 1);
+                            return cursor.mapPipelined(tuple -> {
+                                final Tuple key = Tuple.fromList(tuple.getItems());
+                                return findChildForKey(context, listFrom, key, 1, 0);
+                            }, 1);
                         })),
                 context.getExecutor()
         );
@@ -526,13 +535,20 @@ public class KeySpaceDirectory {
                     .setScanProperties(scanProperties)
                     .build();
         } else {
-            cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            KeyValueCursor.Builder builder = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
-                    .setLow(subspace.pack(lastTuple.get().get(0)), EndpointType.RANGE_EXCLUSIVE)
-                    .setHigh(range.getHighKey(), range.getHighEndpoint())
                     .setContinuation(null)
-                    .setScanProperties(scanProperties)
-                    .build();
+                    .setScanProperties(scanProperties);
+
+            if (scanProperties.isReverse()) {
+                cursor = builder.setLow(range.getLowKey(), range.getLowEndpoint())
+                        .setHigh(subspace.pack(lastTuple.get().get(0)), EndpointType.RANGE_EXCLUSIVE)
+                        .build();
+            } else {
+                cursor = builder.setLow(subspace.pack(lastTuple.get().get(0)), EndpointType.RANGE_EXCLUSIVE)
+                        .setHigh(range.getHighKey(), range.getHighEndpoint())
+                        .build();
+            }
         }
 
         return cursor.onHasNext().thenApply( hasNext -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/ChainedCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/ChainedCursorTest.java
@@ -20,19 +20,29 @@
 
 package com.apple.foundationdb.record.cursors;
 
+import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link ChainedCursor}.
  */
-public class ChainedCursorTest {
+@Tag(Tags.RequiresFDB)
+public class ChainedCursorTest extends FDBTestBase {
 
     @Test
     public void testChainedCursor() {
@@ -62,6 +72,78 @@ public class ChainedCursorTest {
         assertEquals(25, i);
     }
 
+    @Test
+    public void testObeysReturnedRowLimit() {
+        limitBy(5, Integer.MAX_VALUE, RecordCursor.NoNextReason.RETURN_LIMIT_REACHED);
+    }
+
+    @Test
+    public void testObeysScanLimit() {
+        limitBy(Integer.MAX_VALUE, 5, RecordCursor.NoNextReason.SCAN_LIMIT_REACHED);
+    }
+
+
+    private void limitBy(int returnedRowLimit, int recordScanLimit, RecordCursor.NoNextReason noNextReason) {
+        // Note that this test only requires a database and a context because the ChainedCursor API requires
+        // a context to be passed in when you are applying scan limits.
+        FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
+        try (FDBRecordContext context = database.openContext()) {
+            ScanProperties props = new ScanProperties(ExecuteProperties.newBuilder()
+                    .setReturnedRowLimit(returnedRowLimit)
+                    .setScannedRecordsLimit(recordScanLimit)
+                    .setFailOnScanLimitReached(false)
+                    .build());
+
+            RecordCursor<Long> cursor = new ChainedCursor<>(
+                    context,
+                    (lastKey) -> nextKey(lastKey),
+                    (key) -> Tuple.from(key).pack(),
+                    (prevContinuation) -> Tuple.fromBytes(prevContinuation).getLong(0),
+                    null,
+                    props);
+
+            int count = 0;
+            while (cursor.hasNext()) {
+                assertEquals(Long.valueOf(count), cursor.next());
+                ++count;
+            }
+
+            assertEquals(Math.min(returnedRowLimit, recordScanLimit), count);
+            assertEquals(cursor.getNoNextReason(), noNextReason);
+        }
+    }
+
+    @Test
+    public void testObeysTimeLimit() {
+        FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
+        try (FDBRecordContext context = database.openContext()) {
+            ScanProperties props = new ScanProperties(ExecuteProperties.newBuilder()
+                    .setTimeLimit(4L)
+                    .setFailOnScanLimitReached(false)
+                    .build());
+
+            RecordCursor<Long> cursor = new ChainedCursor<>(
+                    context,
+                    (lastKey) -> nextKey(lastKey).thenApply(value -> {
+                        sleep(1L);
+                        return value;
+                    }),
+                    (key) -> Tuple.from(key).pack(),
+                    (prevContinuation) -> Tuple.fromBytes(prevContinuation).getLong(0),
+                    null,
+                    props);
+
+            int count = 0;
+            while (cursor.hasNext()) {
+                assertEquals(Long.valueOf(count), cursor.next());
+                ++count;
+            }
+
+            assertEquals(cursor.getNoNextReason(), RecordCursor.NoNextReason.TIME_LIMIT_REACHED);
+            assertTrue(count < 5, "Too many values returned");
+        }
+    }
+
     private RecordCursor<Long> newCursor(byte[] continuation) {
         return new ChainedCursor<>(
                 (lastKey) -> nextKey(lastKey),
@@ -85,5 +167,13 @@ public class ChainedCursorTest {
         }
 
         return CompletableFuture.completedFuture(ret);
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
@@ -60,6 +60,7 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -545,6 +546,123 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
                 return ((DirWithMetadataWrapper) path1).metadata(context).join();
             }
         }, is(Tuple.from("new-metadata").pack()), 120, 10);
+    }
+
+    @Test
+    public void testListObeysTimeLimits() {
+        KeySpace root = new KeySpace(
+                new KeySpaceDirectory("root", KeyType.STRING, "root-" + random.nextInt(Integer.MAX_VALUE))
+                        .addSubdirectory(new KeySpaceDirectory("a", KeyType.LONG)
+                                .addSubdirectory(new KeySpaceDirectory("b", KeyType.LONG)
+                                        .addSubdirectory(new KeySpaceDirectory("c", KeyType.LONG)))));
+
+        final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
+        try (FDBRecordContext context = database.openContext()) {
+            Transaction tr = context.ensureActive();
+            for (int i = 0; i < 10; i++) {
+                for (int j = 0; j < 3; j++) {
+                    for (int k = 0; k < 5; k++) {
+                        tr.set(root.path("root")
+                                .add("a", i)
+                                .add("b", j)
+                                .add("c", k)
+                                .toTuple(context).pack(), Tuple.from(i + j).pack());
+                    }
+                }
+            }
+            tr.commit().join();
+        }
+
+        try (FDBRecordContext context = database.openContext()) {
+            // Iteration will inject a 1ms pause in each "a" value we iterate over (there are 10 of them)
+            // so we want to make the time limit long enough to make *some* progress, but short enough to
+            // to make sure we cannot get them all.
+            ScanProperties props = new ScanProperties(ExecuteProperties.newBuilder()
+                    .setFailOnScanLimitReached(false)
+                    .setTimeLimit(5L)
+                    .build());
+            RecordCursor<KeySpacePath> cursor = RecordCursor.flatMapPipelined(
+                    outerContinuation ->
+                            root.path("root").listAsync(context, "a", outerContinuation, props)
+                                    .map(value -> {
+                                        sleep(1L);
+                                        return value;
+                                    }),
+                    (aPath, innerContinuation) ->
+                            aPath.add("b", 0).listAsync(context, "c", innerContinuation, props),
+                    null,
+                    10
+            );
+
+            int count = 0;
+            while (cursor.hasNext()) {
+                cursor.next();
+                ++count;
+            }
+
+            assertEquals(RecordCursor.NoNextReason.TIME_LIMIT_REACHED, cursor.getNoNextReason());
+            // With a 1ms delay we should read no more than 5 "a" values (there are a total of 10)
+            // and each "c" value has 4 values. so we shouldn't have been able to read more than 40
+            // total values.
+            assertTrue(count <= 40, "Read too many values, query should have timed out");
+        }
+    }
+
+    @Test
+    public void testListObeysReturnedRowAndScanLimits() {
+        KeySpace root = new KeySpace(
+                new KeySpaceDirectory("root", KeyType.STRING, "root-" + random.nextInt(Integer.MAX_VALUE))
+                        .addSubdirectory(new KeySpaceDirectory("a", KeyType.LONG)
+                                .addSubdirectory(new KeySpaceDirectory("b", KeyType.LONG))));
+
+        final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
+        try (FDBRecordContext context = database.openContext()) {
+            Transaction tr = context.ensureActive();
+            for (int i = 0; i < 5; i++) {
+                for (int j = 0; j < 2; j++) {
+                    tr.set(root.path("root")
+                            .add("a", i)
+                            .add("b", j)
+                            .toTuple(context).pack(), Tuple.from(i + j).pack());
+                }
+            }
+            tr.commit().join();
+        }
+
+        doLimitedScan(database, root, 5, Integer.MAX_VALUE, RecordCursor.NoNextReason.RETURN_LIMIT_REACHED);
+        doLimitedScan(database, root, Integer.MAX_VALUE, 5, RecordCursor.NoNextReason.SCAN_LIMIT_REACHED);
+    }
+
+    private void doLimitedScan(FDBDatabase database, KeySpace root, int returnedRowLimit, int scannedRecordLimit,
+                               RecordCursor.NoNextReason noNextReason) {
+        try (FDBRecordContext context = database.openContext()) {
+            // Iteration will inject a 1ms pause in each "a" value we iterate over (there are 10 of them)
+            // so we want to make the time limit long enough to make *some* progress, but short enough to
+            // to make sure we cannot get them all.
+            ScanProperties props = new ScanProperties(ExecuteProperties.newBuilder()
+                    .setFailOnScanLimitReached(false)
+                    .setReturnedRowLimit(returnedRowLimit)
+                    .setScannedRecordsLimit(scannedRecordLimit)
+                    .build());
+            RecordCursor<KeySpacePath> cursor = root.path("root").listAsync(context, "a", null, props);
+
+            int count = 0;
+            while (cursor.hasNext()) {
+                cursor.next();
+                ++count;
+            }
+
+            assertEquals(noNextReason, cursor.getNoNextReason());
+            assertEquals(Math.min(returnedRowLimit, scannedRecordLimit), count, "Wrong number of results");
+        }
+    }
+
+    private static void sleep(long ms) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(ms);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private Function<FDBRecordContext, CompletableFuture<LocatableResolver>> getGenerator() {


### PR DESCRIPTION
The `ChainedCursor` was relyig on any cursor that it was wrapping to enfoce
scan limit (that is, if it was even wrapping a cursor at all).  The problem
was that in almost any sane use case, the cursor that it would be wrapping
is going to be asked to read only signle row at a time (see
`KeySpaceDirectory.listAsync` for an example of this), and our cursors have
the policy that they will *always* be able to make some progress.  That is,
they will allways be able to advance one element, regardless of whether
our limits have been reached.  Due to this behavior, the `ChainedCursor`
would never actually stop.  Aditionally, even if it was not wrappping
a cursor that did reads, it would never obey the time limits.

This change promotes `ChainedCursor` up to a `BaseCursor` in that it will
now do the policy enforcement of limits. It retains a way to build it in
which it will not do any enforcement (other than returned rows) if needed