### PR TITLE
Resolves #474: Mark OnlineIndexer::asyncToSync as INTERNAL

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -38,6 +38,10 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 In order to simplify typed record stores, the `FDBRecordStoreBase` class was turned into an interface and all I/O was placed in the `FDBRecordStore` class. This makes the `FDBTypedRecordStore` serve as only a type-safe wrapper around the `FDBRecordStore` class. As part of this work, the `IndexMaintainer` interface and its implementations lost their type parameters and now only interact with `Message` types, and the `OnlineIndexerBase` class was removed. Additionally, the `FDBEvaluationContext` class was removed in favor of using `EvaluationContext` (without a type parameter) directly. That class also no longer carries around an `FDBRecordStore` reference, so query plans now require an explicit record store in addition to an evaluation context. Finally, the `evaluate` family of methods on key expressions no longer take evaluation contexts. Users should switch any uses of the `OnlineIndexerBase` to a generic `OnlineIndexer` and will need to update any explicit key expression evluation calls. Users should also switch from calling `RecordQueryPlan::execute` to calling `FDBRecordStore::executeQuery` if possible as that second API is more stable (and was not changed as part of the recent work).
 
+### Newly Deprecated
+
+The `asyncToSync` method of the `OnlineIndexer` has been marked as `INTERNAL`. Users should transition to using one of the `asyncToSync` methods defined on either `FDBDatabase`, `FDBRecordContext`, or `FDBDatabaseRunner`. This method may be removed from our public API in a later release (see [Issue # 473](https://github.com/FoundationDB/fdb-record-layer/issues/473)).
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -62,6 +66,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Deprecated** The `asyncToSync` method of the `OnlineIndexer` has been marked `INTERNAL` [(Issue #474)](https://github.com/FoundationDB/fdb-record-layer/issues/474)
 
 // end next release
 -->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1007,10 +1007,19 @@ public class OnlineIndexer implements AutoCloseable {
 
     /**
      * Wait for asynchronous index build to complete.
+     *
+     * <p>
+     * This method was marked {@link API.Status#INTERNAL INTERNAL} in a 2.5 release of the Record Layer, and it may be
+     * removed in version 2.7. Outside users of the Record Layer should use the {@code asyncToSync} methods of {@link FDBRecordContext},
+     * {@link FDBDatabase}, or {@link FDBDatabaseRunner} instead. See
+     * <a href="https://github.com/FoundationDB/fdb-record-layer/issues/473">Issue #473</a> for more details.
+     * </p>
+     *
      * @param buildIndexFuture the result of {@link #buildIndexAsync}
      * @param <T> return type of function to run
      * @return future that will contain the result of {@code buildIndexFuture} after successful run and commit
      */
+    @API(API.Status.INTERNAL)
     public <T> T asyncToSync(@Nonnull CompletableFuture<T> buildIndexFuture) {
         return runner.asyncToSync(FDBStoreTimer.Waits.WAIT_ONLINE_BUILD_INDEX, buildIndexFuture);
     }


### PR DESCRIPTION
This resolves #474. This is to eventually allow us to remove the method entirely (see #473).