### PR TITLE
Fixes #380: TimeLimitedCursor attempts to set a bad NO_NEXT_REASON if exhausted at timeout

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -46,6 +46,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** `FDBRecordStore.IndexUniquenessCheck.check` needs to be async [(Issue #357)](https://github.com/FoundationDB/fdb-record-layer/issues/357)
+* **Bug fix** The `TimeLimitedCursor` could throw an error when setting its result's `NoNextReason` if the inner cursor was exhausted exactly as the time limit was reached [(Issue #380)](https://github.com/FoundationDB/fdb-record-layer/issues/380)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
@@ -485,7 +485,7 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
      * Get a new cursor that will only return records up to the specified time limit (in milliseconds).
      * @param timeLimit the maximum number of milliseconds to run
      * @return a new cursor that stops early if {@code timeLimit} is exceeded
-     * @deprecated in favour of a {@link TimeScanLimiter} as part of every {@link com.apple.foundationdb.record.cursors.BaseCursor}
+     * @deprecated in favor of a {@link TimeScanLimiter} as part of every {@link com.apple.foundationdb.record.cursors.BaseCursor}
      */
     @Deprecated
     @Nonnull
@@ -498,7 +498,7 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
      * @param timeStartingFrom the starting time from which to measure the time limit
      * @param timeLimit the maximum number of milliseconds to run 
      * @return a new cursor that stops early when {@code timeLimit} after {@code timeStartingFrom} is reached
-     * @deprecated in favour of a {@link TimeScanLimiter} as part of every {@link com.apple.foundationdb.record.cursors.BaseCursor}
+     * @deprecated in favor of a {@link TimeScanLimiter} as part of every {@link com.apple.foundationdb.record.cursors.BaseCursor}
      */
     @Deprecated
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/TimeLimitedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/TimeLimitedCursor.java
@@ -88,7 +88,11 @@ public class TimeLimitedCursor<T> implements RecordCursor<T> {
                                     "cursorElapsedMillis", (now - startTime),
                                     "cursorTimeLimitMillis", timeLimitMillis));
                         }
-                        timedOutResult = RecordCursorResult.withoutNextValue(innerResult.getContinuation(), NoNextReason.TIME_LIMIT_REACHED);
+                        if (innerResult.getContinuation().isEnd()) {
+                            timedOutResult = RecordCursorResult.exhausted();
+                        } else {
+                            timedOutResult = RecordCursorResult.withoutNextValue(innerResult.getContinuation(), NoNextReason.TIME_LIMIT_REACHED);
+                        }
                     }
                 }
                 nextResult = innerResult;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/TimeLimitedCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/TimeLimitedCursorTest.java
@@ -1,0 +1,71 @@
+/*
+ * TimeLimitedCursorTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.cursors;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests of the {@link TimeLimitedCursor}.
+ */
+public class TimeLimitedCursorTest {
+
+    @Test
+    public void exhaustedWhenTimeLimited() throws ExecutionException, InterruptedException {
+        TimeLimitedCursor<Object> cursor = new TimeLimitedCursor<>(RecordCursor.empty(), System.currentTimeMillis() - 200, 100);
+        RecordCursorResult<Object> cursorResult = cursor.onNext().get();
+        assertThat(cursorResult.hasNext(), is(false));
+        assertThat(cursorResult.getContinuation().isEnd(), is(true));
+        assertNull(cursorResult.getContinuation().toBytes());
+        assertEquals(RecordCursor.NoNextReason.SOURCE_EXHAUSTED, cursorResult.getNoNextReason());
+    }
+
+    @Test
+    public void singleResult() throws ExecutionException, InterruptedException {
+        TimeLimitedCursor<Integer> cursor = new TimeLimitedCursor<>(RecordCursor.fromList(Arrays.asList(1, 2)), System.currentTimeMillis() - 200, 100);
+        RecordCursorResult<Integer> cursorResult = cursor.onNext().get();
+        assertThat(cursorResult.hasNext(), is(true));
+        assertEquals(1, (int)cursorResult.get());
+        final RecordCursorContinuation continuation = cursorResult.getContinuation();
+        cursorResult = cursor.onNext().get();
+        assertThat(cursorResult.hasNext(), is(false));
+        assertEquals(RecordCursor.NoNextReason.TIME_LIMIT_REACHED, cursorResult.getNoNextReason());
+        assertThat(cursorResult.getContinuation().isEnd(), is(false));
+        assertNotNull(cursorResult.getContinuation().toBytes());
+        assertArrayEquals(continuation.toBytes(), cursorResult.getContinuation().toBytes());
+
+        RecordCursor<Integer> resumedCursor = RecordCursor.fromList(Arrays.asList(1, 2), cursor.getContinuation());
+        assertEquals(2, (int)resumedCursor.onNext().get().get());
+        assertThat(resumedCursor.onNext().get().hasNext(), is(false));
+    }
+}


### PR DESCRIPTION
This makes it so that a `TimeLimitedCursor` first checks to see if the inner cursor has been exhausted before deciding on a `NoNextReason` for its child result. In particular, if the inner cursor's last result is an end continuation, the `TimeLimitedCursor` is itself exhausted and returns `RecordCursor.exhausted()` as its result. Otherwise, it returns an empty result with `TIME_LIMIT_REACHED` as the final result (as before).

I don't think the new `ScanTimeLimiter` has this same pathology as its mechanism for propagating up the scan limit reason is different. I haven't validated this though through experimentation.