### PR TITLE
Resolves #376: Add more convenience methods to FDBMetaDataStore

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -56,7 +56,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** `FDBMetaDataStore` class now has convenience methods for adding and deprecating record types and fields [(Issue #376)](https://github.com/FoundationDB/fdb-record-layer/issues/376)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
@@ -1298,5 +1298,4 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
             super("Error converting from protobuf", cause);
         }
     }
-
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
@@ -53,7 +53,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Serialization of {@link RecordMetaData} into the database.
@@ -730,20 +729,19 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      *
      * <p>
      * This method applies the given mutation callback on the stored meta-data and then saves it back to the store.
-     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
-     * changes that the callback perform.
+     * Callers might need to provide an appropriate {@link MetaDataEvolutionValidator} to the meta-data store, depending on the
+     * changes that the callback performs.
      * </p>
      *
      * <p>
-     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * Also, callers must be cautious about modifying the stored records descriptor using mutation callbacks, as this will make the
      * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
      * copy of a {@code .proto} file under source control.
      * </p>
      *
-     *
      * @param mutateMetaDataProto a callback that mutates the meta-data proto
      */
-    public void mutateMetaData(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto) {
+    public void mutateMetaData(@Nonnull Consumer<RecordMetaDataProto.MetaData.Builder> mutateMetaDataProto) {
         context.asyncToSync(FDBStoreTimer.Waits.WAIT_MUTATE_METADATA, mutateMetaDataAsync(mutateMetaDataProto));
     }
 
@@ -751,13 +749,15 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * Mutate the stored meta-data proto and record meta-data builder using mutation callbacks.
      *
      * <p>
-     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store.
-     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
+     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store. Note the
+     * order that the callbacks are executed. {@code mutateMetaDataProto} is called first on the meta-data proto and then the
+     * second {@code mutateRecordMetaDataBuilder} is executed on the meta-data builder.
+     * Callers might need to provide an appropriate {@link MetaDataEvolutionValidator} to the meta-data store, depending on the
      * changes that the callbacks perform.
      * </p>
      *
      * <p>
-     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * Also, callers must be cautious about modifying the stored records descriptor using mutation callbacks, as this will make the
      * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
      * copy of a {@code .proto} file under source control.
      * </p>
@@ -765,7 +765,7 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * @param mutateMetaDataProto a callback that mutates the meta-data proto
      * @param mutateRecordMetaDataBuilder a callback that mutates the record meta-data builder after the meta-data proto is mutated
      */
-    public void mutateMetaData(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto,
+    public void mutateMetaData(@Nonnull Consumer<RecordMetaDataProto.MetaData.Builder> mutateMetaDataProto,
                                @Nullable Consumer<RecordMetaDataBuilder> mutateRecordMetaDataBuilder) {
         context.asyncToSync(FDBStoreTimer.Waits.WAIT_MUTATE_METADATA, mutateMetaDataAsync(mutateMetaDataProto, mutateRecordMetaDataBuilder));
     }
@@ -774,13 +774,13 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * Mutate the stored meta-data proto using a mutation callback asynchronously.
      *
      * <p>
-     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store.
-     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
-     * changes that the callbacks perform.
+     * This method applies the given mutation callback on the stored meta-data and then saves it back to the store.
+     * Callers might need to provide an appropriate {@link MetaDataEvolutionValidator} to the meta-data store, depending on the
+     * changes that the callback performs.
      * </p>
      *
      * <p>
-     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * Also, callers must be cautious about modifying the stored records descriptor using mutation callbacks, as this will make the
      * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
      * copy of a {@code .proto} file under source control.
      * </p>
@@ -789,7 +789,7 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * @return a future that completes when the meta-data is mutated
      */
     @Nonnull
-    public CompletableFuture<Void> mutateMetaDataAsync(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto) {
+    public CompletableFuture<Void> mutateMetaDataAsync(@Nonnull Consumer<RecordMetaDataProto.MetaData.Builder> mutateMetaDataProto) {
         return mutateMetaDataAsync(mutateMetaDataProto, null);
     }
 
@@ -797,13 +797,15 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * Mutate the stored meta-data proto and record meta-data builder using mutation callbacks asynchronously.
      *
      * <p>
-     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store.
-     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
+     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store. Note the
+     * order that the callbacks are executed. {@code mutateMetaDataProto} is called first on the meta-data proto and then the
+     * second {@code mutateRecordMetaDataBuilder} is executed on the meta-data builder.
+     * Callers might need to provide an appropriate {@link MetaDataEvolutionValidator} to the meta-data store, depending on the
      * changes that the callbacks perform.
      * </p>
      *
      * <p>
-     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * Also, callers must be cautious about modifying the stored records descriptor using mutation callbacks, as this will make the
      * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
      * copy of a {@code .proto} file under source control.
      * </p>
@@ -813,11 +815,12 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * @return a future that completes when the meta-data is mutated
      */
     @Nonnull
-    public CompletableFuture<Void> mutateMetaDataAsync(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto,
+    public CompletableFuture<Void> mutateMetaDataAsync(@Nonnull Consumer<RecordMetaDataProto.MetaData.Builder> mutateMetaDataProto,
                                                        @Nullable Consumer<RecordMetaDataBuilder> mutateRecordMetaDataBuilder) {
         return loadCurrentProto().thenCompose(metaDataProto -> {
-            RecordMetaDataProto.MetaData metaData = mutateMetaDataProto.apply(metaDataProto.toBuilder());
-            RecordMetaDataBuilder recordMetaDataBuilder = createMetaDataBuilder(metaData);
+            RecordMetaDataProto.MetaData.Builder metaDataBuilder = metaDataProto.toBuilder();
+            mutateMetaDataProto.accept(metaDataBuilder);
+            RecordMetaDataBuilder recordMetaDataBuilder = createMetaDataBuilder(metaDataBuilder.build());
             recordMetaDataBuilder.setVersion(metaDataProto.getVersion() + 1);
             if (mutateRecordMetaDataBuilder != null) {
                 mutateRecordMetaDataBuilder.accept(recordMetaDataBuilder);
@@ -854,11 +857,11 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * Enable splitting long records.
      *
      * <p>
-     * Note that enabling splitting long records could result in data corruption if the record store was initially created with format version older than
+     * Note that enabling splitting long records could result in data corruption if the record store was initially created with a format version older than
      * {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore#SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION}.
      * Hence the default evolution validator will fail if one enables it. To enable this, first build a custom evolution validator that {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}
      * and use {@link #setEvolutionValidator(MetaDataEvolutionValidator)} to set the evolution validator used by this store.
-     * For more details see {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}.
+     * For more details, see {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}.
      * </p>
      */
     public void enableSplitLongRecords() {
@@ -869,11 +872,11 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
      * Enable splitting long records asynchronously.
      *
      * <p>
-     * Note that enabling splitting long records could result in data corruption if the record store was initially created with format version older than
+     * Note that enabling splitting long records could result in data corruption if the record store was initially created with a format version older than
      * {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore#SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION}.
      * Hence the default evolution validator will fail if one enables it. To enable this, first build a custom evolution validator that {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}
      * and use {@link #setEvolutionValidator(MetaDataEvolutionValidator)} to set the evolution validator used by this store.
-     * For more details see {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}.
+     * For more details, see {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}.
      * </p>
      *
      * @return a future that completes when {@code splitLongRecords} is set

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStore.java
@@ -31,9 +31,9 @@ import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataEvolutionValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
@@ -52,6 +52,8 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Serialization of {@link RecordMetaData} into the database.
@@ -719,6 +721,168 @@ public class FDBMetaDataStore extends FDBStoreBase implements RecordMetaDataProv
             // Update the records without using its local file descriptor. Let saveAndSetCurrent use the local file descriptor when saving the meta-data.
             RecordMetaDataBuilder recordMetaDataBuilder = createMetaDataBuilder(metaDataProto, false);
             recordMetaDataBuilder.updateRecords(recordsDescriptor);
+            return saveAndSetCurrent(recordMetaDataBuilder.getRecordMetaData().toProto());
+        });
+    }
+
+    /**
+     * Mutate the stored meta-data proto using a mutation callback.
+     *
+     * <p>
+     * This method applies the given mutation callback on the stored meta-data and then saves it back to the store.
+     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
+     * changes that the callback perform.
+     * </p>
+     *
+     * <p>
+     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
+     * copy of a {@code .proto} file under source control.
+     * </p>
+     *
+     *
+     * @param mutateMetaDataProto a callback that mutates the meta-data proto
+     */
+    public void mutateMetaData(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto) {
+        context.asyncToSync(FDBStoreTimer.Waits.WAIT_MUTATE_METADATA, mutateMetaDataAsync(mutateMetaDataProto));
+    }
+
+    /**
+     * Mutate the stored meta-data proto and record meta-data builder using mutation callbacks.
+     *
+     * <p>
+     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store.
+     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
+     * changes that the callbacks perform.
+     * </p>
+     *
+     * <p>
+     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
+     * copy of a {@code .proto} file under source control.
+     * </p>
+     *
+     * @param mutateMetaDataProto a callback that mutates the meta-data proto
+     * @param mutateRecordMetaDataBuilder a callback that mutates the record meta-data builder after the meta-data proto is mutated
+     */
+    public void mutateMetaData(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto,
+                               @Nullable Consumer<RecordMetaDataBuilder> mutateRecordMetaDataBuilder) {
+        context.asyncToSync(FDBStoreTimer.Waits.WAIT_MUTATE_METADATA, mutateMetaDataAsync(mutateMetaDataProto, mutateRecordMetaDataBuilder));
+    }
+
+    /**
+     * Mutate the stored meta-data proto using a mutation callback asynchronously.
+     *
+     * <p>
+     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store.
+     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
+     * changes that the callbacks perform.
+     * </p>
+     *
+     * <p>
+     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
+     * copy of a {@code .proto} file under source control.
+     * </p>
+     *
+     * @param mutateMetaDataProto a callback that mutates the meta-data proto
+     * @return a future that completes when the meta-data is mutated
+     */
+    @Nonnull
+    public CompletableFuture<Void> mutateMetaDataAsync(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto) {
+        return mutateMetaDataAsync(mutateMetaDataProto, null);
+    }
+
+    /**
+     * Mutate the stored meta-data proto and record meta-data builder using mutation callbacks asynchronously.
+     *
+     * <p>
+     * This method applies the given mutation callbacks on the stored meta-data and then saves it back to the store.
+     * Callers might need to provide an appropriate meta-data evolution validator to the meta-data store, depending on the
+     * changes that the callbacks perform.
+     * </p>
+     *
+     * <p>
+     * Also, callers must be cautious about modifying the stored meta-data using mutation callbacks, as this will make the
+     * meta-data store the ultimate (and sole) source of truth for the record definitions and not just the in-database
+     * copy of a {@code .proto} file under source control.
+     * </p>
+     *
+     * @param mutateMetaDataProto a callback that mutates the meta-data proto
+     * @param mutateRecordMetaDataBuilder a callback that mutates the record meta-data builder after the meta-data proto is mutated
+     * @return a future that completes when the meta-data is mutated
+     */
+    @Nonnull
+    public CompletableFuture<Void> mutateMetaDataAsync(@Nonnull Function<RecordMetaDataProto.MetaData.Builder, RecordMetaDataProto.MetaData> mutateMetaDataProto,
+                                                       @Nullable Consumer<RecordMetaDataBuilder> mutateRecordMetaDataBuilder) {
+        return loadCurrentProto().thenCompose(metaDataProto -> {
+            RecordMetaDataProto.MetaData metaData = mutateMetaDataProto.apply(metaDataProto.toBuilder());
+            RecordMetaDataBuilder recordMetaDataBuilder = createMetaDataBuilder(metaData);
+            recordMetaDataBuilder.setVersion(metaDataProto.getVersion() + 1);
+            if (mutateRecordMetaDataBuilder != null) {
+                mutateRecordMetaDataBuilder.accept(recordMetaDataBuilder);
+            }
+            return saveAndSetCurrent(recordMetaDataBuilder.getRecordMetaData().toProto());
+        });
+    }
+
+    /**
+     * Update whether record versions should be stored in the meta-data.
+     *
+     * @param storeRecordVersions whether record versions should be stored
+     */
+    public void updateStoreRecordVersions(boolean storeRecordVersions) {
+        context.asyncToSync(FDBStoreTimer.Waits.WAIT_UPDATE_STORE_RECORD_VERSIONS, updateStoreRecordVersionsAsync(storeRecordVersions));
+    }
+
+    /**
+     * Update whether record versions should be stored in the meta-data asynchronously.
+     *
+     * @param storeRecordVersions whether record versions should be stored
+     * @return a future that completes when {@code storeRecordVersions} is updated
+     */
+    @Nonnull
+    public CompletableFuture<Void> updateStoreRecordVersionsAsync(boolean storeRecordVersions) {
+        return loadCurrentProto().thenCompose(metaDataProto -> {
+            RecordMetaDataBuilder recordMetaDataBuilder = createMetaDataBuilder(metaDataProto);
+            recordMetaDataBuilder.setStoreRecordVersions(storeRecordVersions);
+            return saveAndSetCurrent(recordMetaDataBuilder.getRecordMetaData().toProto());
+        });
+    }
+
+    /**
+     * Enable splitting long records.
+     *
+     * <p>
+     * Note that enabling splitting long records could result in data corruption if the record store was initially created with format version older than
+     * {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore#SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION}.
+     * Hence the default evolution validator will fail if one enables it. To enable this, first build a custom evolution validator that {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}
+     * and use {@link #setEvolutionValidator(MetaDataEvolutionValidator)} to set the evolution validator used by this store.
+     * For more details see {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}.
+     * </p>
+     */
+    public void enableSplitLongRecords() {
+        context.asyncToSync(FDBStoreTimer.Waits.WAIT_ENABLE_SPLIT_LONG_RECORDS, enableSplitLongRecordsAsync());
+    }
+
+    /**
+     * Enable splitting long records asynchronously.
+     *
+     * <p>
+     * Note that enabling splitting long records could result in data corruption if the record store was initially created with format version older than
+     * {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore#SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION}.
+     * Hence the default evolution validator will fail if one enables it. To enable this, first build a custom evolution validator that {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}
+     * and use {@link #setEvolutionValidator(MetaDataEvolutionValidator)} to set the evolution validator used by this store.
+     * For more details see {@link MetaDataEvolutionValidator#allowsUnsplitToSplit()}.
+     * </p>
+     *
+     * @return a future that completes when {@code splitLongRecords} is set
+     */
+    @Nonnull
+    public CompletableFuture<Void> enableSplitLongRecordsAsync() {
+        return loadCurrentProto().thenCompose(metaDataProto -> {
+            RecordMetaDataBuilder recordMetaDataBuilder = createMetaDataBuilder(metaDataProto);
+            recordMetaDataBuilder.setSplitLongRecords(true);
             return saveAndSetCurrent(recordMetaDataBuilder.getRecordMetaData().toProto());
         });
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -254,6 +254,12 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_DROP_INDEX("wait for dropping an index"),
         /** Wait for updating records descriptor. */
         WAIT_UPDATE_RECORDS_DESCRIPTOR("wait for updating the records descriptor"),
+        /** Wait for meta-data mutation. */
+        WAIT_MUTATE_METADATA("wait for meta-data mutation"),
+        /** Wait for updating if record versions should be stored. */
+        WAIT_UPDATE_STORE_RECORD_VERSIONS("wait for updating if record versions must be stored"),
+        /** Wait for enabling splitting long records. */
+        WAIT_ENABLE_SPLIT_LONG_RECORDS("wait for enabling splitting long records"),
         /**
          * Wait for the updated version stamp from a committed transaction.
          * This future should normally be completed already, so this is mainly for error checking.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -78,6 +78,9 @@ public class MetaDataProtoEditor {
 
     private static void addFieldToUnion(@Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder, @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
         DescriptorProtos.DescriptorProto.Builder unionBuilder = fetchUnionBuilder(fileBuilder);
+        if (unionBuilder.getOneofDeclCount() > 0) {
+            throw new MetaDataException("Adding record type to oneOf is not allowed");
+        }
         DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = DescriptorProtos.FieldDescriptorProto.newBuilder()
                 .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
                 .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -1,0 +1,241 @@
+/*
+ * MetaDataProtoEditor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.API;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
+import com.apple.foundationdb.record.RecordMetaDataProto;
+import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.google.protobuf.DescriptorProtos;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+/**
+ * A helper class for mutating the meta-data proto.
+ *
+ * <p>
+ * This class contains several helper methods for modifying a serialized meta-data, e.g. add a new record type to the meta-data.
+ * {@link FDBMetaDataStore#mutateMetaData(Function)} is one example of where these methods can be useful. {@code FDBMetaDataStore#mutateMetaData}
+ * modifies the stored meta-data using a mutation callback and saves it back to the meta-data store.
+ * </p>
+ *
+ */
+@API(API.Status.EXPERIMENTAL)
+public class MetaDataProtoEditor {
+    /**
+     * Add a new record type to the meta-data.
+     *
+     * <p>
+     * Adding the record type involves three steps: the message type is added to the list of file descriptor's
+     * message types, a field of the given type is added to the union, and its primary key is set. This method takes
+     * care of the first two. Callers must also set the primary key
+     * ({@link com.apple.foundationdb.record.metadata.RecordTypeBuilder#setPrimaryKey} for the type.
+     * Note that adding {@code UNION} record types is not allowed. To add {@code NESTED} record types use {@link #addNestedRecordType}.
+     * </p>
+     *
+     * @param metaDataBuilder the meta-data builder
+     * @param newRecordType the new record type
+     * @return the modified meta-data
+     */
+    @Nonnull
+    public static RecordMetaDataProto.MetaData addRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
+        RecordMetaDataOptionsProto.RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
+        if (newRecordType.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME) ||
+                newRecordTypeUsage == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION) {
+            throw new MetaDataException("Adding UNION record type not allowed");
+        }
+        if (newRecordTypeUsage == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+            throw new MetaDataException("Use addNestedRecordType for adding NESTED record types");
+        }
+        if (findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), newRecordType.getName()) != null) {
+            throw new MetaDataException("Record type " + newRecordType.getName() + " already exists");
+        }
+        metaDataBuilder.getRecordsBuilder().addMessageType(newRecordType);
+        addFieldToUnion(metaDataBuilder.getRecordsBuilder(), newRecordType);
+        return metaDataBuilder.build();
+    }
+
+    private static void addFieldToUnion(@Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder, @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
+        DescriptorProtos.DescriptorProto.Builder unionBuilder = fetchUnionBuilder(fileBuilder);
+        DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = DescriptorProtos.FieldDescriptorProto.newBuilder()
+                .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
+                .setTypeName(newRecordType.getName())
+                .setName("_" + newRecordType.getName())
+                .setNumber(assignFieldNumber(unionBuilder));
+        unionBuilder.addField(fieldBuilder);
+    }
+
+    @Nonnull
+    private static DescriptorProtos.DescriptorProto.Builder fetchUnionBuilder(@Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder) {
+        for (DescriptorProtos.DescriptorProto.Builder messageTypeBuilder : fileBuilder.getMessageTypeBuilderList()) {
+            if (isUnion(messageTypeBuilder)) {
+                return messageTypeBuilder;
+            }
+        }
+        throw new MetaDataException("Union descriptor not found");
+    }
+
+    private static boolean isUnion(@Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder) {
+        if (messageTypeBuilder.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME)) {
+            return true;
+        }
+        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageTypeBuilder.getOptions()
+                .getExtension(RecordMetaDataOptionsProto.record);
+        return recordTypeOptions != null &&
+               recordTypeOptions.hasUsage() &&
+               recordTypeOptions.getUsage() == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+    }
+
+    private static int assignFieldNumber(@Nonnull DescriptorProtos.DescriptorProto.Builder messageType) {
+        if (messageType.getFieldCount() == 0) {
+            return 1;
+        }
+        return messageType.getFieldList().stream().mapToInt(DescriptorProtos.FieldDescriptorProto::getNumber).max().getAsInt() + 1;
+    }
+
+    /**
+     * Add a new NESTED record type to the meta-data.
+     *
+     * @param metaDataBuilder the meta-data builder
+     * @param newRecordType the new record type
+     * @return the modified meta-data
+     */
+    @Nonnull
+    public static RecordMetaDataProto.MetaData addNestedRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
+        RecordMetaDataOptionsProto.RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
+        if (newRecordTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED &&
+                newRecordTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNSET) {
+            throw new MetaDataException("Record type is not NESTED");
+        }
+        if (findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), newRecordType.getName()) != null) {
+            throw new MetaDataException("Record type " + newRecordType.getName() + " already exists");
+        }
+        metaDataBuilder.getRecordsBuilder().addMessageType(newRecordType);
+        return metaDataBuilder.build();
+    }
+
+    @Nonnull
+    private static RecordMetaDataOptionsProto.RecordTypeOptions.Usage getMessageTypeUsage(@Nonnull DescriptorProtos.DescriptorProto messageType) {
+        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
+                .getExtension(RecordMetaDataOptionsProto.record);
+        if (recordTypeOptions != null && recordTypeOptions.hasUsage()) {
+            return recordTypeOptions.getUsage();
+        }
+        return RecordMetaDataOptionsProto.RecordTypeOptions.Usage.RECORD;
+    }
+
+    @Nullable
+    private static DescriptorProtos.DescriptorProto.Builder findMessageTypeByName(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder, @Nonnull String recordType) {
+        return recordsBuilder.getMessageTypeBuilderList().stream().filter(m -> m.getName().equals(recordType)).findAny().orElse(null);
+    }
+
+    /**
+     * Deprecate a record type from the meta-data.
+     *
+     * @param metaDataBuilder the meta-data builder
+     * @param recordType the record type to be deprecated
+     * @return the modified meta-data
+     */
+    @Nonnull
+    public static RecordMetaDataProto.MetaData deprecateRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull String recordType) {
+        DescriptorProtos.DescriptorProto.Builder unionBuilder = fetchUnionBuilder(metaDataBuilder.getRecordsBuilder());
+        if (unionBuilder.getName().equals(recordType)) {
+            throw new MetaDataException("Cannot deprecate the union");
+        }
+        // deprecate all fields of type recordType from the union.
+        boolean found = false;
+        for (DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder : unionBuilder.getFieldBuilderList()) {
+            if (fieldBuilder.getTypeName().equals(recordType)) {
+                setDeprecated(fieldBuilder);
+                found = true;
+            }
+        }
+        if (!found) {
+            throw new MetaDataException("Record type " + recordType + " not found");
+        }
+        return metaDataBuilder.build();
+    }
+
+    /**
+     * Add a field to a record type.
+     *
+     * @param metaDataBuilder the meta-data builder
+     * @param recordType the record type to add the field to
+     * @param field the field to be added
+     * @return the modified meta-data
+     */
+    @Nonnull
+    public static RecordMetaDataProto.MetaData addField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull String recordType, @Nonnull DescriptorProtos.FieldDescriptorProto field) {
+        DescriptorProtos.DescriptorProto.Builder messageType = findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
+        if (messageType == null) {
+            throw new MetaDataException("Record type " + recordType + " does not exist");
+        }
+        DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = findFieldByName(messageType, field.getName());
+        if (fieldBuilder != null) {
+            throw new MetaDataException("Field " + field.getName() + " already exists in record type " + recordType);
+        }
+        messageType.addField(field);
+        return metaDataBuilder.build();
+    }
+
+    /**
+     * Deprecate a field from a record type.
+     *
+     * @param metaDataBuilder the meta-data builder
+     * @param recordType the record type to deprecate the field from
+     * @param fieldName the name of the field to be deprecated
+     * @return the modified meta-data
+     */
+    @Nonnull
+    public static RecordMetaDataProto.MetaData deprecateField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull String recordType, @Nonnull String fieldName) {
+        // Find the record type
+        DescriptorProtos.DescriptorProto.Builder messageType = findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
+        if (messageType == null) {
+            throw new MetaDataException("Record type " + recordType + " does not exist");
+        }
+
+        // Deprecate the field
+        DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = findFieldByName(messageType, fieldName);
+        if (fieldBuilder == null) {
+            throw new MetaDataException("Field " + fieldName + " not found in record type " + recordType);
+        }
+        setDeprecated(fieldBuilder);
+        return metaDataBuilder.build();
+    }
+
+    private static void setDeprecated(DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder) {
+        if (fieldBuilder.hasOptions()) {
+            fieldBuilder.getOptionsBuilder().setDeprecated(true);
+        } else {
+            fieldBuilder.setOptions(DescriptorProtos.FieldOptions.newBuilder().setDeprecated(true).build());
+        }
+    }
+
+    @Nullable
+    private static DescriptorProtos.FieldDescriptorProto.Builder findFieldByName(@Nonnull DescriptorProtos.DescriptorProto.Builder messageType, @Nonnull String fieldName) {
+        return messageType.getFieldBuilderList().stream().filter(m -> m.getName().equals(fieldName)).findAny().orElse(null);
+    }
+
+}


### PR DESCRIPTION
This change adds more convenience methods to the FDBMetaDataStore class.
These are mostly methods that require manipulating the proto message itself.