### PR TITLE
Resolves #429: OnlineIndexer should log successful progress

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1172,8 +1172,8 @@ public class OnlineIndexer implements AutoCloseable {
 
         /**
          * Get the minimum time between successful progress logs when building across transactions.
-         * @return the minimum time between successful progress logs.
          * Negative will not log at all, 0 will log after every commit.
+         * @return the minimum time between successful progress logs in milliseconds.
          */
         public long getProgressLogIntervalMillis() {
             return progressLogIntervalMillis;
@@ -1181,8 +1181,8 @@ public class OnlineIndexer implements AutoCloseable {
 
         /**
          * Set the minimum time between successful progress logs when building across transactions.
-         * @param millis the number of millis to wait between successful logs.
          * Negative will not log at all, 0 will log after every commit.
+         * @param millis the number of milliseconds to wait between successful logs
          * @return this builder
          */
         public Builder setProgressLogIntervalMillis(long millis) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -537,8 +537,9 @@ public class OnlineIndexer implements AutoCloseable {
 
     private void maybeLogBuildProgress(Subspace subspace, Tuple startTuple, Tuple endTuple, Tuple realEnd) {
         if (LOGGER.isInfoEnabled()
-                && (progressLogIntervalMillis >= 0
-                    && System.currentTimeMillis() - timeOfLastProgressLogMillis >= progressLogIntervalMillis)) {
+                && (progressLogIntervalMillis > 0
+                    && System.currentTimeMillis() - timeOfLastProgressLogMillis > progressLogIntervalMillis)
+                || progressLogIntervalMillis == 0) {
             LOGGER.info(KeyValueLogMessage.of("Built Range",
                     "indexName", index.getName(),
                     "indexVersion", index.getLastModifiedVersion(),


### PR DESCRIPTION
There is now an option to log after every successful build of a range, optionally limiting to once every N milliseconds.