### PR TITLE
Resolves #313: Update fdb-java to 6.0.15

### DIFF
--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,8 +1,8 @@
 FROM centos:7
-LABEL version=0.0.9
+LABEL version=0.0.10
 
 RUN yum install -y java-1.8.0-openjdk-devel python git unzip wget which time
-RUN yum install -y https://www.foundationdb.org/downloads/5.2.5/rhel6/installers/foundationdb-clients-5.2.5-1.el6.x86_64.rpm nmap
+RUN yum install -y https://www.foundationdb.org/downloads/6.0.15/rhel6/installers/foundationdb-clients-6.0.15-1.el6.x86_64.rpm nmap
 
 RUN mkdir -p /usr/local/bin
 COPY fdb_create_cluster_file.bash /usr/local/bin/fdb_create_cluster_file.bash

--- a/build/Dockerfile.fdbserver
+++ b/build/Dockerfile.fdbserver
@@ -1,7 +1,7 @@
 FROM centos:7
-LABEL version=5.2.5
+LABEL version=6.0.15
 
-RUN yum install -y which initscripts rsync net-tools passwd https://www.foundationdb.org/downloads/5.2.5/rhel6/installers/foundationdb-clients-5.2.5-1.el6.x86_64.rpm https://www.foundationdb.org/downloads/5.2.5/rhel6/installers/foundationdb-server-5.2.5-1.el6.x86_64.rpm
+RUN yum install -y which initscripts rsync net-tools passwd https://www.foundationdb.org/downloads/6.0.15/rhel6/installers/foundationdb-clients-6.0.15-1.el6.x86_64.rpm https://www.foundationdb.org/downloads/6.0.15/rhel6/installers/foundationdb-server-6.0.15-1.el6.x86_64.rpm
 
 USER root
 

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: fdb-record-layer-build:0.0.1
+    image: fdb-record-layer-build:0.0.10
     build:
       context: .
       dockerfile: Dockerfile.build
@@ -17,7 +17,7 @@ services:
       - FDBHOSTNAME=fdbserver
 
   fdbserver:
-    image: foundationdb-server:5.2.5-2
+    image: foundationdb-server:6.0.15
     environment:
       - FDBSTARTOPT=2
       - HOST_IP=0.0.0.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -44,6 +44,8 @@ The `IndexMaintainer` class now has a new public method `validateEntries`. Subcl
 
 The `SubspaceProvider` interface is changed to no longer require an `FDBRecordContext` at construction. Instead, methods that resolve subspaces are directly provided with an `FDBRecordContext`. This provides implementations with the flexibility to resolve logical subspace representations against different FoundationDB backends.
 
+This version of the Record Layer requires a FoundationDB server version of at least version 6.0. Attempting to connect to older versions may result in the client hanging when attempting to connect to the database.
+
 ### Newly deprecated
 
 Methods for retrieving a record from a record store based on an index entry generally took both an index and an index entry. As index entries now store a reference to their associatedindex, these methods have been deprecated in favor of methods that only take an index entry. The earlier methods may be removed in a future release. The same is true for a constructor on `FDBIndexedRecord` which no longer needs to take both an index and an index entry.
@@ -76,6 +78,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Breaking change** The API stability annotations have been moved into `com.apple.foundationdb.annotation` [(Issue #406)](https://github.com/FoundationDB/fdb-record-layer/issues/406)
 * **Breaking change** `SubspaceProvider` receives an `FDBRecordContext` when a subspace is resolved instead of when constructed.[(Issue #338)](https://github.com/FoundationDB/fdb-record-layer/issues/338)
 * **Breaking change** The `MetaDataCache` interface is now `EXPERIMENTAL` [(Issue #447)](https://github.com/FoundationDB/fdb-record-layer/issues/447)
+* **Breaking change** The Record Layer now requires a minimum FoundationDB version of 6.0 [(Issue #313)](https://github.com/FoundationDB/fdb-record-layer/issues/313)
 
 // end next release
 -->

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
@@ -112,7 +112,7 @@ public class RangeSetTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        db = FDB.selectAPIVersion(520).open();
+        db = FDB.selectAPIVersion(600).open();
         rsSubspace = DirectoryLayer.getDefault().createOrOpen(db, PathUtil.from(getClass().getSimpleName())).get();
         rs = new RangeSet(rsSubspace);
         rs.clear(db).join();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
@@ -61,7 +61,7 @@ public class RankedSetTest
 
     @BeforeEach
     public void setUp() throws Exception {
-        FDB fdb = FDB.selectAPIVersion(520);
+        FDB fdb = FDB.selectAPIVersion(600);
         if (TRACE) {
             NetworkOptions options = fdb.options();
             options.setTraceEnable("/tmp");

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
@@ -104,7 +104,7 @@ public class BunchedMapScanTest {
 
     @BeforeAll
     public static void setup() throws InterruptedException, ExecutionException {
-        FDB fdb = FDB.selectAPIVersion(520);
+        FDB fdb = FDB.selectAPIVersion(600);
         fdb.setUnclosedWarning(true);
         db = fdb.open();
         bmSubspace = DirectoryLayer.getDefault().createOrOpen(db, PathUtil.from(BunchedMapIterator.class.getSimpleName())).get();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
@@ -94,7 +94,7 @@ public class BunchedMapTest {
 
     @BeforeAll
     public static void setup() throws InterruptedException, ExecutionException {
-        FDB fdb = FDB.selectAPIVersion(520);
+        FDB fdb = FDB.selectAPIVersion(600);
         fdb.setUnclosedWarning(true);
         db = fdb.open();
         bmSubspace = DirectoryLayer.getDefault().createOrOpen(db, PathUtil.from(BunchedMap.class.getSimpleName())).get();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -50,6 +50,7 @@ public class FDBDatabaseFactory {
      * {@link com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver} retrieval requests.
      */
     public static final int DEFAULT_DIRECTORY_CACHE_SIZE = 5000;
+    private static final int API_VERSION = 600;
 
     @Nonnull
     private static final FDBDatabaseFactory INSTANCE = new FDBDatabaseFactory();
@@ -99,7 +100,7 @@ public class FDBDatabaseFactory {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(KeyValueLogMessage.of("Starting FDB"));
             }
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(API_VERSION);
             fdb.setUnclosedWarning(unclosedWarning);
             NetworkOptions options = fdb.options();
             if (traceDirectory != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ group=org.foundationdb
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation
 
-fdbVersion=5.2.5
+fdbVersion=6.0.15
 jsr305Version=3.0.1
 slf4jVersion=1.7.14
 commonsLang3Version=3.1


### PR DESCRIPTION
In addition to updating the dependency, this also updates the API version. There were not any differences between API versions 520 and 600, but this enforces that clients only versions 6.0 and newer.

This resolves #313.