### PR TITLE
Resolves #338 and #386.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,6 +42,8 @@ The API stability annotations have been moved to their own package. This allows 
 
 The `IndexMaintainer` class now has a new public method `validateEntries`. Subclasses inheriting it should implement the new method. It does not break classes extending `StandardIndexMaintainer` which has a default implementation that does nothing.
 
+The `SubspaceProvider` interface is changed to no longer require an `FDBRecordContext` at construction. Instead, methods that resolve subspaces are directly provided with an `FDBRecordContext`. This provides implementations with the flexibility to resolve logical subspace representations against different FoundationDB backends.
+
 ### Newly deprecated
 
 Methods for retrieving a record from a record store based on an index entry generally took both an index and an index entry. As index entries now store a reference to their associatedindex, these methods have been deprecated in favor of methods that only take an index entry. The earlier methods may be removed in a future release. The same is true for a constructor on `FDBIndexedRecord` which no longer needs to take both an index and an index entry.
@@ -70,6 +72,7 @@ Methods for retrieving a record from a record store based on an index entry gene
 * **Breaking change** `IndexMaintainer`s should implement `validateEntries` to validate orphan index entries [(Issue #383)](https://github.com/FoundationDB/fdb-record-layer/issues/383)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** The API stability annotations have been moved into `com.apple.foundationdb.annotation` [(Issue #406)](https://github.com/FoundationDB/fdb-record-layer/issues/406)
+* **Breaking change** `SubspaceProvider` receives an `FDBRecordContext` when a subspace is resolved instead of when constructed.[(Issue #338)](https://github.com/FoundationDB/fdb-record-layer/issues/338)
 
 // end next release
 -->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
@@ -209,14 +209,14 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
                     addPendingCacheUpdate(recordMetaData);
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(KeyValueLogMessage.of("Using cached serialized meta-data",
-                                subspaceProvider.logKey(), subspaceProvider,
+                                subspaceProvider.logKey(), subspaceProvider.toString(context),
                                 LogMessageKeys.VERSION, currentVersion));
                     }
                     return CompletableFuture.completedFuture(metaDataProto);
                 }
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug(KeyValueLogMessage.of("Cached serialized meta-data is out-of-date",
-                            subspaceProvider.logKey(), subspaceProvider,
+                            subspaceProvider.logKey(), subspaceProvider.toString(context),
                             LogMessageKeys.VERSION, currentVersion,
                             "cachedVersion", cachedSerializedVersion));
                 }
@@ -245,7 +245,7 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
                     }
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(KeyValueLogMessage.of("Loaded meta-data",
-                                subspaceProvider.logKey(), subspaceProvider,
+                                subspaceProvider.logKey(), subspaceProvider.toString(context),
                                 LogMessageKeys.VERSION, metaDataProto.getVersion()));
                     }
                     return metaDataProto;
@@ -265,7 +265,7 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
                                     if (oldRawRecord != null) {
                                         final byte[] oldBytes = oldRawRecord.getRawRecord();
                                         LOGGER.info(KeyValueLogMessage.of("Upgrading old-format meta-data store",
-                                                subspaceProvider.logKey(), subspaceProvider));
+                                                subspaceProvider.logKey(), subspaceProvider.toString(context)));
                                         ensureContextActive().clear(getSubspace().range(OLD_FORMAT_KEY));
                                         SplitHelper.saveWithSplit(context, getSubspace(), CURRENT_KEY, oldBytes, null);
                                         return oldBytes;
@@ -327,7 +327,7 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
                 int oldVersion = oldProto.getVersion();
                 if (metaDataProto.getVersion() <= oldVersion) {
                     LOGGER.warn(KeyValueLogMessage.of("Meta-data version did not increase",
-                            subspaceProvider.logKey(), subspaceProvider,
+                            subspaceProvider.logKey(), subspaceProvider.toString(context),
                             "old", oldVersion,
                             "new", metaDataProto.getVersion()));
                     throw new MetaDataException("meta-data version must increase");
@@ -379,14 +379,14 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
                             if (currentVersion == recordMetaData.getVersion()) {
                                 if (LOGGER.isDebugEnabled()) {
                                     LOGGER.debug(KeyValueLogMessage.of("Using cached meta-data",
-                                                                   subspaceProvider.logKey(), subspaceProvider,
+                                                                   subspaceProvider.logKey(), subspaceProvider.toString(context),
                                                                    LogMessageKeys.VERSION, currentVersion));
                                 }
                                 return CompletableFuture.completedFuture(recordMetaData);
                             }
                             if (LOGGER.isDebugEnabled()) {
                                 LOGGER.debug(KeyValueLogMessage.of("Cached meta-data is out-of-date",
-                                                               subspaceProvider.logKey(), subspaceProvider,
+                                                               subspaceProvider.logKey(), subspaceProvider.toString(context),
                                                                LogMessageKeys.VERSION, currentVersion,
                                                                "cachedVersion", recordMetaData.getVersion()));
                             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -976,7 +976,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                                 LogMessageKeys.INDEX_NAME, entry.getIndex().getName(),
                                 LogMessageKeys.PRIMARY_KEY, primaryKey,
                                 LogMessageKeys.INDEX_KEY, entry.getKey(),
-                                getSubspaceProvider().logKey(), getSubspaceProvider());
+                                getSubspaceProvider().logKey(), getSubspaceProvider().toString(getContext()));
                     default:
                         throw new RecordCoreException("Unexpected index orphan behavior: " + orphanBehavior);
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
@@ -41,8 +41,17 @@ import java.util.concurrent.Executor;
 public abstract class FDBStoreBase {
     @Nonnull
     protected final FDBRecordContext context;
+
     @Nonnull
     protected final SubspaceProvider subspaceProvider;
+
+    //cache of resolved subspace future used by getSubspaceAsync; do not directly access
+    @Nullable
+    private CompletableFuture<Subspace> subspaceFuture;
+
+    //cache of resolved subspace used by getSubspace; do not directly access
+    @Nullable
+    private Subspace subspace;
 
     // It is recommended to use {@link #FDBStoreBase(FDBRecordContext, SubspaceProvider)} instead.
     @API(API.Status.UNSTABLE)
@@ -81,8 +90,24 @@ public abstract class FDBStoreBase {
     }
 
     @Nonnull
+    public CompletableFuture<Subspace> getSubspaceAsync() {
+        if (subspaceFuture == null) {
+            return subspaceProvider.getSubspaceAsync(context).whenComplete((s, e) -> {
+                if (e == null) { //only cache if no exception
+                    subspace = s;
+                    subspaceFuture = CompletableFuture.completedFuture(subspace);
+                }
+            });
+        }
+        return subspaceFuture;
+    }
+
+    @Nonnull
     public Subspace getSubspace() {
-        return subspaceProvider.getSubspace();
+        if (subspace == null) {
+            subspace = context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_PATH_RESOLVE, getSubspaceAsync());
+        }
+        return subspace;
     }
 
     public void addConflictForSubspace(boolean write) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollector.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollector.java
@@ -50,7 +50,7 @@ import java.util.concurrent.CompletableFuture;
 @API(API.Status.EXPERIMENTAL)
 public class SizeStatisticsCollector {
     @Nonnull
-    private final Subspace subspace;
+    private final SubspaceProvider subspaceProvider;
     private long keyCount;
     private long keySize;
     private long maxKeySize;
@@ -62,8 +62,8 @@ public class SizeStatisticsCollector {
     private byte[] continuation;
     private boolean done;
 
-    private SizeStatisticsCollector(@Nonnull Subspace subspace) {
-        this.subspace = subspace;
+    private SizeStatisticsCollector(@Nonnull SubspaceProvider subspaceProvider) {
+        this.subspaceProvider = subspaceProvider;
         this.keyCount = 0;
         this.keySize = 0;
         this.maxKeySize = 0;
@@ -86,48 +86,52 @@ public class SizeStatisticsCollector {
      *
      * @param context the transaction context in which to collect statistics
      * @param executeProperties limits on execution
-     * @return a future that completes to <code>true</code> if this object is done collecting statistics or <code>false</code> otherwise
+     *
+     * @return a future that completes to <code>true</code> if this object is done collecting statistics or
+     * <code>false</code> otherwise
      */
     @Nonnull
     public CompletableFuture<Boolean> collectAsync(@Nonnull FDBRecordContext context, @Nonnull ExecuteProperties executeProperties) {
         if (done) {
             return AsyncUtil.READY_TRUE;
         }
-        final ScanProperties scanProperties = new ScanProperties(executeProperties)
-                .setStreamingMode(CursorStreamingMode.WANT_ALL);
-        final KeyValueCursor kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
-                .setContext(context)
-                .setContinuation(continuation)
-                .setScanProperties(scanProperties)
-                .build();
-        return kvCursor.forEach(kv -> {
-            keyCount += 1;
-            keySize += kv.getKey().length;
-            maxKeySize = Math.max(maxKeySize, kv.getKey().length);
-            valueSize += kv.getValue().length;
-            maxValueSize = Math.max(maxValueSize, kv.getValue().length);
-            int totalSize = kv.getKey().length + kv.getValue().length;
-            if (totalSize > 0) {
-                sizeBuckets[Integer.SIZE - Integer.numberOfLeadingZeros(totalSize) - 1] += 1;
-            }
-            continuation = kvCursor.getContinuation();
-        }).handle((vignore, err) -> {
-            if (err == null) {
-                boolean exhausted = kvCursor.getNoNextReason().isSourceExhausted();
-                if (!exhausted) {
-                    continuation = kvCursor.getContinuation();
-                } else {
-                    done = true;
+        return subspaceProvider.getSubspaceAsync(context).thenCompose(subspace -> {
+            final ScanProperties scanProperties = new ScanProperties(executeProperties)
+                    .setStreamingMode(CursorStreamingMode.WANT_ALL);
+            final KeyValueCursor kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
+                    .setContext(context)
+                    .setContinuation(continuation)
+                    .setScanProperties(scanProperties)
+                    .build();
+            return kvCursor.forEach(kv -> {
+                keyCount += 1;
+                keySize += kv.getKey().length;
+                maxKeySize = Math.max(maxKeySize, kv.getKey().length);
+                valueSize += kv.getValue().length;
+                maxValueSize = Math.max(maxValueSize, kv.getValue().length);
+                int totalSize = kv.getKey().length + kv.getValue().length;
+                if (totalSize > 0) {
+                    sizeBuckets[Integer.SIZE - Integer.numberOfLeadingZeros(totalSize) - 1] += 1;
                 }
-                return exhausted;
-            } else {
-                if (FDBExceptions.isRetriable(err)) {
-                    return false;
+                continuation = kvCursor.getContinuation();
+            }).handle((vignore, err) -> {
+                if (err == null) {
+                    boolean exhausted = kvCursor.getNoNextReason().isSourceExhausted();
+                    if (!exhausted) {
+                        continuation = kvCursor.getContinuation();
+                    } else {
+                        done = true;
+                    }
+                    return exhausted;
                 } else {
-                    throw context.getDatabase().mapAsyncToSyncException(err);
+                    if (FDBExceptions.isRetriable(err)) {
+                        return false;
+                    } else {
+                        throw context.getDatabase().mapAsyncToSyncException(err);
+                    }
                 }
-            }
-        }).whenComplete((vignore, err) -> kvCursor.close());
+            }).whenComplete((vignore, err) -> kvCursor.close());
+        });
     }
 
     /**
@@ -136,6 +140,7 @@ public class SizeStatisticsCollector {
      *
      * @param context the transaction context in which to collect statistics
      * @param executeProperties limits on execution
+     *
      * @return <code>true</code> if this object is done collecting statistics or <code>false</code> otherwise
      */
     public boolean collect(@Nonnull FDBRecordContext context, @Nonnull ExecuteProperties executeProperties) {
@@ -144,6 +149,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the number of keys in the requested key range.
+     *
      * @return the number of keys
      */
     public long getKeyCount() {
@@ -152,6 +158,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the total size (in bytes) of all keys in the requested key range.
+     *
      * @return the size (in bytes) of the requested keys
      */
     public long getKeySize() {
@@ -160,6 +167,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the total size (in bytes) of all values in the requested key range.
+     *
      * @return the size (in bytes) of the requested values
      */
     public long getValueSize() {
@@ -168,6 +176,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the total size (in bytes) of all keys and values in the requested key range.
+     *
      * @return the size (in bytes) of the requested keys and values
      */
     public long getTotalSize() {
@@ -176,6 +185,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the size (in bytes) of the largest key in the requested key range.
+     *
      * @return the size (in bytes) of the largest key
      */
     public long getMaxKeySize() {
@@ -184,6 +194,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the size (in bytes) of the largest value in the requested key range.
+     *
      * @return the size (in bytes) of the largest value
      */
     public long getMaxValueSize() {
@@ -192,6 +203,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the mean size (in bytes) of keys in the requested key range.
+     *
      * @return the mean size (in bytes) of all keys
      */
     public double getAverageKeySize() {
@@ -200,6 +212,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the mean size (in bytes) of values in the requested key range.
+     *
      * @return the mean size (in bytes) of all values
      */
     public double getAverageValueSize() {
@@ -208,6 +221,7 @@ public class SizeStatisticsCollector {
 
     /**
      * Get the mean size (in bytes) of combined key-value pairs in the requested key range.
+     *
      * @return the mean size (in bytes) of all key-value pairs
      */
     public double getAverage() {
@@ -238,6 +252,7 @@ public class SizeStatisticsCollector {
      * interpolated from the recorded size distribution.
      *
      * @param proportion the proportion of key-value pairs that should have a size less than the returned size
+     *
      * @return an estimate for the size that is consistent with the given proportion
      */
     public double getProportion(double proportion) {
@@ -295,11 +310,12 @@ public class SizeStatisticsCollector {
      * This includes records, indexes, and other meta-data.
      *
      * @param store the store from which to collect statistics on key and value sizes
+     *
      * @return a statistics collector of that store
      */
     @Nonnull
     public static SizeStatisticsCollector ofStore(@Nonnull FDBRecordStore store) {
-        return new SizeStatisticsCollector(store.getSubspace());
+        return new SizeStatisticsCollector(store.getSubspaceProvider());
     }
 
     /**
@@ -307,11 +323,12 @@ public class SizeStatisticsCollector {
      * This only looks at the records stored by that store, not any indexes.
      *
      * @param store the store from which to collect statistics on key and value sizes
+     *
      * @return a statistics collector of the records of that store
      */
     @Nonnull
     public static SizeStatisticsCollector ofRecords(@Nonnull FDBRecordStore store) {
-        return new SizeStatisticsCollector(store.recordsSubspace());
+        return new SizeStatisticsCollector(new SubspaceProviderBySubspace(store.recordsSubspace()));
     }
 
     /**
@@ -320,6 +337,7 @@ public class SizeStatisticsCollector {
      *
      * @param store a store with the given index
      * @param indexName the name of the index to collect statistics on key and value sizes
+     *
      * @return a statistics collector of the given index
      */
     @Nonnull
@@ -334,47 +352,23 @@ public class SizeStatisticsCollector {
      *
      * @param store a store with the given index
      * @param index the index to collect statistics on key and value sizes
+     *
      * @return a statistics collector of the given index
      */
     @Nonnull
     public static SizeStatisticsCollector ofIndex(@Nonnull FDBRecordStore store, @Nonnull Index index) {
-        return new SizeStatisticsCollector(store.indexSubspace(index));
+        return new SizeStatisticsCollector(new SubspaceProviderBySubspace(store.indexSubspace(index)));
     }
 
     /**
      * Create a statistics collector of all keys used by index within a given {@link Subspace}.
      *
      * @param subspace the subspace to collect statistics on key and value sizes
+     *
      * @return a statistics collector of the given subspace
      */
     @Nonnull
     public static SizeStatisticsCollector ofSubspace(@Nonnull Subspace subspace) {
-        return new SizeStatisticsCollector(subspace);
-    }
-
-    /**
-     * Create a statistics collector of all keys used by index within a given {@link SubspaceProvider}'s subspace.
-     * If the implementation of {@link SubspaceProvider#getSubspace() getSubspace()} is blocking for the
-     * given <code>SubspaceProvide</code>, then this method will also be blocking.
-     *
-     * @param subspaceProvider the provider of the subspace to collect statistics on key and value sizes
-     * @return a statistics collector of the given subspace
-     */
-    @Nonnull
-    public static SizeStatisticsCollector ofSubspaceProvider(@Nonnull SubspaceProvider subspaceProvider) {
-        return new SizeStatisticsCollector(subspaceProvider.getSubspace());
-    }
-
-    /**
-     * Create a statistics collector of all keys used by index within a given {@link SubspaceProvider}'s subspace.
-     * This method is non-blocking, and it returns a future that will contain the statistics collector when
-     * ready.
-     *
-     * @param subspaceProvider the provider of the subspace to collect statistics on key and value sizes
-     * @return a future containing the statistics collector of the given subspace
-     */
-    @Nonnull
-    public static CompletableFuture<SizeStatisticsCollector> ofSubspaceProviderAsync(@Nonnull SubspaceProvider subspaceProvider) {
-        return subspaceProvider.getSubspaceAsync().thenApply(SizeStatisticsCollector::new);
+        return new SizeStatisticsCollector(new SubspaceProviderBySubspace(subspace));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProvider.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProvider.java
@@ -23,27 +23,47 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.subspace.Subspace;
-
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Subspace provider can provide a subspace (might be blocking) and logging information to the subspace (non-blocking).
  */
-@API(API.Status.MAINTAINED)
+@API(API.Status.INTERNAL)
 public interface SubspaceProvider {
     /**
      * This might be blocking if the subspace is never fetched before.
+     *
+     * @param context record context used to resolve the subspace
+     *
      * @return Subspace
      */
     @Nonnull
-    Subspace getSubspace();
+    Subspace getSubspace(@Nonnull FDBRecordContext context);
 
+    /**
+     * Asynchronously resolves the subspace against the database associated with {@link FDBRecordContext}.
+     *
+     * @param context record context used to resolve the subspace
+     *
+     * @return CompletableFuture&lt;Subspace&gt;
+     */
     @Nonnull
-    CompletableFuture<Subspace> getSubspaceAsync();
+    CompletableFuture<Subspace> getSubspaceAsync(@Nonnull FDBRecordContext context);
 
     @Nonnull
     LogMessageKeys logKey();
+
+    /**
+     * This method is typically called in support of error logging; hence, implementations should not assume
+     * a working {@link FDBRecordContext} but might, for example, use it to retrieve a subspace previously
+     * resolved against the corresponding database.
+     *
+     * @param context record context used to resolve the subspace
+     *
+     * @return CompletableFuture&lt;Subspace&gt;
+     */
+    String toString(@Nonnull FDBRecordContext context);
 
     @Override
     String toString();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderBySubspace.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SubspaceProviderBySubspace.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * A SubspaceProvider wrapping a subspace. Getting the subspace from this provider is not blocking.
  */
-@API(API.Status.MAINTAINED)
+@API(API.Status.INTERNAL)
 public class SubspaceProviderBySubspace implements SubspaceProvider {
     @Nonnull
     private Subspace subspace;
@@ -42,13 +42,13 @@ public class SubspaceProviderBySubspace implements SubspaceProvider {
 
     @Nonnull
     @Override
-    public Subspace getSubspace() {
+    public Subspace getSubspace(@Nonnull FDBRecordContext context) {
         return subspace;
     }
 
     @Nonnull
     @Override
-    public CompletableFuture<Subspace> getSubspaceAsync() {
+    public CompletableFuture<Subspace> getSubspaceAsync(@Nonnull FDBRecordContext context) {
         return CompletableFuture.completedFuture(subspace);
     }
 
@@ -56,6 +56,11 @@ public class SubspaceProviderBySubspace implements SubspaceProvider {
     @Override
     public LogMessageKeys logKey() {
         return LogMessageKeys.SUBSPACE;
+    }
+
+    @Override
+    public String toString(@Nonnull FDBRecordContext context) {
+        return toString();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
@@ -547,4 +547,15 @@ public interface KeySpacePath {
                                                         @Nonnull String subdirName) {
         return listSubdirectory(context, subdirName, null, null, ScanProperties.FORWARD_SCAN);
     }
+
+    /**
+     * String representation of this {@link KeySpacePath} that shows correspondences between original and resolved
+     * directory values in accordance with the input {@link Tuple}.
+     *
+     * @param tuple representing the directory values of this path in resolved form
+     *
+     * @return a string representation of the path that shows both original and resolved directory values
+     */
+    @API(API.Status.UNSTABLE)
+    String toString(@Nonnull Tuple tuple);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
@@ -221,4 +221,9 @@ public class KeySpacePathWrapper implements KeySpacePath {
     public String toString() {
         return inner.toString();
     }
+
+    @Override
+    public String toString(@Nonnull Tuple t) {
+        return inner.toString(t);
+    }
 }


### PR DESCRIPTION
Removes requirement for FDBRecordContext and instantiation time. Instead methods for retrieving a subspace require an FDBRecordContext to be passed. toString also accepts and FDBRecordContext so that the logging string shows correspondences between logical and resolved names (in the case where the SubspaceProvider is based on a KeySpacePath). Needless to say this is a breaking change for the SubspaceProvider interface.