### PR TITLE
Resolves #419: Rework ExpressionMatchers for complex child matching.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Bindable.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Bindable.java
@@ -25,7 +25,7 @@ import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * A planner type that supports rule binding. Both {@link PlannerExpression} and {@link ExpressionRef} implement
@@ -39,22 +39,5 @@ public interface Bindable {
      * @return a map of bindings if the match succeeded, or an empty <code>Optional</code> if it failed
      */
     @Nonnull
-    default Optional<PlannerBindings> bindWith(@Nonnull ExpressionMatcher<? extends Bindable> binding) {
-        return bindWithExisting(binding, new PlannerBindings());
-    }
-
-    /**
-     * Attempt to match the binding to this bindable object, returning a map consisting of the old keys along with new
-     * bindings from this <code>Bindable</code>.
-     * The returned map is guaranteed to contain all of the keys from <code>existing</code>.
-     * This method is meant to make it easier to implement recursive matching.
-     * When implementing a new <code>Bindable</code>, implementing this method is sufficient.
-     * When implementing this method, take care to ensure that the the existing bindings are not mutated and that new
-     * bindings are added only when a match is certain.
-     * @param binding the binding to match against
-     * @param existing an existing map of bindings
-     * @return a map of bindings if the match succeeded, or an empty <code>Optional</code> if it failed
-     */
-    @Nonnull
-    Optional<PlannerBindings> bindWithExisting(@Nonnull ExpressionMatcher<? extends Bindable> binding, @Nonnull PlannerBindings existing);
+    Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> binding);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
@@ -22,8 +22,11 @@ package com.apple.foundationdb.record.query.plan.temp;
 
 import com.apple.foundationdb.API;
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 
 import javax.annotation.Nonnull;
+import java.util.stream.Stream;
 
 /**
  * This interface is used mostly as an (admittedly surmountable) barrier to rules mutating bound references directly,
@@ -43,6 +46,37 @@ public interface ExpressionRef<T extends PlannerExpression> extends Bindable {
     T get();
 
     <U> U acceptPropertyVisitor(@Nonnull PlannerProperty<U> property);
+
+    /**
+     * Try to bind the given matcher to this reference. It should not try to match to the members of the reference;
+     * if the given matcher needs to match to a {@link PlannerExpression} rather than an {@link ExpressionRef}, it will
+     * call {@link #bindWithin(ExpressionMatcher)} instead.
+     *
+     * <p>
+     * Binding to references can be a bit subtle: some matchers (such as {@code ReferenceMatcher}) can bind to references
+     * directly while others (such as {@code TypeMatcher}) can't, since they need access to the underlying operator
+     * which might not even be well defined. This method implements binding to the <em>reference</em>, rather than to
+     * its member(s).
+     * </p>
+     * @param matcher a matcher to match with
+     * @return a stream of bindings if the match succeeded or an empty stream if it failed
+     */
+    @Nonnull
+    @Override
+    default Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> matcher) {
+        return matcher.matchWith(this);
+    }
+
+    /**
+     * Try to bind the given matcher to the members of this reference. If this reference has more than one member,
+     * it should try to match to any of them and produce a stream of bindings covering all possible combinations.
+     * If possible, this should be done in a lazy fashion using the {@link Stream} API, so as to minimize unnecessary
+     * work.
+     * @param matcher an expression matcher to match the member(s) of this reference with
+     * @return a stream of bindings if the match succeeded or an empty stream if it failed
+     */
+    @Nonnull
+    Stream<PlannerBindings> bindWithin(@Nonnull ExpressionMatcher<? extends Bindable> matcher);
 
     /**
      * An exception thrown when {@link #get()} is called on a reference that does not support it, such as a group reference.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerExpression.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.query.plan.temp;
 
 import com.apple.foundationdb.API;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 
@@ -30,7 +29,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * The basic type that represents a part of the planner expression tree. An expression is generally an immutable
@@ -65,35 +64,15 @@ public interface PlannerExpression extends Bindable {
     /**
      * Matches a matcher expression to an expression tree rooted at this node, adding to some existing bindings.
      * @param binding the binding to match against
-     * @param existing an existing map of bindings
      * @return the existing bindings extended with some new ones if the match was successful or <code>Optional.empty()</code> otherwise
      */
     @Override
     @Nonnull
-    default Optional<PlannerBindings> bindWithExisting(@Nonnull ExpressionMatcher<? extends Bindable> binding, @Nonnull PlannerBindings existing) {
-        if (existing.containsKey(binding)) {
-            throw new RecordCoreException("tried to bind to a matcher that is already bound");
-        }
-
-        if (!binding.matches(this).equals(ExpressionMatcher.Result.MATCHES)) {
-            return Optional.empty();
-        }
-        Iterator<? extends ExpressionRef<? extends PlannerExpression>> childIterator = getPlannerExpressionChildren();
-        Iterator<ExpressionMatcher<? extends Bindable>> bindingIterator = binding.getChildren().iterator();
-
-        while (childIterator.hasNext() && bindingIterator.hasNext()) {
-            Optional<PlannerBindings> possible = childIterator.next().bindWithExisting(bindingIterator.next(), existing);
-            if (!possible.isPresent()) {
-                return possible;
-            }
-            existing = possible.get();
-        }
-
-        if (childIterator.hasNext() || bindingIterator.hasNext()) { // unable to match completely
-            return Optional.empty();
-        }
-        existing.put(binding, this);
-        return Optional.of(existing);
+    default Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> binding) {
+        Stream<PlannerBindings> bindings = binding.matchWith(this);
+        // TODO this is probably kind of inefficient for the really common case where we don't match at all.
+        return bindings.flatMap(outerBindings -> binding.getChildrenMatcher().matches(getPlannerExpressionChildren())
+                .map(outerBindings::mergedWith));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RewritePlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RewritePlanner.java
@@ -36,7 +36,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A simple planner that applies rewrite rules until it can't apply any more of them, then returns the resulting plan.
@@ -123,16 +122,16 @@ public class RewritePlanner implements QueryPlanner {
 
     private PlannerRule.ChangesMade applyRulesTo(@Nonnull PlannerRuleSet ruleSet, @Nonnull SingleExpressionRef<PlannerExpression> expression) {
         Iterator<PlannerRule<? extends PlannerExpression>> possibleRules = ruleSet.getRulesMatching(expression.get());
-        PlannerRule.ChangesMade madeChanges = PlannerRule.ChangesMade.NO_CHANGE;
         while (possibleRules.hasNext()) {
-            Optional<RewriteRuleCall> attemptedCall = RewriteRuleCall.tryMatchRule(context, possibleRules.next(), expression);
-            if (attemptedCall.isPresent()) {
-                if (attemptedCall.get().run().equals(PlannerRule.ChangesMade.MADE_CHANGES)) {
-                    possibleRules = ruleSet.getRulesMatching(expression.get());
-                    madeChanges = PlannerRule.ChangesMade.MADE_CHANGES;
+            Iterator<RewriteRuleCall> calls = RewriteRuleCall.tryMatchRule(context, possibleRules.next(), expression).iterator();
+
+            while (calls.hasNext()) {
+                RewriteRuleCall call = calls.next();
+                if (call.run().equals(PlannerRule.ChangesMade.MADE_CHANGES)) {
+                    return PlannerRule.ChangesMade.MADE_CHANGES;
                 }
             }
         }
-        return madeChanges;
+        return PlannerRule.ChangesMade.NO_CHANGE;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RewriteRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RewriteRuleCall.java
@@ -25,7 +25,7 @@ import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * A rule call implementation for the {@link com.apple.foundationdb.record.query.plan.temp.RewritePlanner}.
@@ -101,11 +101,11 @@ public class RewriteRuleCall implements PlannerRuleCall {
      * @param root a single expression reference containing a planner expression to apply the rule to
      * @return an {@code Optional} containing a rewrite rule call if the rule's matcher matched or {@code Optional.empty()} otherwise
      */
-    public static Optional<RewriteRuleCall> tryMatchRule(
+    public static Stream<RewriteRuleCall> tryMatchRule(
             @Nonnull PlanContext context,
             @Nonnull PlannerRule<? extends PlannerExpression> rule,
             @Nonnull SingleExpressionRef<PlannerExpression> root) {
-        return root.bindWith(rule.getMatcher()).map(bindings -> new RewriteRuleCall(context, rule, root, bindings));
+        return root.bindTo(rule.getMatcher()).map(bindings -> new RewriteRuleCall(context, rule, root, bindings));
     }
 
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/SingleExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/SingleExpressionRef.java
@@ -21,13 +21,12 @@
 package com.apple.foundationdb.record.query.plan.temp;
 
 import com.apple.foundationdb.API;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * A mutable reference to a single planner expression. Since it references a single expression, it can provide
@@ -73,29 +72,9 @@ public class SingleExpressionRef<T extends PlannerExpression> implements Mutable
         return new SingleExpressionRef<>(expression);
     }
 
-    /**
-     * Implement binding of an expression matcher to the planner expression contained by this reference.
-     * Binding to references can be a bit subtle: some matchers (such as <code>ReferenceMatcher</code>) can bind to references
-     * directly while others (such as <code>TypeMatcher</code>) can't, since they need access to the underlying operator
-     * which might not even be well defined. If possible, the matcher binds to the reference; if the binding returns
-     * <code>Result.UNKNOWN</code>, then it tries to bind to the expression behind the reference.
-     * @param binding the binding to match against
-     * @param existing an existing map of bindings
-     * @return a map of bindings if the match succeeded, or an empty <code>Optional</code> if it failed
-     */
-    @Override
     @Nonnull
-    public Optional<PlannerBindings> bindWithExisting(@Nonnull ExpressionMatcher<? extends Bindable> binding, @Nonnull PlannerBindings existing) {
-        switch (binding.matches(this)) {
-            case UNKNOWN:
-                return expression.bindWithExisting(binding, existing);
-            case MATCHES:
-                existing.put(binding, this);
-                return Optional.of(existing);
-            case DOES_NOT_MATCH:
-                return Optional.empty();
-            default:
-                throw new RecordCoreException("added another variant to the Result enum but did not update switch");
-        }
+    @Override
+    public Stream<PlannerBindings> bindWithin(@Nonnull ExpressionMatcher<? extends Bindable> matcher) {
+        return expression.bindTo(matcher);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AllChildrenMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AllChildrenMatcher.java
@@ -1,0 +1,78 @@
+/*
+ * AllChildrenMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.matchers;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.query.plan.temp.Bindable;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * An expression children matcher that tries to match all children to a single {@link ExpressionMatcher}.
+ *
+ * Given a single {@code ExpressionMatcher}, this matcher tries to match it to every child. If it matches all of them, it
+ * produces a stream of bindings containing the Cartesian product of the streams of bindings from each child, merged
+ * using {@link PlannerBindings#mergedWith(PlannerBindings)}. Because the same matcher is used for all children, the
+ * merged bindings will map the single child matcher to a collected list of {@link Bindable}s; such a binding must be
+ * retrieved using {@link PlannerBindings#getAll(ExpressionMatcher)} rather than the usual {@code get()} method.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class AllChildrenMatcher implements ExpressionChildrenMatcher {
+    @Nonnull
+    private final ExpressionMatcher<? extends Bindable> childMatcher;
+
+    AllChildrenMatcher(@Nonnull ExpressionMatcher<? extends Bindable> childMatcher) {
+        this.childMatcher = childMatcher;
+    }
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> matches(@Nonnull Iterator<? extends ExpressionRef<? extends PlannerExpression>> childIterator) {
+        Stream<PlannerBindings> bindingStream = Stream.of(PlannerBindings.empty());
+
+        // The children need to be merged in the same order that they appear to satisfy the contract of
+        // PlannerBindings.getAll().
+        while (childIterator.hasNext()) {
+            List<PlannerBindings> individualBindings = childIterator.next().bindTo(childMatcher).collect(Collectors.toList());
+            if (individualBindings.isEmpty()) {
+                return Stream.empty();
+            }
+            bindingStream = bindingStream.flatMap(existing -> individualBindings.stream().map(existing::mergedWith));
+        }
+        return bindingStream;
+    }
+
+    /**
+     * Get a matcher that tries to match all children with the given {@link ExpressionMatcher}.
+     * @param childMatcher an expression matcher to match all of the children
+     * @return a matcher that tries to match all children with the given child matcher
+     */
+    @Nonnull
+    public static AllChildrenMatcher allMatching(@Nonnull ExpressionMatcher<? extends Bindable> childMatcher) {
+        return new AllChildrenMatcher(childMatcher);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildMatcher.java
@@ -1,0 +1,65 @@
+/*
+ * AnyChildMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.matchers;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.query.plan.temp.Bindable;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * An expression children matcher that tries to match any child to the given {@link ExpressionMatcher}, producing a
+ * stream of bindings that is the concatenation of the (possibly empty) streams of bindings from attempting to match each
+ * child to the given matcher.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class AnyChildMatcher implements ExpressionChildrenMatcher {
+    @Nonnull
+    private final ExpressionMatcher<? extends Bindable> childMatcher;
+
+    private AnyChildMatcher(@Nonnull ExpressionMatcher<? extends Bindable> childMatcher) {
+        this.childMatcher = childMatcher;
+    }
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> matches(@Nonnull Iterator<? extends ExpressionRef<? extends PlannerExpression>> childIterator) {
+        Stream<? extends ExpressionRef<? extends PlannerExpression>> childStream = StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(childIterator, 0), false);
+        return childStream.flatMap(child -> child.bindTo(childMatcher));
+    }
+
+    /**
+     * Get a matcher that tries to match any child with the given {@link ExpressionMatcher}.
+     * @param childMatcher an expression matcher to match any one of the children
+     * @return a matcher that tries to match any child with the given child matcher
+     */
+    @Nonnull
+    public static AnyChildMatcher anyMatching(@Nonnull ExpressionMatcher<? extends Bindable> childMatcher) {
+        return new AnyChildMatcher(childMatcher);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionChildrenMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionChildrenMatcher.java
@@ -1,0 +1,64 @@
+/*
+ * ExpressionChildrenMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.matchers;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * An {@code ExpressionChildrenMatcher} describes how to match the children of a {@link PlannerExpression} (i.e., the
+ * references returned by the {@link PlannerExpression#getPlannerExpressionChildren()} method). Bindings can be
+ * retrieved from the rule call using the {@code ExpressionChildMatcher} that produced them.
+ *
+ * <p>
+ * In most cases, the most natural way to bind to the children of a planner expression is by defining a matcher for each
+ * child. This behavior is implemented in the {@link ListChildrenMatcher} and exposed by the
+ * {@link TypeMatcher#of(Class, ExpressionMatcher[])} helper method. However, this does not work when there is no
+ * <i>a priori</i> bound on the number of children returned by {@link PlannerExpression#getPlannerExpressionChildren()}.
+ * For example, an {@link com.apple.foundationdb.record.query.expressions.AndComponent} can have an arbitrary number of
+ * other {@code QueryComponent}s as children.
+ * </p>
+ * <p>
+ * Note that an {@code ExpressionChildrenMatcher} should generally only define how to distribute children to one or more
+ * child matchers, and that these child matchers should generally match to the children themselves. For example, see
+ * the implementation of {@link ListChildrenMatcher}. Extreme care should be taken when implementing an
+ * {@code ExpressionChildrenMatcher}. In particular, expression matchers may (or may not) be reused between successive
+ * rule calls and should be stateless. Additionally, implementors of <code>ExpressionMatcher</code> must use the
+ * (default) reference {@code equals()} method.
+ * </p>
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface ExpressionChildrenMatcher {
+    /**
+     * Apply this matcher to the children provided by the given iterator and produce a stream of possible bindings.
+     * If the match is not successful, produce an empty stream. Note that this method should not generally match to the
+     * children themselves; instead, it should delegate that work to one or more inner {@link ExpressionMatcher}s.
+     * @param childIterator an iterator of references to the children of a planner expression
+     * @return a stream of the possible bindings from applying this match to the children in the given iterator
+     */
+    @Nonnull
+    Stream<PlannerBindings> matches(@Nonnull Iterator<? extends ExpressionRef<? extends PlannerExpression>> childIterator);
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ListChildrenMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ListChildrenMatcher.java
@@ -1,0 +1,100 @@
+/*
+ * ListChildrenMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.matchers;
+
+import com.apple.foundationdb.record.query.plan.temp.Bindable;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A matcher for a children that tries to match each child to a specified matcher. It implements the "default" matching
+ * for children, as exposed by the {@link TypeMatcher#of(Class, ExpressionMatcher[])} helper method.
+ *
+ * <p>
+ * If every child matches the specified matcher and if every matcher matches a child, the {@link ListChildrenMatcher}
+ * returns a stream of bindings that includes the Cartesian product of the stream of bindings from each child. Note that
+ * this matcher can only match a fixed number of children. Currently, matching is not especially efficient: the cross
+ * product is computed by collecting each child stream into a list.
+ * </p>
+ */
+public class ListChildrenMatcher implements ExpressionChildrenMatcher {
+    @Nonnull
+    private static final ListChildrenMatcher EMPTY = new ListChildrenMatcher(Collections.emptyList());
+
+    @Nonnull
+    private final List<ExpressionMatcher<? extends Bindable>> childMatchers;
+
+    private ListChildrenMatcher(@Nonnull List<ExpressionMatcher<? extends Bindable>> childMatchers) {
+        this.childMatchers = childMatchers;
+    }
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> matches(@Nonnull Iterator<? extends ExpressionRef<? extends PlannerExpression>> childIterator) {
+        Iterator<ExpressionMatcher<? extends Bindable>> bindingIterator = childMatchers.iterator();
+
+        Stream<PlannerBindings> bindingStream = Stream.of(PlannerBindings.empty());
+        while (childIterator.hasNext() && bindingIterator.hasNext()) {
+            List<PlannerBindings> possible = childIterator.next().bindTo(bindingIterator.next()).collect(Collectors.toList());
+            if (possible.isEmpty()) {
+                return Stream.empty();
+            }
+            bindingStream = bindingStream.flatMap(existing -> possible.stream().map(existing::mergedWith));
+        }
+
+        if (childIterator.hasNext() || bindingIterator.hasNext()) { // unable to match completely
+            return Stream.empty();
+        }
+        return bindingStream;
+    }
+
+    /**
+     * Get a matcher with no child matchers which matches an empty collection of children. The returned matcher may
+     * be a static instance and may not be distinct across different calls. Unlike an {@link ExpressionMatcher},
+     * an {@code ExpressionChildrenMatcher} is not used for creating bindings and so need not be a distinct object.
+     * @return a matcher that matches an empty collection of children
+     */
+    @Nonnull
+    public static ListChildrenMatcher empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Get a matcher that tries to match the planner expression children, in order, to the given list of
+     * {@code ExpressionMatcher}s.
+     * @param childMatchers a list of matcher for the children, in order
+     * @return a matcher that attempts to match the children, in order, to the given list of matchers
+     */
+    @Nonnull
+    public static ListChildrenMatcher of(List<ExpressionMatcher<? extends Bindable>> childMatchers) {
+        if (childMatchers.isEmpty()) {
+            return empty();
+        }
+        return new ListChildrenMatcher(childMatchers);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/PlannerBindings.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/PlannerBindings.java
@@ -21,62 +21,147 @@
 package com.apple.foundationdb.record.query.plan.temp.matchers;
 
 import com.apple.foundationdb.API;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+import com.google.common.collect.ImmutableListMultimap;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * <code>PlannerBindings</code> is a map-like structure that supports a map from a binding to both {@link PlannerExpression}s
- * and {@link ExpressionRef}s, enforcing that a single name may map to only one binding of either type.
- * A binding keys is a pointer to the {@link ExpressionMatcher} that created the binding, eliminating the need for a
- * unique string or symbol identifier.
+ * A map-like structure that supports a map from a binding to a collection of {@link Bindable}s, such as
+ * {@link PlannerExpression}s and {@link ExpressionRef}s. A binding's key is a pointer to the {@link ExpressionMatcher}
+ * that created the binding, eliminating the need for a unique string or symbol identifier. A {@code PlannerBindings}
+ * is immutable but has a {@link Builder} that can be used to build up a set of bindings incrementally. Additionally,
+ * bindings can be combined using {@link #mergedWith(PlannerBindings)}.
  */
 @API(API.Status.EXPERIMENTAL)
 public class PlannerBindings {
     @Nonnull
-    private final Map<ExpressionMatcher<? extends Bindable>, Bindable> bindings = new HashMap<>();
+    private static final PlannerBindings EMPTY = new PlannerBindings(ImmutableListMultimap.of());
+
+    @Nonnull
+    private final ImmutableListMultimap<ExpressionMatcher<? extends Bindable>, Bindable> bindings;
+
+    private PlannerBindings(@Nonnull ImmutableListMultimap<ExpressionMatcher<? extends Bindable>, Bindable> bindings) {
+        this.bindings = bindings;
+    }
 
     /**
-     * Checks whether there is a bindable bound to <code>key</code>.
+     * Checks whether there is a bindable bound to {@code key}.
      * @param key a matcher
-     * @return whether there is an object bound to <code>key</code>
+     * @return whether there is an object bound to {@code key}
      */
     public boolean containsKey(@Nonnull ExpressionMatcher<? extends Bindable> key) {
         return bindings.containsKey(key);
     }
 
     /**
-     * Retrieve the object bound to <code>key</code>.
+     * Retrieve the single bindable bound to {@code key}. This method is meant to be a convenient shortcut for the case
+     * where the developer is certain that precisely one bindable could be bound to this key. If no bindable is bound to
+     * this key, or if there are multiple {@link Bindable}s bound to this key, this throws a {@link NoSuchElementException}.
      * @param key a matcher
-     * @param <T> the type of {@link Bindable} that was bound to <code>key</code>
+     * @param <T> the type of {@link Bindable} that was bound to {@code key}
      * @return the bindable object bound to key
+     * @throws NoSuchElementException if the number of bindables bound to this key is not exactly one
      */
     @Nonnull
     @SuppressWarnings("unchecked")
     public <T extends Bindable> T get(@Nonnull ExpressionMatcher<T> key) {
         if (bindings.containsKey(key)) {
-            return (T) bindings.get(key);
+            List<? extends Bindable> bindingsForKey = bindings.get(key);
+            if (bindingsForKey.size() == 1) {
+                return (T)bindingsForKey.get(0);
+            } else {
+                throw new NoSuchElementException("attempted to retrieve individual bindable but multiple keys were bound");
+            }
         }
         throw new NoSuchElementException("attempted to extract bindable from binding using non-existent key");
     }
 
     /**
-     * Bind the given key to the provided {@link Bindable}. Note that <code>bindable</code> must be an instance
-     * of the type parameter of <code>key</code>, although the compiler cannot enforce this because of how it is used
-     * in {@link Bindable#bindWithExisting(ExpressionMatcher, PlannerBindings)}.
-     * @param key a matcher with type parameter that is a super class of the class of <code>bindable</code>
-     * @param bindable a bindable object to bind to the key
+     * Retrieve all bindables bound to {@code key} if there is at least one such bindable. The bindables in the returned
+     * list appear in same order as they appear in the list of children of the {@link PlannerExpression} that produced
+     * this set of bindings. If no bindable is bound to this key, throw a {@link NoSuchElementException}.
+     * @param key a matcher
+     * @param <T> the type of {@link Bindable} that was bound to {@code key}
+     * @return a list of bindable objects bound to the key
+     * @throws NoSuchElementException if no bindable objects are bound to the given key
      */
-    public void put(@Nonnull ExpressionMatcher<? extends Bindable> key, @Nonnull Bindable bindable) {
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public <T extends Bindable> List<T> getAll(@Nonnull ExpressionMatcher<T> key) {
         if (bindings.containsKey(key)) {
-            throw new RecordCoreException("attempted to add a binding that already exists");
+            return (List<T>) bindings.get(key);
         }
-        bindings.put(key, bindable);
+        throw new NoSuchElementException("attempted to extract bindable from binding using non-existent key");
+    }
+
+    /**
+     * Combine this set of bindings with the given set of bindings. If both sets of bindings contain a binding with the
+     * same key, the resulting set of bindings will contain the <em>concatenation</em> of the bindables from this set
+     * of bindings and the bindables from the given set of bindings, in that order, providing a predictable ordering
+     * of bindings for planner rules that might need it.
+     * @param other a set of bindings, which may share keys with this set of bindings
+     * @return a new set of bindings that contains the bindings from both both sets of bindings
+     */
+    @Nonnull
+    public PlannerBindings mergedWith(@Nonnull PlannerBindings other) {
+        ImmutableListMultimap.Builder<ExpressionMatcher<? extends Bindable>, Bindable> combined = ImmutableListMultimap.builder();
+        combined.putAll(this.bindings);
+        combined.putAll(other.bindings);
+        return new PlannerBindings(combined.build());
+    }
+
+    /**
+     * Build a new set of bindings containing a single binding from the given key to the given bindable.
+     * @param key an expression matcher
+     * @param bindable a bindable object
+     * @return a new set of bindings containing a single binding from {@code key} to {@code bindable}
+     */
+    @Nonnull
+    public static PlannerBindings from(@Nonnull ExpressionMatcher<? extends Bindable> key, @Nonnull Bindable bindable) {
+        return new PlannerBindings(ImmutableListMultimap.of(key, bindable));
+    }
+
+    /**
+     * Return an empty set of bindings.
+     * @return an empty set of bindings
+     */
+    @Nonnull
+    public static PlannerBindings empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Return a new builder.
+     * @return a new builder
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * A mutable builder for a set of {@link PlannerBindings} which can be used to incrementally build up a set of
+     * bindings without repeatedly calling {@link #mergedWith(PlannerBindings)}, which is less efficient.
+     */
+    public static class Builder {
+        @Nonnull
+        private final ImmutableListMultimap.Builder<ExpressionMatcher<? extends Bindable>, Bindable> map;
+
+        public Builder() {
+            this.map = ImmutableListMultimap.builder();
+        }
+
+        public Builder put(@Nonnull ExpressionMatcher<? extends Bindable> key, @Nonnull Bindable bindable) {
+            map.put(key, bindable);
+            return this;
+        }
+
+        public PlannerBindings build() {
+            return new PlannerBindings(map.build());
+        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ReferenceMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ReferenceMatcher.java
@@ -21,13 +21,11 @@
 package com.apple.foundationdb.record.query.plan.temp.matchers;
 
 import com.apple.foundationdb.API;
-import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * An expression matcher that matches against any reference at all. It is frequently used by rules that want to capture
@@ -58,17 +56,20 @@ public class ReferenceMatcher<T extends PlannerExpression> implements Expression
 
     @Nonnull
     @Override
-    public List<ExpressionMatcher<? extends Bindable>> getChildren() {
-        return Collections.emptyList();
+    public ExpressionChildrenMatcher getChildrenMatcher() {
+        return ListChildrenMatcher.empty();
     }
 
+    @Nonnull
     @Override
-    public Result matches(@Nonnull Bindable bindable) {
-        if (bindable instanceof ExpressionRef) {
-            return Result.MATCHES;
-        } else {
-            return Result.DOES_NOT_MATCH;
-        }
+    public Stream<PlannerBindings> matchWith(@Nonnull ExpressionRef<? extends PlannerExpression> ref) {
+        return Stream.of(PlannerBindings.from(this, ref));
+    }
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> matchWith(@Nonnull PlannerExpression expression) {
+        return Stream.empty();
     }
 
     /**
@@ -78,7 +79,7 @@ public class ReferenceMatcher<T extends PlannerExpression> implements Expression
      * @param <U> the type of {@link PlannerExpression} that is guaranteed (by programmer knowledge) to be behind the references that this matcher will bind to
      * @return a new, distinct matcher that matches to any reference
      */
-    public static <U extends PlannerExpression> ExpressionMatcher<ExpressionRef<U>> anyRef() {
+    public static <U extends PlannerExpression> ReferenceMatcher<U> anyRef() {
         // This must return a new matcher so that it is distinct from other ReferenceMatchers according to pointer comparison.
         return new ReferenceMatcher<>();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/TypeMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/TypeMatcher.java
@@ -27,26 +27,25 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * A matcher that is specified by the class of its expression: to match any of several types of expressions, they must all
  * implement a common interface (which itself extends <code>PlannerExpression</code>). The bindings produced by this
  * matcher provide access to a single expression only, and allow it to be accessed by the rule.
- * @param <T> the bindable type that this matcher binds to
+ * @param <T> the planner expression type that this matcher binds to
  */
 @API(API.Status.EXPERIMENTAL)
 public class TypeMatcher<T extends PlannerExpression> implements ExpressionMatcher<T> {
     @Nonnull
     private final Class<? extends T> expressionClass;
     @Nonnull
-    private final List<ExpressionMatcher<? extends Bindable>> children;
+    private final ExpressionChildrenMatcher childrenMatcher;
 
     private TypeMatcher(@Nonnull Class<? extends T> expressionClass,
-                        @Nonnull List<ExpressionMatcher<? extends Bindable>> children) {
+                        @Nonnull ExpressionChildrenMatcher childrenMatcher) {
         this.expressionClass = expressionClass;
-        this.children = children;
+        this.childrenMatcher = childrenMatcher;
     }
 
     @Override
@@ -57,12 +56,12 @@ public class TypeMatcher<T extends PlannerExpression> implements ExpressionMatch
 
     @Override
     @Nonnull
-    public List<ExpressionMatcher<? extends Bindable>> getChildren() {
-        return children;
+    public ExpressionChildrenMatcher getChildrenMatcher() {
+        return childrenMatcher;
     }
 
     public static <U extends PlannerExpression> TypeMatcher<U> of(@Nonnull Class<? extends U> expressionClass) {
-        return new TypeMatcher<>(expressionClass, Collections.emptyList());
+        return new TypeMatcher<>(expressionClass, ListChildrenMatcher.empty());
     }
 
     @SafeVarargs
@@ -72,23 +71,28 @@ public class TypeMatcher<T extends PlannerExpression> implements ExpressionMatch
         for (ExpressionMatcher<? extends Bindable> child : children) {
             builder.add(child);
         }
-        return of(expressionClass, builder.build());
+        return of(expressionClass, ListChildrenMatcher.of(builder.build()));
     }
 
     public static <U extends PlannerExpression> TypeMatcher<U> of(@Nonnull Class<? extends U> expressionClass,
-                                                                  @Nonnull List<ExpressionMatcher<? extends Bindable>> children) {
-        return new TypeMatcher<>(expressionClass, children);
+                                                                  @Nonnull ExpressionChildrenMatcher childrenMatcher) {
+        return new TypeMatcher<>(expressionClass, childrenMatcher);
     }
 
+    @Nonnull
     @Override
-    public Result matches(@Nonnull Bindable bindable) {
-        if (bindable instanceof ExpressionRef) {
-            return Result.UNKNOWN;
-        }
-        if (expressionClass.isInstance(bindable)) {
-            return Result.MATCHES;
+    public Stream<PlannerBindings> matchWith(@Nonnull ExpressionRef<? extends PlannerExpression> ref) {
+        // A type matcher will never match a reference. Ask the reference whether its contents match properly.
+        return ref.bindWithin(this);
+    }
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> matchWith(@Nonnull PlannerExpression expression) {
+        if (expressionClass.isInstance(expression)) {
+            return Stream.of(PlannerBindings.from(this, expression));
         } else {
-            return Result.DOES_NOT_MATCH;
+            return Stream.empty();
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRuleTest.java
@@ -60,7 +60,7 @@ public class CombineFilterRuleTest {
             QueryComponent filter2 = Query.field("testField2").equalsValue(10);
             SingleExpressionRef<PlannerExpression> root = SingleExpressionRef.of(
                     new LogicalFilterExpression(filter1, new LogicalFilterExpression(filter2, basePlan)));
-            Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(blankContext, rule, root);
+            Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(blankContext, rule, root).findFirst();
             assertTrue(possibleMatch.isPresent());
             rule.onMatch(possibleMatch.get());
             assertEquals(root.get(), new LogicalFilterExpression(Query.and(filter1, filter2), basePlan));
@@ -73,7 +73,7 @@ public class CombineFilterRuleTest {
             QueryComponent filter1 = Query.field("testField").equalsValue(5);
             SingleExpressionRef<PlannerExpression> root = SingleExpressionRef.of(
                     new LogicalFilterExpression(filter1, new LogicalFilterExpression(filter1, basePlan)));
-            Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(blankContext, rule, root);
+            Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(blankContext, rule, root).findFirst();
             assertTrue(possibleMatch.isPresent());
             rule.onMatch(possibleMatch.get());
             // this rule should not try to coalesce the two filters
@@ -87,7 +87,7 @@ public class CombineFilterRuleTest {
             QueryComponent filter1 = Query.field("testField").equalsValue(5);
             SingleExpressionRef<PlannerExpression> root = SingleExpressionRef.of(
                     new LogicalFilterExpression(filter1, basePlan));
-            Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(blankContext, rule, root);
+            Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(blankContext, rule, root).findFirst();
             assertFalse(possibleMatch.isPresent());
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithScanRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithScanRuleTest.java
@@ -56,7 +56,7 @@ public class FilterWithScanRuleTest {
         RecordQueryIndexPlan inner = new RecordQueryIndexPlan(singleFieldIndex.getName(), IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false);
         SingleExpressionRef<PlannerExpression> root = SingleExpressionRef.of(new LogicalFilterExpression(
                 Query.field("aField").equalsValue(5), inner));
-        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root);
+        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root).findFirst();
         assertTrue(possibleMatch.isPresent());
         rule.onMatch(possibleMatch.get());
         assertEquals(new RecordQueryIndexPlan(singleFieldIndex.getName(), IndexScanType.BY_VALUE,
@@ -69,7 +69,7 @@ public class FilterWithScanRuleTest {
         RecordQueryIndexPlan inner = new RecordQueryIndexPlan(concatIndex.getName(), IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false);
         SingleExpressionRef<PlannerExpression> root = SingleExpressionRef.of(new LogicalFilterExpression(
                 Query.field("aField").equalsValue(5), inner));
-        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root);
+        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root).findFirst();
         assertTrue(possibleMatch.isPresent());
         rule.onMatch(possibleMatch.get());
         assertEquals(new RecordQueryIndexPlan(concatIndex.getName(), IndexScanType.BY_VALUE,
@@ -83,7 +83,7 @@ public class FilterWithScanRuleTest {
         RecordQueryIndexPlan inner = new RecordQueryIndexPlan(concatIndex.getName(), IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false);
         PlannerExpression original = new LogicalFilterExpression(Query.field("anotherField").equalsValue(5), inner);
         SingleExpressionRef<PlannerExpression> root = SingleExpressionRef.of(original);
-        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root);
+        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root).findFirst();
         assertTrue(possibleMatch.isPresent()); // the matcher should match, since the structure is right
         rule.onMatch(possibleMatch.get());
         assertEquals(original, root.get());
@@ -96,7 +96,7 @@ public class FilterWithScanRuleTest {
                 ScanComparisons.from(inequalityComparison), false);
         PlannerExpression original = new LogicalFilterExpression(Query.field("aField").equalsValue(5), inner);
         SingleExpressionRef<PlannerExpression> root = SingleExpressionRef.of(original);
-        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root);
+        Optional<RewriteRuleCall> possibleMatch = RewriteRuleCall.tryMatchRule(context, rule, root).findFirst();
         assertTrue(possibleMatch.isPresent());
         rule.onMatch(possibleMatch.get());
         assertEquals(original, root.get());


### PR DESCRIPTION
This is a pretty big rework of how planner rule matching works, based on writing a whole bunch of rules (some of which aren't out for review yet). The key things are:

1) It adds a new `ExpressionChildrenMatcher` interface that does the work of
applying some matchers to the children of a planner expression. The "default" `ListChildrenMatcher` implements the current behaviour of matching individual matchers to expression children. However, it's more flexible than that; see the `AllChildrenMatcher` and `AnyChildMatcher`.
2) Pushes more work (such as producing bindings) into the `ExpressionMatcher` and related cases while simplifying the `Bindable` interface. This seemed cleaner to me.
3) Makes most types related to matching, including PlannerBindings, immutable to sidestep
the tricky issue of bindings that don't end up working out. As part of this, it adds support for a single match to produce multiple bindings and combine them appropriately (using a Cartesian product if necessary).

This proved powerful enough to implement #366.