### PR TITLE
Fixes #395: AsyncLoadingCache can cache exceptional futures

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `AsyncLoadingCache` could cache exceptional futures in rare scenarios [(Issue #395)](https://github.com/FoundationDB/fdb-record-layer/issues/395)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AsyncLoadingCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AsyncLoadingCache.java
@@ -65,12 +65,11 @@ public class AsyncLoadingCache<K, V> {
      */
     public CompletableFuture<V> orElseGet(@Nonnull K key, @Nonnull Supplier<CompletableFuture<V>> supplier) {
         try {
-            return cache.get(key, () -> MoreAsyncUtil.getWithDeadline(deadlineTimeMillis, supplier)
-                    .whenComplete((ignored, e) -> {
-                        if (e != null) {
-                            cache.invalidate(key);
-                        }
-                    }));
+            return cache.get(key, () -> MoreAsyncUtil.getWithDeadline(deadlineTimeMillis, supplier)).whenComplete((ignored, e) -> {
+                if (e != null) {
+                    cache.invalidate(key);
+                }
+            });
         } catch (Exception e) {
             throw new RecordCoreException("failed getting value", e).addLogInfo("cacheKey", key);
         }


### PR DESCRIPTION
There was a possibility that an exceptionally completing future was added to the cache *after* it's async callback tried to invalidate it. This protects against this by first adding the future to the cache regardless of whether the result is exceptional or not and then adds the callback. This means that the callback gets added to some extra futures (in particular, it get's added to any future that was already in the cache), which is a little unfortunate. There are slightly more sophisticated ways around that that involve checking for done-ness from the future.

This was caught (intermittently) by an existing test, but I added an additional test to more reliably reproduce it.