### PR TITLE
Resolves #364: Add a generic QueryPlan that can return things other than records

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
@@ -48,11 +48,11 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
 
     /**
      * Execute this query plan.
-     * @param store record store from which to fetch records
+     * @param store record store from which to fetch items
      * @param context evaluation context containing parameter bindings
      * @param continuation continuation from a previous execution of this same plan
      * @param executeProperties limits on execution
-     * @return a cursor of records that match the query criteria
+     * @return a cursor of items that match the query criteria
      */
     @Nonnull
     RecordCursor<T> execute(@Nonnull FDBRecordStore store, @Nonnull EvaluationContext context,
@@ -60,8 +60,8 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
 
     /**
      * Execute this query plan.
-     * @param store record store from which to fetch records
-     * @return a cursor of records that match the query criteria
+     * @param store record store from which to fetch items
+     * @return a cursor of items that match the query criteria
      */
     @Nonnull
     default RecordCursor<T> execute(@Nonnull FDBRecordStore store) {
@@ -72,7 +72,7 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
      * Execute this query plan.
      * @param store record store to access
      * @param context evaluation context containing parameter bindings
-     * @return a cursor of records that match the query criteria
+     * @return a cursor of items that match the query criteria
      */
     @Nonnull
     default RecordCursor<T> execute(@Nonnull FDBRecordStore store, @Nonnull EvaluationContext context) {
@@ -84,7 +84,7 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
      * natural order of results of this plan. The return value is <code>true</code> if the plan
      * returns elements in descending order and <code>false</code> if the elements are
      * returned in ascending order.
-     * @return <code>true</code> if this plan returns elements in reverse order.
+     * @return <code>true</code> if this plan returns elements in reverse order
      */
     boolean isReverse();
 
@@ -95,7 +95,7 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
      * they might make use of the primary key index. For example, if they had a compound primary key, and they issued
      * a query for all records that had some value for the first element of their primary key, the planner will produce
      * a plan which scans over a subset of all records.
-     * @return <code>true</code> if this plan (or one of its components) scans at least a subset of the records directly.
+     * @return <code>true</code> if this plan (or one of its components) scans at least a subset of the records directly
      */
     boolean hasRecordScan();
 
@@ -104,20 +104,20 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
      * rather than going through a secondary index.
      * See {@link #hasRecordScan hasRecordScan} for the comparison between two methods.
      * @return <code>true</code> if this plan (or one of its components) must perform a scan over all records in the
-     * store directly.
+     * store directly
      */
     boolean hasFullRecordScan();
 
     /**
      * Indicates whether this plan scans the given index.
      * @param indexName the name of the index to check for
-     * @return <code>true</code> if this plan (or one of its children) scans the given index.
+     * @return <code>true</code> if this plan (or one of its children) scans the given index
      */
     boolean hasIndexScan(@Nonnull String indexName);
 
     /**
      * Returns a set of names of the indexes used by this plan (and its sub-plans).
-     * @return an set of indexes used by this plan.
+     * @return an set of indexes used by this plan
      */
     @Nonnull
     Set<String> getUsedIndexes();
@@ -140,6 +140,14 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
     /**
      * Returns the (zero or more) child {@code QueryPlan}s of this plan. These children may or may not
      * return elements of the same type as their parent plan.
+     *
+     * <p>
+     * <b>Warning</b>: This part of the API is currently undergoing active development. At some point in
+     * the future, this will be renamed {@code getChildren()}. This cannot be done at current, however,
+     * as it would require an incompatible change to {@link RecordQueryPlan#getChildren()}. That method
+     * has been marked {@link API.Status#UNSTABLE} as of version 2.5.
+     * </p>
+     *
      * @return the child plans of this plan
      */
     @SuppressWarnings("squid:S1452") // wildcards in return type

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
@@ -1,0 +1,147 @@
+/*
+ * QueryPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * An executable query plan. A query plan can be executed against a record store to get a stream of items.
+ * Unlike a {@link RecordQueryPlan} (which extends this interface), implementations are not required to
+ * return records but might instead return items of an arbitrary type. Note that
+ * {@link com.apple.foundationdb.record.query.plan.QueryPlanner QueryPlanner}s always return {@code RecordQueryPlan}s,
+ * but the query plan tree might contain intermediate plans that return something other than records.
+ *
+ * @param <T> the type of element produced by executing this plan
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression {
+
+    /**
+     * Execute this query plan.
+     * @param store record store from which to fetch records
+     * @param context evaluation context containing parameter bindings
+     * @param continuation continuation from a previous execution of this same plan
+     * @param executeProperties limits on execution
+     * @return a cursor of records that match the query criteria
+     */
+    @Nonnull
+    RecordCursor<T> execute(@Nonnull FDBRecordStore store, @Nonnull EvaluationContext context,
+                            @Nullable byte[] continuation, @Nonnull ExecuteProperties executeProperties);
+
+    /**
+     * Execute this query plan.
+     * @param store record store from which to fetch records
+     * @return a cursor of records that match the query criteria
+     */
+    @Nonnull
+    default RecordCursor<T> execute(@Nonnull FDBRecordStore store) {
+        return execute(store, EvaluationContext.EMPTY);
+    }
+
+    /**
+     * Execute this query plan.
+     * @param store record store to access
+     * @param context evaluation context containing parameter bindings
+     * @return a cursor of records that match the query criteria
+     */
+    @Nonnull
+    default RecordCursor<T> execute(@Nonnull FDBRecordStore store, @Nonnull EvaluationContext context) {
+        return execute(store, context, null, ExecuteProperties.SERIAL_EXECUTE);
+    }
+
+    /**
+     * Indicates whether this plan will return values in "reverse" order from the
+     * natural order of results of this plan. The return value is <code>true</code> if the plan
+     * returns elements in descending order and <code>false</code> if the elements are
+     * returned in ascending order.
+     * @return <code>true</code> if this plan returns elements in reverse order.
+     */
+    boolean isReverse();
+
+    /**
+     * Indicates whether this plan (or one of its components) scans at least a subset of the record range directly
+     * rather than going through a secondary index.
+     * A plan may only scan over a subset of all records. Someone might not use any secondary indexes explicitly, but
+     * they might make use of the primary key index. For example, if they had a compound primary key, and they issued
+     * a query for all records that had some value for the first element of their primary key, the planner will produce
+     * a plan which scans over a subset of all records.
+     * @return <code>true</code> if this plan (or one of its components) scans at least a subset of the records directly.
+     */
+    boolean hasRecordScan();
+
+    /**
+     * Indicates whether this plan (or one of its components) must perform a scan over all records in the store directly
+     * rather than going through a secondary index.
+     * See {@link #hasRecordScan hasRecordScan} for the comparison between two methods.
+     * @return <code>true</code> if this plan (or one of its components) must perform a scan over all records in the
+     * store directly.
+     */
+    boolean hasFullRecordScan();
+
+    /**
+     * Indicates whether this plan scans the given index.
+     * @param indexName the name of the index to check for
+     * @return <code>true</code> if this plan (or one of its children) scans the given index.
+     */
+    boolean hasIndexScan(@Nonnull String indexName);
+
+    /**
+     * Returns a set of names of the indexes used by this plan (and its sub-plans).
+     * @return an set of indexes used by this plan.
+     */
+    @Nonnull
+    Set<String> getUsedIndexes();
+
+    /**
+     * Adds one to an appropriate {@link StoreTimer} counter for each plan and subplan of this plan, allowing tracking
+     * of which plans are being chosen (e.g. index scan vs. full scan).
+     * @param timer the counters to increment
+     */
+    void logPlanStructure(StoreTimer timer);
+
+    /**
+     * Returns an integer representing the "complexity" of the generated plan.
+     * Currently, this should simply be the number of plans in the plan tree with this plan as the root (i.e. the
+     * number of descendants of this plan, including itself).
+     * @return the complexity of this plan
+     */
+    int getComplexity();
+
+    /**
+     * Returns the (zero or more) child {@code QueryPlan}s of this plan. These children may or may not
+     * return elements of the same type as their parent plan.
+     * @return the child plans of this plan
+     */
+    @SuppressWarnings("squid:S1452") // wildcards in return type
+    List<? extends QueryPlan<?>> getQueryPlanChildren();
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -179,18 +179,18 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
         }
         RecordQueryIntersectionPlan that = (RecordQueryIntersectionPlan) o;
         return reverse == that.reverse &&
-                Objects.equals(Sets.newHashSet(getChildren()), Sets.newHashSet(that.getChildren())) &&
+                Objects.equals(Sets.newHashSet(getQueryPlanChildren()), Sets.newHashSet(that.getQueryPlanChildren())) &&
                 Objects.equals(getComparisonKey(), that.getComparisonKey());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(Sets.newHashSet(getChildren()), getComparisonKey(), reverse);
+        return Objects.hash(Sets.newHashSet(getQueryPlanChildren()), getComparisonKey(), reverse);
     }
 
     @Override
     public int planHash() {
-        return PlanHashable.planHash(getChildren()) + getComparisonKey().planHash() + (reverse ? 1 : 0);
+        return PlanHashable.planHash(getQueryPlanChildren()) + getComparisonKey().planHash() + (reverse ? 1 : 0);
     }
 
     @Override
@@ -203,7 +203,7 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
 
     @Override
     public int getComplexity() {
-        return 1 + getChildren().stream().mapToInt(RecordQueryPlan::getComplexity).sum();
+        return 1 + getChildStream().mapToInt(RecordQueryPlan::getComplexity).sum();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -95,9 +95,19 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>> {
     }
 
     /**
-     * Returns the (zero or more) children of this plan.
+     * Returns the (zero or more) {@code RecordQueryPlan} children of this plan.
+     *
+     * <p>
+     * <b>Warning</b>: This part of the API is undergoing active development. At some point in the future,
+     * the return type of this method will change to allow it to return a list of generic {@link QueryPlan}s.
+     * At current, every {@code RecordQueryPlan} can only have other {@code RecordQueryPlan}s as children.
+     * However, this is not guaranteed to be the case in the future. This method has been marked as
+     * {@link API.Status#UNSTABLE} as of version 2.5.
+     * </p>
+     *
      * @return the child plans
      */
+    @API(API.Status.UNSTABLE)
     @Nonnull
     List<RecordQueryPlan> getChildren();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -23,21 +23,18 @@ package com.apple.foundationdb.record.query.plan.plans;
 import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
-import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Set;
 
 /**
- * An executable query plan.
+ * An executable query plan for producing records.
  *
  * A query plan is run against a record store to produce a stream of matching records.
  *
@@ -48,7 +45,7 @@ import java.util.Set;
  *
  */
 @API(API.Status.STABLE)
-public interface RecordQueryPlan extends PlanHashable, RelationalPlannerExpression  {
+public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>> {
 
     /**
      * Execute this query plan.
@@ -64,6 +61,15 @@ public interface RecordQueryPlan extends PlanHashable, RelationalPlannerExpressi
                                                                   @Nonnull EvaluationContext context,
                                                                   @Nullable byte[] continuation,
                                                                   @Nonnull ExecuteProperties executeProperties);
+
+    @Nonnull
+    @Override
+    default RecordCursor<FDBQueriedRecord<Message>> execute(@Nonnull FDBRecordStore store,
+                                                            @Nonnull EvaluationContext context,
+                                                            @Nullable byte[] continuation,
+                                                            @Nonnull ExecuteProperties executeProperties) {
+        return execute((FDBRecordStoreBase<Message>)store, context, continuation, executeProperties);
+    }
 
     /**
      * Execute this query plan.
@@ -89,67 +95,15 @@ public interface RecordQueryPlan extends PlanHashable, RelationalPlannerExpressi
     }
 
     /**
-     * Indicates whether this plan will return values in "reverse" order from the
-     * natural order of results of this plan. The return value is <code>true</code> if the plan
-     * returns elements in descending order and <code>false</code> if the elements are
-     * returned in ascending order.
-     * @return <code>true</code> if this plan returns elements in reverse order.
-     */
-    boolean isReverse();
-
-    /**
-     * Indicates whether this plan (or one of its components) scans at least a subset of the record range directly
-     * rather than going through a secondary index.
-     * A plan may only scan over a subset of all records. Someone might not use any secondary indexes explicitly, but
-     * they might make use of the primary key index. For example, if they had a compound primary key, and they issued
-     * a query for all records that had some value for the first element of their primary key, the planner will produce
-     * a plan which scans over a subset of all records.
-     * @return <code>true</code> if this plan (or one of its components) scans at least a subset of the records directly.
-     */
-    boolean hasRecordScan();
-
-    /**
-     * Indicates whether this plan (or one of its components) must perform a scan over all records in the store directly
-     * rather than going through a secondary index.
-     * See {@link #hasRecordScan hasRecordScan} for the comparison between two methods.
-     * @return <code>true</code> if this plan (or one of its components) must perform a scan over all records in the
-     * store directly.
-     */
-    boolean hasFullRecordScan();
-
-    /**
-     * Indicates whether this plan scans the given index.
-     * @param indexName the name of the index to check for
-     * @return <code>true</code> if this plan (or one of its children) scans the given index.
-     */
-    boolean hasIndexScan(@Nonnull String indexName);
-
-    /**
-     * Returns a set of names of the indexes used by this plan (and its sub-plans).
-     * @return an set of indexes used by this plan.
-     */
-    @Nonnull
-    Set<String> getUsedIndexes();
-
-    /**
-     * Adds one to an appropriate {@link StoreTimer} counter for each plan and subplan of this plan, allowing tracking
-     * of which plans are being chosen (e.g. index scan vs. full scan).
-     * @param timer the counters to increment
-     */
-    void logPlanStructure(StoreTimer timer);
-
-    /**
-     * Returns an integer representing the "complexity" of the generated plan.
-     * Currently, this should simply be the number of plans in the plan tree with this plan as the root (i.e. the
-     * number of descendants of this plan, including itself).
-     * @return the complexity of this plan
-     */
-    int getComplexity();
-
-    /**
      * Returns the (zero or more) children of this plan.
      * @return the child plans
      */
     @Nonnull
     List<RecordQueryPlan> getChildren();
+
+    @Nonnull
+    @Override
+    default List<? extends QueryPlan<?>> getQueryPlanChildren() {
+        return getChildren();
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -111,12 +111,12 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
 
     @Override
     public int hashCode() {
-        return Objects.hash(Sets.newHashSet(getChildren()), getComparisonKey(), isReverse()); // isomorphic under re-ordering of children
+        return Objects.hash(Sets.newHashSet(getQueryPlanChildren()), getComparisonKey(), isReverse()); // isomorphic under re-ordering of children
     }
 
     @Override
     public int planHash() {
-        return PlanHashable.planHash(getChildren()) + getComparisonKey().planHash() + (isReverse() ? 1 : 0);
+        return PlanHashable.planHash(getQueryPlanChildren()) + getComparisonKey().planHash() + (isReverse() ? 1 : 0);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -160,17 +160,17 @@ abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChildren {
         }
         RecordQueryUnionPlanBase that = (RecordQueryUnionPlanBase) o;
         return reverse == that.reverse &&
-               Objects.equals(Sets.newHashSet(getChildren()), Sets.newHashSet(that.getChildren()));  // isomorphic under re-ordering of children
+               Objects.equals(Sets.newHashSet(getQueryPlanChildren()), Sets.newHashSet(that.getQueryPlanChildren()));  // isomorphic under re-ordering of children
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(Sets.newHashSet(getChildren()), reverse); // isomorphic under re-ordering of children
+        return Objects.hash(Sets.newHashSet(getQueryPlanChildren()), reverse); // isomorphic under re-ordering of children
     }
 
     @Override
     public int planHash() {
-        return PlanHashable.planHash(getChildren()) + (reverse ? 1 : 0);
+        return PlanHashable.planHash(getQueryPlanChildren()) + (reverse ? 1 : 0);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.OrComponent;
 import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
@@ -77,6 +78,7 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that an OR of compatibly-ordered (up to reversal) indexed fields can be implemented as a union.
      */
+    @SuppressWarnings("rawtypes") // Bug with raw types and method references: https://bugs.openjdk.java.net/browse/JDK-8063054
     @Test
     public void testComplexQuery6() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
@@ -93,7 +95,7 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
         assertThat(plan, union(
                 indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(hasTupleString("[[odd],[odd]]")))),
                 indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(hasTupleString("[[0],[0]]"))))));
-        assertTrue(plan.getChildren().stream().allMatch(RecordQueryPlan::isReverse));
+        assertTrue(plan.getQueryPlanChildren().stream().allMatch(QueryPlan::isReverse));
         assertEquals(-2067012572, plan.planHash());
 
         Set<Long> seen = new HashSet<>();


### PR DESCRIPTION
The new interface, `QueryPlan`, has been added. It does not currently do anything except serve as a parent interface to `RecordQueryPlan`. Note that there are no new methods added to the `RecordQueryPlan` interface that do not have default implementations, so this is not a breaking change.

I have the beginnings of an `IndexScanPlan` locally. I considered getting that out prior to this change, but I figured I would ask for a look at this interface first. The most questionable thing (I think) is the `getQueryPlanChildren` method, which is designed to allow the implementor to return information about their children in a way that allows the `RecordQueryPlan` interface to implement it with a default method. But the drawback is this requires returning a wildcard in the return type.

I also didn't add a release note for this as its an interface with no current uses, but I can add one if people think that would be a good idea.

This resolves #364.