### PR TITLE
Fixes #437: UnorderedUnionCursors can loop if there are exceptional children

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -45,7 +45,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `UnorderedUnionCursor` should now propagate errors from its children instead of sometimes swallowing the exception [(Issue #437)](https://github.com/FoundationDB/fdb-record-layer/issues/437)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
@@ -103,7 +104,7 @@ abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implements Recor
         List<S> nonExhausted = new ArrayList<>(cursorStates.size());
         for (S cursorState : cursorStates) {
             if (!cursorState.isExhausted()) {
-                if (cursorState.getOnNextFuture().isDone()) {
+                if (MoreAsyncUtil.isCompletedNormally(cursorState.getOnNextFuture())) {
                     // Short-circuit and return immediately if we find a state that is already done.
                     return AsyncUtil.DONE;
                 } else {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
 import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
@@ -125,7 +126,7 @@ public class ProbableIntersectionCursor<T> extends MergeCursor<T, T, ProbableInt
             boolean allDone = true;
             for (ProbableIntersectionCursorState<T> cursorState : cursorStates) {
                 final CompletableFuture<RecordCursorResult<T>> onNextFuture = cursorState.getOnNextFuture();
-                if (!onNextFuture.isDone()) {
+                if (!MoreAsyncUtil.isCompletedNormally(onNextFuture)) {
                     allDone = false;
                     continue;
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
 import com.apple.foundationdb.API;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
@@ -71,7 +72,7 @@ public class UnorderedUnionCursor<T> extends UnionCursorBase<T, MergeCursorState
             MergeCursorState<T> nextState = null;
             boolean allDone = true;
             for (MergeCursorState<T> cursorState : cursorStates) {
-                if (!cursorState.getOnNextFuture().isDone()) {
+                if (!MoreAsyncUtil.isCompletedNormally(cursorState.getOnNextFuture())) {
                     allDone = false;
                     continue;
                 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreLimitTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreLimitTestBase.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -128,5 +129,11 @@ public class FDBRecordStoreLimitTestBase extends FDBRecordStoreTestBase {
                         new RecordQueryFilterPlan(firstChild, middleFilter),
                         new RecordQueryFilterPlan(secondChild, Query.field("rec_no").lessThan(55L)),
                         primaryKey(), false)));
+    }
+
+    public Stream<Arguments> unorderedPlans(boolean fail) {
+        return Stream.of(
+                Arguments.of("unordered union", fail, new RecordQueryUnorderedUnionPlan(indexPlanEquals("MySimpleRecord$str_value_indexed", "even"), indexPlanEquals("MySimpleRecord$num_value_3_indexed", 2), false))
+        );
     }
 }


### PR DESCRIPTION
The `UnorderedUnionCursor` now checks to see if things have been completed normally rather than if they are just done. In the exceptional case, this now results in the thing being eventually caught by the `whenAny` function and then propagated up to the user.

We should probably do a more thorough audit of uses of `isDone` within the code base, as a fairly easy way to lose exceptions is something like:

```java
if (myFuture.isDone()) {
   return CompletableFuture.completedFuture(thing);
} else {
   return myFuture.thenApply(ignore -> thing);
}
```

This was slightly more sophisticated than that, but it's of a similar idea. I also wanted to get this fix out first before doing a more thorough audit in the name of getting things done.

This fixes #437.