### PR TITLE
Resolves #397: Add AutoContinuingCursor to chain cursors across transactions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -56,7 +56,7 @@ Methods for retrieving a record from a record store based on an index entry gene
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** A new cursor type `AutoContinuingCursor` which can iterate over a cursor across transactions [(Issue #397)](https://github.com/FoundationDB/fdb-record-layer/issues/397)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
@@ -201,10 +201,10 @@ public class RecordCursorResult<T> {
     }
 
     /**
-     * Returns true if the cursor has reached its end but a continuation is still available (i.e. the source is not yet exhausted).
-     * @return {@code true} if this result does not include a next value but include a continuation and {@code false} otherwise
+     * Returns {@code true} if the cursor has reached its end but a continuation is not an end continuation. (i.e. the source is not yet exhausted).
+     * @return {@code true} if the cursor has reached its end but a continuation is not an end continuation and {@code false} otherwise
      */
-    public boolean noNextButHasContinuation() {
+    public boolean hasStoppedBeforeEnd() {
         return !hasNext && !continuation.isEnd();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
@@ -201,6 +201,14 @@ public class RecordCursorResult<T> {
     }
 
     /**
+     * Return whether or not this result does not include a next value but include a continuation (i.e. source is not exhausted).
+     * @return {@code true} if this result does not include a next value but include a continuation and {@code false} otherwise
+     */
+    public boolean noNextButHasContinuation() {
+        return !hasNext && !continuation.isEnd();
+    }
+
+    /**
      * Create a new {@code RecordCursorResult} that has a value, using the given value and continuation.
      * @param nextValue the value of the result
      * @param continuation the continuation of the result

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorResult.java
@@ -201,7 +201,7 @@ public class RecordCursorResult<T> {
     }
 
     /**
-     * Return whether or not this result does not include a next value but include a continuation (i.e. source is not exhausted).
+     * Returns true if the cursor has reached its end but a continuation is still available (i.e. the source is not yet exhausted).
      * @return {@code true} if this result does not include a next value but include a continuation and {@code false} otherwise
      */
     public boolean noNextButHasContinuation() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/AutoContinuingCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/AutoContinuingCursor.java
@@ -69,7 +69,7 @@ import java.util.function.BiFunction;
  * @param <T> the type of elements returned by this cursor
  */
 @API(API.Status.EXPERIMENTAL)
-public class AutoContinuingCursor<T> implements BaseCursor<T> {
+public class AutoContinuingCursor<T> implements RecordCursor<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AutoContinuingCursor.class);
 
     @Nonnull
@@ -184,7 +184,9 @@ public class AutoContinuingCursor<T> implements BaseCursor<T> {
 
     @Override
     public boolean accept(@Nonnull RecordCursorVisitor visitor) {
-        visitor.visitEnter(this);
+        if (visitor.visitEnter(this) && currentCursor != null) {
+            currentCursor.accept(visitor);
+        }
         return visitor.visitLeave(this);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/AutoContinuingCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/AutoContinuingCursor.java
@@ -1,0 +1,153 @@
+/*
+ * AutoContinuingCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.cursors;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+
+/**
+ * A wrapper for a cursor to iterate across multiple transactions.
+ * @param <T> the type of elements returned by this cursor
+ */
+@API(API.Status.EXPERIMENTAL)
+public class AutoContinuingCursor<T> implements BaseCursor<T> {
+
+    @Nonnull
+    private FDBDatabaseRunner runner;
+    @Nonnull
+    private BiFunction<FDBRecordContext, byte[], RecordCursor<T>> nextCursorGenerator;
+
+    @Nullable
+    RecordCursor<T> currentCursor;
+    @Nullable
+    FDBRecordContext currentContext;
+
+    @Nullable
+    private CompletableFuture<Boolean> nextFuture;
+    @Nullable
+    private RecordCursorResult<T> lastResult;
+
+    // for detecting incorrect cursor usage
+    private boolean mayGetContinuation = false;
+
+    public AutoContinuingCursor(@Nonnull FDBDatabaseRunner runner,
+                                @Nonnull BiFunction<FDBRecordContext, byte[], RecordCursor<T>> nextCursorGenerator) {
+        this.runner = runner;
+        this.nextCursorGenerator = nextCursorGenerator;
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<RecordCursorResult<T>> onNext() {
+        if (currentCursor == null) {
+            openContextAndGenerateCursor(null);
+        }
+        return currentCursor.onNext().thenCompose(recordCursorResult -> {
+            if (recordCursorResult.noNextButHasContinuation()) {
+                currentContext.close();
+                openContextAndGenerateCursor(lastResult.getContinuation().toBytes());
+                return currentCursor.onNext().thenApply(finalRecordCursorResult -> {
+                    if (finalRecordCursorResult.noNextButHasContinuation()) {
+                        throw new RecordCoreException("failed to continue the cursor in a new context");
+                    }
+                    lastResult = finalRecordCursorResult;
+                    return lastResult;
+                });
+            } else {
+                lastResult = recordCursorResult;
+                return CompletableFuture.completedFuture(lastResult);
+            }
+        });
+    }
+
+    private void openContextAndGenerateCursor(@Nullable byte[] continuation) {
+        currentContext = runner.openContext();
+        currentCursor = nextCursorGenerator.apply(currentContext, continuation);
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Boolean> onHasNext() {
+        if (nextFuture == null) {
+            mayGetContinuation = false;
+            nextFuture = onNext().thenApply(RecordCursorResult::hasNext);
+        }
+        return nextFuture;
+    }
+
+    @Nullable
+    @Override
+    public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        nextFuture = null;
+        mayGetContinuation = true;
+        return lastResult.get();
+    }
+
+    @Nullable
+    @Override
+    public byte[] getContinuation() {
+        IllegalContinuationAccessChecker.check(mayGetContinuation);
+        return lastResult.getContinuation().toBytes();
+    }
+
+    @Override
+    public NoNextReason getNoNextReason() {
+        return lastResult.getNoNextReason();
+    }
+
+    @Override
+    public void close() {
+        if (nextFuture != null) {
+            nextFuture.cancel(true);
+        }
+        if (currentContext != null) {
+            currentContext.close();
+        }
+    }
+
+    @Nonnull
+    @Override
+    public Executor getExecutor() {
+        return runner.getExecutor();
+    }
+
+    @Override
+    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+        visitor.visitEnter(this);
+        return visitor.visitLeave(this);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
@@ -51,8 +51,8 @@ import java.util.function.Function;
  *             } else {
  *                 return Optional.empty();
  *             }
- *             return Optional.of(1);
  *         }
+ *         return Optional.of(1);
  *     }
  * </pre>
  * Given this function, the <code>ChainedCursor</code> would iteratively generate the value from 1 to 10.
@@ -70,7 +70,6 @@ import java.util.function.Function;
  *                 } else {
  *                     return Optional.empty();
  *                 }
- *                 return Optional.of(1);
  *             }
  *             return Optional.of(1);
  *         },

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/AutoContinuingCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/AutoContinuingCursorTest.java
@@ -1,0 +1,69 @@
+/*
+ * AutoContinuingCursorTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.cursors;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for {@link AutoContinuingCursor}.
+ */
+@Tag(Tags.RequiresFDB)
+public class AutoContinuingCursorTest extends FDBTestBase {
+    private FDBDatabase database;
+
+    @BeforeEach
+    public void getDatabase() {
+        database = FDBDatabaseFactory.instance().getDatabase();
+    }
+
+    @Test
+    public void testAutoContinuingCursor() {
+        try (FDBDatabaseRunner runner = database.newRunner()) {
+            List<Integer> list = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+            RecordCursor<Integer> cursor = new AutoContinuingCursor<>(
+                    runner,
+                    (context, continuation) -> new ListCursor<>(list, continuation).limitRowsTo(3)
+            );
+
+            List<Integer> returnedList = new ArrayList<>();
+            while (cursor.hasNext()) {
+                returnedList.add(cursor.next());
+            }
+
+            assertEquals(list, returnedList);
+        }
+    }
+}


### PR DESCRIPTION
- Implemented AutoContinuingCursor and AutoContinuingCursorTest
- Added a helper method noNextButHasContinuation in RecordCursorResult
- Fix doc in ChainedCursor