### PR TITLE
Resolves #356: Add limit on the size of the DNF during normalization.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -70,6 +70,9 @@ public enum LogMessageKeys {
     PARENT_FILTER("parent_filter"),
     CHILD_FILTER("child_filter"),
     OTHER_FILTER("other_filter"),
+    // Boolean normalization
+    DNF_SIZE("dnf_size"),
+    DNF_SIZE_LIMIT("dnf_size_limit"),
     // index-related keys
     INDEX_NAME("index_name"),
     VALUE_KEY("value_key"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -188,7 +188,8 @@ public class RecordQueryPlanner implements QueryPlanner {
 
         final PlanContext planContext = getPlanContext(query);
 
-        final QueryComponent filter = BooleanNormalizer.normalize(query.getFilter());
+        final BooleanNormalizer normalizer = BooleanNormalizer.withLimit(complexityThreshold);
+        final QueryComponent filter = normalizer.normalizeIfPossible(query.getFilter());
         final KeyExpression sort = query.getSort();
         final boolean sortReverse = query.isSortReverse();
 
@@ -1444,7 +1445,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             indexExpr = EmptyKeyExpression.EMPTY;
         }
         final ScoredPlan scoredPlan = planCandidateScan(candidateScan, indexExpr,
-                BooleanNormalizer.normalize(query.getFilter()), query.getSort());
+                BooleanNormalizer.withLimit(complexityThreshold).normalizeIfPossible(query.getFilter()), query.getSort());
         // It would be possible to handle unsatisfiedFilters if they, too, only involved group key (covering) fields.
         if (scoredPlan == null || !scoredPlan.unsatisfiedFilters.isEmpty() || !(scoredPlan.plan instanceof RecordQueryIndexPlan)) {
             return null;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -1279,7 +1279,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     @Nonnull
     private List<Long> querySimpleDocumentsWithScan(@Nonnull QueryComponent filter, int planHash) throws InterruptedException, ExecutionException {
         return queryDocuments(Collections.singletonList(SIMPLE_DOC), Collections.singletonList(field("doc_id")), filter, planHash,
-                    filter(equalTo(BooleanNormalizer.normalize(filter)), typeFilter(contains(SIMPLE_DOC), PlanMatchers.scan(bounds(unbounded())))))
+                    filter(equalTo(BooleanNormalizer.getDefaultInstance().normalize(filter)), typeFilter(contains(SIMPLE_DOC), PlanMatchers.scan(bounds(unbounded())))))
                 .map(t -> t.getLong(0))
                 .asList()
                 .get();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/planning/BooleanNormalizerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/planning/BooleanNormalizerTest.java
@@ -21,13 +21,22 @@
 package com.apple.foundationdb.record.query.plan.planning;
 
 import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.query.expressions.OrComponent;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link BooleanNormalizer}.
@@ -46,56 +55,125 @@ public class BooleanNormalizerTest {
 
     @Test
     public void atomic() {
-        assertFilterEquals(P1, BooleanNormalizer.normalize(P1));
-        assertFilterEquals(Query.not(P1), BooleanNormalizer.normalize(Query.not(P1)));
+        assertExpectedNormalization(P1, P1);
+        assertExpectedNormalization(Query.not(P1), Query.not(P1));
 
-        assertFilterEquals(PNested, BooleanNormalizer.normalize(PNested));
-        assertFilterEquals(POneOf, BooleanNormalizer.normalize(POneOf));
-        assertFilterEquals(PRank, BooleanNormalizer.normalize(PRank));
+        assertExpectedNormalization(PNested, PNested);
+        assertExpectedNormalization(POneOf, POneOf);
+        assertExpectedNormalization(PRank, PRank);
     }
     
     @Test
     public void flatten() {
-        assertFilterEquals(Query.and(P1, P2, P3),
-                BooleanNormalizer.normalize(Query.and(Query.and(P1, P2), P3)));
-        assertFilterEquals(Query.and(P1, P2, P3),
-                BooleanNormalizer.normalize(Query.and(P1, Query.and(P2, P3))));
-        assertFilterEquals(Query.and(P1, P2, P3, P4, P5),
-                BooleanNormalizer.normalize(Query.and(P1, Query.and(P2, Query.and(P3, Query.and(P4, P5))))));
-        assertFilterEquals(Query.and(P1, P2, P3, P4, P5),
-                BooleanNormalizer.normalize(Query.and(Query.and(Query.and(Query.and(P1, P2), P3), P4), P5)));
-        assertFilterEquals(Query.or(P1, P2, P3),
-                BooleanNormalizer.normalize(Query.or(Query.or(P1, P2), P3)));
-        assertFilterEquals(Query.or(P1, P2, P3),
-                BooleanNormalizer.normalize(Query.or(P1, Query.or(P2, P3))));
+        assertExpectedNormalization(Query.and(P1, P2, P3),
+                Query.and(Query.and(P1, P2), P3));
+        assertExpectedNormalization(Query.and(P1, P2, P3),
+                Query.and(P1, Query.and(P2, P3)));
+        assertExpectedNormalization(Query.and(P1, P2, P3, P4, P5),
+                Query.and(P1, Query.and(P2, Query.and(P3, Query.and(P4, P5)))));
+        assertExpectedNormalization(Query.and(P1, P2, P3, P4, P5),
+                Query.and(Query.and(Query.and(Query.and(P1, P2), P3), P4), P5));
+        assertExpectedNormalization(Query.or(P1, P2, P3),
+                Query.or(Query.or(P1, P2), P3));
+        assertExpectedNormalization(Query.or(P1, P2, P3),
+                Query.or(P1, Query.or(P2, P3)));
     }
 
     @Test
     public void distribute() {
-        assertFilterEquals(Query.or(Query.and(P1, P2), Query.and(P3, P4)),
-                BooleanNormalizer.normalize(Query.or(Query.and(P1, P2), Query.and(P3, P4))));
-        assertFilterEquals(Query.or(Query.and(P1, P2), Query.and(P1, P3)),
-                BooleanNormalizer.normalize(Query.and(P1, Query.or(P2, P3))));
-        assertFilterEquals(Query.or(Query.and(P1, P3), Query.and(P2, P3), Query.and(P1, P4), Query.and(P2, P4)),
-                BooleanNormalizer.normalize(Query.and(Query.or(P1, P2), Query.or(P3, P4))));
+        assertExpectedNormalization(Query.or(Query.and(P1, P2), Query.and(P3, P4)),
+                Query.or(Query.and(P1, P2), Query.and(P3, P4)));
+        assertExpectedNormalization(Query.or(Query.and(P1, P2), Query.and(P1, P3)),
+                Query.and(P1, Query.or(P2, P3)));
+        assertExpectedNormalization(Query.or(Query.and(P1, P3), Query.and(P2, P3), Query.and(P1, P4), Query.and(P2, P4)),
+                Query.and(Query.or(P1, P2), Query.or(P3, P4)));
     }
 
     @Test
     public void deMorgan() {
-        assertFilterEquals(Query.or(Query.not(P1), Query.not(P2)),
-                BooleanNormalizer.normalize(Query.not(Query.and(P1, P2))));
-        assertFilterEquals(Query.and(Query.not(P1), Query.not(P2)),
-                BooleanNormalizer.normalize(Query.not(Query.or(P1, P2))));
+        assertExpectedNormalization(Query.or(Query.not(P1), Query.not(P2)),
+                Query.not(Query.and(P1, P2)));
+        assertExpectedNormalization(Query.and(Query.not(P1), Query.not(P2)),
+                Query.not(Query.or(P1, P2)));
     }
 
     @Test
     public void complex() {
-        assertFilterEquals(Query.or(Query.and(P1, Query.not(P2)), Query.and(P1, Query.not(P3), Query.not(P4))),
-                BooleanNormalizer.normalize(Query.and(P1, Query.not(Query.and(P2, Query.or(P3, P4))))));
+        assertExpectedNormalization(Query.or(Query.and(P1, Query.not(P2)), Query.and(P1, Query.not(P3), Query.not(P4))),
+                Query.and(P1, Query.not(Query.and(P2, Query.or(P3, P4)))));
+    }
+
+    @Test
+    public void cnf() {
+        List<QueryComponent> conjuncts = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            List<QueryComponent> disjuncts = new ArrayList<>();
+            for (int j = 0; j < 5; j++) {
+                disjuncts.add(Query.field("f").equalsValue(i * 4 + j));
+            }
+            conjuncts.add(Query.or(disjuncts));
+        }
+        final QueryComponent cnf = Query.and(conjuncts);
+
+        final BooleanNormalizer normalizer = BooleanNormalizer.getDefaultInstance();
+        assertNotEquals(cnf, normalizer.normalize(cnf));
+        assertEquals(numberOfTerms(normalizer.normalize(cnf)), normalizer.getNormalizedSize(cnf));
+
+        final BooleanNormalizer lowLimitNormalizer = BooleanNormalizer.withLimit(2);
+        assertThrows(BooleanNormalizer.DNFTooLargeException.class, () -> lowLimitNormalizer.normalize(cnf));
+        assertEquals(cnf, lowLimitNormalizer.normalizeIfPossible(cnf));
+    }
+
+    @Test
+    public void bigNonCnf() {
+        final QueryComponent cnf = Query.and(
+                IntStream.rangeClosed(1, 9).boxed().map(i ->
+                        Query.or(IntStream.rangeClosed(1, 9).boxed()
+                                .map(j -> Query.and(
+                                        Query.field("num_value_3_indexed").equalsValue(i * 9 + j),
+                                        Query.field("str_value_indexed").equalsValue("foo")))
+                                .collect(Collectors.toList())))
+                        .collect(Collectors.toList()));
+        final BooleanNormalizer lowLimitNormalizer = BooleanNormalizer.withLimit(RecordQueryPlanner.DEFAULT_COMPLEXITY_THRESHOLD);
+        assertThrows(BooleanNormalizer.DNFTooLargeException.class, () -> lowLimitNormalizer.normalize(cnf));
+        assertEquals(cnf, lowLimitNormalizer.normalizeIfPossible(cnf));
+    }
+
+    @Test
+    public void bigCnfThatWouldOverflow() {
+        // A CNF who's DNF size doesn't fit in an int.
+        List<QueryComponent> conjuncts = new ArrayList<>();
+        for (int i = 0; i < 32; i++) {
+            List<QueryComponent> disjuncts = new ArrayList<>();
+            for (int j = 0; j < 2; j++) {
+                disjuncts.add(Query.field("f").equalsValue(i * 100 + j));
+            }
+            conjuncts.add(Query.or(disjuncts));
+        }
+        final QueryComponent cnf = Query.and(conjuncts);
+        final BooleanNormalizer normalizer = BooleanNormalizer.getDefaultInstance();
+        assertThrows(ArithmeticException.class, () -> normalizer.getNormalizedSize(cnf));
+        assertThrows(BooleanNormalizer.DNFTooLargeException.class, () -> normalizer.normalize(cnf));
+        assertEquals(cnf, normalizer.normalizeIfPossible(cnf));
+    }
+
+    protected static void assertExpectedNormalization(@Nonnull final QueryComponent expected, @Nonnull final QueryComponent given) {
+        final BooleanNormalizer normalizer = BooleanNormalizer.getDefaultInstance();
+        final QueryComponent normalized = normalizer.normalize(given);
+        assertFilterEquals(expected, normalized);
+        assertEquals(numberOfTerms(expected), normalizer.getNormalizedSize(given));
     }
 
     // Query components do not implement equals, but they have distinctive enough printed representations.
     protected static void assertFilterEquals(@Nonnull final QueryComponent expected, @Nonnull final QueryComponent actual) {
         assertEquals(expected.toString(), actual.toString());
+    }
+
+    private static int numberOfTerms(@Nonnull final QueryComponent predicate) {
+        if (predicate instanceof OrComponent) {
+            return ((OrComponent)predicate).getChildren().size();
+        } else {
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
Currently, the `RecordQueryPlanner` tries to normalize Boolean predicates into disjunctive normal form. The DNF of some expressions can be exponentially larger than the given form; in the worst case, this can cause out-of-memory errors. This adds a limit to the Boolean normalizer so that it will not attempt to normalize expressions with a DNF size larger than the limit, using methods which determine the size of the DNF without computing it.

I think the main points of potential controversy here are:
- The size metric. I used the common definition of the size of a DNF (i.e., the number of terms in the disjunction). This is convenient because it's cheap to compute and differs from the total number of leafs in the expression tree by at most a factor of the number of literals.
- How the size limit gets passed to the normalizer. I used the existing plan complexity limit that we already pass to the planner. The argument here is that we mostly normalize so we can produce union plans and so there's no point in producing a DNF that would produce a union that's too big to pass the complexity limit. I don't think this especially needs to be configurable since it's very much a planner implementation detail.