### PR TITLE
Resolves #281: Add some convenience APIs to FDBMetaDataStore

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -57,6 +57,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** `FDBMetaDataStore` class now has convenience methods for `addIndex`, `dropIndex` and `updateRecords` [(Issue #281)](https://github.com/FoundationDB/fdb-record-layer/issues/281)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/RecordTypeBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/RecordTypeBuilder.java
@@ -65,6 +65,21 @@ public class RecordTypeBuilder implements RecordTypeOrBuilder {
         this.multiTypeIndexes = new ArrayList<>();
     }
 
+    /**
+     * Copy constructor for {@code RecordTypeBuilder} that copies all fields except the descriptor.
+     * @param descriptor the descriptor of the new record type
+     * @param other the record type builder to copy from
+     */
+    public RecordTypeBuilder(@Nonnull Descriptors.Descriptor descriptor, @Nonnull RecordTypeBuilder other) {
+        this.descriptor = descriptor;
+        this.name = other.name;
+        this.indexes = other.indexes;
+        this.multiTypeIndexes = other.multiTypeIndexes;
+        this.primaryKey = other.primaryKey;
+        this.recordTypeKey = other.recordTypeKey;
+        this.sinceVersion = other.sinceVersion;
+    }
+
     @Override
     @Nonnull
     public String getName() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -248,6 +248,12 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_REVERSE_DIRECTORY_LOCATE("wait for finding reverse directory location"),
         /** Wait for an {@link IndexOperation} to complete. */
         WAIT_INDEX_OPERATION("wait for index operation"),
+        /** Wait for adding an index. */
+        WAIT_ADD_INDEX("wait for adding an index"),
+        /** Wait for dropping an index. */
+        WAIT_DROP_INDEX("wait for dropping an index"),
+        /** Wait for updating records descriptor. */
+        WAIT_UPDATE_RECORDS_DESCRIPTOR("wait for updating the records descriptor"),
         /**
          * Wait for the updated version stamp from a committed transaction.
          * This future should normally be completed already, so this is mainly for error checking.

--- a/fdb-record-layer-core/src/test/proto/test_records_1_evolved_again.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_1_evolved_again.proto
@@ -1,0 +1,62 @@
+/*
+ * test_records_1_evolved_again.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.test1evolvedagain;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecords1EvolvedAgainProto";
+
+import "record_metadata_options.proto";
+
+option (schema).store_record_versions = true;
+
+message MySimpleRecord {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  optional string str_value_indexed = 2 [(field).index = {}];
+  optional int32 num_value_unique = 3 [(field).index = { unique: true }];
+  optional int32 num_value_2 = 4;
+  optional int32 num_value_3_indexed = 5 [(field).index = {}];
+  repeated int32 repeater = 6;
+}
+
+message MyOtherRecord {
+  required int64 rec_no = 1 [(field).primary_key = true];
+  optional int32 num_value_2 = 4;
+  optional int32 num_value_3_indexed = 5;
+}
+
+message AnotherRecord {
+  required int64 rec_no = 1 [(field).primary_key = true];
+  optional int32 num_value_2 = 4;
+  optional int32 num_value_3_indexed = 5 [(field).index = { unique: true }];
+  optional int32 num_value_4 = 6;
+}
+
+message OneMoreRecord {
+  required int64 rec_no = 1 [(field).primary_key = true];
+}
+
+message RecordTypeUnion {
+  optional MySimpleRecord _MySimpleRecord = 1;
+  optional MyOtherRecord _MyOtherRecord = 2;
+  optional AnotherRecord _AnotherRecord = 3;
+  optional OneMoreRecord _OneMoreRecord = 4;
+}


### PR DESCRIPTION
This change adds addIndex, dropIndex and updateRecords to FDBMetaDataStore.
Implementing addIndex and dropIndex is fairly straightforward. For updateRecords,
we decided to add the following two functionalities to RecordMetaDataBuilder:
- Add new record types and process extensions for them if user asks for it.
- Update the descriptors of the existing unionFields and record types.