### PR TITLE
Fixes #421: byte limit doesn't reliably throw limit-reached exceptions.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -43,7 +43,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 ### NEXT_RELEASE
 
 * **Bug fix** Record type and index subspace keys with identical serializations are now validated for collisions [(Issue #394)](https://github.com/FoundationDB/fdb-record-layer/issues/394)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Byte scan limit now reliably throws exceptions when `ExecuteProperties.failOnScanLimitReached` is `true` [(Issue #422)](https://github.com/FoundationDB/fdb-record-layer/issues/422)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
@@ -149,7 +149,6 @@ public class CursorLimitManager {
     public void reportScannedBytes(long byteSize) {
         if (byteScanLimiter != null) {
             byteScanLimiter.registerScannedBytes(byteSize);
-            haltedDueToByteScanLimit = !byteScanLimiter.hasBytesRemaining() && usedInitialPass;
         }
     }
 }


### PR DESCRIPTION
The byte scan limit could return `BYTE_LIMIT_REACHED` without throwing an exception, even when the ExecuteProperties flag for throwing an exception on reaching a scan limit is set to `true`.

I added some tests to check for regressions. Because the byte scan limit would _sometimes_ throw exceptions before this change, they don't always fail without this change. However, there are enough of them that at least one of them usually fails without this change. Of course, they always pass with this change. :)