### PR TITLE
Resolves #204: Add a default union descriptor to record meta-data

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -77,7 +77,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Automatically add a default union to the record meta-data if missing [(Issue #204)](https://github.com/FoundationDB/fdb-record-layer/issues/204)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -77,19 +78,18 @@ public class MetaDataProtoEditor {
                 .setPrimaryKey(primaryKey.toKeyExpression())
                 .setSinceVersion(metaDataBuilder.getVersion())
                 .build());
-        addFieldToUnion(metaDataBuilder.getRecordsBuilder(), newRecordType);
+        addFieldToUnion(fetchUnionBuilder(metaDataBuilder.getRecordsBuilder()), newRecordType.getName(), newRecordType.getName());
     }
 
-    private static void addFieldToUnion(@Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder, @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
-        DescriptorProtos.DescriptorProto.Builder unionBuilder = fetchUnionBuilder(fileBuilder);
+    private static void addFieldToUnion(@Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder, @Nonnull String name, @Nonnull String typeName) {
         if (unionBuilder.getOneofDeclCount() > 0) {
             throw new MetaDataException("Adding record type to oneof is not allowed");
         }
         DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = DescriptorProtos.FieldDescriptorProto.newBuilder()
                 .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
                 .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
-                .setTypeName(newRecordType.getName())
-                .setName("_" + newRecordType.getName())
+                .setName("_" + name)
+                .setTypeName(typeName)
                 .setNumber(assignFieldNumber(unionBuilder));
         unionBuilder.addField(fieldBuilder);
     }
@@ -109,6 +109,17 @@ public class MetaDataProtoEditor {
             return true;
         }
         RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageTypeBuilder.getOptions()
+                .getExtension(RecordMetaDataOptionsProto.record);
+        return recordTypeOptions != null &&
+               recordTypeOptions.hasUsage() &&
+               recordTypeOptions.getUsage() == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+    }
+
+    private static boolean isUnion(@Nonnull Descriptors.Descriptor messageType) {
+        if (messageType.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME)) {
+            return true;
+        }
+        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
                 .getExtension(RecordMetaDataOptionsProto.record);
         return recordTypeOptions != null &&
                recordTypeOptions.hasUsage() &&
@@ -238,4 +249,138 @@ public class MetaDataProtoEditor {
         return messageType.getFieldBuilderList().stream().filter(m -> m.getName().equals(fieldName)).findAny().orElse(null);
     }
 
+    /**
+     * Add a default union to the given records descriptor if missing.
+     *
+     * <p>
+     * This method is a no-op if the union is present. Otherwise, the method will add a union to the records
+     * descriptor. The union descriptor will be filled in with all of the record types defined in the file except
+     * {@code NESTED} record types.
+     * </p>
+     *
+     * @param fileDescriptor the records descriptor of the record meta-data
+     * @return the resulting records descriptor
+     */
+    @Nonnull
+    public static Descriptors.FileDescriptor addDefaultUnionIfMissing(@Nonnull Descriptors.FileDescriptor fileDescriptor) {
+        if (MetaDataProtoEditor.hasUnion(fileDescriptor)) {
+            return fileDescriptor;
+        }
+        DescriptorProtos.FileDescriptorProto fileDescriptorProto = fileDescriptor.toProto();
+        DescriptorProtos.FileDescriptorProto.Builder fileBuilder = fileDescriptorProto.toBuilder();
+        fileBuilder.addMessageType(createDefaultUnion(fileDescriptor));
+        try {
+            return Descriptors.FileDescriptor.buildFrom(fileBuilder.build(), fileDescriptor.getDependencies().toArray(new Descriptors.FileDescriptor[0]));
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new MetaDataException("Failed to add a default union", e);
+        }
+    }
+
+    /**
+     * Creates a default union descriptor for the given file descriptor if missing.
+     *
+     * <p>
+     * If the given file descriptor is missing a union message, this method will add one before updating the meta-data.
+     * The generated union descriptor is constructed by adding any non-{@code NESTED} types in the file descriptor to the
+     * union descriptor from the currently stored meta-data. A new field is not added if a field of the given type already
+     * exists, and the order of any existing fields is preserved. Note that types are identified by name, so renaming
+     * top-level message types may result in validation errors when trying to update the record descriptor.
+     * </p>
+     *
+     * @param fileDescriptor the file descriptor to create a union for
+     * @param baseUnionDescriptor the base union descriptor
+     * @return the builder for the union
+     */
+    @Nonnull
+    public static Descriptors.FileDescriptor addDefaultUnionIfMissing(@Nonnull Descriptors.FileDescriptor fileDescriptor, @Nonnull Descriptors.Descriptor baseUnionDescriptor) {
+        if (MetaDataProtoEditor.hasUnion(fileDescriptor)) {
+            return fileDescriptor;
+        }
+        DescriptorProtos.FileDescriptorProto fileDescriptorProto = fileDescriptor.toProto();
+        DescriptorProtos.FileDescriptorProto.Builder fileBuilder = fileDescriptorProto.toBuilder();
+        DescriptorProtos.DescriptorProto.Builder unionDescriptorBuilder = createSyntheticUnion(fileDescriptor, baseUnionDescriptor);
+        for (Descriptors.Descriptor messageType : fileDescriptor.getMessageTypes()) {
+            RecordMetaDataOptionsProto.RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType.toProto());
+            if (messageTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+                if (!hasField(unionDescriptorBuilder, messageType)) {
+                    addFieldToUnion(unionDescriptorBuilder, messageType.getName(), getFullyQualifiedFullName(messageType));
+                }
+            }
+        }
+        fileBuilder.addMessageType(unionDescriptorBuilder);
+        try {
+            return Descriptors.FileDescriptor.buildFrom(fileBuilder.build(), fileDescriptor.getDependencies().toArray(new Descriptors.FileDescriptor[0]));
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new MetaDataException("Failed to add a default union", e);
+        }
+    }
+
+    @Nonnull
+    private static DescriptorProtos.DescriptorProto.Builder createDefaultUnion(@Nonnull Descriptors.FileDescriptor fileDescriptor) {
+        DescriptorProtos.DescriptorProto.Builder unionMessageType = DescriptorProtos.DescriptorProto.newBuilder();
+        unionMessageType.setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME);
+        for (Descriptors.Descriptor messageType : fileDescriptor.getMessageTypes()) {
+            RecordMetaDataOptionsProto.RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType.toProto());
+            if (messageTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+                addFieldToUnion(unionMessageType, messageType.getName(), getFullyQualifiedFullName(messageType));
+            }
+        }
+        return unionMessageType;
+    }
+
+    /**
+     * Creates a default union descriptor for the given file descriptor and a base union descriptor. It adds all of the
+     * non-{@code NESTED} message types that exist in the base union to the synthetic union.
+     * @param fileDescriptor the file descriptor to create a union for
+     * @param baseUnionDescriptor the base union descriptor
+     * @return the builder for the union
+     */
+    @Nonnull
+    @API(API.Status.INTERNAL)
+    public static DescriptorProtos.DescriptorProto.Builder createSyntheticUnion(@Nonnull Descriptors.FileDescriptor fileDescriptor, @Nonnull Descriptors.Descriptor baseUnionDescriptor) {
+        DescriptorProtos.DescriptorProto.Builder unionMessageType = DescriptorProtos.DescriptorProto.newBuilder();
+        unionMessageType.setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME);
+        if (baseUnionDescriptor.getOneofs().size() > 0) {
+            throw new MetaDataException("Adding record type to oneof is not allowed");
+        }
+        for (Descriptors.FieldDescriptor field : baseUnionDescriptor.getFields()) {
+            Descriptors.Descriptor messageType = fileDescriptor.findMessageTypeByName(field.getMessageType().getName());
+            if (messageType == null) {
+                throw new MetaDataException("Record type " + field.getMessageType().getName() + " removed");
+            }
+            RecordMetaDataOptionsProto.RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType.toProto());
+            if (messageTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+                unionMessageType.addField(field.toProto().toBuilder().setTypeName(getFullyQualifiedFullName(messageType)));
+            }
+        }
+        return unionMessageType;
+    }
+
+    /**
+     * Checks if the file descriptor has a union.
+     * @param fileDescriptor the file descriptor
+     * @return true if the file descriptor has a union
+     */
+    public static boolean hasUnion(@Nonnull Descriptors.FileDescriptor fileDescriptor) {
+        for (Descriptors.Descriptor messageType : fileDescriptor.getMessageTypes()) {
+            if (isUnion(messageType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasField(@Nonnull DescriptorProtos.DescriptorProto.Builder builder, @Nonnull Descriptors.Descriptor messageType) {
+        for (DescriptorProtos.FieldDescriptorProto field : builder.getFieldList()) {
+            // TODO: this should call fieldHasType once issue https://github.com/FoundationDB/fdb-record-layer/issues/508 is closed.
+            if (field.getTypeName().equals(getFullyQualifiedFullName(messageType))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String getFullyQualifiedFullName(@Nonnull Descriptors.Descriptor messageType) {
+        return "." + messageType.getFullName();
+    }
 }

--- a/fdb-record-layer-core/src/test/proto/test_no_union.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union.proto
@@ -1,9 +1,9 @@
 /*
- * test_records_1_evolved_again.proto
+ * test_no_union.proto
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@
  */
 syntax = "proto2";
 
-package com.apple.foundationdb.record.test1evolvedagain;
+package com.apple.foundationdb.record.testnounion;
 
 option java_package = "com.apple.foundationdb.record";
-option java_outer_classname = "TestRecords1EvolvedAgainProto";
+option java_outer_classname = "TestNoUnionProto";
 
 import "record_metadata_options.proto";
 
@@ -35,32 +35,4 @@ message MySimpleRecord {
   optional int32 num_value_2 = 4;
   optional int32 num_value_3_indexed = 5 [(field).index = {}];
   repeated int32 repeater = 6;
-}
-
-message MyOtherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5;
-}
-
-message AnotherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5 [(field).index = { unique: true }];
-  optional int32 num_value_4 = 6;
-}
-
-message OneMoreRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message Record {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message RecordTypeUnion {
-  optional MySimpleRecord _MySimpleRecord = 1;
-  optional MyOtherRecord _MyOtherRecord = 2;
-  optional AnotherRecord _AnotherRecord = 3;
-  optional OneMoreRecord _OneMoreRecord = 4;
 }

--- a/fdb-record-layer-core/src/test/proto/test_no_union_evolved.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union_evolved.proto
@@ -1,0 +1,45 @@
+/*
+ * test_no_union_evolved.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.testnounionevolved;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestNoUnionEvolvedProto";
+
+import "record_metadata_options.proto";
+
+option (schema).store_record_versions = true;
+
+// It's intentional that this message is before MySimpleRecord.
+message MyOtherRecord {
+  required int64 rec_no = 1 [(field).primary_key = true];
+  optional int32 num_value_2 = 4;
+  optional int32 num_value_3_indexed = 5;
+}
+
+message MySimpleRecord {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  optional string str_value_indexed = 2 [(field).index = {}];
+  optional int32 num_value_unique = 3 [(field).index = { unique: true }];
+  optional int32 num_value_2 = 4;
+  optional int32 num_value_3_indexed = 5 [(field).index = {}];
+  repeated int32 repeater = 6;
+}

--- a/fdb-record-layer-core/src/test/proto/test_no_union_evolved_illegal.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union_evolved_illegal.proto
@@ -1,9 +1,9 @@
 /*
- * test_records_1_evolved_again.proto
+ * test_no_union_evolved_illegal.proto
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,48 +19,21 @@
  */
 syntax = "proto2";
 
-package com.apple.foundationdb.record.test1evolvedagain;
+package com.apple.foundationdb.record.testnounionevolvedillegal;
 
 option java_package = "com.apple.foundationdb.record";
-option java_outer_classname = "TestRecords1EvolvedAgainProto";
+option java_outer_classname = "TestNoUnionEvolvedIllegalProto";
 
 import "record_metadata_options.proto";
 
 option (schema).store_record_versions = true;
 
 message MySimpleRecord {
+  option (com.apple.foundationdb.record.record).usage = NESTED;
   optional int64 rec_no = 1 [(field).primary_key = true];
   optional string str_value_indexed = 2 [(field).index = {}];
   optional int32 num_value_unique = 3 [(field).index = { unique: true }];
   optional int32 num_value_2 = 4;
   optional int32 num_value_3_indexed = 5 [(field).index = {}];
   repeated int32 repeater = 6;
-}
-
-message MyOtherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5;
-}
-
-message AnotherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5 [(field).index = { unique: true }];
-  optional int32 num_value_4 = 6;
-}
-
-message OneMoreRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message Record {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message RecordTypeUnion {
-  optional MySimpleRecord _MySimpleRecord = 1;
-  optional MyOtherRecord _MyOtherRecord = 2;
-  optional AnotherRecord _AnotherRecord = 3;
-  optional OneMoreRecord _OneMoreRecord = 4;
 }

--- a/fdb-record-layer-core/src/test/proto/test_no_union_evolved_renamed_type.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union_evolved_renamed_type.proto
@@ -1,9 +1,9 @@
 /*
- * test_records_1_evolved_again.proto
+ * test_no_union_evolved_renamed_type.proto
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,48 +19,20 @@
  */
 syntax = "proto2";
 
-package com.apple.foundationdb.record.test1evolvedagain;
+package com.apple.foundationdb.record.testnounionrenamedrecordtype;
 
 option java_package = "com.apple.foundationdb.record";
-option java_outer_classname = "TestRecords1EvolvedAgainProto";
+option java_outer_classname = "TestNoUnionEvolvedRenamedRecordTypeProto";
 
 import "record_metadata_options.proto";
 
 option (schema).store_record_versions = true;
 
-message MySimpleRecord {
+message MySimpleRecordRenamed {
   optional int64 rec_no = 1 [(field).primary_key = true];
   optional string str_value_indexed = 2 [(field).index = {}];
   optional int32 num_value_unique = 3 [(field).index = { unique: true }];
   optional int32 num_value_2 = 4;
   optional int32 num_value_3_indexed = 5 [(field).index = {}];
   repeated int32 repeater = 6;
-}
-
-message MyOtherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5;
-}
-
-message AnotherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5 [(field).index = { unique: true }];
-  optional int32 num_value_4 = 6;
-}
-
-message OneMoreRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message Record {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message RecordTypeUnion {
-  optional MySimpleRecord _MySimpleRecord = 1;
-  optional MyOtherRecord _MyOtherRecord = 2;
-  optional AnotherRecord _AnotherRecord = 3;
-  optional OneMoreRecord _OneMoreRecord = 4;
 }

--- a/fdb-record-layer-core/src/test/proto/test_records_implicit_usage.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_implicit_usage.proto
@@ -1,9 +1,9 @@
 /*
- * test_records_1_evolved_again.proto
+ * test_records_implicit_usage.proto
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@
  */
 syntax = "proto2";
 
-package com.apple.foundationdb.record.test1evolvedagain;
+package com.apple.foundationdb.record.testimplicitusage;
 
 option java_package = "com.apple.foundationdb.record";
-option java_outer_classname = "TestRecords1EvolvedAgainProto";
+option java_outer_classname = "TestRecordsImplicitUsageProto";
 
 import "record_metadata_options.proto";
 
@@ -43,24 +43,6 @@ message MyOtherRecord {
   optional int32 num_value_3_indexed = 5;
 }
 
-message AnotherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5 [(field).index = { unique: true }];
-  optional int32 num_value_4 = 6;
-}
-
-message OneMoreRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message Record {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
 message RecordTypeUnion {
   optional MySimpleRecord _MySimpleRecord = 1;
-  optional MyOtherRecord _MyOtherRecord = 2;
-  optional AnotherRecord _AnotherRecord = 3;
-  optional OneMoreRecord _OneMoreRecord = 4;
 }

--- a/fdb-record-layer-core/src/test/proto/test_records_implicit_usage_no_union.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_implicit_usage_no_union.proto
@@ -1,9 +1,9 @@
 /*
- * test_records_1_evolved_again.proto
+ * test_records_implicit_usage_no_union.proto
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@
  */
 syntax = "proto2";
 
-package com.apple.foundationdb.record.test1evolvedagain;
+package com.apple.foundationdb.record.testimplicitusagenounion;
 
 option java_package = "com.apple.foundationdb.record";
-option java_outer_classname = "TestRecords1EvolvedAgainProto";
+option java_outer_classname = "TestRecordsImplicitUsageNoUnionProto";
 
 import "record_metadata_options.proto";
 
@@ -43,24 +43,3 @@ message MyOtherRecord {
   optional int32 num_value_3_indexed = 5;
 }
 
-message AnotherRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 num_value_2 = 4;
-  optional int32 num_value_3_indexed = 5 [(field).index = { unique: true }];
-  optional int32 num_value_4 = 6;
-}
-
-message OneMoreRecord {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message Record {
-  required int64 rec_no = 1 [(field).primary_key = true];
-}
-
-message RecordTypeUnion {
-  optional MySimpleRecord _MySimpleRecord = 1;
-  optional MyOtherRecord _MyOtherRecord = 2;
-  optional AnotherRecord _AnotherRecord = 3;
-  optional OneMoreRecord _OneMoreRecord = 4;
-}


### PR DESCRIPTION
[Please only review the top commit. I needed the other commit, which has a pending PR already, for testing this. I will merge / rebase later once that's in. Thanks]

This change adds a missing union descriptor to the record meta-data if FDBMetaDataStore is
    used. The assumption is the following steps are involved:

    - A .proto file is created that has some record types but doesn't have a union.
    - The .proto file is saved using FDBMetaDataStore.saveRecordMetaData(). The missing union
     is added using saveRecordMetaData before it saves the meta-data into the store.
    - Users can continue adding record types to this meta-data, which will add a field to the
    now-existing union.