### PR TITLE
OnlineIndexer progress log includes record counts

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -52,7 +52,7 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** OnlineIndexer logs number of records scanned [(Issue #479)](https://github.com/FoundationDB/fdb-record-layer/issues/479)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -165,7 +165,7 @@ public class OnlineIndexer implements AutoCloseable {
     private long timeOfLastProgressLogMillis;
     /**
      * The total number of records scanned in the build.
-     * Unlike {@link FDBStoreTimer.Counts#ONLINE_INDEX_BUILDER_RECORDS_SCANNED} this will not include records that
+     * Unlike {@link FDBStoreTimer.Counts#ONLINE_INDEX_BUILDER_RECORDS_SCANNED}, this will not include records that
      * are scanned as part of a failed transaction.
      * @see Builder#setProgressLogIntervalMillis(long)
      */
@@ -1352,12 +1352,12 @@ public class OnlineIndexer implements AutoCloseable {
          *     <li>realEnd - the tuple that was successfully scanned to (always before endTuple)</li>
          *     <li>recordsScanned - the number of records successfully scanned and processed
          *     <p>
-         *         If one of the transactional methods is used to build the index (i.e. a context is provided),
+         *         If one of the transactional methods is used to build the index (i.e., a context is provided),
          *         then this will simply be the number of records scanned by this {@code OnlineIndexer}.
          *         If one of the methods that builds in multiple transactions (e.g. {@link #buildIndexAsync()} or
          *         {@link #buildRange(Key.Evaluated, Key.Evaluated)}) is called, then transactions that fail will not
          *         count towards this value, only transactions that succeed. As a side effect, this means that transactions
-         *         that get commit_unknown_result will not get counted towards this value, so this value may be short by
+         *         that get {@code commit_unknown_result} will not get counted towards this value, so this value may be short by
          *         the number of records scanned in those transactions if they actually succeeded.
          *     </p></li>
          * </ul>

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -61,7 +61,6 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.ThreadContext;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,8 +103,14 @@ import java.util.stream.Stream;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -375,9 +380,9 @@ public class OnlineIndexerTest extends FDBTestBase {
                 additionalScans += (long)recordsWhileBuilding.size();
             }
             assertThat(indexBuilder.getTotalRecordsScanned(),
-                    Matchers.allOf(
-                            Matchers.greaterThanOrEqualTo((long)records.size()),
-                            Matchers.lessThanOrEqualTo((long)records.size() + additionalScans)
+                    allOf(
+                            greaterThanOrEqualTo((long)records.size()),
+                            lessThanOrEqualTo((long)records.size() + additionalScans)
                     ));
         }
         LOGGER.info(KeyValueLogMessage.of("building index - completed", "index", index));
@@ -2458,16 +2463,16 @@ public class OnlineIndexerTest extends FDBTestBase {
             while (!future.isDone() && timer.getCount(FDBStoreTimer.Events.COMMIT) < 10 && pass++ < 100) {
                 Thread.sleep(100);
             }
-            assertThat("Should have done several transactions in a few seconds", pass, Matchers.lessThan(100));
+            assertThat("Should have done several transactions in a few seconds", pass, lessThan(100));
         }
         int count1 = timer.getCount(FDBStoreTimer.Events.COMMIT);
         assertThrows(FDBDatabaseRunner.RunnerClosed.class, () -> fdb.asyncToSync(timer, FDBStoreTimer.Waits.WAIT_ONLINE_BUILD_INDEX, future));
         Thread.sleep(50);
         int count2 = timer.getCount(FDBStoreTimer.Events.COMMIT);
         // Might close just after committing but before recording.
-        assertThat("At most one more commits should have occurred", count2, Matchers.isOneOf(count1, count1 + 1));
+        assertThat("At most one more commits should have occurred", count2, isOneOf(count1, count1 + 1));
         Thread.sleep(50);
         int count3 = timer.getCount(FDBStoreTimer.Events.COMMIT);
-        assertThat("No more commits should have occurred", count3, Matchers.is(count2));
+        assertThat("No more commits should have occurred", count3, is(count2));
     }
 }


### PR DESCRIPTION
Resolves #479
This could be a little cleaner if I was willing to change the api
There are also a handful of edge cases that could cause the value to
be off, but it's not worth introducing the kind of checks that would
prevent this being off.
extracted OnlineIndexerTest.setupRunAsync