### PR TITLE
Fix the sample program:

### DIFF
--- a/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
+++ b/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
@@ -278,7 +278,7 @@ public class Main {
         // preference_tag field and keep track of the number of customer
         // records with each value.
         rmdBuilder.addIndex("Customer", new Index("preference_tag_count",
-                field("customer_id").groupBy(field("preference_tag", FanType.FanOut)),
+                new GroupingKeyExpression(field("preference_tag", FanType.FanOut), 0),
                 IndexTypes.COUNT));
 
         // Add a nested secondary index for order such that each value for


### PR DESCRIPTION
Instead of fixing to be `COUNT_NOT_NULL(customer_id) GROUP BY preference_tag`, as #337 does, make it `COUNT(*)`.
The other fix in that PR was handled by #415.
Note that this is against the 2.6 branch.