### PR TITLE
 Resolves #490: Document unsafety of opening multiple record stores on the same data in a single transaction

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializer.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 /**
- * Serialize records using default Protobuf serialization using supplied message builder for the union message type.
+ * Serialize records using default Protobuf serialization using the supplied message builder for the union message type.
  */
 @API(API.Status.UNSTABLE)
 public class MessageBuilderRecordSerializer extends MessageBuilderRecordSerializerBase<Message, Message, Message.Builder> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -117,7 +117,25 @@ import java.util.stream.Collectors;
 /**
  * A multi-type record store.
  *
- * Uses Protobuf dynamic messages to process records.
+ * By default, this uses Protobuf dynamic messages to process records. However, one can specify a custom {@link RecordSerializer}
+ * such as a {@link com.apple.foundationdb.record.provider.common.MessageBuilderRecordSerializer MessageBuilderRecordSerializer}
+ * or a {@link com.apple.foundationdb.record.provider.common.TransformedRecordSerializer TransformedRecordSerializer} to use
+ * as an alternative. Unlike the serializers used by an {@link FDBTypedRecordStore} which only need to be able to process records
+ * of the appropriate record type, the provided serializer must be able to serialize and deseralize all record types specified by
+ * the record store's {@link RecordMetaData}.
+ *
+ * <p>
+ * <b>Warning</b>: It is unsafe to create and use two {@code FDBRecordStore}s concurrently over the same {@link Subspace}
+ * within the context of a single transaction, i.e., with the same {@link FDBRecordContext}. This is because the {@code FDBRecordStore}
+ * object maintains state about certain uncommitted operations, and concurrent access through two objects will not see
+ * changes to this in-memory state. See <a href="https://github.com/FoundationDB/fdb-record-layer/issues/489">Issue #489</a>
+ * for more details. Note also that the record stores returned by {@link #getTypedRecordStore(RecordSerializer)} and
+ * {@link #getUntypedRecordStore()} will share an {@code FDBRecordStore} with the record store on which they are called,
+ * so it <em>is</em> safe to have a typed- and untyped-record store open over the same {@code Subspace} within the context
+ * of the same transaction if one uses one of those methods.
+ * </p>
+ *
+ * @see FDBRecordStoreBase
  */
 @API(API.Status.STABLE)
 public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<Message> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -71,6 +71,41 @@ import java.util.concurrent.Executor;
 
 /**
  * Base interface for typed and untyped record stores.
+ *
+ * This interface is the main front-end for most operations inserting, modifying, or querying data through
+ * the Record Layer. A record store combines:
+ *
+ * <ul>
+ *     <li>A {@link Subspace} (often specified via a {@link KeySpacePath})</li>
+ *     <li>The {@link com.apple.foundationdb.record.RecordMetaData RecordMetaData} associated with the data stored with the data in that subspace</li>
+ *     <li>An {@link FDBRecordContext} which wraps a FoundationDB {@link com.apple.foundationdb.Transaction Transaction}</li>
+ * </ul>
+ *
+ * <p>
+ * All of the record store's data&mdash;including index data&mdash;are stored durably within the given subspace. Note that
+ * the meta-data is <em>not</em> stored by the record store directly. However, information about the store's current meta-data
+ * version is persisted with the store to detect when the meta-data have changed and to know if any action needs to be taken
+ * to begin using the new meta-data. (For example, new indexes might need to be built and removed indexes deleted.) The same
+ * meta-data may be used for multiple record stores, and separating the meta-data from the data makes updating the shared
+ * meta-data simpler as it only needs to be updated in one place. The {@link FDBMetaDataStore} may be used if one wishes
+ * to persist the meta-data into a FoundationDB cluster.
+ * </p>
+ *
+ * <p>
+ * All operations conducted by a record store are conducted within the lifetime single transaction, and no data is persisted
+ * to the database until the transaction is committed by calling {@link FDBRecordContext#commit()} or
+ * {@link FDBRecordContext#commitAsync()}. Record Layer transactions inherit all of the guarantees and limitations of
+ * the transactions exposed by FoundationDB, including their durability and consistency guarantees as well as size and
+ * duration limits. See the FoundationDB <a href="https://apple.github.io/foundationdb/known-limitations.html">known limitations</a>
+ * for more details.
+ * </p>
+ *
+ * <p>
+ * The record store also allows the user to tweak additional parameters such as what the parallelism of pipelined operations
+ * should be (through the {@link PipelineSizer}) and what serializer should be used to read and write data to the database.
+ * See the {@link BaseBuilder} interface for more details.
+ * </p>
+ *
  * @param <M> type used to represent stored records
  * @see FDBRecordStore
  * @see FDBTypedRecordStore

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -70,6 +70,8 @@ import java.util.function.Supplier;
  * store with the same underlying untyped record store.
  *
  * @param <M> type used to represent stored records
+ * @see FDBRecordStore
+ * @see FDBRecordStoreBase
  */
 @API(API.Status.MAINTAINED)
 public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBase<M> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
@@ -76,21 +76,23 @@ import java.util.function.Function;
 
 /**
  * The index maintainer class for full-text indexes. This takes an expression whose first
- * column (not counting grouping columns) is of type <code>string</code>. It will split the
- * text found at that column using a {@link TextTokenizer} and then write separate index keys
+ * column (not counting grouping columns) is of type {@link com.google.protobuf.Descriptors.FieldDescriptor.Type#STRING string}.
+ * It will split the text found at that column using a {@link TextTokenizer} and then write separate index keys
  * for each token found in the text. This then supports queries on the tokenized text, such as:
  *
  * <ul>
- *     <li>All records containing <i>all</i> elements from a set of tokens: <code>Query.field(fieldName).text().containsAll(tokens)</code></li>
- *     <li>All records containing <i>any</i> elements from a set of tokens: <code>Query.field(fieldName).text().containsAny(tokens)</code></li>
- *     <li>All records containing all elements from a set of tokens within some maximum span: Query.field(fieldName).text().containsAll(tokens, span)</li>
- *     <li>All records containing an exact phrase (modulo normalization and stop-word removal done by the tokenizer): <code>Query.field(fieldName).text().containsPhrase(phrase)</code></li>
- *     <li>All records containing at least one token that begins with a given prefix: <code>Query.field(fieldName).text().containsPrefix(prefix)</code></li>
+ *     <li>All records containing <em>all</em> elements from a set of tokens: {@code Query.field(fieldName).text().containsAll(tokens)}</li>
+ *     <li>All records containing <em>any</em> elements from a set of tokens: {@code Query.field(fieldName).text().containsAny(tokens)}</li>
+ *     <li>All records containing all elements from a set of tokens within some maximum span: {@code Query.field(fieldName).text().containsAll(tokens, span)}</li>
+ *     <li>All records containing an exact phrase (modulo normalization and stop-word removal done by the tokenizer): {@code Query.field(fieldName).text().containsPhrase(phrase)}</li>
+ *     <li>All records containing at least one token that begins with a given prefix: {@code Query.field(fieldName).text().containsPrefix(prefix)}</li>
+ *     <li>All records containing at least one token that begins with <em>any</em> of a set of prefixes: {@code Query.field(fieldName).text().containsAnyPrefix(prefixes)}</li>
+ *     <li>All records containing at least one token that begins with <em>each</em> of a set of prefixes: {@code Query.field(fieldName).text().containsAllPrefixes(prefixes)}</li>
  * </ul>
  *
  * <p>
- * One can specify a tokenizer to use by setting the "{@value IndexOptions#TEXT_TOKENIZER_NAME_OPTION}" and
- * "{@value IndexOptions#TEXT_TOKENIZER_VERSION_OPTION}" options on the index. If no tokenizer is given,
+ * One can specify a tokenizer to use by setting the {@value IndexOptions#TEXT_TOKENIZER_NAME_OPTION} and
+ * {@value IndexOptions#TEXT_TOKENIZER_VERSION_OPTION} options on the index. If no tokenizer is given,
  * it will use a {@link com.apple.foundationdb.record.provider.common.text.DefaultTextTokenizer DefaultTextTokenizer},
  * and if no version is specified, it will assume version {@value TextTokenizer#GLOBAL_MIN_VERSION}.
  * There should be one {@link TextTokenizer} implementation that uses that name and one
@@ -112,8 +114,8 @@ import java.util.function.Function;
  * between records that arrive simultaneously, though it should be noted that the underlying data structure of the
  * text index means that it is already likely that two records that happen to share common tokens that are updated
  * simultaneously will conflict, so it might not actually produce more conflicts in practice. To enable adding
- * conflict ranges over larger areas, set the "{@value IndexOptions#TEXT_ADD_AGGRESSIVE_CONFLICT_RANGES_OPTION}" option
- * to "true". <b>Warning:</b> This feature is currently experimental, and may change at any moment without prior notice.
+ * conflict ranges over larger areas, set the {@value IndexOptions#TEXT_ADD_AGGRESSIVE_CONFLICT_RANGES_OPTION} option
+ * to {@code true}. <b>Warning:</b> This feature is currently experimental, and may change at any moment without prior notice.
  * <!-- TODO: Remove the above disclaimer if/when we are happy with this feature staying in.-->
  * </p>
  *


### PR DESCRIPTION
This resolves #490 by adding documentation on the limits of the `FDBRecordStore`. This also attempts to resolve #492, and it looks better locally, but I kind of would have expected more changes.

As this is a documentation-only change, I didn't update the release notes.