### PR TITLE
Resolves #352: Set a default extension registry within an FDBMetaDataStore

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -56,7 +56,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** By default, `FDBMetaDataStore`s are now initialized with an extension registry with all extensions from `record_metadata_options.proto` [(Issue #352)](https://github.com/FoundationDB/fdb-record-layer/issues/352)
 * **Feature** `FDBMetaDataStore` class now has convenience methods for `addIndex`, `dropIndex` and `updateRecords` [(Issue #281)](https://github.com/FoundationDB/fdb-record-layer/issues/281)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java-proto2/com/apple/foundationdb/record/ProtoVersionSupplier.java
+++ b/fdb-record-layer-core/src/test/java-proto2/com/apple/foundationdb/record/ProtoVersionSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * ProtoVersionSupplier.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+/**
+ * A utility class that that specifies what the Protocol buffer version is.
+ */
+public class ProtoVersionSupplier {
+
+    /**
+     * Get the major version of the Protocol buffer version.
+     *
+     * @return the major version of the Protocol buffer dependency
+     */
+    public static int getProtoVersion() {
+        return 2;
+    }
+
+    private ProtoVersionSupplier() {
+    }
+}

--- a/fdb-record-layer-core/src/test/java-proto3/com/apple/foundationdb/record/ProtoVersionSupplier.java
+++ b/fdb-record-layer-core/src/test/java-proto3/com/apple/foundationdb/record/ProtoVersionSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * ProtoVersionSupplier.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+/**
+ * A utility class that that specifies what the Protocol buffer version is.
+ */
+public class ProtoVersionSupplier {
+
+    /**
+     * Get the major version of the Protocol buffer version.
+     *
+     * @return the major version of the Protocol buffer dependency
+     */
+    public static int getProtoVersion() {
+        return 3;
+    }
+
+    private ProtoVersionSupplier() {
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -67,7 +67,6 @@ import com.apple.test.Tags;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -1899,9 +1898,6 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         metaDataStore.setMaintainHistory(false);
         assertEquals(metaDataSubspace, metaDataStore.getSubspace());
         metaDataStore.setDependencies(new Descriptors.FileDescriptor[]{RecordMetaDataOptionsProto.getDescriptor()});
-        ExtensionRegistry extensionRegistry = ExtensionRegistry.newInstance();
-        RecordMetaDataOptionsProto.registerAllExtensions(extensionRegistry);
-        metaDataStore.setExtensionRegistry(extensionRegistry);
         metaDataStore.setLocalFileDescriptor(localFileDescriptor);
         return metaDataStore;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
+import com.apple.foundationdb.record.ProtoVersionSupplier;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestRecordsNulls2Proto;
@@ -73,11 +74,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Tag(Tags.RequiresFDB)
 public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
-    @Nullable
-    static final String PROTO_VERSION = System.getenv("PROTO_VERSION");
-
     protected static boolean isProto3() {
-        return "3".equals(PROTO_VERSION);
+        return ProtoVersionSupplier.getProtoVersion() == 3;
     }
 
     protected static RecordMetaData proto2MetaData() {


### PR DESCRIPTION
This creates a default extension registry that contains the extension options included in `record_metadata_options.proto`. Existing code that used an `FDBMetaDataStore` but did not set an extension registry will (a) in proto3, no longer throw a `NullPointerException` and (b) in proto2, process the `(record).usage` extension, which was not the case before.

For proto2, I think this leads to the following hypothetical situation: a user who had something like two message types defined, one called `RecordTypeUnion` and another called, say, `UnionDescriptor` where they had initially stored the meta-data using the `UnionDescriptor` message (using the `(record).usage = UNION` extension option) and then switched to using the `RecordTypeUnion` message without removing the old extension (and instead relying on the lack of extension processing to avoid a "duplicate union" conflict). I think this is rare enough to be discounted, but I wanted to bring it up as a potential pitfall of this change.

This resolves #352.