### PR TITLE
Fixes #455: Make KeyWithValueExpression.getChild() return just the key.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -65,6 +65,10 @@ public enum LogMessageKeys {
     ACTUAL_COLUMN_SIZE("actual_column_size"),
     KEY_EXPRESSION("key_expression"),
     KEY_EVALUATED("key_evaluated"),
+    // manipulating subkeys of key expressions
+    REQUESTED_START("requested_start"),
+    REQUESTED_END("requested_end"),
+    COLUMN_SIZE("column_size"),
     // query components
     FILTER("filter"),
     PARENT_FILTER("parent_filter"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
@@ -178,7 +178,7 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
     @Nonnull
     @Override
     public KeyExpression getChild() {
-        return getInnerKey();
+        return getKeyExpression();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
@@ -96,14 +96,15 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
     }
 
     @Nonnull
+    @Override
+    protected KeyExpression getSubKeyImpl(int start, int end) {
+        return getInnerKey().getSubKey(start, end);
+    }
+
+    @Nonnull
     public KeyExpression getKeyExpression() {
         if (keyExpression == null) {
-            List<KeyExpression> allKeys = normalizeKeyForPositions();
-            if (splitPoint == 1) {
-                keyExpression = allKeys.get(0);
-            } else {
-                keyExpression = new ThenKeyExpression(allKeys, 0, splitPoint);
-            }
+            return getInnerKey().getSubKey(0, splitPoint);
         }
         return keyExpression;
     }
@@ -205,7 +206,7 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
 
     @Override
     public String toString() {
-        return "covering(" + innerKey.toString() + " split " + splitPoint + ")";
+        return "covering(" + getInnerKey().toString() + " split " + splitPoint + ")";
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryToKeyMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryToKeyMatcher.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.BaseKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
@@ -287,7 +288,11 @@ public class QueryToKeyMatcher {
             return matches(query, ((GroupingKeyExpression) key).getWholeKey(), matchingMode, filterMask);
         }
         if (key instanceof KeyWithValueExpression) {
-            return matches(query, ((KeyWithValueExpression) key).getKeyExpression(), matchingMode, filterMask);
+            try {
+                return matches(query, ((KeyWithValueExpression)key).getKeyExpression(), matchingMode, filterMask);
+            } catch (BaseKeyExpression.UnsplittableKeyExpressionException e) {
+                return Match.none();
+            }
         }
         // Both of these COULD be used for matching by the planner, but they aren't today, so...
         if (key instanceof FunctionKeyExpression

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -42,6 +42,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -49,6 +52,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin.NULL;
 import static com.apple.foundationdb.record.metadata.Key.Evaluated.concatenate;
@@ -57,6 +61,7 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.keyWithValue;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.value;
 import static com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression.EMPTY;
 import static com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression.VERSION;
@@ -725,103 +730,113 @@ public class KeyExpressionTest {
                 evaluate(splitConcat, numbers));
     }
 
-    @Test
-    public void testIsPrefixKey() {
-        final Object[][] tests = {
-                {field("a"),
+    public static Stream<Arguments> getPrefixKeyComparisons() {
+        return Stream.of(
+                Arguments.of(field("a"),
                         concat(field("a"), field("b"), field("c")),
-                        true},
-                {field("x"),
+                        true),
+                Arguments.of(field("x"),
                         concat(field("a"), field("b"), field("c")),
-                        false},
-                {concat(concat(field("a"), EMPTY), EMPTY),
+                        false),
+                Arguments.of(concat(concat(field("a"), EMPTY), EMPTY),
                         field("a"),
-                        true},
-                {field("a"),
+                        true),
+                Arguments.of(field("a"),
                         concat(concat(field("a"), EMPTY), EMPTY),
-                        true},
-                {concat(field("a"), field("b")),
+                        true),
+                Arguments.of(concat(field("a"), field("b")),
                         concat(field("a"), concat(field("b"), field("c"))),
-                        true},
-                {concat(field("a").nest("b"), field("c")),
+                        true),
+                Arguments.of(concat(field("a").nest("b"), field("c")),
                         concat(field("a").nest("b"), concat(field("c"), field("d"))),
-                        true},
-                {field("a").nest("b"),
+                        true),
+                Arguments.of(field("a").nest("b"),
                         concat(field("a").nest("b"), field("a").nest("c")),
-                        true},
-                {field("a").nest("b"),
+                        true),
+                Arguments.of(field("a").nest("b"),
                         field("a").nest(concat(field("b"), field("c"))),
-                        true},
-                {concat(field("a"), field("b")),
+                        true),
+                Arguments.of(concat(field("a"), field("b")),
                         concat(field("a"), new GroupingKeyExpression(concat(field("b"), field("c")), 1)),
-                        true},
-                {concat(field("a"), field("b"), field("c")),
+                        true),
+                Arguments.of(concat(field("a"), field("b"), field("c")),
                         new GroupingKeyExpression(concat(field("a"), field("b"), field("c")), 1),
-                        false},
-                {new GroupingKeyExpression(concat(field("a"), field("b")),1),
+                        false),
+                Arguments.of(new GroupingKeyExpression(concat(field("a"), field("b")), 1),
                         new GroupingKeyExpression(concat(field("a"), field("b")), 1),
-                        true}, // a grouping should not be a prefix, unless both prefix and key are identical
-                {new GroupingKeyExpression(concat(field("a"), field("b")),1),
+                        true), // a grouping should not be a prefix, unless both prefix and key are identical
+                Arguments.of(new GroupingKeyExpression(concat(field("a"), field("b")), 1),
                         new GroupingKeyExpression(concat(field("a"), field("b"), field("c")), 1),
-                        false}, // a grouping should not be a prefix, unless both prefix and key are identical
-                {field("a"),
+                        false), // a grouping should not be a prefix, unless both prefix and key are identical
+                Arguments.of(field("a"),
                         field("a"),
-                        true},
-                {field("a", FanType.FanOut),
+                        true),
+                Arguments.of(field("a", FanType.FanOut),
                         field("a", FanType.FanOut),
-                        true},
-                {field("a", FanType.Concatenate),
+                        true),
+                Arguments.of(field("a", FanType.Concatenate),
                         field("a", FanType.Concatenate),
-                        true},
-                {field("a", FanType.FanOut),
+                        true),
+                Arguments.of(field("a", FanType.FanOut),
                         field("a", FanType.Concatenate),
-                        false},
-                {field("a", FanType.FanOut),
+                        false),
+                Arguments.of(field("a", FanType.FanOut),
                         field("a", FanType.None),
-                        false},
-                {field("a", FanType.Concatenate),
+                        false),
+                Arguments.of(field("a", FanType.Concatenate),
                         field("a", FanType.FanOut),
-                        false},
-                {field("a", FanType.Concatenate),
+                        false),
+                Arguments.of(field("a", FanType.Concatenate),
                         field("a", FanType.None),
-                        false},
-                {field("a", FanType.None),
+                        false),
+                Arguments.of(field("a", FanType.None),
                         field("a", FanType.Concatenate),
-                        false},
-                {field("a", FanType.None),
+                        false),
+                Arguments.of(field("a", FanType.None),
                         field("a", FanType.FanOut),
-                        false},
-                {field("a", FanType.FanOut).nest("b"),
+                        false),
+                Arguments.of(field("a", FanType.FanOut).nest("b"),
                         field("a", FanType.FanOut).nest(concat(field("b"), field("c"))),
-                        true},
-                {field("a", FanType.FanOut).nest("b"),
+                        true),
+                Arguments.of(field("a", FanType.FanOut).nest("b"),
                         concat(field("a", FanType.FanOut).nest("b"), field("a", FanType.FanOut).nest("c")),
-                        true},
-                {field("a", FanType.FanOut).nest(concat(field("b"), field("c"))),
+                        true),
+                Arguments.of(field("a", FanType.FanOut).nest(concat(field("b"), field("c"))),
                         concat(field("a", FanType.FanOut).nest("b"), field("a", FanType.FanOut).nest("c")),
-                        false},
-                {concat(field("a"), VERSION),
+                        false),
+                Arguments.of(concat(field("a"), VERSION),
                         concat(field("a"), field("b")),
-                        false},
-                {concat(field("a"), VERSION),
+                        false),
+                Arguments.of(concat(field("a"), VERSION),
                         concat(field("a"), VERSION),
-                        true},
-                {field("a").split(3),
+                        true),
+                Arguments.of(field("a").split(3),
                         concat(field("a").split(3), field("b"), field("c")),
-                        true},
-                {field("a").split(2),
+                        true),
+                Arguments.of(field("a").split(2),
                         field("a").split(3),
-                        false},
-                {field("a").split(3),
+                        false),
+                Arguments.of(field("a").split(3),
                         field("a").split(2),
-                        false}
-        };
+                        false),
+                Arguments.of(keyWithValue(concat(field("a"), field("b")), 1),
+                        concat(field("a"), field("c")),
+                        true),
+                Arguments.of(keyWithValue(concat(field("a"), field("b")), 1),
+                        field("a"),
+                        true),
+                Arguments.of(concat(field("a"), field("b")),
+                        keyWithValue(concat(field("a"), field("b"), field("c")), 2),
+                        true),
+                Arguments.of(concat(field("a"), field("b")),
+                        keyWithValue(concat(field("a"), field("b")), 1),
+                        false));
+    }
 
-        for (Object[] test : tests) {
-            assertEquals(test[2],
-                    ((KeyExpression) test[0]).isPrefixKey((KeyExpression) test[1]),
-                    "\nPrefix: " + test[0] + "\nKey: " + test[1]);
-        }
+    @ParameterizedTest
+    @MethodSource("getPrefixKeyComparisons")
+    public void testIsPrefixKey(@Nonnull KeyExpression prefix, @Nonnull KeyExpression key, boolean shouldBePrefix) {
+        assertEquals(shouldBePrefix, prefix.isPrefixKey(key));
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -731,6 +731,9 @@ public class KeyExpressionTest {
     }
 
     public static Stream<Arguments> getPrefixKeyComparisons() {
+        final KeyExpression nestedKeyWithValue = keyWithValue(field("a", FanType.FanOut).nest(
+                        concat(field("b"), field("c"), field("d"))), 2);
+
         return Stream.of(
                 Arguments.of(field("a"),
                         concat(field("a"), field("b"), field("c")),
@@ -825,11 +828,31 @@ public class KeyExpressionTest {
                 Arguments.of(keyWithValue(concat(field("a"), field("b")), 1),
                         field("a"),
                         true),
+                Arguments.of(keyWithValue(concat(field("a"), field("b"), field("c")), 2),
+                        concat(field("a"), field("c")), false),
                 Arguments.of(concat(field("a"), field("b")),
                         keyWithValue(concat(field("a"), field("b"), field("c")), 2),
                         true),
                 Arguments.of(concat(field("a"), field("b")),
                         keyWithValue(concat(field("a"), field("b")), 1),
+                        false),
+                Arguments.of(field("a", FanType.FanOut).nest(field("b")),
+                        nestedKeyWithValue,
+                        true),
+                Arguments.of(field("a", FanType.FanOut).nest(concat(field("b"), field("c"))),
+                        nestedKeyWithValue,
+                        true),
+                Arguments.of(field("a", FanType.FanOut).nest(
+                        concat(field("b"), field("c"), field("d"))),
+                        nestedKeyWithValue,
+                        false),
+                Arguments.of(concat(field("a", FanType.FanOut).nest(
+                        field("b")), field("a", FanType.FanOut).nest("b")),
+                        nestedKeyWithValue,
+                        false),
+                Arguments.of(concat(field("a", FanType.FanOut).nest(
+                        field("b")), field("a", FanType.FanOut).nest("c")),
+                        nestedKeyWithValue,
                         false));
     }
 


### PR DESCRIPTION
Previously, the `KeyWithValueExpression` returned its whole key as the child, when it should have returned just the part from before the split point (i.e., what ends up in the key).