### PR TITLE
OnlineIndexer can increase limit after successful range builds

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -53,6 +53,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add an `AsyncIteratorCursor` between `IteratorCursor` and `KeyValueCursor` [(Issue #449)](https://github.com/FoundationDB/fdb-record-layer/issues/449)
+* **Feature** OnlineIndexer can increase limit after successful range builds [(Issue #444)](https://github.com/FoundationDB/fdb-record-layer/issues/444)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
@@ -361,7 +361,7 @@ public class FDBDatabaseRunner implements AutoCloseable {
 
         @SuppressWarnings("squid:S1181")
         public CompletableFuture<T> runAsync(@Nonnull final Function<? super FDBRecordContext, CompletableFuture<? extends T>> retriable,
-                                             @Nonnull final BiFunction<T, Throwable, Pair<T, Throwable>> handlePostTransaction) {
+                                             @Nonnull final BiFunction<? super T, Throwable, ? extends Pair<? extends T, ? extends Throwable>> handlePostTransaction) {
             CompletableFuture<T> future = new CompletableFuture<>();
             addFutureToCompleteExceptionally(future);
             AsyncUtil.whileTrue(() -> {
@@ -370,7 +370,7 @@ public class FDBDatabaseRunner implements AutoCloseable {
                     return retriable.apply(context).thenCompose(val ->
                         context.commitAsync().thenApply( vignore -> val)
                     ).handle((result, ex) -> {
-                        Pair<T, Throwable> newResult = handlePostTransaction.apply(result, ex);
+                        Pair<? extends T, ? extends Throwable> newResult = handlePostTransaction.apply(result, ex);
                         return handle(newResult.getLeft(), newResult.getRight());
                     }).thenCompose(Function.identity());
                 } catch (Exception e) {
@@ -460,7 +460,7 @@ public class FDBDatabaseRunner implements AutoCloseable {
      */
     @Nonnull
     public <T> CompletableFuture<T> runAsync(@Nonnull final Function<? super FDBRecordContext, CompletableFuture<? extends T>> retriable,
-                                             @Nonnull final BiFunction<T, Throwable, Pair<T, Throwable>> handlePostTransaction) {
+                                             @Nonnull final BiFunction<? super T, Throwable, ? extends Pair<? extends T, ? extends Throwable>> handlePostTransaction) {
         return new RunRetriable<T>().runAsync(retriable, handlePostTransaction);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1060,8 +1060,8 @@ public class OnlineIndexer implements AutoCloseable {
 
         /**
          * Get the maximum number of times to retry a single range rebuild.
-         * This retry is on top of the retries caused by {@link #getMaxAttempts()}, and will also retry for other error
-         * codes, such as {@code transaction_too_lange}.
+         * This retry is on top of the retries caused by {@link #getMaxAttempts()}, and it will also retry for other error
+         * codes, such as {@code transaction_too_large}.
          * @return the maximum number of times to retry a single range rebuild
          */
         public int getMaxRetries() {
@@ -1070,8 +1070,8 @@ public class OnlineIndexer implements AutoCloseable {
 
         /**
          * Set the maximum number of times to retry a single range rebuild.
-         * This retry is on top of the retries caused by {@link #getMaxAttempts()}, and will also retry for other error
-         * codes, such as {@code transaction_too_lange}.
+         * This retry is on top of the retries caused by {@link #getMaxAttempts()}, it and will also retry for other error
+         * codes, such as {@code transaction_too_large}.
          *
          * The default number of retries is {@link #DEFAULT_MAX_RETRIES} = {@value #DEFAULT_MAX_RETRIES}.
          * @param maxRetries the maximum number of times to retry a single range rebuild
@@ -1186,7 +1186,7 @@ public class OnlineIndexer implements AutoCloseable {
         /**
          * Set the number of successful range builds before re-increasing the number of records to process in a single
          * transaction. The number of records to process in a single transaction will never go above {@link #limit}.
-         * If this is {@code -1}, it will not reincrease after successes.
+         * If this is {@code -1}, it will not re-increase after successes.
          * @param increaseLimitAfter the number of successful range builds before increasing the number of records
          * processed in a single transaction
          * @return this builder
@@ -1199,7 +1199,7 @@ public class OnlineIndexer implements AutoCloseable {
         /**
          * Get the number of successful range builds before re-increasing the number of records to process in a single
          * transaction.
-         * If this is {@code -1}, it will not reincrease after successes.
+         * If this is {@code -1}, it will not re-increase after successes.
          * @return the number of successful range builds before increasing the number of records processed in a single
          * transaction
          * @see #limit

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -2192,7 +2192,6 @@ public class OnlineIndexerTest extends FDBTestBase {
         Supplier<RuntimeException> createException =
                 () -> new RecordCoreException("Non-retriable", new FDBException("transaction_too_large", 2101));
 
-
         Queue<Pair<Integer, Supplier<RuntimeException>>> queue = new LinkedList<>();
         // failures until it hits 42
         for (int i = 100; i > 42; i = (3 * i) / 4) {
@@ -2286,7 +2285,7 @@ public class OnlineIndexerTest extends FDBTestBase {
                     indexBuilder.runAsync(store -> {
                         Pair<Integer, Supplier<RuntimeException>> behavior = queue.poll();
                         if (behavior == null) {
-                            return CompletableFuture.completedFuture(false);
+                            return AsyncUtil.READY_FALSE;
                         } else {
                             int currentAttempt = attempts.getAndIncrement();
                             assertEquals(behavior.getLeft().intValue(), indexBuilder.getLimit(),
@@ -2294,7 +2293,7 @@ public class OnlineIndexerTest extends FDBTestBase {
                             if (behavior.getRight() != null) {
                                 throw behavior.getRight().get();
                             }
-                            return CompletableFuture.completedFuture(true);
+                            return AsyncUtil.READY_TRUE;
                         }
                     })).join();
             assertNull(queue.poll());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -59,6 +59,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.ThreadContext;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -78,9 +79,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
@@ -2144,6 +2147,157 @@ public class OnlineIndexerTest extends FDBTestBase {
                 assertEquals("my cool mdc value", ThreadContext.get("mdcKey"));
                 return null;
             }).join();
+        }
+    }
+
+    @Test
+    public void lessenLimits() {
+        Index index = new Index("newIndex", field("num_value_2"));
+        openSimpleMetaData(metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index));
+
+        try (FDBRecordContext context = openContext()) {
+            // OnlineIndexer.runAsync checks that the index is not readable
+            recordStore.clearAndMarkIndexWriteOnly(index).join();
+            context.commit();
+        }
+        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
+                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                .setLimit(100).setMaxRetries(30).setRecordsPerSecond(10000)
+                .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
+                .setMaxAttempts(3)
+                .build()) {
+
+            AtomicInteger attempts = new AtomicInteger();
+            AtomicInteger limit = new AtomicInteger(100);
+
+            // Non-retriable error that is in lessen work codes.
+            attempts.set(0);
+            indexBuilder.runAsync(store -> {
+                assertEquals(attempts.getAndIncrement(), indexBuilder.getLimit(),
+                        limit.getAndUpdate(x -> Math.max(x, (3 * x) / 4)));
+                throw new RecordCoreException("Non-retriable", new FDBException("transaction_too_large", 2101));
+            }).handle((val, e) -> {
+                assertNotNull(e);
+                assertThat(e, instanceOf(RecordCoreException.class));
+                assertEquals("Non-retriable", e.getMessage());
+                return null;
+            }).join();
+            assertEquals(31, attempts.get());
+        }
+    }
+
+    @Test
+    void notReincreaseLimit() {
+        // Non-retriable error that is in lessen work codes.
+        Supplier<RuntimeException> createException =
+                () -> new RecordCoreException("Non-retriable", new FDBException("transaction_too_large", 2101));
+
+
+        Queue<Pair<Integer, Supplier<RuntimeException>>> queue = new LinkedList<>();
+        // failures until it hits 42
+        for (int i = 100; i > 42; i = (3 * i) / 4) {
+            queue.add(Pair.of(i, createException));
+        }
+        // a whole bunch of successes
+        for (int i = 0; i < 100; i++) {
+            queue.add(Pair.of(42, null));
+        }
+        reincreaseLimit(queue, index ->
+                OnlineIndexer.newBuilder()
+                        .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                        .setLimit(100).setMaxRetries(queue.size() + 3).setRecordsPerSecond(10000)
+                        .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
+                        .setMaxAttempts(3)
+                        .build());
+    }
+
+    @Test
+    public void reincreaseLimit() {
+        // Non-retriable error that is in lessen work codes.
+        Supplier<RuntimeException> createException =
+                () -> new RecordCoreException("Non-retriable", new FDBException("transaction_too_large", 2101));
+
+        Queue<Pair<Integer, Supplier<RuntimeException>>> queue = new LinkedList<>();
+        // failures until it hits 1
+        for (int i = 100; i > 1; i = (3 * i) / 4) {
+            queue.add(Pair.of(i, createException));
+        }
+        // queue size = 13
+        // success for a while
+        for (int i = 0; i < 10; i++) {
+            queue.add(Pair.of(1, null));
+        }
+        // queue size = 23
+        // now starts re-increasing
+        queue.add(Pair.of(2, null));
+        queue.add(Pair.of(3, null));
+        queue.add(Pair.of(4, null));
+        for (int i = 5; i < 100; i = (i * 4) / 3) {
+            queue.add(Pair.of(i, null));
+        }
+        // queue size = 38
+        // does not pass original max
+        queue.add(Pair.of(100, null));
+        queue.add(Pair.of(100, null));
+        queue.add(Pair.of(100, null));
+        for (int i = 100; i > 42; i = (3 * i) / 4) {
+            queue.add(Pair.of(i, createException));
+        }
+        // queue size = 44
+        // success for a while
+        for (int i = 0; i < 10; i++) {
+            queue.add(Pair.of(42, null));
+        }
+        // queue size = 54
+        // fail once
+        queue.add(Pair.of(56, createException));
+        for (int i = 0; i < 10; i++) {
+            queue.add(Pair.of(42, null));
+        }
+        // queue size = 65
+        queue.add(Pair.of(56, createException));
+        queue.add(Pair.of(42, null));
+
+        reincreaseLimit(queue, index ->
+                OnlineIndexer.newBuilder()
+                        .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                        .setLimit(100).setMaxRetries(queue.size() + 3).setRecordsPerSecond(10000)
+                        .setIncreaseLimitAfter(10)
+                        .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
+                        .setMaxAttempts(3)
+                        .build());
+    }
+
+    private void reincreaseLimit(Queue<Pair<Integer, Supplier<RuntimeException>>> queue,
+                                 final Function<Index, OnlineIndexer> buildOnlineIndexer) {
+        Index index = new Index("newIndex", field("num_value_2"));
+        openSimpleMetaData(metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index));
+
+        try (FDBRecordContext context = openContext()) {
+            // OnlineIndexer.runAsync checks that the index is not readable
+            recordStore.clearAndMarkIndexWriteOnly(index).join();
+            context.commit();
+        }
+        try (OnlineIndexer indexBuilder = buildOnlineIndexer.apply(index)) {
+
+            AtomicInteger attempts = new AtomicInteger();
+            attempts.set(0);
+            AsyncUtil.whileTrue(() ->
+                    indexBuilder.runAsync(store -> {
+                        Pair<Integer, Supplier<RuntimeException>> behavior = queue.poll();
+                        if (behavior == null) {
+                            return CompletableFuture.completedFuture(false);
+                        } else {
+                            int currentAttempt = attempts.getAndIncrement();
+                            assertEquals(behavior.getLeft().intValue(), indexBuilder.getLimit(),
+                                    "Attempt " + currentAttempt);
+                            if (behavior.getRight() != null) {
+                                throw behavior.getRight().get();
+                            }
+                            return CompletableFuture.completedFuture(true);
+                        }
+                    })).join();
+            assertNull(queue.poll());
         }
     }
 


### PR DESCRIPTION
This introduces a new setting on the OnlineIndexer to increase
the limit of records to process in a single transaction after
some successes.
Also, added some javadoc for the two different types of retries.
Resolves #444