### PR TITLE
Fixes #472 KeyValueLogMessage sanitizes `'` but quotes with `"`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -46,7 +46,7 @@ The `asyncToSync` method of the `OnlineIndexer` has been marked as `INTERNAL`. U
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** KeyValueLogMessage now converts `"` to `'` in values [(Issue #472)](https://github.com/FoundationDB/fdb-record-layer/issues/472)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
@@ -89,7 +89,7 @@ public class KeyValueLogMessage {
 
     @Nonnull
     private static String sanitizeValue(@Nonnull final String value) {
-        return value.replace("'", "");
+        return value.replace("\"", "'");
     }
 
     @Nonnull


### PR DESCRIPTION
Instead of stripping out single quote, replace double quote with a
single quote.