### PR TITLE
Resolves #441: Audit code for incorrect uses of CompletableFuture::isDone

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -416,7 +416,7 @@ public class MoreAsyncUtil {
                         nextFuture = whileTrue(() -> {
                             List<CompletableFuture<Boolean>> waitOn = new ArrayList<>(2);
                             CompletableFuture<Boolean> outer = iterator.onHasNext();
-                            if (outer.isDone()) {
+                            if (isCompletedNormally(outer)) {
                                 if (outer.getNow(false) && (pipeline.size() < pipelineSize)) {
                                     AsyncIterator<T2> next = func.apply(iterator.next()).iterator();
                                     pipeline.add(next);
@@ -431,7 +431,7 @@ public class MoreAsyncUtil {
                             AsyncIterator<T2> current = pipeline.peek();
                             if (current != null) {
                                 inner = current.onHasNext();
-                                if (inner.isDone()) {
+                                if (isCompletedNormally(inner)) {
                                     if (inner.getNow(false)) {
                                         // inner onHasNext returned true, break out of whileTrue
                                         return AsyncUtil.READY_FALSE; // First available

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -403,7 +403,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
 
     @Nullable
     public <T> T asyncToSync(FDBStoreTimer.Wait event, @Nonnull CompletableFuture<T> async) {
-        if (hookForAsyncToSync != null && (!async.isDone() || async.isCompletedExceptionally())) {
+        if (hookForAsyncToSync != null && !MoreAsyncUtil.isCompletedNormally(async)) {
             hookForAsyncToSync.accept(event);
         }
         return database.asyncToSync(timer, event, async);


### PR DESCRIPTION
Nothing major was found. There were a few instances where we were not using the cached `READY_TRUE` and `READY_FALSE` futures, so I fixed those. A few places, the error was generated, thrown, and then caught, so I instead made it check for normal completion so that propagating the error was a little cheaper. I did not touch the `MapPipelinedCursor` or `FlatMapPipelined` cursor (except for a few comments), though I tried to add tests to exercise some of the code paths that might encounter exceptions. Those were all either directly or later calling `.join()` on the future they were checking, so they should all report errors, though there may be ways to fix those up so that they do not need to throw. I started down that path, then I decided that it was probably better to avoid accidentally introducing a new bug under the axiom of not trying to fix what is not Baroque.

I purposefully omitted any release notes as I didn't find any real bugs.