### PR TITLE
Resolves #447: Decrease the stability of MetaDataCache

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -48,6 +48,8 @@ The `SubspaceProvider` interface is changed to no longer require an `FDBRecordCo
 
 Methods for retrieving a record from a record store based on an index entry generally took both an index and an index entry. As index entries now store a reference to their associatedindex, these methods have been deprecated in favor of methods that only take an index entry. The earlier methods may be removed in a future release. The same is true for a constructor on `FDBIndexedRecord` which no longer needs to take both an index and an index entry.
 
+While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundationdb/fdb-record-layer-core/latest/com/apple/foundationdb/record/provider/foundationdb/MetaDataCache.html) interface's stability has been lessened from [`MAINTAINED`](https://javadoc.io/page/org.foundationdb/fdb-extensions/latest/com/apple/foundationdb/annotation/API.Status.html#MAINTAINED) to [`EXPERIMENTAL`](https://javadoc.io/page/org.foundationdb/fdb-extensions/latest/com/apple/foundationdb/annotation/API.Status.html#EXPERIMENTAL). That interface may undergo further changes as work progresses on [Issue #280](https://github.com/FoundationDB/fdb-record-layer/issues/280). Clients are discouraged from using that interface until work evolving that API has progressed.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -73,6 +75,7 @@ Methods for retrieving a record from a record store based on an index entry gene
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** The API stability annotations have been moved into `com.apple.foundationdb.annotation` [(Issue #406)](https://github.com/FoundationDB/fdb-record-layer/issues/406)
 * **Breaking change** `SubspaceProvider` receives an `FDBRecordContext` when a subspace is resolved instead of when constructed.[(Issue #338)](https://github.com/FoundationDB/fdb-record-layer/issues/338)
+* **Breaking change** The `MetaDataCache` interface is now `EXPERIMENTAL` [(Issue #447)](https://github.com/FoundationDB/fdb-record-layer/issues/447)
 
 // end next release
 -->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataCache.java
@@ -32,8 +32,16 @@ import java.util.concurrent.CompletableFuture;
  * A cache implementation can implement any subset of object, serialized and version cached.
  * The caller is responsible for calling all of the relevant the <code>set</code> methods
  * when something changes.
+ *
+ * <p>
+ * Note that this interface is currently undergoing active development. Work on evolving
+ * this API is currently being tracked as part of
+ * <a href="https://github.com/FoundationDB/fdb-record-layer/issues/280">Issue #280</a>.
+ * Users are advised to avoid implementing or using this interface until work on that issue
+ * has been completed.
+ * </p>
  */
-@API(API.Status.MAINTAINED)
+@API(API.Status.EXPERIMENTAL)
 public interface MetaDataCache {
     /**
      * Get a version to use for cache validation of <code>-1</code> to skip validation.


### PR DESCRIPTION
It is now marked EXPERIMENTAL, which I think more accurately reflects the state of that API. In theory, it should actually be UNSTABLE. I think it would also be reasonable to bump it "up" to UNSTABLE once #280 has been completed.

Note that this is against the 2.6 branch rather than master.