### PR TITLE
Resolves #56: Add rules for planning sort-only queries as index scans.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -219,7 +219,7 @@ public interface KeyExpression extends PlanHashable, PlannerExpression {
      * @param key the whole key to check
      * @return {@code true} if {@code prefix} is a left subset of {@code key}
      */
-    boolean isPrefixKey(KeyExpression key);
+    boolean isPrefixKey(@Nonnull KeyExpression key);
 
     default boolean hasProperInterfaces() {
         return this instanceof KeyExpressionWithChildren || this instanceof KeyExpressionWithoutChildren;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
@@ -71,9 +71,13 @@ public class RecordQueryFilterPlan implements RecordQueryPlanWithChild {
     private static final Set<StoreTimer.Count> failureCounts = Collections.singleton(FDBStoreTimer.Counts.QUERY_DISCARDED);
 
     public RecordQueryFilterPlan(@Nonnull RecordQueryPlan inner, @Nonnull QueryComponent filter) {
-        this.inner = SingleExpressionRef.of(inner);
-        this.filter = SingleExpressionRef.of(filter);
-        this.children = ImmutableList.of(this.inner, this.filter);
+        this(SingleExpressionRef.of(inner), SingleExpressionRef.of(filter));
+    }
+
+    public RecordQueryFilterPlan(@Nonnull ExpressionRef<RecordQueryPlan> inner, @Nonnull ExpressionRef<QueryComponent> filter) {
+        this.inner = inner;
+        this.filter = filter;
+        this.children = ImmutableList.of(inner, filter);
     }
 
     public RecordQueryFilterPlan(@Nonnull RecordQueryPlan inner, @Nonnull List<QueryComponent> filters) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
@@ -67,7 +67,11 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
     private static final Set<StoreTimer.Count> failureCounts = Collections.singleton(FDBStoreTimer.Counts.QUERY_DISCARDED);
 
     public RecordQueryTypeFilterPlan(@Nonnull RecordQueryPlan inner, @Nonnull Collection<String> recordTypes) {
-        this.inner = SingleExpressionRef.of(inner);
+        this(SingleExpressionRef.of(inner), recordTypes);
+    }
+
+    public RecordQueryTypeFilterPlan(@Nonnull ExpressionRef<RecordQueryPlan> inner, @Nonnull Collection<String> recordTypes) {
+        this.inner = inner;
         this.recordTypes = recordTypes;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRule.java
@@ -76,6 +76,7 @@ public abstract class PlannerRule<T extends PlannerExpression> {
         this.matcher = matcher;
     }
 
+    @Nonnull
     public abstract ChangesMade onMatch(@Nonnull PlannerRuleCall call);
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
@@ -22,10 +22,13 @@ package com.apple.foundationdb.record.query.plan.temp;
 
 import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.query.plan.temp.rules.CombineFilterRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.ImplementFilterRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.FilterWithFieldWithComparisonRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.FilterWithScanRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementTypeFilterRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.PushTypeFilterBelowFilterRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.RemoveRedundantTypeFilterRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.SortToIndexRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
@@ -45,11 +48,14 @@ public class PlannerRuleSet {
     private static final List<PlannerRule<? extends PlannerExpression>> REWRITE_RULES = ImmutableList.of(
             new FilterWithScanRule(),
             new CombineFilterRule(),
+            new SortToIndexRule(),
             new FilterWithFieldWithComparisonRule(),
             new RemoveRedundantTypeFilterRule()
     );
     private static final List<PlannerRule<? extends PlannerExpression>> IMPLEMENTATION_RULES = ImmutableList.of(
-            new ImplementTypeFilterRule()
+            new ImplementTypeFilterRule(),
+            new ImplementFilterRule(),
+            new PushTypeFilterBelowFilterRule()
     );
 
     public static final PlannerRuleSet REWRITE = new PlannerRuleSet(REWRITE_RULES);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RewritePlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RewritePlanner.java
@@ -104,20 +104,19 @@ public class RewritePlanner implements QueryPlanner {
         while (!toTry.isEmpty()) {
             SingleExpressionRef<PlannerExpression> current = toTry.remove();
             PlannerRule.ChangesMade changed = applyRulesTo(ruleSet, current);
-
-            PlannerExpression currentExpression = current.get();
-            Iterator<? extends ExpressionRef<? extends PlannerExpression>> childrenIterator = currentExpression.getPlannerExpressionChildren();
-            while (childrenIterator.hasNext()) {
-                ExpressionRef<? extends PlannerExpression> child = childrenIterator.next();
-                if (child instanceof SingleExpressionRef) {
-                    toTry.add((SingleExpressionRef<PlannerExpression>) child);
-                } else {
-                    throw new RecordCoreException("invalid reference given to rewrite planner");
-                }
-            }
-
             if (changed.equals(PlannerRule.ChangesMade.MADE_CHANGES)) { // TODO optimize here
                 toTry.add(currentRoot);
+            } else {
+                PlannerExpression currentExpression = current.get();
+                Iterator<? extends ExpressionRef<? extends PlannerExpression>> childrenIterator = currentExpression.getPlannerExpressionChildren();
+                while (childrenIterator.hasNext()) {
+                    ExpressionRef<? extends PlannerExpression> child = childrenIterator.next();
+                    if (child instanceof SingleExpressionRef) {
+                        toTry.add((SingleExpressionRef<PlannerExpression>)child);
+                    } else {
+                        throw new RecordCoreException("invalid reference given to rewrite planner");
+                    }
+                }
             }
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalSortExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalSortExpression.java
@@ -1,0 +1,103 @@
+/*
+ * LogicalSortExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.expressions;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+import com.apple.foundationdb.record.query.plan.temp.SingleExpressionRef;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A relational planner expression that represents an unimplemented sort on the records produced by its inner
+ * relational planner expression.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LogicalSortExpression implements RelationalExpressionWithChildren {
+    @Nonnull
+    private final ExpressionRef<KeyExpression> sort;
+    private final boolean reverse;
+    @Nonnull
+    private final ExpressionRef<RelationalPlannerExpression> inner;
+    @Nonnull
+    private final List<ExpressionRef<? extends PlannerExpression>> expressionChildren;
+
+    public LogicalSortExpression(@Nonnull KeyExpression sort, boolean reverse, @Nonnull RelationalPlannerExpression inner) {
+        this(SingleExpressionRef.of(sort), reverse, SingleExpressionRef.of(inner));
+    }
+
+    public LogicalSortExpression(@Nonnull ExpressionRef<KeyExpression> sort, boolean reverse, @Nonnull ExpressionRef<RelationalPlannerExpression> inner) {
+        this.sort = sort;
+        this.reverse = reverse;
+        this.inner = inner;
+        this.expressionChildren = ImmutableList.of(this.sort, this.inner);
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
+        return expressionChildren.iterator();
+    }
+
+    @Override
+    public int getRelationalChildCount() {
+        return 1;
+    }
+
+    @Nonnull
+    public KeyExpression getSort() {
+        return sort.get();
+    }
+
+    public boolean isReverse() {
+        return reverse;
+    }
+
+    @Nonnull
+    public RelationalPlannerExpression getInner() {
+        return inner.get();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LogicalSortExpression that = (LogicalSortExpression)o;
+        return isReverse() == that.isReverse() &&
+               Objects.equals(getSort(), that.getSort()) &&
+               Objects.equals(getInner(), that.getInner());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getSort(), isReverse(), getInner());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
@@ -53,6 +53,7 @@ public class CombineFilterRule extends PlannerRule<LogicalFilterExpression> {
         super(root);
     }
 
+    @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
         ExpressionRef<QueryComponent> first = call.get(firstMatcher);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithFieldWithComparisonRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithFieldWithComparisonRule.java
@@ -58,6 +58,7 @@ public class FilterWithFieldWithComparisonRule extends PlannerRule<LogicalFilter
         super(root);
     }
 
+    @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
         if (!call.get(scanMatcher).hasFullRecordScan()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithFieldWithComparisonRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithFieldWithComparisonRule.java
@@ -39,6 +39,7 @@ import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -73,25 +74,41 @@ public class FilterWithFieldWithComparisonRule extends PlannerRule<LogicalFilter
             return ChangesMade.NO_CHANGE;
         }
 
+        FieldKeyExpression field = firstField(call.getContext().getCommonPrimaryKey());
+        if (field != null && Objects.equals(singleField.getFieldName(), field.getFieldName())) {
+            call.yield(SingleExpressionRef.of(new RecordQueryScanPlan(scanComparisons, false)));
+            return ChangesMade.MADE_CHANGES;
+        }
+
         for (Index index : call.getContext().getIndexes()) {
-            KeyExpression indexExpression = index.getRootExpression();
-
-            if (indexExpression instanceof ThenKeyExpression) {
-                ThenKeyExpression then = (ThenKeyExpression) indexExpression;
-                // First column will do it all or not.
-                indexExpression = then.getChildren().get(0);
-            }
-
-            if (indexExpression instanceof FieldKeyExpression) {
-                FieldKeyExpression field = (FieldKeyExpression)indexExpression;
-                if (Objects.equals(singleField.getFieldName(), field.getFieldName())) {
-                    call.yield(SingleExpressionRef.of(
-                            new RecordQueryIndexPlan(index.getName(), IndexScanType.BY_VALUE, scanComparisons, false)));
-                    return ChangesMade.MADE_CHANGES;
-                }
+            field = firstField(index.getRootExpression());
+            if (field != null && Objects.equals(singleField.getFieldName(), field.getFieldName())) {
+                call.yield(SingleExpressionRef.of(
+                        new RecordQueryIndexPlan(index.getName(), IndexScanType.BY_VALUE, scanComparisons, false)));
+                return ChangesMade.MADE_CHANGES;
             }
         }
         // couldn't find an index
         return ChangesMade.NO_CHANGE;
     }
+
+    @Nullable
+    private FieldKeyExpression firstField(@Nullable KeyExpression indexExpression) {
+        if (indexExpression == null) {
+            return null;
+        }
+
+        if (indexExpression instanceof ThenKeyExpression) {
+            ThenKeyExpression then = (ThenKeyExpression) indexExpression;
+            // First column will do it all or not.
+            indexExpression = then.getChildren().get(0);
+        }
+
+        if (indexExpression instanceof FieldKeyExpression) {
+            return (FieldKeyExpression)indexExpression;
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithScanRule.java
@@ -67,14 +67,16 @@ public class FilterWithScanRule extends PlannerRule<LogicalFilterExpression> {
         KeyExpression indexExpression = call.getContext().getIndexByName(indexScan.getIndexName()).getRootExpression();
 
         if (indexScan.getComparisons().isEmpty() &&
-                comparison.getType().equals(Comparisons.Type.EQUALS) &&
                 Key.Expressions.field(filter.getFieldName()).isPrefixKey(indexExpression)) {
-            call.yield(call.ref(new RecordQueryIndexPlan(
-                    indexScan.getIndexName(),
-                    indexScan.getScanType(),
-                    ScanComparisons.from(new Comparisons.SimpleComparison(comparison.getType(), comparison.getComparand())),
-                    indexScan.isReverse())));
-            return ChangesMade.MADE_CHANGES;
+            final ScanComparisons scanComparisons = ScanComparisons.from(comparison);
+            if (scanComparisons != null) {
+                call.yield(call.ref(new RecordQueryIndexPlan(
+                        indexScan.getIndexName(),
+                        indexScan.getScanType(),
+                        scanComparisons,
+                        indexScan.isReverse())));
+                return ChangesMade.MADE_CHANGES;
+            }
         }
         return ChangesMade.NO_CHANGE;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithScanRule.java
@@ -53,6 +53,7 @@ public class FilterWithScanRule extends PlannerRule<LogicalFilterExpression> {
         super(root);
     }
 
+    @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
         RecordQueryIndexPlan indexScan = call.get(indexScanMatcher);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
@@ -45,6 +45,7 @@ public class ImplementTypeFilterRule extends PlannerRule<LogicalTypeFilterExpres
         super(root);
     }
 
+    @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
         LogicalTypeFilterExpression typeFilter = call.get(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushTypeFilterBelowFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushTypeFilterBelowFilterRule.java
@@ -1,0 +1,67 @@
+/*
+ * PushTypeFilterBelowFilterRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.rules;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
+import com.apple.foundationdb.record.query.plan.temp.SingleExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+/**
+ * A rule that moves a {@link RecordQueryTypeFilterPlan} below a {@link RecordQueryFilterPlan}. While this doesn't make
+ * a difference in terms of plan semantics it ensures that the generated plans have the same form as those produced by
+ * the {@link com.apple.foundationdb.record.query.plan.RecordQueryPlanner}.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class PushTypeFilterBelowFilterRule extends PlannerRule<RecordQueryTypeFilterPlan> {
+    private static final ExpressionMatcher<ExpressionRef<RecordQueryPlan>> innerMatcher = ReferenceMatcher.anyRef();
+    private static final ExpressionMatcher<ExpressionRef<QueryComponent>> filterMatcher = ReferenceMatcher.anyRef();
+    private static final ExpressionMatcher<RecordQueryFilterPlan> filterPlanMatcher = TypeMatcher.of(RecordQueryFilterPlan.class,
+            innerMatcher, filterMatcher);
+    private static final ExpressionMatcher<RecordQueryTypeFilterPlan> root = TypeMatcher.of(RecordQueryTypeFilterPlan.class, filterPlanMatcher);
+
+    public PushTypeFilterBelowFilterRule() {
+        super(root);
+    }
+
+    @Nonnull
+    @Override
+    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+        final ExpressionRef<RecordQueryPlan> inner = call.get(innerMatcher);
+        final ExpressionRef<QueryComponent> filter = call.get(filterMatcher);
+        final Collection<String> recordTypes = call.get(root).getRecordTypes();
+
+        call.yield(SingleExpressionRef.of(new RecordQueryFilterPlan(
+                SingleExpressionRef.of(new RecordQueryTypeFilterPlan(inner, recordTypes)), filter)));
+        return ChangesMade.MADE_CHANGES;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveRedundantTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveRedundantTypeFilterRule.java
@@ -49,6 +49,7 @@ public class RemoveRedundantTypeFilterRule extends PlannerRule<LogicalTypeFilter
         super(root);
     }
 
+    @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
         LogicalTypeFilterExpression typeFilter = call.get(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/SortToIndexRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/SortToIndexRule.java
@@ -1,0 +1,95 @@
+/*
+ * SortToIndexRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.rules;
+
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
+import com.apple.foundationdb.record.query.plan.temp.SingleExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalSortExpression;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A rule for implementing a {@link LogicalSortExpression} as a scan of an appropriately-ordered index.
+ * There are a few things to note about how this rule currently works:
+ * <ul>
+ *     <li>
+ *         It relies on {@link KeyExpression#isPrefixKey(KeyExpression)} to do the "heavy lifting" of determining
+ *         whether or not a sort can be implemented using an index, which currently involves calling
+ *         {@link ExpressionRef#get()}. This obviously does not work if the {@code ExpressionRef} is not gettable
+ *         (for example, if it were a group).
+ *     </li>
+ *     <li>
+ *         It will plan the sort using the first index with an appropriate ordering.
+ *     </li>
+ * </ul>
+ * Ths first of these details will definitely change as the planner improves.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class SortToIndexRule extends PlannerRule<LogicalSortExpression> {
+    private static final ExpressionMatcher<RecordQueryScanPlan> innerMatcher = TypeMatcher.of(RecordQueryScanPlan.class);
+    private static final ExpressionMatcher<KeyExpression> sortMatcher = TypeMatcher.of(KeyExpression.class);
+    private static final ExpressionMatcher<LogicalSortExpression> root = TypeMatcher.of(LogicalSortExpression.class,
+            sortMatcher, innerMatcher);
+
+    public SortToIndexRule() {
+        super(root);
+    }
+
+    @Nonnull
+    @Override
+    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+        final RecordQueryScanPlan inner = call.get(innerMatcher);
+        final KeyExpression requestedSort = call.get(sortMatcher);
+        final boolean reverse = call.get(root).isReverse();
+
+        if (!inner.hasFullRecordScan()) {
+            //scan is somehow already implemented. Not safe to convert to index scan.
+            return ChangesMade.NO_CHANGE;
+        }
+
+        final KeyExpression primaryKey = call.getContext().getCommonPrimaryKey();
+        if (primaryKey != null && requestedSort.isPrefixKey(primaryKey)) {
+            call.yield(SingleExpressionRef.of(new RecordQueryScanPlan(ScanComparisons.EMPTY, reverse)));
+            return ChangesMade.MADE_CHANGES;
+        }
+
+        for (Index index : call.getContext().getIndexes()) {
+            if (requestedSort.isPrefixKey(index.getRootExpression())) {
+                call.yield(SingleExpressionRef.of(new RecordQueryIndexPlan(index.getName(), IndexScanType.BY_VALUE, ScanComparisons.EMPTY, reverse)));
+                return ChangesMade.MADE_CHANGES;
+            }
+        }
+
+        return ChangesMade.NO_CHANGE;
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/DualPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/DualPlannerTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -34,5 +35,7 @@ import java.lang.annotation.Target;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
+@ExtendWith(DualPlannerExtension.class)
 public @interface DualPlannerTest {
+
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
@@ -64,7 +64,7 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that sorting by a common field on a universal index returns all types of records in an index scan.
      */
-    @Test
+    @DualPlannerTest
     public void testCrossRecordTypeQuery() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
@@ -114,7 +114,7 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
      * Verify that multi-type record queries can scan multi-type indexes.
      * Verify that single-type record queries can scan multi-type indexes with a type filter.
      */
-    @Test
+    @DualPlannerTest
     public void testMultiRecordTypeIndexScan() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
@@ -258,7 +258,7 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that filtering by a field on a universal index works.
      */
-    @Test
+    @DualPlannerTest
     public void testCrossRecordTypeQueryFiltered() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -193,7 +193,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
     // Proto 2 or syntax = proto2 in Proto 3 generates hasXXX for scalar fields and so reliably distinguishes
     // missing values.
-    @Test
+    @DualPlannerTest
     public void testProto2() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, proto2MetaData());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
@@ -49,7 +49,6 @@ import com.google.protobuf.Message;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,7 +87,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  * {@link com.apple.foundationdb.record.provider.foundationdb.query}.
  */
 @Tag(Tags.RequiresFDB)
-@ExtendWith(DualPlannerExtension.class)
 public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     @DualPlannerTest
     public void query() throws Exception {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
@@ -205,7 +205,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that simple queries execute properly with continuations.
      */
-    @Test
+    @DualPlannerTest
     public void queryWithContinuation() throws Exception {
         setupSimpleRecordStore(null, (i, builder) -> {
             builder.setRecNo(i);
@@ -417,7 +417,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that a record scan can implement a filter on the primary key.
      */
-    @Test
+    @DualPlannerTest
     public void testPartialRecordScan() throws Exception {
         RecordMetaDataHook hook = complexPrimaryKeyHook();
         complexQuerySetup(hook);
@@ -435,7 +435,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that enum field indexes are used.
      */
-    @Test
+    @DualPlannerTest
     public void enumFields() throws Exception {
         RecordMetaDataHook hook = metaData -> {
             final RecordTypeBuilder type = metaData.getRecordType("MyShapeRecord");
@@ -471,7 +471,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Test
+    @DualPlannerTest
     public void nullQuery() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
@@ -548,7 +548,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
      * Verify that complex queries on multiple types with uncommon primary keys are implemented, but only with record
      * scans, type filters, and filters.
      */
-    @Test
+    @DualPlannerTest
     public void testUncommonPrimaryKey() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openMultiRecordStore(context);
@@ -627,7 +627,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that null is excluded from an index scan.
      */
-    @Test
+    @DualPlannerTest
     public void queryExcludeNull() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
@@ -690,7 +690,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
         });
     }
 
-    @Test
+    @DualPlannerTest
     public void uuidPrimaryKey() throws Exception {
         try (FDBRecordContext context = openContext()) {
             final List<UUID> uuids = setupTupleFields(context);
@@ -711,7 +711,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Test
+    @DualPlannerTest
     public void nullableInt32() throws Exception {
         try (FDBRecordContext context = openContext()) {
             final List<UUID> uuids = setupTupleFields(context);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBReturnedRecordLimitQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBReturnedRecordLimitQueryTest.java
@@ -66,7 +66,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
      * Verify that a returned record limit works properly against a query with a filter on one field and a sort on another,
      * when the filter field is un-indexed and the sort is in reverse order.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexLimits2() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -102,7 +102,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
     /**
      * Verify that a returned record limit works properly against a filter on an un-indexed field.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexLimits3() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -134,7 +134,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
     /**
      * Verify that a returned record limit works properly with type filters.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexLimits6() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -163,7 +163,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
      * Verify that a returned record limit works properly when no filter is needed.
      * Verify that a type filter that is trivially satisfied is elided from the final plan.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexLimits7() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
@@ -121,7 +121,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
     /**
      * Verify that simple sorts are implemented using index scans.
      */
-    @Test
+    @DualPlannerTest
     public void sort() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
@@ -162,6 +162,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
     /**
      * Verify that if the sort matches an index that can satisfy a filter that the index is used.
      */
+    @DualPlannerTest
     @ParameterizedTest
     @MethodSource("hooks")
     public void sortWithScannableFilterOnIndex(RecordMetaDataHook hook, PlannableIndexTypes indexTypes) throws Exception {
@@ -194,6 +195,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
      * of a filter (because that comparison cannot be accomplished with a scan) that the index
      * is still used solely to accomplish sorting.
      */
+    @DualPlannerTest
     @ParameterizedTest
     @MethodSource("hooks")
     public void sortWithNonScannableFilterOnIndex(RecordMetaDataHook hook, PlannableIndexTypes indexTypes) throws Exception {
@@ -261,6 +263,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
     /**
      * Verify that we can sort by the primary key if possible.
      */
+    @DualPlannerTest
     @ParameterizedTest(name = "sortByPrimaryKey() [{0}]")
     @EnumSource(TestHelpers.BooleanEnum.class)
     public void sortByPrimaryKey(TestHelpers.BooleanEnum reverse) throws Exception {
@@ -428,7 +431,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
     /**
      * Verify that a sort is implemented using an appropriate index.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexQuery5() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -460,7 +463,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
     /**
      * Verify that a sort can be implemented by traversing an index in the reverse order.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexQuery5r() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -494,7 +497,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
      * Verify that a query with a filter on one field and a sort on another uses the index of the sort preferentially,
      * and falls back to filtering to implement the filter if an appropriate multi-field index is not available.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexQuery8x() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -528,7 +531,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
     /**
      * Verify that reverse sorts can be implemented by a reverse index scan.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexLimits1() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -743,7 +746,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
      * Verify that the planner does not accept sorts on multiple record types with uncommon primary keys, even when a
      * multi-field index exists.
      */
-    @Test
+    @DualPlannerTest
     public void testUncommonMultiIndex() throws Exception {
         assertThrows(RecordCoreException.class, () -> {
             try (FDBRecordContext context = openContext()) {


### PR DESCRIPTION
Adds a variety of rules for planning sorts as index scans. With some minor modifications, this also supports pushing down filters that can be satisfied by the same index to the index scan level using the methods in `ScanComparisons`. As a result, a sizeable number of our current planning tests now pass against the experimental planner. Also fix some bugs in the implementation of phasing in the `RewritePlanner`.

I took a major shortcut in implementing this by using the existing `KeyExpression.isPrefixKey()` method rather than writing one that can properly deal with `ExpressionRef`s that aren't `get()`-able (like groups). This is fine for now but we'll have to deal with it at some point (and it's pretty annoying).

Lastly, the `DualPlannerExtension` required some crazy hijinks to make it play nicely with the `ParameterizedTestExtension`. I know it isn't pretty but it works. :)