### PR TITLE
Fixes #394: Meta-data validation should combine types with identical serialized forms when validating subspace keys

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Record type and index subspace keys with identical serializations are now validated for collisions [(Issue #394)](https://github.com/FoundationDB/fdb-record-layer/issues/394)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
@@ -35,11 +35,8 @@ import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.RecordTypeKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
 import com.apple.foundationdb.tuple.Tuple;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.ProtocolMessageEnum;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -499,13 +496,13 @@ public class Key {
 
         @Nullable
         public Object getObject(int idx) {
-            return toTupleAppropriateValue(values.get(idx));
+            return TupleTypeUtil.toTupleAppropriateValue(values.get(idx));
         }
 
         @Nullable
         @SuppressWarnings("PMD.PreserveStackTrace")
         public <T> T getObject(int idx, Class<T> clazz) {
-            final Object result = toTupleAppropriateValue(values.get(idx));
+            final Object result = TupleTypeUtil.toTupleAppropriateValue(values.get(idx));
             try {
                 return clazz.cast(result);
             } catch (ClassCastException e) {
@@ -581,35 +578,6 @@ public class Key {
             return toTupleAppropriateList();
         }
 
-        @Nullable
-        private static Object toTupleAppropriateValue(@Nullable Object o) {
-            if (o instanceof NullStandin) {
-                return null;
-            } else if (o instanceof ByteString) {
-                return ((ByteString) o).toByteArray();
-            } else if (o instanceof List) {
-                return toTupleAppropriateList((List<?>) o);
-            // Following two are both Internal.EnumLite, so could use that, too.
-            } else if (o instanceof ProtocolMessageEnum) {
-                return ((ProtocolMessageEnum) o).getNumber();
-            } else if (o instanceof Descriptors.EnumValueDescriptor) {
-                return ((Descriptors.EnumValueDescriptor) o).getNumber();
-            } else if (o instanceof FDBRecordVersion) {
-                return ((FDBRecordVersion) o).toVersionstamp(false);
-            } else {
-                return o;
-            }
-        }
-
-        @Nonnull
-        private static List<Object> toTupleAppropriateList(@Nonnull List<?> values) {
-            List<Object> tupleAppropriateList = new ArrayList<>(values.size());
-            for (Object o : values) {
-                tupleAppropriateList.add(toTupleAppropriateValue(o));
-            }
-            return tupleAppropriateList;
-        }
-
         /**
          * Converts to a list. Useful for creating tuples. If possible the underlying objects will be converted to
          * types that Tuple can handle.
@@ -618,7 +586,7 @@ public class Key {
         @Nonnull
         public List<Object> toTupleAppropriateList() {
             if (tupleAppropriateList == null) {
-                tupleAppropriateList = toTupleAppropriateList(values);
+                tupleAppropriateList = TupleTypeUtil.toTupleAppropriateList(values);
             }
             return tupleAppropriateList;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataValidator.java
@@ -80,12 +80,10 @@ public class MetaDataValidator implements RecordMetaDataProvider {
     protected void validateRecordType(@Nonnull RecordType recordType) {
         metaData.getUnionFieldForRecordType(recordType);    // Throws if missing.
         validatePrimaryKeyForRecordType(recordType.getPrimaryKey(), recordType);
-        if (recordType.getPrimaryKey().hasRecordTypeKey()) {
-            RecordType otherRecordType = recordTypeKeys.put(recordType.getRecordTypeKey(), recordType);
-            if (otherRecordType != null) {
-                throw new MetaDataException("Same record type key " + recordType.getRecordTypeKey() +
-                                            " used by both " + recordType.getName() + " and " + otherRecordType.getName());
-            }
+        RecordType otherRecordType = recordTypeKeys.put(recordType.getRecordTypeKey(), recordType);
+        if (otherRecordType != null) {
+            throw new MetaDataException("Same record type key " + recordType.getRecordTypeKey() +
+                                        " used by both " + recordType.getName() + " and " + otherRecordType.getName());
         }
         if (recordType.getSinceVersion() != null && recordType.getSinceVersion() > metaData.getVersion()) {
             throw new MetaDataException("Record type " + recordType.getName() + " has since version of " +

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/RecordTypeBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/RecordTypeBuilder.java
@@ -127,7 +127,7 @@ public class RecordTypeBuilder implements RecordTypeOrBuilder {
                 recordTypeKey instanceof String || recordTypeKey instanceof byte[])) {
             throw new MetaDataException("Only primitive types are allowed as record type key");
         }
-        this.recordTypeKey = recordTypeKey;
+        this.recordTypeKey = TupleTypeUtil.toTupleEquivalentValue(recordTypeKey);
         return this;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/TupleTypeUtil.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/TupleTypeUtil.java
@@ -1,0 +1,172 @@
+/*
+ * TupleTypeUtil.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata;
+
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.ProtocolMessageEnum;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for dealing with {@link Tuple} types. In theory, these methods should live in
+ * {@link com.apple.foundationdb.tuple.TupleHelpers TupleHelpers} except that they use some Protobuf specific things
+ * like the {@link ByteString} class, and {@code TupleHelpers} is defined in the
+ * <a href="https://javadoc.io/doc/org.foundationdb/fdb-extensions/">fdb-extensions</a> sub-project
+ * which does not (and probably should not) take Protobuf as a dependency.
+ */
+class TupleTypeUtil {
+    @Nonnull
+    private static final BigInteger BIG_INT_MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);
+    @Nonnull
+    private static final BigInteger BIG_INT_MIN_LONG = BigInteger.valueOf(Long.MIN_VALUE);
+
+    /**
+     * Normalize a list of values so that it can be checked for equality with other lists sharing
+     * the same {@link Tuple} representation. In other words, it should be the case that:
+     *
+     * <pre> {@code
+     *   toTupleEquivalentValue(list1).equals(toTupleEquivalentValue)
+     *      == Arrays.equals(Tuple.fromList(toTupleAppropriateList(list1)).pack(), Tuple.fromList(toTupleAppropriateList(list2)).pack())
+     * }</pre>
+     *
+     * <p>
+     * for any two lists {@code list1} and {@code list2}.
+     * </p>
+     *
+     * @param values the list of values to normalized
+     * @return a new list containing the normalized elements of {@code values}
+     */
+    @Nonnull
+    static List<Object> toTupleEquivalentList(@Nonnull List<?> values) {
+        List<Object> tupleEquivalentList = new ArrayList<>(values.size());
+        for (Object o : values) {
+            tupleEquivalentList.add(toTupleEquivalentValue(o));
+        }
+        return tupleEquivalentList;
+    }
+
+    /**
+     * Normalize a value so that it compares equal to anything with the same {@link Tuple} representation.
+     * The value that is returned cannot necessarily be packed by a {@code Tuple} (for example,
+     * a <code>byte[]</code> is returned as a {@link ByteString}), but it does implement {@link Object#equals(Object)}
+     * and {@link Object#hashCode()}, so the value can be used in hash-based data structures like
+     * {@link java.util.HashSet HashSet}s and {@link java.util.HashMap HashMap}s. In other words, it should
+     * bethe case that:
+     *
+     * <pre> {@code
+     *   Objects.equals(toTupleEquivalentValue(value1), toTupleEquivalentValue(value2))
+     *     == Arrays.equals(Tuple.from(value1).pack(), Tuple.from(value2).pack())
+     * }</pre>
+     *
+     * <p>
+     * for any two values {@code value1} and {@code value2}.
+     * </p>
+     *
+     * <p>
+     * This will only return {@code null} if {@link #toTupleAppropriateValue(Object)} would return {@code null}
+     * on the same input. If the object is already in
+     * </p>
+     *
+     * @param obj the value to normalize
+     * @return a value that has the same representation when {@link Tuple}-encoded
+     */
+    @Nullable
+    static Object toTupleEquivalentValue(@Nullable Object obj) {
+        if (obj == null || obj instanceof Key.Evaluated.NullStandin) {
+            return null;
+        } else if (obj instanceof List<?>) {
+            List<?> list = (List<?>)obj;
+            return toTupleEquivalentList(list);
+        } else if (obj instanceof Tuple) {
+            return toTupleEquivalentList(((Tuple)obj).getItems());
+        } else if (obj instanceof byte[]) {
+            return ByteString.copyFrom((byte[]) obj);
+        } else if ((obj instanceof Byte) || (obj instanceof Short) || (obj instanceof Integer)) {
+            return ((Number)obj).longValue();
+        } else if (obj instanceof BigInteger) {
+            BigInteger bigInt = (BigInteger)obj;
+            if (bigInt.compareTo(BIG_INT_MIN_LONG) > 0 && bigInt.compareTo(BIG_INT_MAX_LONG) < 0) {
+                return bigInt.longValue();
+            } else {
+                return bigInt;
+            }
+        } else if (obj instanceof ProtocolMessageEnum) {
+            return (long)((ProtocolMessageEnum)obj).getNumber();
+        } else if (obj instanceof Descriptors.EnumValueDescriptor) {
+            return (long)((Descriptors.EnumValueDescriptor)obj).getNumber();
+        } else if (obj instanceof FDBRecordVersion) {
+            return ((FDBRecordVersion)obj).toVersionstamp(false);
+        } else {
+            return obj;
+        }
+    }
+
+    /**
+     * Convert a list of values into items that can all be stored within a {@link Tuple}.
+     *
+     * @param values a list of values
+     * @return a new list with {@link Tuple}-encodable versions of the elements of {@code values}
+     */
+    @Nonnull
+    static List<Object> toTupleAppropriateList(@Nonnull List<?> values) {
+        List<Object> tupleAppropriateList = new ArrayList<>(values.size());
+        for (Object o : values) {
+            tupleAppropriateList.add(toTupleAppropriateValue(o));
+        }
+        return tupleAppropriateList;
+    }
+
+    /**
+     * Convert a value into a type that can be stored within a {@link Tuple}.
+     *
+     * @param obj the value to convert
+     * @return the value converted to some {@link Tuple}-encodable type
+     */
+    @Nullable
+    static Object toTupleAppropriateValue(@Nullable Object obj) {
+        if (obj instanceof Key.Evaluated.NullStandin) {
+            return null;
+        } else if (obj instanceof ByteString) {
+            return ((ByteString) obj).toByteArray();
+        } else if (obj instanceof List) {
+            return toTupleAppropriateList((List<?>) obj);
+        // Following two are both Internal.EnumLite, so could use that, too.
+        } else if (obj instanceof ProtocolMessageEnum) {
+            return ((ProtocolMessageEnum) obj).getNumber();
+        } else if (obj instanceof Descriptors.EnumValueDescriptor) {
+            return ((Descriptors.EnumValueDescriptor) obj).getNumber();
+        } else if (obj instanceof FDBRecordVersion) {
+            return ((FDBRecordVersion) obj).toVersionstamp(false);
+        } else {
+            return obj;
+        }
+    }
+
+    private TupleTypeUtil() {
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -566,7 +566,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
     @Nonnull
     public Subspace indexSubspace(@Nonnull Index index) {
-        return getSubspace().subspace(Tuple.from(INDEX_KEY, index.getSubspaceKey()));
+        return getSubspace().subspace(Tuple.from(INDEX_KEY, index.getSubspaceTupleKey()));
     }
 
     @Nonnull
@@ -581,7 +581,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
     @Nonnull
     public Subspace indexSecondarySubspace(@Nonnull Index index) {
-        return getSubspace().subspace(Tuple.from(INDEX_SECONDARY_SPACE_KEY, index.getSubspaceKey()));
+        return getSubspace().subspace(Tuple.from(INDEX_SECONDARY_SPACE_KEY, index.getSubspaceTupleKey()));
     }
 
     /**
@@ -593,7 +593,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public Subspace indexRangeSubspace(@Nonnull Index index) {
-        return getSubspace().subspace(Tuple.from(INDEX_RANGE_SPACE_KEY, index.getSubspaceKey()));
+        return getSubspace().subspace(Tuple.from(INDEX_RANGE_SPACE_KEY, index.getSubspaceTupleKey()));
     }
 
     /**
@@ -605,7 +605,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public Subspace indexUniquenessViolationsSubspace(@Nonnull Index index) {
-        return getSubspace().subspace(Tuple.from(INDEX_UNIQUENESS_VIOLATIONS_KEY, index.getSubspaceKey()));
+        return getSubspace().subspace(Tuple.from(INDEX_UNIQUENESS_VIOLATIONS_KEY, index.getSubspaceTupleKey()));
     }
 
     /**
@@ -1337,7 +1337,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         indexMaintainer = IndexFunctionHelper.indexMaintainerForAggregateFunction(this, aggregateFunction, Collections.emptyList());
         if (indexMaintainer.isPresent()) {
             RecordType recordType = getRecordMetaData().getRecordType(recordTypeName);
-            return indexMaintainer.get().evaluateAggregateFunction(aggregateFunction, TupleRange.allOf(Tuple.from(recordType.getRecordTypeKey())), IsolationLevel.SNAPSHOT)
+            return indexMaintainer.get().evaluateAggregateFunction(aggregateFunction, TupleRange.allOf(recordType.getRecordTypeKeyTuple()), IsolationLevel.SNAPSHOT)
                     .thenApply(tuple -> tuple.getLong(0));
         }
         throw new RecordCoreException("Require a COUNT index on " + recordTypeName);
@@ -2471,7 +2471,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         if (singleRecordTypeWithPrefixKey == null) {
             records = scanRecords(null, scanProperties);
         } else {
-            records = scanRecords(TupleRange.allOf(Tuple.from(singleRecordTypeWithPrefixKey.getRecordTypeKey())), null, scanProperties);
+            records = scanRecords(TupleRange.allOf(singleRecordTypeWithPrefixKey.getRecordTypeKeyTuple()), null, scanProperties);
         }
         return records.onHasNext()
                 .thenApply(hasAny -> {
@@ -2618,11 +2618,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         }
         final long startTime = System.nanoTime();
         Transaction tr = ensureContextActive();
-        tr.clear(getSubspace().range(Tuple.from(INDEX_KEY, formerIndex.getSubspaceKey())));
-        tr.clear(getSubspace().range(Tuple.from(INDEX_SECONDARY_SPACE_KEY, formerIndex.getSubspaceKey())));
-        tr.clear(getSubspace().range(Tuple.from(INDEX_RANGE_SPACE_KEY, formerIndex.getSubspaceKey())));
-        tr.clear(getSubspace().pack(Tuple.from(INDEX_STATE_SPACE_KEY, formerIndex.getSubspaceKey())));
-        tr.clear(getSubspace().range(Tuple.from(INDEX_UNIQUENESS_VIOLATIONS_KEY, formerIndex.getSubspaceKey())));
+        tr.clear(getSubspace().range(Tuple.from(INDEX_KEY, formerIndex.getSubspaceTupleKey())));
+        tr.clear(getSubspace().range(Tuple.from(INDEX_SECONDARY_SPACE_KEY, formerIndex.getSubspaceTupleKey())));
+        tr.clear(getSubspace().range(Tuple.from(INDEX_RANGE_SPACE_KEY, formerIndex.getSubspaceTupleKey())));
+        tr.clear(getSubspace().pack(Tuple.from(INDEX_STATE_SPACE_KEY, formerIndex.getSubspaceTupleKey())));
+        tr.clear(getSubspace().range(Tuple.from(INDEX_UNIQUENESS_VIOLATIONS_KEY, formerIndex.getSubspaceTupleKey())));
         if (getTimer() != null) {
             getTimer().recordSinceNanoTime(FDBStoreTimer.Events.REMOVE_FORMER_INDEX, startTime);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -175,7 +175,7 @@ public class OnlineIndexer implements AutoCloseable {
                 // If any of the types to build for does not have a prefix, give up.
                 return TupleRange.ALL;
             }
-            Tuple prefix = Tuple.from(recordType.getRecordTypeKey());
+            Tuple prefix = recordType.getRecordTypeKeyTuple();
             if (low == null) {
                 low = high = prefix;
             } else {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
@@ -621,10 +621,10 @@ public class MetaDataEvolutionValidatorTest {
         RecordMetaData metaData4 = replaceRecordsDescriptor(metaData3, updatedFile);
         RecordType recordType3 = metaData3.getRecordType("MySimpleRecord");
         assertEquals(1066, metaData3.getUnionFieldForRecordType(recordType3).getNumber());
-        assertEquals(1066, recordType3.getRecordTypeKey());
+        assertEquals(1066L, recordType3.getRecordTypeKey());
         RecordType recordType4 = metaData4.getRecordType("MySimpleRecord");
         assertEquals(1066, metaData4.getUnionFieldForRecordType(recordType4).getNumber());
-        assertEquals(800, recordType4.getRecordTypeKey());
+        assertEquals(800L, recordType4.getRecordTypeKey());
         assertInvalid("first occurrence of record type in union descriptor changed", metaData3, metaData4);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/TupleTypeUtilTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/TupleTypeUtilTest.java
@@ -1,0 +1,167 @@
+/*
+ * TupleTypeUtilTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata;
+
+import com.apple.foundationdb.record.TestRecordsEnumProto;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
+import com.apple.foundationdb.tuple.Versionstamp;
+import com.apple.test.Tags;
+import com.google.common.base.Charsets;
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests of the {@link TupleTypeUtil} class. These tests require FDB because an API version must be set in order to
+ * pack {@link Tuple}s with incomplete versionstamps due to the difference in format starting with API version 520.
+ */
+@Tag(Tags.RequiresFDB)
+public class TupleTypeUtilTest extends FDBTestBase {
+    @Nonnull
+    private static final List<Object> VALUES = Arrays.asList(
+            null,
+            Key.Evaluated.NullStandin.NULL,
+            Key.Evaluated.NullStandin.NULL_UNIQUE,
+            Key.Evaluated.NullStandin.NOT_NULL,
+            "hello",
+            String.copyValueOf(new char[]{'h', 'e', 'l', 'l', 'o'}),
+            "hello".getBytes(Charsets.UTF_8),
+            new byte[]{(byte)'h', (byte)'e', (byte)'l', (byte)'l', (byte)'o'},
+            ByteString.copyFromUtf8("hello"),
+            (byte)42,
+            (short)42,
+            42,
+            42L,
+            BigInteger.valueOf(42L),
+            BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN),
+            BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.TEN),
+            3.14f,
+            3.14,
+            Float.NaN,
+            Double.NaN,
+            true,
+            false,
+            UUID.randomUUID(),
+            TestRecordsEnumProto.MyShapeRecord.Size.SMALL,
+            TestRecordsEnumProto.MyShapeRecord.Size.SMALL.getValueDescriptor(),
+            TestRecordsEnumProto.MyShapeRecord.Size.SMALL.getNumber(),
+            (long)TestRecordsEnumProto.MyShapeRecord.Size.SMALL.getNumber(),
+            Tuple.from("hello", null),
+            Arrays.asList("hello", null),
+            FDBRecordVersion.firstInDBVersion(1066L),
+            Versionstamp.fromBytes(FDBRecordVersion.firstInDBVersion(1066L).toBytes()),
+            FDBRecordVersion.incomplete(1415),
+            Versionstamp.incomplete(1415)
+    );
+
+    @Nonnull
+    private byte[] toBytes(@Nullable Object value) {
+        Object tupleValue = TupleTypeUtil.toTupleAppropriateValue(value);
+        if (tupleValue instanceof Versionstamp && !((Versionstamp)tupleValue).isComplete()) {
+            return Tuple.from(tupleValue).packWithVersionstamp();
+        } else {
+            return Tuple.from(tupleValue).pack();
+        }
+    }
+
+    @Nonnull
+    public static Stream<Object> valueEquivalenceSource() {
+        return VALUES.stream();
+    }
+
+    @ParameterizedTest(name = "valueEquivalenceSource [value = {0}]")
+    @MethodSource("valueEquivalenceSource")
+    public void valueEquivalence(Object value) {
+        Object normalizedValue = TupleTypeUtil.toTupleEquivalentValue(value);
+        byte[] tupleRep = toBytes(value);
+
+        if (normalizedValue == null) {
+            if (value != null) {
+                assertThat(value, instanceOf(Key.Evaluated.NullStandin.class));
+            }
+        } else {
+            assertNotNull(value);
+            if (value.getClass().equals(normalizedValue.getClass()) && !(value instanceof List<?>) && !(value instanceof Tuple)) {
+                assertSame(value, normalizedValue);
+            }
+        }
+
+        for (Object otherValue : VALUES) {
+            Object otherNormalizedValue = TupleTypeUtil.toTupleEquivalentValue(otherValue);
+            byte[] otherTupleRep = toBytes(otherValue);
+
+            if (Arrays.equals(tupleRep, otherTupleRep)) {
+                assertEquals(normalizedValue, otherNormalizedValue);
+                if (normalizedValue != null) {
+                    assertNotNull(otherNormalizedValue);
+                    assertEquals(normalizedValue.hashCode(), otherNormalizedValue.hashCode());
+                }
+            } else {
+                assertNotEquals(normalizedValue, otherNormalizedValue);
+            }
+        }
+    }
+
+    @Test
+    public void listEquivalence() {
+        List<Object> packableValues = VALUES.stream().filter(value -> {
+            if (value instanceof FDBRecordVersion) {
+                return ((FDBRecordVersion)value).isComplete();
+            } else if (value instanceof Versionstamp) {
+                return ((Versionstamp)value).isComplete();
+            } else {
+                return true;
+            }
+        }).collect(Collectors.toList());
+
+        List<Object> equivalentList = TupleTypeUtil.toTupleEquivalentList(packableValues);
+        Tuple tupleWithNormalizing = Tuple.fromList(TupleTypeUtil.toTupleAppropriateList(equivalentList));
+        Tuple tupleWithoutNormalizing = Tuple.fromList(TupleTypeUtil.toTupleAppropriateList(packableValues));
+        assertThat(TupleHelpers.equals(tupleWithNormalizing, tupleWithoutNormalizing), is(true));
+        assertArrayEquals(tupleWithoutNormalizing.pack(), tupleWithNormalizing.pack());
+
+        Tuple deserializedTuple = Tuple.fromBytes(tupleWithNormalizing.pack());
+        assertThat(TupleHelpers.equals(tupleWithNormalizing, deserializedTuple), is(true));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
@@ -33,6 +33,12 @@ public abstract class FDBTestBase {
     public static final String BLOCKING_IN_ASYNC_PROPERTY = "com.apple.foundationdb.record.blockingInAsyncDetection";
 
     @BeforeAll
+    public static void initFDB() {
+        FDBDatabaseFactory.instance().setUnclosedWarning(true);
+        FDBDatabaseFactory.instance().initFDB();
+    }
+
+    @BeforeAll
     public static void setupBlockingInAsyncDetection() {
         final String str = System.getProperty(BLOCKING_IN_ASYNC_PROPERTY);
         if (str != null) {


### PR DESCRIPTION
This creates a new method, `toTupleEquivalentValue`, which converts an object to a canonical form where types with identical `Tuple` serializations are assigned to Java objects where `.equals` and `.hashCode` work correctly. This method is then applied to record type keys and index subspace keys so that if the user assigns, say, the integer 42 to one index and the long 42 to another, meta-data validation fails.

This fixes #394.