### PR TITLE
Resolves #461: Remove per-record time-to-load

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -50,6 +50,8 @@ The `SubspaceProvider` interface is changed to no longer require an `FDBRecordCo
 
 This version of the Record Layer requires a FoundationDB server version of at least version 6.0. Attempting to connect to older versions may result in the client hanging when attempting to connect to the database.
 
+The `getTimeToLoad` and `getTimeToDeserialize` methods on `FDBStoredRecord` have been removed. These were needed for a short-term experiment but stuck around longer than intended.
+
 ### Newly deprecated
 
 Methods for retrieving a record from a record store based on an index entry generally took both an index and an index entry. As index entries now store a reference to their associatedindex, these methods have been deprecated in favor of methods that only take an index entry. The earlier methods may be removed in a future release. The same is true for a constructor on `FDBIndexedRecord` which no longer needs to take both an index and an index entry.
@@ -84,6 +86,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Breaking change** The `MetaDataCache` interface is now `EXPERIMENTAL` [(Issue #447)](https://github.com/FoundationDB/fdb-record-layer/issues/447)
 * **Breaking change** The `AsyncIterator` methods on `RecordCursor` are now deprecated [(Issue #368)](https://github.com/FoundationDB/fdb-record-layer/issues/368)
 * **Breaking change** The Record Layer now requires a minimum FoundationDB version of 6.0 [(Issue #313)](https://github.com/FoundationDB/fdb-record-layer/issues/313)
+* **Breaking change** Remove per-record time-to-load [(Issue #461)](https://github.com/FoundationDB/fdb-record-layer/issues/461)
 
 // end next release
 -->

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -62,7 +62,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** getVersionstamp() future can complete a tiny bit after the commit() future [(Issue #476)](https://github.com/FoundationDB/fdb-record-layer/issues/476)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordVersion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordVersion.java
@@ -574,7 +574,7 @@ public class FDBRecordVersion implements Comparable<FDBRecordVersion> {
 
     /**
      * Complete this version with the version from as successful commit.
-     * @param committedVersion the result of {@link FDBRecordContext#versionStamp}
+     * @param committedVersion the result of {@link FDBRecordContext#getVersionStamp}
      * @return a new record version with a complete version
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
@@ -27,7 +27,6 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 /**
  * A record stored in the database.
@@ -54,25 +53,15 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     private final boolean split;
     private final boolean versionedInline;
 
-    // TODO: Remove these at some point once experiments are complete.
-    private final Optional<Long> timeToLoad;
-    private final Optional<Long> timeToDeserialize;
-
-    @SuppressWarnings("squid:S00107") // Allow this many args since mostly initialized by builder.
-    protected FDBStoredRecord(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record,
-                              @Nonnull int keyCount, int keySize, int valueSize, boolean split, boolean versionedInline, @Nullable FDBRecordVersion recordVersion) {
-        this(primaryKey, recordType, record, keyCount, keySize, valueSize, split, versionedInline, recordVersion, Optional.empty(), Optional.empty());
-    }
-
     public FDBStoredRecord(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record,
                            @Nonnull FDBStoredSizes size, @Nullable FDBRecordVersion recordVersion) {
         this(primaryKey, recordType, record, size.getKeyCount(), size.getKeySize(), size.getValueSize(), size.isSplit(), size.isVersionedInline(), recordVersion);
     }
 
+    @API(API.Status.INTERNAL)
     @SuppressWarnings("squid:S00107")
     public FDBStoredRecord(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record,
-                           @Nonnull int keyCount, int keySize, int valueSize, boolean split, boolean versionedInline, @Nullable FDBRecordVersion recordVersion,
-                           @Nonnull Optional<Long> timeToLoad, @Nonnull Optional<Long> timeToDeserialize) {
+                           int keyCount, int keySize, int valueSize, boolean split, boolean versionedInline, @Nullable FDBRecordVersion recordVersion) {
 
         this.primaryKey = primaryKey;
         this.recordType = recordType;
@@ -84,9 +73,6 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
         this.split = split;
         this.recordVersion = recordVersion;
         this.versionedInline = versionedInline;
-
-        this.timeToLoad = timeToLoad;
-        this.timeToDeserialize = timeToDeserialize;
     }
 
     @Override
@@ -174,13 +160,12 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
         return new FDBStoredRecord<>(primaryKey, recordType, record, this, recordVersion);
     }
 
-
     /**
      * Get this record with an updated version after committing.
      *
      * If this record has an incomplete version, it is completed with the given version stamp.
      * If the version is already complete or this record does not have a version, this record is returned.
-     * @param committedVersion the result of {@link FDBRecordContext#versionStamp}
+     * @param committedVersion the result of {@link FDBRecordContext#getVersionStamp}
      * @return a stored record with the given version
      */
     @Nonnull
@@ -189,16 +174,6 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
             return this;
         }
         return withVersion(recordVersion.withCommittedVersion(committedVersion));
-    }
-
-    @Nonnull
-    public Optional<Long> getTimeToLoad() {
-        return timeToLoad;
-    }
-
-    @Nonnull
-    public Optional<Long> getTimeToDeserialize() {
-        return timeToDeserialize;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
@@ -28,7 +28,6 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 /**
  * A builder for {@link FDBStoredRecord}.
@@ -50,11 +49,6 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
     private int valueSize;
     private boolean split;
     private boolean versionedInline;
-
-    @Nonnull
-    private Optional<Long> timeToLoad = Optional.empty();
-    @Nonnull
-    private Optional<Long> timeToDeserialize = Optional.empty();
 
     public FDBStoredRecordBuilder() {
         // Real initialization via set methods.
@@ -128,16 +122,6 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
         return versionedInline;
     }
 
-    @Nonnull
-    public Optional<Long> getTimeToLoad() {
-        return timeToLoad;
-    }
-
-    @Nonnull
-    public Optional<Long> getTimeToDeserialize() {
-        return timeToDeserialize;
-    }
-
     public FDBStoredRecordBuilder<M> setPrimaryKey(Tuple primaryKey) {
         this.primaryKey = primaryKey;
         return this;
@@ -192,19 +176,8 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
         return this;
     }
 
-    public FDBStoredRecordBuilder<M> setTimeToLoad(final long time) {
-        timeToLoad = Optional.of(time);
-        return this;
-    }
-
-    public FDBStoredRecordBuilder<M> setTimeToDeserialize(final long time) {
-        timeToDeserialize = Optional.of(time);
-        return this;
-    }
-
     public FDBStoredRecord<M> build() {
         return new FDBStoredRecord<>(getPrimaryKey(), getRecordType(), getRecord(),
-                getKeyCount(), getKeySize(), getValueSize(), isSplit(), isVersionedInline(), getVersion(),
-                getTimeToLoad(), getTimeToDeserialize());
+                getKeyCount(), getKeySize(), getValueSize(), isSplit(), isVersionedInline(), getVersion());
     }
 }


### PR DESCRIPTION
Note that this is against the 2.6 branch.

Although there were TODO comments about this, the methods being removed weren't annotated in any particular way. So perhaps there should be a gentler multi-stage removal.

Also includes a fix for #476. Some version tests were failing pretty reliably with this branch.