### PR TITLE
Resolves #402: Add ResolvedKeySpacePath to represent path resolved against a database

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
@@ -228,16 +228,18 @@ public class DirectoryLayerDirectory extends KeySpaceDirectory {
 
     @Nonnull
     @Override
-    protected CompletableFuture<Optional<KeySpacePath>> pathFromKey(@Nonnull FDBRecordContext context,
-                                                                    @Nullable KeySpacePath parent,
-                                                                    @Nonnull Tuple key,
-                                                                    int keySize,
-                                                                    int keyIndex) {
+    protected CompletableFuture<Optional<ResolvedKeySpacePath>> pathFromKey(@Nonnull FDBRecordContext context,
+                                                                            @Nullable ResolvedKeySpacePath parent,
+                                                                            @Nonnull Tuple key,
+                                                                            int keySize,
+                                                                            int keyIndex) {
         final Object tupleValue = key.get(keyIndex);
         // Only a directory layer value can be reversed into this directory
         if (!(tupleValue instanceof Long)) {
             return DIRECTORY_NOT_FOR_KEY;
         }
+
+        final KeySpacePath parentPath = parent == null ? null : parent.toPath();
 
         return doReverseLookup(context, (Long)tupleValue)
                 .thenCompose(directoryString -> {
@@ -245,16 +247,20 @@ public class DirectoryLayerDirectory extends KeySpaceDirectory {
                     if (this.value != ANY_VALUE && !(directoryString.equals(this.value))) {
                         return DIRECTORY_NOT_FOR_KEY;
                     }
+
                     return lookupInScope(context, directoryString).thenCompose(directoryResolverResult -> {
                         final int childKeyIndex = keyIndex + 1;
                         final boolean canHaveChild = !subdirs.isEmpty() && childKeyIndex < keySize;
                         final Tuple remainder = canHaveChild || childKeyIndex == key.size()
                                                 ? null
                                                 : TupleHelpers.subTuple(key, childKeyIndex, key.size());
+                        final PathValue pathValue = toPathValue(directoryResolverResult);
 
                         // Make sure that the path is constructed with the text-name from the directory layer.
-                        KeySpacePath myPath = KeySpacePathImpl.newPath(parent, this, directoryString, true,
-                                toPathValue(directoryResolverResult), remainder);
+                        ResolvedKeySpacePath myPath = new ResolvedKeySpacePath(parent,
+                                KeySpacePathImpl.newPath(parentPath, this, directoryString,
+                                        true, pathValue, remainder),
+                                pathValue, remainder);
 
                         // We are finished if there are no more subdirectories or no more tuple to consume
                         if (!canHaveChild) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayer.java
@@ -36,7 +36,6 @@ import com.google.common.primitives.Bytes;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.charset.Charset;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -67,31 +66,42 @@ public class ExtendedDirectoryLayer extends LocatableResolver {
     private final Subspace contentSubspace;
 
     /**
-     * Create an extended directory layer. This constructor utilizes blocking calls and should not
-     * be used in an asynchronous context.
+     * Create an extended directory layer.
      *
      * @param context the context that will be used to resolve the provided path into the subspace at which
      *   the directory layer will be created. This context is only used during the construction of the
      *   this class is not subsequently used
      * @param path the path at which the directory layer should store its mappings.
+     * @deprecated use {@link #ExtendedDirectoryLayer(FDBDatabase, ResolvedKeySpacePath)} instead
      */
+    @Deprecated
+    @API(API.Status.DEPRECATED)
     public ExtendedDirectoryLayer(@Nonnull FDBRecordContext context, @Nonnull KeySpacePath path) {
-        this(context.getDatabase(), context, path);
+        this(context.getDatabase(), path, path.toResolvedPathAsync(context));
+    }
+
+    /**
+     * Create an extended directory layer.
+     *
+     * @param database database that will be used when resolving values
+     * @param path the path at which the directory layer should store its mappings.
+     */
+    public ExtendedDirectoryLayer(@Nonnull FDBDatabase database, @Nonnull ResolvedKeySpacePath path) {
+        this(database, path.toPath(), CompletableFuture.completedFuture(path));
     }
 
     private ExtendedDirectoryLayer(@Nonnull FDBDatabase database,
-                                   @Nullable FDBRecordContext context,
-                                   @Nullable KeySpacePath path) {
-        super(database, path);
-        if (path == null) {
+                                   @Nullable KeySpacePath path,
+                                   @Nullable CompletableFuture<ResolvedKeySpacePath> resolvedPathFuture) {
+        super(database, path, resolvedPathFuture);
+        if (path == null && resolvedPathFuture == null) {
             this.isRootLevel = true;
             this.baseSubspaceFuture = CompletableFuture.completedFuture(DEFAULT_BASE_SUBSPACE);
             this.nodeSubspaceFuture = CompletableFuture.completedFuture(DEFAULT_NODE_SUBSPACE);
             this.contentSubspace = DEFAULT_CONTENT_SUBSPACE;
         } else {
-            Objects.requireNonNull(context, "non null path requires non null context");
             this.isRootLevel = false;
-            this.baseSubspaceFuture = path.toSubspaceAsync(context);
+            this.baseSubspaceFuture = resolvedPathFuture.thenApply(ResolvedKeySpacePath::toSubspace);
             this.nodeSubspaceFuture = baseSubspaceFuture.thenApply(base ->
                     new Subspace(Bytes.concat(base.getKey(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())));
             this.contentSubspace = new Subspace(RESERVED_CONTENT_SUBSPACE_PREFIX);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
@@ -66,7 +66,7 @@ public class KeySpaceDirectory {
      * Return value from <code>pathFromKey</code> to indicate that a given tuple value is not appropriate
      * for a given directory.
      */
-    protected static final CompletableFuture<Optional<KeySpacePath>> DIRECTORY_NOT_FOR_KEY =
+    protected static final CompletableFuture<Optional<ResolvedKeySpacePath>> DIRECTORY_NOT_FOR_KEY =
             CompletableFuture.completedFuture(Optional.empty());
 
     /**
@@ -193,29 +193,36 @@ public class KeySpaceDirectory {
      * {@code keyIndex} position in the {@code key}
      */
     @Nonnull
-    protected CompletableFuture<Optional<KeySpacePath>> pathFromKey(@Nonnull FDBRecordContext context,
-                                                                    @Nullable KeySpacePath parent,
-                                                                    @Nonnull Tuple key,
-                                                                    final int keySize,
-                                                                    final int keyIndex) {
+    protected CompletableFuture<Optional<ResolvedKeySpacePath>> pathFromKey(@Nonnull FDBRecordContext context,
+                                                                            @Nullable ResolvedKeySpacePath parent,
+                                                                            @Nonnull Tuple key,
+                                                                            final int keySize,
+                                                                            final int keyIndex) {
         final Object tupleValue = key.get(keyIndex);
         if (KeyType.typeOf(tupleValue) != getKeyType()
                 || (this.value != ANY_VALUE && !areEqual(this.value, tupleValue))) {
             return DIRECTORY_NOT_FOR_KEY;
         }
 
+        final KeySpacePath parentPath = parent == null ? null : parent.toPath();
+        final PathValue pathValue = new PathValue(tupleValue);
+
         return toTupleValueAsync(context, tupleValue).thenCompose(resolvedValue -> {
             // Have we hit the leaf of the tree or run out of tuple to process?
             if (subdirs.isEmpty() || keyIndex + 1 == keySize) {
+                final Tuple remainder = (keyIndex + 1 == key.size()) ? null : TupleHelpers.subTuple(key, keyIndex + 1, key.size());
+                final KeySpacePath path = KeySpacePathImpl.newPath(parentPath, this, tupleValue,
+                        true, resolvedValue, remainder);
+
                 return CompletableFuture.completedFuture(
-                        Optional.of(KeySpacePathImpl.newPath(parent, this, tupleValue, true, resolvedValue,
-                                (keyIndex + 1 == key.size()) ? null : TupleHelpers.subTuple(key, keyIndex + 1, key.size()))));
+                        Optional.of(new ResolvedKeySpacePath(parent, path, new PathValue(tupleValue), remainder)));
             } else {
+                final KeySpacePath path = KeySpacePathImpl.newPath(parentPath, this, tupleValue,
+                        true, resolvedValue, null);
                 return findChildForKey(context,
-                        KeySpacePathImpl.newPath(parent, this, tupleValue, true, resolvedValue, null),
+                        new ResolvedKeySpacePath(parent, path, pathValue, null),
                         key, keySize, keyIndex + 1).thenApply(Optional::of);
             }
-
         });
     }
 
@@ -233,20 +240,20 @@ public class KeySpaceDirectory {
      * @throws RecordCoreArgumentException if no compatible child can be found
      */
     @Nonnull
-    protected CompletableFuture<KeySpacePath> findChildForKey(@Nonnull FDBRecordContext context,
-                                                              @Nullable KeySpacePath parent,
-                                                              @Nonnull Tuple key,
-                                                              final int keySize,
-                                                              final int keyIndex) {
+    protected CompletableFuture<ResolvedKeySpacePath> findChildForKey(@Nonnull FDBRecordContext context,
+                                                                      @Nullable ResolvedKeySpacePath parent,
+                                                                      @Nonnull Tuple key,
+                                                                      final int keySize,
+                                                                      final int keyIndex) {
         return nextChildForKey(0, context, parent, key, keySize, keyIndex);
     }
 
-    protected CompletableFuture<KeySpacePath> nextChildForKey(final int childIndex,
-                                                              @Nonnull FDBRecordContext context,
-                                                              @Nullable KeySpacePath parent,
-                                                              @Nonnull Tuple key,
-                                                              final int keySize,
-                                                              final int keyIndex) {
+    protected CompletableFuture<ResolvedKeySpacePath> nextChildForKey(final int childIndex,
+                                                                      @Nonnull FDBRecordContext context,
+                                                                      @Nullable ResolvedKeySpacePath parent,
+                                                                      @Nonnull Tuple key,
+                                                                      final int keySize,
+                                                                      final int keyIndex) {
         if (childIndex >= subdirs.size()) {
             throw new RecordCoreArgumentException("No subdirectory available to hold provided type",
                     LogMessageKeys.PARENT_DIR, getName(),
@@ -387,31 +394,31 @@ public class KeySpaceDirectory {
     }
 
     @Nonnull
-    protected RecordCursor<KeySpacePath> listAsync(@Nullable KeySpacePath listFrom,
-                                                   @Nonnull FDBRecordContext context,
-                                                   @Nonnull String subdirName,
-                                                   @Nullable byte[] continuation,
-                                                   @Nonnull ScanProperties scanProperties) {
-        return listAsync(listFrom, context, subdirName, null, continuation, scanProperties);
+    protected RecordCursor<ResolvedKeySpacePath> listSubdirectoryAsync(@Nullable KeySpacePath listFrom,
+                                                                       @Nonnull FDBRecordContext context,
+                                                                       @Nonnull String subdirName,
+                                                                       @Nullable byte[] continuation,
+                                                                       @Nonnull ScanProperties scanProperties) {
+        return listSubdirectoryAsync(listFrom, context, subdirName, null, continuation, scanProperties);
     }
 
     @Nonnull
     @SuppressWarnings("squid:S2095") // SonarQube doesn't realize that the cursor is wrapped and returned
-    protected RecordCursor<KeySpacePath> listAsync(@Nullable KeySpacePath listFrom,
-                                                   @Nonnull FDBRecordContext context,
-                                                   @Nonnull String subdirName,
-                                                   @Nullable ValueRange<?> valueRange,
-                                                   @Nullable byte[] continuation,
-                                                   @Nonnull ScanProperties scanProperties) {
+    protected RecordCursor<ResolvedKeySpacePath> listSubdirectoryAsync(@Nullable KeySpacePath listFrom,
+                                                                       @Nonnull FDBRecordContext context,
+                                                                       @Nonnull String subdirName,
+                                                                       @Nullable ValueRange<?> valueRange,
+                                                                       @Nullable byte[] continuation,
+                                                                       @Nonnull ScanProperties scanProperties) {
         if (listFrom != null && listFrom.getDirectory() != this) {
             throw new RecordCoreException("Provided path does not belong to this directory")
                     .addLogInfo("path", listFrom, "directory", this.getName());
         }
 
         final KeySpaceDirectory subdir = getSubdirectory(subdirName);
-        final CompletableFuture<Subspace> fromSubspaceFuture = listFrom == null
-                ? CompletableFuture.completedFuture(new Subspace())
-                : listFrom.toSubspaceAsync(context);
+        final CompletableFuture<ResolvedKeySpacePath> resolvedFromFuture = listFrom == null
+                ? CompletableFuture.completedFuture(null)
+                : listFrom.toResolvedPathAsync(context);
 
         // The chained cursor cannot implement reverse scan, so we implement it by having the
         // inner key value cursor do the reversing but telling the chained cursor we are moving
@@ -431,21 +438,23 @@ public class KeySpaceDirectory {
                 props -> props.clearState().setReturnedRowLimit(1));
 
         return new LazyCursor<>(
-                fromSubspaceFuture.thenCompose(subspace ->
-                        subdir.getValueRange(context, valueRange, subspace).thenApply(range -> {
-                            final RecordCursor<Tuple> cursor = new ChainedCursor<>(
-                                    context,
-                                    lastKey -> nextTuple(context, subspace, range, lastKey, keyReadScanProperties),
-                                    Tuple::pack,
-                                    Tuple::fromBytes,
-                                    continuation,
-                                    chainedCursorScanProperties);
+                resolvedFromFuture.thenCompose(resolvedFrom -> {
+                    final Subspace subspace = resolvedFrom == null ? new Subspace() : resolvedFrom.toSubspace();
+                    return subdir.getValueRange(context, valueRange, subspace).thenApply(range -> {
+                        final RecordCursor<Tuple> cursor = new ChainedCursor<>(
+                                context,
+                                lastKey -> nextTuple(context, subspace, range, lastKey, keyReadScanProperties),
+                                Tuple::pack,
+                                Tuple::fromBytes,
+                                continuation,
+                                chainedCursorScanProperties);
 
-                            return cursor.mapPipelined(tuple -> {
-                                final Tuple key = Tuple.fromList(tuple.getItems());
-                                return findChildForKey(context, listFrom, key, 1, 0);
-                            }, 1);
-                        })),
+                        return cursor.mapPipelined(tuple -> {
+                            final Tuple key = Tuple.fromList(tuple.getItems());
+                            return findChildForKey(context, resolvedFrom, key, 1, 0);
+                        }, 1);
+                    });
+                }),
                 context.getExecutor()
         );
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
@@ -288,7 +288,7 @@ public interface KeySpacePath {
      *
      * <p>The listing is performed by reading the first key of the data type (and possibly constant value) for the
      * subdirectory and, if a key is found, skipping to the next available value after the first one that was found,
-     * and so one, each time resulting in an additional <code>KeySpacePath</code> that is returned.  In each case,
+     * and so on, each time resulting in an additional <code>KeySpacePath</code> that is returned.  In each case,
      * the returned <code>KeySpacePath</code> may contain a remainder (see {@link #getRemainder()}) of the portion
      * of the key tuple that was read.
      *
@@ -325,7 +325,7 @@ public interface KeySpacePath {
      *
      * <p>The listing is performed by reading the first key of the data type (and possibly constant value) for the
      * subdirectory and, if a key is found, skipping to the next available value after the first one that was found,
-     * and so one, each time resulting in an additional <code>KeySpacePath</code> that is returned.  In each case,
+     * and so on, each time resulting in an additional <code>KeySpacePath</code> that is returned.  In each case,
      * the returned <code>KeySpacePath</code> may contain a remainder (see {@link #getRemainder()}) of the portion
      * of the key tuple that was read.
      *
@@ -413,17 +413,19 @@ public interface KeySpacePath {
      * keyspace for that directory. For example, given the tree:
      * <pre>
      * root
-     *   +- node
-     *       +- leaf
+     *   +- dirA
+     *       +- dirB
+     *           +- dirC
      * </pre>
-     * Performing a <code>listSubdirectoryAsync</code> from a given <code>node</code>, will result in a list of paths,
-     * one for each <code>leaf</code> that is available within the <code>node</code>'s scope.
+     * Performing a <code>listSubdirectoryAsync</code> from <code>dirA</code> for subdirectory <code>dirB</code>
+     * will path to each distinct value of <code>dirB</code>.
      *
      * <p>The listing is performed by reading the first key of the data type (and possibly constant value) for the
      * subdirectory and, if a key is found, skipping to the next available value after the first one that was found,
-     * and so one, each time resulting in an additional <code>ResolvedKeySpacePath</code> that is returned.  In each case,
+     * and so on, each time resulting in an additional <code>ResolvedKeySpacePath</code> that is returned.  In each case,
      * the returned <code>ResolvedKeySpacePath</code> may contain a remainder (see {@link ResolvedKeySpacePath#getRemainder()})
-     * of the portion of the key tuple that was read.
+     * of the portion of the key tuple that was read. In the above example, each unique value of <code>dirB</code>
+     * would contain a remainder <code>Tuple</code> of the first value of <code>dirC</code>.
      *
      * @param context the transaction in which to perform the listing
      * @param subdirName the name of the subdirectory that is to be listed
@@ -448,17 +450,19 @@ public interface KeySpacePath {
      * keyspace for that directory. For example, given the tree:
      * <pre>
      * root
-     *   +- node
-     *       +- leaf
+     *   +- dirA
+     *       +- dirB
+     *           +- dirC
      * </pre>
-     * Performing a <code>listSubdirectoryAsync</code> from a given <code>node</code>, will result in a list of paths,
-     * one for each <code>leaf</code> that is available within the <code>node</code>'s scope.
+     * Performing a <code>listSubdirectoryAsync</code> from <code>dirA</code> for subdirectory <code>dirB</code>
+     * will path to each distinct value of <code>dirB</code>.
      *
      * <p>The listing is performed by reading the first key of the data type (and possibly constant value) for the
      * subdirectory and, if a key is found, skipping to the next available value after the first one that was found,
-     * and so one, each time resulting in an additional <code>ResolvedKeySpacePath</code> that is returned.  In each case,
+     * and so on, each time resulting in an additional <code>ResolvedKeySpacePath</code> that is returned.  In each case,
      * the returned <code>ResolvedKeySpacePath</code> may contain a remainder (see {@link ResolvedKeySpacePath#getRemainder()})
-     * of the portion of the key tuple that was read.
+     * of the portion of the key tuple that was read. In the above example, each unique value of <code>dirB</code>
+     * would contain a remainder <code>Tuple</code> of the first value of <code>dirC</code>.
      *
      * @param context the transaction in which to perform the listing
      * @param subdirName the name of the subdirectory that is to be listed

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
@@ -106,6 +106,7 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.add(dirName, value);
     }
 
+    @Deprecated
     @Override
     @Nullable
     public Tuple getRemainder() {
@@ -135,12 +136,14 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.getValue();
     }
 
+    @Deprecated
     @Override
     @Nonnull
     public PathValue getStoredValue() {
         return inner.getStoredValue();
     }
 
+    @Deprecated
     @Override
     public boolean hasStoredValue() {
         return inner.hasStoredValue();
@@ -176,6 +179,7 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.deleteAllDataAsync(context);
     }
 
+    @Deprecated
     @Override
     @Nonnull
     public RecordCursor<KeySpacePath> listAsync(@Nonnull FDBRecordContext context,
@@ -185,6 +189,23 @@ public class KeySpacePathWrapper implements KeySpacePath {
                                                 @Nonnull ScanProperties scanProperties) {
         return inner.listAsync(context, subdirName, range, continuation, scanProperties);
     }
+
+    @Nonnull
+    @Override
+    public RecordCursor<ResolvedKeySpacePath> listSubdirectoryAsync(@Nonnull FDBRecordContext context,
+                                                                    @Nonnull String subdirName,
+                                                                    @Nullable ValueRange<?> range,
+                                                                    @Nullable byte[] continuation,
+                                                                    @Nonnull ScanProperties scanProperties) {
+        return inner.listSubdirectoryAsync(context, subdirName, range, continuation, scanProperties);
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<ResolvedKeySpacePath> toResolvedPathAsync(@Nonnull FDBRecordContext context) {
+        return inner.toResolvedPathAsync(context);
+    }
+
 
     @Override
     public boolean equals(Object obj) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -63,14 +63,36 @@ public abstract class LocatableResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(LocatableResolver.class);
     @Nonnull
     protected final FDBDatabase database;
-    @Nullable
-    protected final KeySpacePath path;
+    // NOTE: Once the deprecated code has been removed this should be switched to a ResolvedKeySpacePath
+    @Nonnull
+    protected final ResolverLocation location;
     protected final int hashCode;
 
+    /**
+     * Created a locatable resolver.
+     *
+     * <p>This constructor may seem a little strange in taking two paths that are, effectively, the same. The
+     * encouraged behavior for your resolvers is to create them from a {@link ResolvedKeySpacePath}, however for
+     * backward compatibility we still allow resolvers to be created from a {@link FDBRecordContext} and a {@link KeySpacePath}.
+     * All of the implementations of <code>LocatableResolver</code> are built such that if they are starting
+     * from a <code>KeySpacePath</code>, they will then turn it into a resolved path, then use that to get the subspace,
+     * but if they are created from a <code>ResolvedKeySpacePath</code>, they will instead directly get the subspace.
+     * This constructor is handed both the path and the potentially completed resolved form of that path, and when
+     * logging the path, if the resolved path is completed, will log that since it provides more detail.
+     *
+     * @param database the database to use for resolution
+     * @param path the path at which the resolver has its data located
+     * @param resolvedPath the resolved form of the path
+     */
     protected LocatableResolver(@Nonnull FDBDatabase database,
-                                @Nullable KeySpacePath path) {
+                                @Nullable KeySpacePath path,
+                                @Nullable CompletableFuture<ResolvedKeySpacePath> resolvedPath) {
+        if ((path == null && resolvedPath != null)
+                || (resolvedPath == null && path != null)) {
+            throw new IllegalArgumentException("Path and resolved path must both be null or neither be null");
+        }
         this.database = database;
-        this.path = path;
+        this.location = new ResolverLocation(path, resolvedPath);
         this.hashCode = Objects.hash(getClass(), path, database);
     }
 
@@ -232,7 +254,7 @@ public abstract class LocatableResolver {
                 .thenCompose(checkValues -> {
                     if (checkValues.contains(false)) {
                         throw new LocatableResolverLockedException("prewrite check failed")
-                                .addLogInfo(LogMessageKeys.RESOLVER_PATH, path)
+                                .addLogInfo(LogMessageKeys.RESOLVER_PATH, location)
                                 .addLogInfo(LogMessageKeys.RESOLVER_KEY, key);
                     }
                     return readResolverStateInTransaction(context);
@@ -241,7 +263,7 @@ public abstract class LocatableResolver {
                     if (!readState.equals(cachedState)) {
                         LOGGER.warn(KeyValueLogMessage.of("cached state and read stated differ",
                                 LogMessageKeys.RESOLVER_KEY, key,
-                                LogMessageKeys.RESOLVER_PATH, path,
+                                LogMessageKeys.RESOLVER_PATH, location,
                                 "cachedState", cachedState,
                                 "readState", readState));
                     }
@@ -251,7 +273,7 @@ public abstract class LocatableResolver {
                     if (state.getLock() != ResolverStateProto.WriteLock.UNLOCKED) {
                         throw new LocatableResolverLockedException("locatable resolver is not writable")
                                 .addLogInfo(LogMessageKeys.RESOLVER_KEY, key)
-                                .addLogInfo(LogMessageKeys.RESOLVER_PATH, path)
+                                .addLogInfo(LogMessageKeys.RESOLVER_PATH, location)
                                 .addLogInfo("lockState", state.getLock());
                     }
                     return create(context, key, metadata);
@@ -506,8 +528,7 @@ public abstract class LocatableResolver {
 
     @Override
     public String toString() {
-        return this.getClass().getName() +
-               (path == null ? "GLOBAL" : path.toString());
+        return this.getClass().getName() + ":" + location.toString();
     }
 
     @Override
@@ -521,7 +542,7 @@ public abstract class LocatableResolver {
         }
         LocatableResolver that = this.getClass().cast(obj);
 
-        return Objects.equals(this.database, that.database) && Objects.equals(this.path, that.path);
+        return Objects.equals(this.database, that.database) && this.location.equals(that.location);
     }
 
     @Override
@@ -566,4 +587,46 @@ public abstract class LocatableResolver {
         }
     }
 
+    /**
+     * Simple class to hide what type of path (if any) the resolver was created with, providing nothing but
+     * the ability to log the value.
+     */
+    private static class ResolverLocation {
+        @Nullable KeySpacePath path;
+        @Nullable ResolvedKeySpacePath resolvedKeySpacePath;
+
+        public ResolverLocation(@Nullable KeySpacePath path, @Nullable CompletableFuture<ResolvedKeySpacePath> resolvedFuture) {
+            if (resolvedFuture != null && resolvedFuture.isDone() && !resolvedFuture.isCompletedExceptionally()) {
+                this.resolvedKeySpacePath = resolvedFuture.join();
+            }
+            this.path = path;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ResolverLocation that = (ResolverLocation)o;
+            return Objects.equals(this.path, that.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return path == null ? 0 : path.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            if (resolvedKeySpacePath != null) {
+                return resolvedKeySpacePath.toString();
+            } else if (path != null) {
+                return path.toString();
+            }
+            return "GLOBAL";
+        }
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolvedKeySpacePath.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolvedKeySpacePath.java
@@ -1,0 +1,258 @@
+/*
+ * ResolvedKeySpacePath.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.keyspace;
+
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A <code>KeySpacePath</code> that has been resolved into the value that will be physically stored to
+ * represent the path element in the FDB keyspace.  A {@link KeySpacePath} represents a path through a
+ * logical directory tree defined by a {@link KeySpaceDirectory}.  Some directories, such as a the
+ * {@link DirectoryLayerDirectory} logically represent their values in one format (such as a string)
+ * but store their version in another "resolved" format (such as a long).  A <code>ResolvedKeySpacePath</code>
+ * represents the value for a path entry as resolved from a <code>KeySpacePath</code>.
+ */
+public class ResolvedKeySpacePath {
+    @Nullable
+    private final ResolvedKeySpacePath parent;
+    @Nonnull
+    private final KeySpacePath inner;
+    @Nonnull
+    private final PathValue value;
+    @Nullable
+    private final Tuple remainder;
+
+    @Nullable
+    private Tuple cachedTuple;
+    @Nullable
+    private Subspace cachedSubspace;
+
+    /**
+     * Create a resolved keyspace path.
+     *
+     * @param parent the parent resolved path
+     * @param inner the path for which the value was resolved
+     * @param value the resolved value
+     * @param remainder if the path was resolved from a <code>Tuple</code> this is the remaining portion that
+     *   extends beyond the end of the path.
+     */
+    protected ResolvedKeySpacePath(@Nullable ResolvedKeySpacePath parent, @Nonnull KeySpacePath inner,
+                                   @Nonnull PathValue value, @Nullable Tuple remainder) {
+        this.parent = parent;
+        this.inner = inner;
+        this.value = value;
+        this.remainder = remainder;
+    }
+
+    /**
+     * Get the length of the path.
+     * @return the length of the path
+     */
+    public int size() {
+        return inner.size();
+    }
+
+    /**
+     * Returns the parent path element.
+     * @return the parent path element or <code>null</code> if this is the root of the path
+     */
+    @Nullable
+    public ResolvedKeySpacePath getParent() {
+        return parent;
+    }
+
+    /**
+     * Returns the directory name for this path element.
+     * @return the directory name
+     */
+    @Nonnull
+    public String getDirectoryName() {
+        return inner.getDirectoryName();
+    }
+
+    /**
+     * Returns the directory that corresponds to this path entry.
+     * @return returns the directory that corresponds to this path entry
+     */
+    @Nonnull
+    KeySpaceDirectory getDirectory() {
+        return inner.getDirectory();
+    }
+
+    /**
+     * Returns the logical value (prior to resolving) for this path element.
+     *
+     * @return the logical value for this path element
+     */
+    @Nullable
+    public Object getLogicalValue() {
+        return inner.getValue();
+    }
+
+    /**
+     * Returns the value that will be physically stored to represent this path element along with any metadata that
+     * may be associated with it.
+     *
+     * @return the value that will be stored stored for the path element
+     */
+    @Nonnull
+    public PathValue getResolvedPathValue() {
+        return value;
+    }
+
+    /**
+     * Returns the value that will be physically stored to represent this path element.
+     *
+     * @return the value that will be stored stored for the path element
+     */
+    @Nullable
+    public Object getResolvedValue() {
+        return value.getResolvedValue();
+    }
+
+    /**
+     * Returns any metadata that may be stored along with the resolved value for this path element. Metadata is
+     * produced from {@link DirectoryLayerDirectory} entries in which the {@link LocatableResolver} that is
+     * performing the string to long mapping is also configured to store additional metadata associated with
+     * that entry.
+     *
+     * @return the metadata that is stored along with the resolved value for this path element or <code>null</code>
+     *   if there is no metadata
+     */
+    @Nullable
+    public byte[] getResolvedMetadata() {
+        return value.getMetadata();
+    }
+
+    /**
+     * Converts the resolved path into a <code>Tuple</code>.
+     *
+     * @return the <code>Tuple</code> form of the resolved path
+     */
+    @Nonnull
+    public Tuple toTuple() {
+        if (cachedTuple == null) {
+            final int len = size();
+
+            final Object[] values = new Object[len];
+            ResolvedKeySpacePath current = this;
+            for (int i = len - 1; i >= 0; i--) {
+                values[i] = current.getResolvedValue();
+                current = current.getParent();
+            }
+            cachedTuple = Tuple.from(values);
+        }
+        return cachedTuple;
+    }
+
+    @Nonnull
+    public Subspace toSubspace() {
+        if (cachedSubspace == null) {
+            cachedSubspace = new Subspace(toTuple().pack());
+        }
+        return cachedSubspace;
+    }
+
+    /**
+     * Convert the resolved path back into a {@link KeySpacePath}.
+     *
+     * @return The <code>KeySpacePath</code> for this resolved path
+     */
+    @Nonnull
+    public KeySpacePath toPath() {
+        return inner;
+    }
+
+    /**
+     * If this path was created via {@link KeySpace#resolveFromKey(FDBRecordContext, Tuple)}, this returns
+     * any remaining portion of the input tuple that was not used to construct the path.
+     * @return the remaining portion of the original input tuple or <code>null</code>
+     */
+    @Nullable
+    public Tuple getRemainder() {
+        return remainder;
+    }
+
+    /**
+     * Flattens the path into a list of <code>ResolvedKeySpacePath</code> entries, with the root of the path
+     * located at position 0.
+     *
+     * @return this path as a list
+     */
+    @Nonnull
+    public List<ResolvedKeySpacePath> flatten() {
+        final int len = size();
+        final ResolvedKeySpacePath[] flat = new ResolvedKeySpacePath[len];
+        ResolvedKeySpacePath current = this;
+        for (int i = len - 1; i >= 0; i--) {
+            flat[i] = current;
+            current = current.getParent();
+        }
+        return Arrays.asList(flat);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ResolvedKeySpacePath)) {
+            return false;
+        }
+
+        ResolvedKeySpacePath otherPath = (ResolvedKeySpacePath) other;
+        return this.inner.equals(otherPath.inner)
+               && Objects.equals(this.getResolvedValue(), otherPath.getResolvedValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inner, getResolvedPathValue());
+    }
+
+    @Override
+    public String toString() {
+        final List<ResolvedKeySpacePath> path = flatten();
+        final StringBuilder sb = new StringBuilder();
+        for (ResolvedKeySpacePath current : path) {
+            sb.append('/').append(current.getDirectoryName()).append(':');
+            KeySpacePathImpl.appendValue(sb, current.getLogicalValue());
+            if (!Objects.equals(current.getLogicalValue(), current.getResolvedValue())) {
+                sb.append('[');
+                KeySpacePathImpl.appendValue(sb, current.getResolvedValue());
+                sb.append(']');
+            }
+            if (current.getRemainder() != null) {
+                sb.append('+').append(current.getRemainder());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayer.java
@@ -33,7 +33,6 @@ import com.google.common.primitives.Bytes;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -58,28 +57,39 @@ public class ScopedDirectoryLayer extends LocatableResolver {
     private final Subspace contentSubspace;
 
     /**
-     * Creates a scoped directory layer. This constructor invokes blocking calls and must not
-     * not be called in the context of an asynchronous operation.
+     * Creates a scoped directory layer.
      *
      * @param context a context that is used only during the construction of this scope in order to
      *   resolve the provided path into a subspace
      * @param path the path at which the directory layer should live
+     * @deprecated use {@link #ScopedDirectoryLayer(FDBDatabase, ResolvedKeySpacePath)} instead
      */
+    @Deprecated
+    @API(API.Status.DEPRECATED)
     public ScopedDirectoryLayer(@Nonnull FDBRecordContext context,
                                 @Nonnull KeySpacePath path) {
-        this(context.getDatabase(), context, path);
+        this(context.getDatabase(), path, path.toResolvedPathAsync(context));
+    }
+
+    /**
+     * Create a scoped directory layer.
+     *
+     * @param database database that will be used when resolving values
+     * @param path the path at which the directory layer should store its mappings.
+     */
+    public ScopedDirectoryLayer(@Nonnull FDBDatabase database, @Nonnull ResolvedKeySpacePath path) {
+        this(database, path.toPath(), CompletableFuture.completedFuture(path));
     }
 
     private ScopedDirectoryLayer(@Nonnull FDBDatabase database,
-                                 @Nullable FDBRecordContext context,
-                                 @Nullable KeySpacePath path) {
-        super(database, path);
-        if (path == null) {
+                                 @Nullable KeySpacePath path,
+                                 @Nullable CompletableFuture<ResolvedKeySpacePath> resolvedPath) {
+        super(database, path, resolvedPath);
+        if (path == null && resolvedPath == null) {
             this.baseSubspaceFuture = CompletableFuture.completedFuture(new Subspace());
             this.contentSubspace = new Subspace();
         } else {
-            Objects.requireNonNull(context, "non null path requires non null context");
-            this.baseSubspaceFuture = path.toSubspaceAsync(context);
+            this.baseSubspaceFuture = resolvedPath.thenApply(ResolvedKeySpacePath::toSubspace);
             this.contentSubspace = new Subspace(RESERVED_CONTENT_SUBSPACE_PREFIX);
         }
         this.nodeSubspaceFuture = baseSubspaceFuture.thenApply(base ->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/ScopedInterningLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/ScopedInterningLayer.java
@@ -26,12 +26,12 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver;
+import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolvedKeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverResult;
 import com.apple.foundationdb.subspace.Subspace;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -57,24 +57,35 @@ public class ScopedInterningLayer extends LocatableResolver {
      * @param context context used to resolve the provided <code>path</code>. This context
      *   is only used during the construction of this class and at no other point
      * @param path the {@link KeySpacePath} where this resolver is rooted
+     * @deprecated use {@link #ScopedInterningLayer(FDBDatabase, ResolvedKeySpacePath)} instead
      */
+    @Deprecated
+    @API(API.Status.DEPRECATED)
     public ScopedInterningLayer(@Nonnull FDBRecordContext context, @Nonnull KeySpacePath path) {
-        this(context.getDatabase(), context, path);
+        this(context.getDatabase(), path, path.toResolvedPathAsync(context));
+    }
+
+    /**
+     * Creates a resolver rooted at the provided <code>KeySpacePath</code>.
+     * @param database database that will be used when resolving values
+     * @param path the {@link ResolvedKeySpacePath} where this resolver is rooted
+     */
+    public ScopedInterningLayer(@Nonnull FDBDatabase database, @Nonnull ResolvedKeySpacePath path) {
+        this(database, path.toPath(), CompletableFuture.completedFuture(path));
     }
 
     private ScopedInterningLayer(@Nonnull FDBDatabase database,
-                                 @Nullable FDBRecordContext context,
-                                 @Nullable KeySpacePath path) {
-        super(database, path);
+                                 @Nullable KeySpacePath path,
+                                 @Nullable CompletableFuture<ResolvedKeySpacePath> resolvedPath) {
+        super(database, path, resolvedPath);
         boolean isRootLevel;
-        if (path == null) {
+        if (path == null && resolvedPath == null) {
             isRootLevel = true;
             this.baseSubspaceFuture = CompletableFuture.completedFuture(new Subspace());
             this.nodeSubspaceFuture = CompletableFuture.completedFuture(new Subspace(GLOBAL_SCOPE_PREFIX_BYTES));
         } else {
-            Objects.requireNonNull(context, "non null path requires non null context");
             isRootLevel = false;
-            this.baseSubspaceFuture = path.toSubspaceAsync(context);
+            this.baseSubspaceFuture = resolvedPath.thenApply(ResolvedKeySpacePath::toSubspace);
             this.nodeSubspaceFuture = baseSubspaceFuture;
         }
         this.stateSubspaceFuture = nodeSubspaceFuture.thenApply(node -> node.get(STATE_SUBSPACE_KEY_SUFFIX));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -29,8 +29,8 @@ import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpace;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory;
-import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver;
+import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolvedKeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ScopedDirectoryLayer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ScopedValue;
 import com.apple.foundationdb.tuple.Tuple;
@@ -653,8 +653,8 @@ public class FDBReverseDirectoryCacheTest extends FDBTestBase {
         final String name = String.format("name-%d", Math.abs(random.nextLong()));
         KeySpace keySpace = new KeySpace(new KeySpaceDirectory(name, KeySpaceDirectory.KeyType.STRING, name));
         FDBRecordContext context = fdb.openContext();
-        KeySpacePath path = keySpace.pathFromKey(context, Tuple.from(name));
-        return new ScopedDirectoryLayer(context, path);
+        ResolvedKeySpacePath path = keySpace.resolveFromKey(context, Tuple.from(name));
+        return new ScopedDirectoryLayer(fdb, path);
     }
 
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerToInterningLayerReplicaTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerToInterningLayerReplicaTest.java
@@ -31,8 +31,8 @@ public class DirectoryLayerToInterningLayerReplicaTest extends ResolverMappingRe
     @BeforeEach
     public void setup() {
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedDirectoryLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedDirectoryLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
@@ -76,9 +76,9 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     @Test
     public void testWriteCompatibilityScoped() {
         try (FDBRecordContext context = database.openContext()) {
-            KeySpacePath path = keySpace.path("path").add("to").add("dirLayer");
-            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(context, path);
-            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
+            ResolvedKeySpacePath path = keySpace.path("path").add("to").add("dirLayer").toResolvedPath(context);
+            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(database, path);
+            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(database, path);
 
             testReadCompatible(backwardsCompatible, scopedDirectoryLayer);
         }
@@ -87,9 +87,9 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     @Test
     public void testReadCompatibilityScoped() {
         try (FDBRecordContext context = database.openContext()) {
-            KeySpacePath path = keySpace.path("path").add("to").add("dirLayer");
-            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(context, path);
-            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
+            ResolvedKeySpacePath path = keySpace.path("path").add("to").add("dirLayer").toResolvedPath(context);
+            LocatableResolver backwardsCompatible = scopedDirectoryGenerator.apply(database, path);
+            LocatableResolver scopedDirectoryLayer = new ScopedDirectoryLayer(database, path);
 
             testReadCompatible(scopedDirectoryLayer, backwardsCompatible);
         }
@@ -175,22 +175,22 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
 
     @Test
     public void testExtendedInParallelWithScopedDirectoryLayer() {
-        KeySpacePath path;
+        ResolvedKeySpacePath path;
         try (FDBRecordContext context = database.openContext()) {
-            path = keySpace.path("path").add("to").add("dirLayer");
-            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
-            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(context, path);
+            path = keySpace.path("path").add("to").add("dirLayer").toResolvedPath(context);
+            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(database, path);
+            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(database, path);
             testParallelAllocation(false, database, extendedDirectoryLayer, scopedDirectoryLayer);
         }
     }
 
     @Test
     public void testScopedDirectoryLayerInParallelWithExtended() {
-        KeySpacePath path;
+        ResolvedKeySpacePath path;
         try (FDBRecordContext context = database.openContext()) {
-            path = keySpace.path("path").add("to").add("dirLayer");
-            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(context, path);
-            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(context, path);
+            path = keySpace.path("path").add("to").add("dirLayer").toResolvedPath(context);
+            ScopedDirectoryLayer scopedDirectoryLayer = new ScopedDirectoryLayer(database, path);
+            ExtendedDirectoryLayer extendedDirectoryLayer = new ExtendedDirectoryLayer(database, path);
             testParallelAllocation(false, database, extendedDirectoryLayer, scopedDirectoryLayer);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToExtendedDirectoryLayerReplicaTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToExtendedDirectoryLayerReplicaTest.java
@@ -33,8 +33,8 @@ public class InterningLayerToExtendedDirectoryLayerReplicaTest extends ResolverM
     @BeforeEach
     public void setup() {
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ExtendedDirectoryLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ExtendedDirectoryLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
         seedWithMetadata = true;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToInterningLayerReplicaTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/InterningLayerToInterningLayerReplicaTest.java
@@ -31,8 +31,8 @@ public class InterningLayerToInterningLayerReplicaTest extends ResolverMappingRe
     @BeforeEach
     public void setup() {
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
         seedWithMetadata = true;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectoryTest.java
@@ -61,6 +61,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -307,19 +308,19 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             assertEquals(path2ExpectedTuple, path2Tuple);
 
             // Now, make sure that we can take a tuple and turn it back into a keyspace path.
-            List<KeySpacePath> revPath1 = root.pathFromKey(context, path1ExpectedTuple).flatten();
+            List<ResolvedKeySpacePath> revPath1 = root.resolveFromKey(context, path1ExpectedTuple).flatten();
             assertEquals("production", revPath1.get(0).getDirectoryName());
-            assertEquals(entries.get(0), revPath1.get(0).resolveAsync(context).get().getResolvedValue());
+            assertEquals(entries.get(0), revPath1.get(0).getResolvedValue());
             assertEquals("userid", revPath1.get(1).getDirectoryName());
-            assertEquals(123456789L, revPath1.get(1).resolveAsync(context).get().getResolvedValue());
+            assertEquals(123456789L, revPath1.get(1).getResolvedValue());
             assertEquals("application", revPath1.get(2).getDirectoryName());
-            assertEquals(entries.get(2), revPath1.get(2).resolveAsync(context).get().getResolvedValue());
+            assertEquals(entries.get(2), revPath1.get(2).getResolvedValue());
             assertEquals("dataStore", revPath1.get(3).getDirectoryName());
-            assertEquals(null, revPath1.get(3).resolveAsync(context).get().getResolvedValue());
+            assertEquals(null, revPath1.get(3).getResolvedValue());
 
             // Tack on extra value to make sure it is in the remainder.
             Tuple extendedPath2 = path2ExpectedTuple.add(10L);
-            List<KeySpacePath> revPath2 = root.pathFromKey(context, extendedPath2).flatten();
+            List<ResolvedKeySpacePath> revPath2 = root.resolveFromKey(context, extendedPath2).flatten();
             assertEquals("test", revPath2.get(0).getDirectoryName());
             assertEquals("userid", revPath2.get(1).getDirectoryName());
             assertEquals("application", revPath2.get(2).getDirectoryName());
@@ -514,7 +515,7 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         }
 
         try (FDBRecordContext context = database.openContext()) {
-            DirWithMetadataWrapper fromPath = (DirWithMetadataWrapper) root.pathFromKey(context, tuple);
+            DirWithMetadataWrapper fromPath = (DirWithMetadataWrapper) root.resolveFromKey(context, tuple).toPath();
             assertArrayEquals(fromPath.metadata(context).join(), DirWithMetadataWrapper.metadataHook(dir));
         }
     }
@@ -581,15 +582,24 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
                     .setFailOnScanLimitReached(false)
                     .setTimeLimit(5L)
                     .build());
-            RecordCursor<KeySpacePath> cursor = RecordCursor.flatMapPipelined(
+
+            // The inner and outer iterator are declared here instead of in-line with the call to flatMapPipelined
+            // because IntelliJ was having issues groking the call as a single call.
+            Function<byte[], RecordCursor<ResolvedKeySpacePath>> aIterator =
                     outerContinuation ->
-                            root.path("root").listAsync(context, "a", outerContinuation, props)
+                            root.path("root").listSubdirectoryAsync(context, "a", outerContinuation, props)
                                     .map(value -> {
                                         sleep(1L);
                                         return value;
-                                    }),
+                                    });
+
+            BiFunction<ResolvedKeySpacePath, byte[], RecordCursor<ResolvedKeySpacePath>> bIterator =
                     (aPath, innerContinuation) ->
-                            aPath.add("b", 0).listAsync(context, "c", innerContinuation, props),
+                            aPath.toPath().add("b", 0).listSubdirectoryAsync(context, "c", innerContinuation, props);
+
+            RecordCursor<ResolvedKeySpacePath> cursor = RecordCursor.flatMapPipelined(
+                    aIterator,
+                    bIterator,
                     null,
                     10
             );
@@ -641,7 +651,7 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
                     .setReturnedRowLimit(returnedRowLimit)
                     .setScannedRecordsLimit(scannedRecordLimit)
                     .build());
-            RecordCursor<KeySpacePath> cursor = root.path("root").listAsync(context, "a", null, props);
+            RecordCursor<ResolvedKeySpacePath> cursor = root.path("root").listSubdirectoryAsync(context, "a", null, props);
 
             int count = 0;
             while (cursor.hasNext()) {
@@ -687,8 +697,8 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         try (FDBRecordContext context = database.openContext()) {
             ScanProperties props = new ScanProperties(ExecuteProperties.newBuilder().build(), true);
             results = root.path("root")
-                    .listAsync(context, "a", null, props).asList().join().stream()
-                    .map(path -> path.toTuple(context))
+                    .listSubdirectoryAsync(context, "a", null, props).asList().join().stream()
+                    .map(path -> path.toTuple())
                     .collect(Collectors.toList());
         }
 
@@ -702,7 +712,8 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         String tmpDirLayer = "tmp-dir-layer-" + random.nextLong();
         KeySpace dirLayerKeySpace = new KeySpace(new KeySpaceDirectory(tmpDirLayer, KeyType.STRING, tmpDirLayer));
         return context ->
-                CompletableFuture.completedFuture(new ScopedInterningLayer(context, dirLayerKeySpace.path(tmpDirLayer)));
+                CompletableFuture.completedFuture(new ScopedInterningLayer(context.getDatabase(),
+                        dirLayerKeySpace.path(tmpDirLayer).toResolvedPath(context)));
     }
 
     private KeySpace rootForMetadataTests(String name,
@@ -766,11 +777,11 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
         try (FDBRecordContext context = database.openContext()) {
             Tuple tuple = Tuple.from(1L, "a");
-            assertEquals(tuple, root.pathFromKey(context, tuple).toTuple(context));
+            assertEquals(tuple, root.resolveFromKey(context, tuple).toTuple());
             tuple = Tuple.from(1L, "b");
-            assertEquals(tuple, root.pathFromKey(context, tuple).toTuple(context));
+            assertEquals(tuple, root.resolveFromKey(context, tuple).toTuple());
             final Tuple badTuple1 = Tuple.from(1L, "c", "d");
-            assertThrows(RecordCoreArgumentException.class, () -> root.pathFromKey(context, badTuple1).toTuple(context),
+            assertThrows(RecordCoreArgumentException.class, () -> root.resolveFromKey(context, badTuple1).toTuple(),
                     "key_tuple", badTuple1,
                     "key_tuple_pos", 1);
         }
@@ -796,10 +807,10 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         }
 
         try (FDBRecordContext context = database.openContext()) {
-            assertEquals("/root:4/dir1:hi/dir2:0x4142+(\"blah\")",
-                    root.pathFromKey(context, Tuple.from(4L, "hi", new byte[] { 0x41, 0x42 }, "blah")).toString());
-            assertEquals("/root:11", root.pathFromKey(context, Tuple.from(11L)).toString());
-            assertEquals("/root:14/dir3:4/dir4:" + barValue + "->_bar", root.pathFromKey(context, Tuple.from(14L, 4L, barValue)).toString());
+            assertEquals("/root:4/dir1:\"hi\"/dir2:0x4142+(\"blah\")",
+                    root.resolveFromKey(context, Tuple.from(4L, "hi", new byte[] { 0x41, 0x42 }, "blah")).toString());
+            assertEquals("/root:11", root.resolveFromKey(context, Tuple.from(11L)).toString());
+            assertEquals("/root:14/dir3:4/dir4:\"_bar\"[" + barValue + "]", root.resolveFromKey(context, Tuple.from(14L, 4L, barValue)).toString());
 
             assertEquals("/root:11/dir3:17/dir4:" + fooValue,
                     root.path("root", 11L)
@@ -833,18 +844,18 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         // list all "b" directories you only get a path leading up to the "b"'s, wth the "c" values as a
         // remainder on the "b" path entry.
         try (FDBRecordContext context = database.openContext()) {
-            List<KeySpacePath> paths;
+            List<ResolvedKeySpacePath> paths;
 
             // Check listing from the root
-            paths = root.list(context, "a");
+            paths = root.listDirectory(context, "a");
             assertThat("Number of paths in 'a'", paths.size(), is(1));
-            assertThat("Value of subdirectory 'a'", paths.get(0).getValue(), is(root.getDirectory("a").getValue()));
+            assertThat("Value of subdirectory 'a'", paths.get(0).getLogicalValue(), is(root.getDirectory("a").getValue()));
             assertThat("Remainder size of 'a'", paths.get(0).getRemainder().size(), is(3));
 
             // List from "b"
-            paths = root.path("a").list(context, "b");
+            paths = root.path("a").listSubdirectory(context, "b");
             assertThat("Number of paths in 'b'", paths.size(), is(5));
-            for (KeySpacePath path : paths) {
+            for (ResolvedKeySpacePath path : paths) {
                 assertThat("Listing of 'b' directory", path.getDirectoryName(), is("b"));
                 Tuple remainder = path.getRemainder();
                 assertThat("Remainder of 'b'", remainder.size(), is(2));
@@ -853,9 +864,9 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             }
 
             // List from "c"
-            paths = root.path("a").add("b", "foo_0").list(context, "c");
+            paths = root.path("a").add("b", "foo_0").listSubdirectory(context, "c");
             assertThat("Number of paths in 'c'", paths.size(), is(1));
-            for (KeySpacePath path  : paths) {
+            for (ResolvedKeySpacePath path  : paths) {
                 assertThat("Listing of 'c' directory", path.getDirectoryName(), is("c"));
                 final Tuple remainder = path.getRemainder();
                 assertThat("Remainder of 'c'", remainder.size(), is(1));
@@ -863,13 +874,13 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             }
 
             // List from "d"
-            paths = root.path("a").add("b", "foo_0").add("c", "hi_0").list(context, "d");
+            paths = root.path("a").add("b", "foo_0").add("c", "hi_0").listSubdirectory(context, "d");
             assertThat("Number of paths in 'd'", paths.size(), is(1));
-            KeySpacePath path = paths.get(0);
+            ResolvedKeySpacePath path = paths.get(0);
             assertThat("Remainder of 'd'", path.getRemainder(), is((Tuple) null));
 
             // List from "e" (which has no data)
-            paths = root.path("a").add("b", "foo_0").add("c", "hi_0").add("d", new byte[] { 0x00 }).list(context, "e");
+            paths = root.path("a").add("b", "foo_0").add("c", "hi_0").add("d", new byte[] { 0x00 }).listSubdirectory(context, "e");
             assertThat("Number of paths in 'e'", paths.size(), is(0));
         }
     }
@@ -1056,14 +1067,14 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
                 "expectedValues", expectedValues,
                 "keyType", keyType).toString();
 
-        List<KeySpacePath> paths = context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_LIST,
+        List<ResolvedKeySpacePath> paths = context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_LIST,
                 root.path("a")
-                        .listAsync(context, keyType.toString(), range, null, ScanProperties.FORWARD_SCAN).asList());
+                        .listSubdirectoryAsync(context, keyType.toString(), range, null, ScanProperties.FORWARD_SCAN).asList());
 
         assertEquals(expectedValues.size(), paths.size(), "The result size does not match" + testCaseInfo);
 
-        for (KeySpacePath path : paths) {
-            Tuple tuple = path.toTuple(context);
+        for (ResolvedKeySpacePath path : paths) {
+            Tuple tuple = path.toTuple();
             assertTrue(expectedValues.remove(Tuple.from(tuple.get(1))), "missing: " + tuple.get(1) + testCaseInfo);
         }
 
@@ -1085,14 +1096,14 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         try (FDBRecordContext context = database.openContext()) {
             // Positive example.
             root.path(rootDir)
-                    .list(context, stringDir,
+                    .listSubdirectory(context, stringDir,
                             new ValueRange<>("A", "B", EndpointType.RANGE_INCLUSIVE, EndpointType.RANGE_EXCLUSIVE),
                             null,
                             ScanProperties.FORWARD_SCAN);
 
             // The range value should be in the same type.
             assertThrows(RecordCoreArgumentException.class, () ->
-                    root.path(rootDir).list(
+                    root.path(rootDir).listSubdirectory(
                             context,
                             stringDir,
                             new ValueRange<>(100, 200, EndpointType.RANGE_INCLUSIVE, EndpointType.RANGE_EXCLUSIVE),
@@ -1102,7 +1113,7 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
 
             // PREFIX_STRING should not be used as a endpoint type.
             assertThrows(RecordCoreArgumentException.class, () ->
-                    root.path(rootDir).list(
+                    root.path(rootDir).listSubdirectory(
                             context,
                             stringDir,
                             new ValueRange<>("A", "B", EndpointType.PREFIX_STRING, EndpointType.RANGE_EXCLUSIVE),
@@ -1112,7 +1123,7 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
 
             // Range should be null when the subdirectory has a value.
             assertThrows(RecordCoreArgumentException.class, () ->
-                    root.path(rootDir).list(
+                    root.path(rootDir).listSubdirectory(
                             context,
                             longConstDir,
                             new ValueRange<>(100, 200, EndpointType.RANGE_INCLUSIVE, EndpointType.RANGE_EXCLUSIVE),
@@ -1142,13 +1153,13 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         int idx = 0;
         do {
             try (final FDBRecordContext context = database.openContext()) {
-                final RecordCursor<KeySpacePath>  cursor = rootPath.listAsync(context, "b", continuation,
+                final RecordCursor<ResolvedKeySpacePath>  cursor = rootPath.listSubdirectoryAsync(context, "b", continuation,
                         new ScanProperties(ExecuteProperties.newBuilder().setReturnedRowLimit(2).build()));
-                List<KeySpacePath> subdirs = context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_LIST, cursor.asList());
+                List<ResolvedKeySpacePath> subdirs = context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_LIST, cursor.asList());
                 if (!subdirs.isEmpty()) {
                     assertEquals(2, subdirs.size(), "Wrong number of path entries returned");
-                    assertEquals("val_" + idx, subdirs.get(0).resolveAsync(context).get().getResolvedValue());
-                    assertEquals("val_" + (idx + 1), subdirs.get(1).resolveAsync(context).get().getResolvedValue());
+                    assertEquals("val_" + idx, subdirs.get(0).getResolvedValue());
+                    assertEquals("val_" + (idx + 1), subdirs.get(1).getResolvedValue());
                     idx += 2;
                     continuation = cursor.getContinuation();
                     System.out.println(continuation == null ? "null" : Tuple.fromBytes(continuation));
@@ -1200,12 +1211,12 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             for (KeyTypeValue kv : valueOfEveryType) {
                 KeySpaceDirectory dir = root.getDirectory("a").getSubdirectory(kv.keyType.name());
 
-                List<KeySpacePath> paths = root.path("a").list(context, kv.keyType.toString());
+                List<ResolvedKeySpacePath> paths = root.path("a").listSubdirectory(context, kv.keyType.toString());
                 assertEquals(1, paths.size());
                 if (dir.getKeyType() == KeyType.BYTES) {
-                    assertTrue(Arrays.equals((byte[]) dir.getValue(), paths.get(0).toTuple(context).getBytes(1)));
+                    assertTrue(Arrays.equals((byte[]) dir.getValue(), paths.get(0).toTuple().getBytes(1)));
                 } else {
-                    assertEquals(dir.getValue(), paths.get(0).toTuple(context).get(1));
+                    assertEquals(dir.getValue(), paths.get(0).toTuple().get(1));
                 }
             }
         }
@@ -1242,23 +1253,23 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         }
 
         try (FDBRecordContext context = database.openContext()) {
-            List<KeySpacePath> paths = root.path("a").list(context, "b");
+            List<ResolvedKeySpacePath> paths = root.path("a").listSubdirectory(context, "b");
             assertEquals(10, paths.size());
 
-            for (KeySpacePath path : paths) {
+            for (ResolvedKeySpacePath path : paths) {
                 final long index = path.getRemainder().getLong(0); // The first part of the remainder was the index
                 // We should always get the "first" key for the value in the directory
                 assertEquals(0, path.getRemainder().getLong(1));
                 assertTrue(index >= 0 && index < 10);
                 assertEquals("a", path.getParent().getDirectoryName());
-                assertEquals(root.getDirectory("a").getValue(), path.getParent().getValue());
-                assertEquals("value_" + index, path.getValue());
+                assertEquals(root.getDirectory("a").getValue(), path.getParent().getLogicalValue());
+                assertEquals("value_" + index, path.getLogicalValue());
             }
 
             for (String subdir : ImmutableList.of("d", "e", "f")) {
-                paths = root.path("a").add("c").list(context, subdir);
+                paths = root.path("a").add("c").listSubdirectory(context, subdir);
                 assertEquals(1, paths.size());
-                assertEquals(subdir, paths.get(0).getValue());
+                assertEquals(subdir, paths.get(0).getLogicalValue());
                 assertEquals(0L, paths.get(0).getRemainder().getLong(0));
                 assertEquals("c", paths.get(0).getParent().getDirectoryName());
                 assertEquals("a", paths.get(0).getParent().getParent().getDirectoryName());
@@ -1293,10 +1304,10 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             assertEquals(Tuple.from(entries.get(0), 123L, entries.get(1), EnvironmentKeySpace.DATA_VALUE), dataStoreTuple);
             assertEquals(Tuple.from(entries.get(0), 123L, entries.get(1), EnvironmentKeySpace.METADATA_VALUE), metadataStoreTuple);
 
-            KeySpacePath path =  keySpace.fromKey(context, dataStoreTuple);
-            assertThat(path, instanceOf(DataPath.class));
+            ResolvedKeySpacePath path =  keySpace.fromKey(context, dataStoreTuple);
+            assertThat(path.toPath(), instanceOf(DataPath.class));
 
-            DataPath mainStorePath = (DataPath) path;
+            DataPath mainStorePath = (DataPath) path.toPath();
             assertEquals(EnvironmentKeySpace.DATA_VALUE, mainStorePath.getValue());
             assertEquals(EnvironmentKeySpace.DATA_VALUE, mainStorePath.resolveAsync(context).get().getResolvedValue());
             assertEquals(entries.get(1), mainStorePath.parent().resolveAsync(context).get().getResolvedValue());
@@ -1306,14 +1317,14 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             assertEquals("production", mainStorePath.parent().parent().parent().getValue());
             assertEquals(null, mainStorePath.parent().parent().parent().parent());
 
-            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 1)), instanceOf(EnvironmentRoot.class));
-            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 2)), instanceOf(UserPath.class));
-            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 3)), instanceOf(ApplicationPath.class));
+            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 1)).toPath(), instanceOf(EnvironmentRoot.class));
+            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 2)).toPath(), instanceOf(UserPath.class));
+            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 3)).toPath(), instanceOf(ApplicationPath.class));
 
             path = keySpace.fromKey(context, metadataStoreTuple);
-            assertThat(path, instanceOf(MetadataPath.class));
+            assertThat(path.toPath(), instanceOf(MetadataPath.class));
 
-            MetadataPath metadataPath = (MetadataPath) path;
+            MetadataPath metadataPath = (MetadataPath) path.toPath();
             assertEquals(EnvironmentKeySpace.METADATA_VALUE, metadataPath.getValue());
             assertEquals(EnvironmentKeySpace.METADATA_VALUE, metadataPath.resolveAsync(context).get().getResolvedValue());
             assertEquals(entries.get(1), metadataPath.parent().resolveAsync(context).get().getResolvedValue());
@@ -1323,16 +1334,16 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
             assertEquals("production", metadataPath.parent().parent().parent().getValue());
             assertEquals(null, metadataPath.parent().parent().parent().parent());
 
-            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 1)), instanceOf(EnvironmentRoot.class));
-            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 2)), instanceOf(UserPath.class));
-            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 3)), instanceOf(ApplicationPath.class));
+            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 1)).toPath(), instanceOf(EnvironmentRoot.class));
+            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 2)).toPath(), instanceOf(UserPath.class));
+            assertThat(keySpace.fromKey(context, TupleHelpers.subTuple(dataStoreTuple, 0, 3)).toPath(), instanceOf(ApplicationPath.class));
 
             // Create a fake main store "record" key to demonstrate that we can get the key as the remainder
             Tuple recordTuple = dataStoreTuple.add(1L).add("someStr").add(0L); // 1=record space, record id, 0=unsplit record
             path =  keySpace.fromKey(context, recordTuple);
-            assertThat(path, instanceOf(DataPath.class));
+            assertThat(path.toPath(), instanceOf(DataPath.class));
             assertEquals(Tuple.from(1L, "someStr", 0L), path.getRemainder());
-            assertEquals(dataStoreTuple, path.toTuple(context));
+            assertEquals(dataStoreTuple, path.toTuple());
         }
     }
 
@@ -1384,8 +1395,8 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
         }
 
         try (FDBRecordContext context = database.openContext()) {
-            List<KeySpacePath> paths = keySpace.path("a", "foo").list(context, "b");
-            for (KeySpacePath path : paths) {
+            List<ResolvedKeySpacePath> paths = keySpace.path("a", "foo").listSubdirectory(context, "b");
+            for (ResolvedKeySpacePath path : paths) {
                 assertThat("Path should be PathB", path, instanceOf(PathB.class));
                 assertThat("parent should be PathA", path.getParent(), instanceOf(PathA.class));
             }
@@ -1542,8 +1553,8 @@ public class KeySpaceDirectoryTest extends FDBTestBase {
          * Given a tuple that represents an FDB key that came from this KeySpace, returns the leaf-most path
          * element in which the tuple resides.
          */
-        public KeySpacePath fromKey(FDBRecordContext context, Tuple tuple) {
-            return root.pathFromKey(context, tuple);
+        public ResolvedKeySpacePath fromKey(FDBRecordContext context, Tuple tuple) {
+            return root.resolveFromKey(context, tuple);
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
@@ -82,8 +82,8 @@ public class ResolverMappingDigestTest extends FDBTestBase {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedDirectoryLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedDirectoryLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
 
         testComputeDigest(primary, replica, false);
@@ -94,8 +94,8 @@ public class ResolverMappingDigestTest extends FDBTestBase {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
 
         testComputeDigest(primary, replica, false);
@@ -106,8 +106,8 @@ public class ResolverMappingDigestTest extends FDBTestBase {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
 
         byte[] metadata = Tuple.from("some-metadata").pack();
@@ -119,8 +119,8 @@ public class ResolverMappingDigestTest extends FDBTestBase {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ExtendedDirectoryLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ExtendedDirectoryLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
 
         testComputeDigest(primary, replica, false);
@@ -131,8 +131,8 @@ public class ResolverMappingDigestTest extends FDBTestBase {
         LocatableResolver primary;
         LocatableResolver replica;
         try (FDBRecordContext context = database.openContext()) {
-            primary = new ScopedInterningLayer(context, keySpace.path("test-path").add("to").add("primary"));
-            replica = new ExtendedDirectoryLayer(context, keySpace.path("test-path").add("to").add("replica"));
+            primary = new ScopedInterningLayer(database, keySpace.path("test-path").add("to").add("primary").toResolvedPath(context));
+            replica = new ExtendedDirectoryLayer(database, keySpace.path("test-path").add("to").add("replica").toResolvedPath(context));
         }
 
         testComputeDigest(primary, replica, true);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
@@ -243,7 +243,7 @@ public abstract class ResolverMappingReplicatorTest extends FDBTestBase {
 
         KeySpacePath path = keySpace.path("test-path").add("to").add("replica");
         try (FDBRecordContext context = differentDB.openContext()) {
-            LocatableResolver resolverInDifferentDB = new ScopedInterningLayer(context, path);
+            LocatableResolver resolverInDifferentDB = new ScopedInterningLayer(differentDB, path.toResolvedPath(context));
             replicator.copyTo(resolverInDifferentDB);
             fail("should throw IllegalArgumentException");
         } catch (IllegalArgumentException ex) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
@@ -129,14 +129,14 @@ public class ScopedDirectoryLayerTest extends LocatableResolverTest {
         );
 
         FDBRecordContext context = database.openContext();
-        KeySpacePath path = keySpace.pathFromKey(context, Tuple.from("path", "to", "dirLayer"));
+        ResolvedKeySpacePath path = keySpace.resolveFromKey(context, Tuple.from("path", "to", "dirLayer"));
 
-        LocatableResolver resolver = scopedDirectoryGenerator.apply(context, path);
+        LocatableResolver resolver = scopedDirectoryGenerator.apply(database, path);
         Long value = resolver.resolve(context.getTimer(), "foo").join();
 
         DirectoryLayer directoryLayer = new DirectoryLayer(
-                new Subspace(Bytes.concat(path.toTuple(context).pack(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())),
-                path.toSubspace(context));
+                new Subspace(Bytes.concat(path.toTuple().pack(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())),
+                path.toSubspace());
         context = database.openContext();
         validate(context, resolver, directoryLayer, "foo", value);
 


### PR DESCRIPTION
.This change ended up being larger than expected:

- New `ResolvedKeySpacePath` represents a path that has been resolved against
  a specific database. It can be turned into a `Tuple` or `Subspace` without
  blocking and when logged will log details about the value to which a path
  element has been resolved against the database.
- Added `KeySpace.resolveFromKey` to turn a `Tuple` back into a `ResolvedKeySpacePath`
  and deprecated the old `KeySpace.pathFromKey`.  Additionally, deprecated the methods
  a `KeySpacePath` that used to return additional information about the tuple that
  was resolved (e.g.  `hasStoredValue()` and `getStoredValue()`).
- Changed all of the "list" methods to new versions that returned `ResolvedKeySpacePath`.
  This means deprecating all of the old list methods and add new versions
  (`KeySpace.listDirectory[Async]()` and `KeySpacePath.listSubdirectory[Async]()`.
- Updated the `LoctableResolver` implementations to support a `ResolvedKeySpacePath` and
  deprecated the old constructors that took a `KeySpacePath`.
- Updated all of the test cases and any other code depending on the deprecated API's

Note that there is still work to be done on the `LocatableResolver`s. Once these deprecated
API's have been removed, the `LoctableResolver` can be updated to no longer work so hard to
make resolving the subspace a piece of each operation that it does.