### PR TITLE
Resolves #359: Plan OR predicates with an unordered union

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,8 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 The Guava version has been updated to version 27. Users of the [shaded variants](Shaded.html#Variants) of the Record Layer dependencies should not be affected by this change. Users of the unshaded variant using an older version of Guava as part of their own project may find that their own Guava dependency is updated automatically by their dependency manager.
 
+Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` have been marked as deprecated in favor of static initializers. This will allow for more flexibility as work on the new planner develops.
+
 <!--
 // begin next release
 ### NEXT_RELEASE

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/AndComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/AndComponent.java
@@ -47,6 +47,7 @@ public class AndComponent extends AndOrComponent {
         super(operands);
     }
 
+    @Nonnull
     public static AndComponent from(@Nonnull List<? extends QueryComponent> operands) {
         ImmutableList.Builder<ExpressionRef<QueryComponent>> operandRefs = ImmutableList.builder();
         for (QueryComponent operand : operands) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -602,7 +602,7 @@ public class RecordQueryPlanner implements QueryPlanner {
         if (includedPlans.size() > 1) {
             // Calculating the new score would require more state, not doing, because we currently ignore the score
             // after this call.
-            final RecordQueryPlan intersectionPlan = new RecordQueryIntersectionPlan(includedPlans, comparisonKey, plan.isReverse());
+            final RecordQueryPlan intersectionPlan = RecordQueryIntersectionPlan.from(includedPlans, comparisonKey);
             if (intersectionPlan.getComplexity() > complexityThreshold) {
                 throw new RecordQueryPlanComplexityException(intersectionPlan);
             }
@@ -1223,7 +1223,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             includedRankComparisons = mergeRankComparisons(includedRankComparisons, subplan.includedRankComparisons);
         }
         boolean showComparisonKey = !comparisonKey.equals(planContext.commonPrimaryKey);
-        final RecordQueryPlan unionPlan = new RecordQueryUnionPlan(childPlans, comparisonKey, reverse, showComparisonKey);
+        final RecordQueryPlan unionPlan = RecordQueryUnionPlan.from(childPlans, comparisonKey, showComparisonKey);
         if (unionPlan.getComplexity() > complexityThreshold) {
             throw new RecordQueryPlanComplexityException(unionPlan);
         }
@@ -1242,7 +1242,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             childPlans.add(subplan.plan);
             includedRankComparisons = mergeRankComparisons(includedRankComparisons, subplan.includedRankComparisons);
         }
-        final RecordQueryUnorderedUnionPlan unionPlan = new RecordQueryUnorderedUnionPlan(childPlans, subplans.get(0).plan.isReverse());
+        final RecordQueryUnorderedUnionPlan unionPlan = RecordQueryUnorderedUnionPlan.from(childPlans);
         if (unionPlan.getComplexity() > complexityThreshold) {
             throw new RecordQueryPlanComplexityException(unionPlan);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -261,7 +261,7 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
     }
 
     /**
-     * Construct a new union of two compatibly-ordered plans. The resulting plan will return all results that are
+     * Construct a new union of two or more compatibly-ordered plans. The resulting plan will return all results that are
      * returned by all of the child plans. Each plan should return results in the same order according to the provided
      * {@code comparisonKey}. The children should also either all return results in forward order, or they should all
      * return results in reverse order. (That is, {@link RecordQueryPlan#isReverse()} should return the same value

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -188,7 +188,7 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
     }
 
     /**
-     * Construct a new union of two compatibly-ordered plans. The resulting plan will return all results that are
+     * Construct a new union of two or more compatibly-ordered plans. The resulting plan will return all results that are
      * returned by any of the child plans. Each plan should return results in the same order according to the provided
      * {@code comparisonKey}. The children should also either all return results in forward order, or they should all
      * return results in reverse order. (That is, {@link RecordQueryPlan#isReverse()} should return the same value

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.plans;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
@@ -44,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A query plan that executes by taking the union of records from two or more compatibly-sorted child plans.
@@ -61,21 +63,52 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
     private final List<ExpressionRef<? extends PlannerExpression>> expressionChildren;
     private final boolean showComparisonKey;
 
+    /**
+     * Construct a new union of two compatibly-ordered plans. This constructor has been deprecated in favor
+     * of the static initializer {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression, boolean)}.
+     *
+     * @param left the first plan to union
+     * @param right the second plan to union
+     * @param comparisonKey a key expression by which the results of both plans are ordered
+     * @param reverse whether both plans return results in reverse (i.e., descending) order by the comparison key
+     * @param showComparisonKey whether the comparison key should be included in string representations of the plan
+     * @deprecated in favor of {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression, boolean)}
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
     public RecordQueryUnionPlan(@Nonnull RecordQueryPlan left, @Nonnull RecordQueryPlan right,
                                 @Nonnull KeyExpression comparisonKey, boolean reverse, boolean showComparisonKey) {
         this(ImmutableList.of(left, right), comparisonKey, reverse, showComparisonKey);
     }
 
+    /**
+     * Construct a union of two or more compatibly-ordered plans. This constructor has been deprecated in favor
+     * of the static initializer {@link #from(List, KeyExpression, boolean)}.
+     *
+     * @param children the list of compatibly-ordered plans to take the union of
+     * @param comparisonKey a key expression by which the results of all plans are ordered
+     * @param reverse whether all plans return results in reverse (i.e., descending) order by the comparison key
+     * @param showComparisonKey whether the comparison key should be included in string representations of the plan
+     * @deprecated in favor of {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression, boolean)}
+     */
+    @API(API.Status.DEPRECATED)
+    @Deprecated
     public RecordQueryUnionPlan(@Nonnull List<RecordQueryPlan> children,
                                 @Nonnull KeyExpression comparisonKey, boolean reverse, boolean showComparisonKey) {
+        this(children.stream().map(SingleExpressionRef::of).collect(Collectors.toList()), SingleExpressionRef.of(comparisonKey),
+                reverse, showComparisonKey);
+    }
+
+    private RecordQueryUnionPlan(@Nonnull List<ExpressionRef<RecordQueryPlan>> children,
+                                 @Nonnull ExpressionRef<KeyExpression> comparisonKey,
+                                 boolean reverse, boolean showComparisonKey) {
         super(children, reverse);
         final ImmutableList.Builder<ExpressionRef<? extends PlannerExpression>> expressionChildrenBuilder = ImmutableList.builder();
         expressionChildrenBuilder.addAll(super.getPlannerExpressionChildren());
-        this.comparisonKey = SingleExpressionRef.of(comparisonKey);
+        this.comparisonKey = comparisonKey;
         this.expressionChildren = expressionChildrenBuilder.add(this.comparisonKey).build();
         this.showComparisonKey = showComparisonKey;
     }
-
 
     @Nonnull
     @Override
@@ -129,5 +162,57 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
     @Override
     StoreTimer.Count getPlanCount() {
         return PLAN_COUNT;
+    }
+
+    /**
+     * Construct a new union of two compatibly-ordered plans. The resulting plan will return all results that are
+     * returned by either the {@code left} or {@code right} child plans. Each plan should return results in the same
+     * order according to the provided {@code comparisonKey}. The two children should also either both return results
+     * in forward order, or they should both return results in reverse order. (That is, {@code left.isReverse()} should
+     * equal {@code right.isReverse()}.)
+     *
+     * @param left the first plan to union
+     * @param right the second plan to union
+     * @param comparisonKey a key expression by which the results of both plans are ordered
+     * @param showComparisonKey whether the comparison key should be included in string representations of the plan
+     * @return a new plan that will return the union of all results from both child plans
+     */
+    @Nonnull
+    public static RecordQueryUnionPlan from(@Nonnull RecordQueryPlan left, @Nonnull RecordQueryPlan right,
+                                            @Nonnull KeyExpression comparisonKey, boolean showComparisonKey) {
+        if (left.isReverse() != right.isReverse()) {
+            throw new RecordCoreArgumentException("left plan and right plan for union do not have same value for reverse field");
+        }
+        final List<ExpressionRef<RecordQueryPlan>> childRefs = ImmutableList.of(SingleExpressionRef.of(left), SingleExpressionRef.of(right));
+        return new RecordQueryUnionPlan(childRefs, SingleExpressionRef.of(comparisonKey), left.isReverse(), showComparisonKey);
+    }
+
+    /**
+     * Construct a new union of two compatibly-ordered plans. The resulting plan will return all results that are
+     * returned by any of the child plans. Each plan should return results in the same order according to the provided
+     * {@code comparisonKey}. The children should also either all return results in forward order, or they should all
+     * return results in reverse order. (That is, {@link RecordQueryPlan#isReverse()} should return the same value
+     * for each child.)
+     *
+     * @param children the list of plans to take the union of
+     * @param comparisonKey a key expression by which the results of both plans are ordered
+     * @param showComparisonKey whether the comparison key should be included in string representations of the plan
+     * @return a new plan that will return the union of all results from all child plans
+     */
+    @Nonnull
+    public static RecordQueryUnionPlan from(@Nonnull List<RecordQueryPlan> children, @Nonnull KeyExpression comparisonKey,
+                                            boolean showComparisonKey) {
+        if (children.size() < 2) {
+            throw new RecordCoreArgumentException("fewer than two children given to union plan");
+        }
+        boolean firstReverse = children.get(0).isReverse();
+        if (!children.stream().allMatch(child -> child.isReverse() == firstReverse)) {
+            throw new RecordCoreArgumentException("children of union plan do all have same value for reverse field");
+        }
+        final ImmutableList.Builder<ExpressionRef<RecordQueryPlan>> childRefsBuilder = ImmutableList.builder();
+        for (RecordQueryPlan child : children) {
+            childRefsBuilder.add(SingleExpressionRef.of(child));
+        }
+        return new RecordQueryUnionPlan(childRefsBuilder.build(), SingleExpressionRef.of(comparisonKey), firstReverse, showComparisonKey);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -63,16 +63,11 @@ abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChildren {
     private final boolean reverse;
 
     public RecordQueryUnionPlanBase(@Nonnull RecordQueryPlan left, @Nonnull RecordQueryPlan right, boolean reverse) {
-        this(ImmutableList.of(left, right), reverse);
+        this(ImmutableList.of(SingleExpressionRef.of(left), SingleExpressionRef.of(right)), reverse);
     }
 
-    public RecordQueryUnionPlanBase(@Nonnull List<RecordQueryPlan> children, boolean reverse) {
-        final ImmutableList.Builder<ExpressionRef<RecordQueryPlan>> childrenBuilder = ImmutableList.builder();
-        for (RecordQueryPlan child : children) {
-            ExpressionRef<RecordQueryPlan> childRef = SingleExpressionRef.of(child);
-            childrenBuilder.add(childRef);
-        }
-        this.children = childrenBuilder.build();
+    public RecordQueryUnionPlanBase(@Nonnull List<ExpressionRef<RecordQueryPlan>> children, boolean reverse) {
+        this.children = children;
         this.reverse = reverse;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -64,7 +64,11 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
             ImmutableSet.of(FDBStoreTimer.Counts.QUERY_PK_DISTINCT_PLAN_DUPLICATES, FDBStoreTimer.Counts.QUERY_DISCARDED);
 
     public RecordQueryUnorderedPrimaryKeyDistinctPlan(@Nonnull RecordQueryPlan inner) {
-        this.inner = SingleExpressionRef.of(inner);
+        this(SingleExpressionRef.of(inner));
+    }
+
+    public RecordQueryUnorderedPrimaryKeyDistinctPlan(@Nonnull ExpressionRef<RecordQueryPlan> inner) {
+        this.inner = inner;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
@@ -27,6 +27,8 @@ import com.apple.foundationdb.record.query.plan.temp.rules.FlattenNestedAndCompo
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementFilterRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.FilterWithFieldWithComparisonRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.LogicalToPhysicalIndexScanRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.ImplementUnorderedUnionRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.OrToUnorderedUnionRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.PickFromPossibilitiesRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.PushConjunctFieldWithComparisonIntoExistingIndexScanRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.PushFieldWithComparisonIntoExistingIndexScanRule;
@@ -60,14 +62,16 @@ public class PlannerRuleSet {
             new PushFieldWithComparisonIntoExistingIndexScanRule(),
             new PushConjunctFieldWithComparisonIntoExistingIndexScanRule(),
             new RemoveRedundantTypeFilterRule(),
-            new FindPossibleIndexForAndComponentRule()
+            new FindPossibleIndexForAndComponentRule(),
+            new OrToUnorderedUnionRule()
     );
     private static final List<PlannerRule<? extends PlannerExpression>> IMPLEMENTATION_RULES = ImmutableList.of(
             new PickFromPossibilitiesRule(),
             new ImplementTypeFilterRule(),
             new ImplementFilterRule(),
             new PushTypeFilterBelowFilterRule(),
-            new LogicalToPhysicalIndexScanRule()
+            new LogicalToPhysicalIndexScanRule(),
+            new ImplementUnorderedUnionRule()
     );
 
     public static final PlannerRuleSet NORMALIZATION = new PlannerRuleSet(NORMALIZATION_RULES);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.rules.CombineFilterRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.FindPossibleIndexForAndComponentRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.FlattenNestedAndComponentRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.ImplementDistinctRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementFilterRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.FilterWithFieldWithComparisonRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.LogicalToPhysicalIndexScanRule;
@@ -71,7 +72,8 @@ public class PlannerRuleSet {
             new ImplementFilterRule(),
             new PushTypeFilterBelowFilterRule(),
             new LogicalToPhysicalIndexScanRule(),
-            new ImplementUnorderedUnionRule()
+            new ImplementUnorderedUnionRule(),
+            new ImplementDistinctRule()
     );
 
     public static final PlannerRuleSet NORMALIZATION = new PlannerRuleSet(NORMALIZATION_RULES);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalDistinctExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalDistinctExpression.java
@@ -1,0 +1,79 @@
+/*
+ * LogicalDistinctPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.expressions;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+import com.apple.foundationdb.record.query.plan.temp.SingleExpressionRef;
+import com.google.common.collect.Iterators;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+
+/**
+ * A relational planner expression representing a stream of unique records. This expression has a single child which
+ * is also a {@link RelationalPlannerExpression}. This expression represents this underlying expression with its result
+ * set de-duplicated.
+ *
+ * @see com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan for the fallback implementation
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LogicalDistinctExpression implements RelationalExpressionWithChildren {
+    @Nonnull
+    private ExpressionRef<RelationalPlannerExpression> inner;
+
+    public LogicalDistinctExpression(@Nonnull RelationalPlannerExpression inner) {
+        this(SingleExpressionRef.of(inner));
+    }
+
+    public LogicalDistinctExpression(@Nonnull ExpressionRef<RelationalPlannerExpression> inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public int getRelationalChildCount() {
+        return 1;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
+        return Iterators.singletonIterator(inner);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LogicalDistinctExpression that = (LogicalDistinctExpression)o;
+        return inner.equals(that.inner);
+    }
+
+    @Override
+    public int hashCode() {
+        return inner.hashCode();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalUnorderedUnionExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalUnorderedUnionExpression.java
@@ -1,0 +1,71 @@
+/*
+ * LogicalUnorderedUnionExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.expressions;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A relational planner expression that represents an unimplemented unordered union of its children.
+ * @see com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan for the fallback implementation
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LogicalUnorderedUnionExpression implements RelationalExpressionWithChildren {
+    @Nonnull
+    private List<ExpressionRef<RelationalPlannerExpression>> expressionChildren;
+
+    public LogicalUnorderedUnionExpression(@Nonnull List<ExpressionRef<RelationalPlannerExpression>> expressionChildren) {
+        this.expressionChildren = expressionChildren;
+    }
+
+    @Override
+    public int getRelationalChildCount() {
+        return expressionChildren.size();
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<? extends ExpressionRef<? extends PlannerExpression>> getPlannerExpressionChildren() {
+        return expressionChildren.iterator();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null || o.getClass() != getClass())  {
+            return false;
+        }
+        LogicalUnorderedUnionExpression that = (LogicalUnorderedUnionExpression)o;
+        return expressionChildren.equals(that.expressionChildren);
+    }
+
+    @Override
+    public int hashCode() {
+        return expressionChildren.hashCode();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/RelationalPlannerExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/RelationalPlannerExpression.java
@@ -50,6 +50,9 @@ public interface RelationalPlannerExpression extends PlannerExpression {
         if (!query.getRecordTypes().isEmpty()) {
             expression = new LogicalTypeFilterExpression(query.getRecordTypes(), expression);
         }
+        if (query.removesDuplicates()) {
+            expression = new LogicalDistinctExpression(expression);
+        }
         return expression;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/RelationalPlannerExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/RelationalPlannerExpression.java
@@ -38,6 +38,7 @@ import javax.annotation.Nonnull;
  */
 @API(API.Status.EXPERIMENTAL)
 public interface RelationalPlannerExpression extends PlannerExpression {
+    @Nonnull
     static PlannerExpression fromRecordQuery(@Nonnull RecordQuery query) {
         RelationalPlannerExpression expression = new RecordQueryScanPlan(ScanComparisons.EMPTY, false);
         if (query.getSort() != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
@@ -1,0 +1,98 @@
+/*
+ * CreatesDuplicatesProperty.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.properties;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A property that determines whether the expression may produce duplicate entries. If the given expression is a
+ * {@link RelationalPlannerExpression}, this will return whether the expression might produce multiple instances
+ * of the same record. If the given expression is a {@link KeyExpression}, then this will return whether the
+ * expression might return multiple results for the same record.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
+    private static final CreatesDuplicatesProperty INSTANCE = new CreatesDuplicatesProperty();
+
+    @Override
+    public boolean shouldVisit(@Nonnull PlannerExpression expression) {
+        return expression instanceof RelationalPlannerExpression || expression instanceof KeyExpression;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull ExpressionRef<? extends PlannerExpression> ref) {
+        return true;
+    }
+
+    @Nonnull
+    @Override
+    public Boolean evaluateAtExpression(@Nonnull PlannerExpression expression, @Nonnull List<Boolean> childResults) {
+        if (expression instanceof KeyExpression) {
+            return ((KeyExpression)expression).createsDuplicates();
+        } else if (expression instanceof RecordQueryUnorderedDistinctPlan ||
+                   expression instanceof RecordQueryUnorderedPrimaryKeyDistinctPlan ||
+                   expression instanceof LogicalDistinctExpression) {
+            // These expressions filter out duplicates, so they therefore will not return duplicates even if their
+            // children will.
+            return Boolean.FALSE;
+        } else if (expression instanceof RecordQueryUnorderedUnionPlan || expression instanceof LogicalUnorderedUnionExpression) {
+            // These expressions can create duplicates even if the underlying children do not.
+            return Boolean.TRUE;
+        } else {
+            // Return whether any visited child creates duplicates.
+            return childResults.stream().anyMatch(b -> b != null && b);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public Boolean evaluateAtRef(@Nonnull ExpressionRef<? extends PlannerExpression> ref, @Nonnull List<Boolean> memberResults) {
+        return memberResults.stream().anyMatch(b -> b != null && b);
+    }
+
+    public static boolean evaluate(@Nonnull ExpressionRef<? extends PlannerExpression> ref) {
+        return ref.acceptPropertyVisitor(INSTANCE);
+    }
+
+    @Nullable
+    public static Boolean evaluate(@Nonnull PlannerExpression expression) {
+        return expression.acceptPropertyVisitor(INSTANCE);
+    }
+
+    public static boolean evaluate(@Nonnull RelationalPlannerExpression expression) {
+        // Won't actually be null for relational planner expressions.
+        return expression.acceptPropertyVisitor(INSTANCE);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalIndexScanExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
 import com.google.common.collect.Sets;
@@ -109,7 +110,8 @@ public class RecordTypesProperty implements PlannerProperty<Set<String>> {
                 // children (like a union or intersection expression) then we must specify some way to combine them.
                 if (expression instanceof RecordQueryUnionPlan ||
                         expression instanceof RecordQueryUnorderedUnionPlan ||
-                        expression instanceof RecordQueryIntersectionPlan) {
+                        expression instanceof RecordQueryIntersectionPlan ||
+                        expression instanceof LogicalUnorderedUnionExpression) {
                     final Set<String> union = new HashSet<>();
                     for (Set<String> childResulSet : childResults) {
                         union.addAll(childResulSet);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/package-info.java
@@ -21,18 +21,24 @@
 /**
  * A package for planner properties (in the sense that Cascades uses them).
  *
+ * <p>
  * In Cascades, a property is an attribute of {@link com.apple.foundationdb.record.query.plan.temp.PlannerExpression}
  * that cannot be described from the structure of the expression tree alone. For example, the set of record types that
  * a relational planner expression produces is a property, but whether or not it has a filter that contains an AND
  * clause is not a property. Properties generally need to be evaluated against an expression, instead of arising from
  * the structural features of a planner expression (which could be matched using an
  * {@link com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher}.
+ * </p>
  *
+ * <p>
  * In the Record Layer, properties are implemented as hierarchical visitors on the {@code PlannerExpression} tree; this
  * approach prevents the accumulation of many methods on the {@code PlannerExpression} interface. Furthermore, some
  * properties (such as the set of possible record types returned) cannot be determined from the {@code PlannerExpression}
  * alone; they also need access to the {@link com.apple.foundationdb.record.query.plan.temp.PlanContext}.
+ * </p>
  *
+ * <p>
  * This package contains various implementations of {@link com.apple.foundationdb.record.query.plan.temp.PlannerProperty}.
+ * </p>
  */
 package com.apple.foundationdb.record.query.plan.temp.properties;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
@@ -44,6 +44,8 @@ import javax.annotation.Nonnull;
  * this rule will then return that plan. This is fine unless the plan is later modified in such a way that it then
  * <em>can</em> produce duplicates. At the moment, none of the rules modify a {@link RecordQueryPlan} once it has
  * been produced, but a future rule that does so may cause errors where plans erroneously produce duplicate records.
+ * To address that, the plan is to add a mechanism for enforcing properties (e.g., distinctness or sort order)
+ * on the plans produced by the planner, but that work has not yet been completed.
  * </p>
  */
 @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
@@ -45,7 +45,7 @@ import javax.annotation.Nonnull;
  * <em>can</em> produce duplicates. At the moment, none of the rules modify a {@link RecordQueryPlan} once it has
  * been produced, but a future rule that does so may cause errors where plans erroneously produce duplicate records.
  * To address that, the plan is to add a mechanism for enforcing properties (e.g., distinctness or sort order)
- * on the plans produced by the planner, but that work has not yet been completed.
+ * on the plans produced by the planner. See <a href="https://github.com/FoundationDB/fdb-record-layer/issues/635">Issue #653</a>.
  * </p>
  */
 @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
@@ -1,0 +1,73 @@
+/*
+ * ImplementDistinctRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.rules;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
+import com.apple.foundationdb.record.query.plan.temp.matchers.AllChildrenMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
+import com.apple.foundationdb.record.query.plan.temp.properties.CreatesDuplicatesProperty;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A rule that implements a distinct expression by adding a {@link RecordQueryUnorderedPrimaryKeyDistinctPlan}
+ * if necessary. In particular, it will only add that wrapping expression if the underlying plan itself might
+ * produce duplicate results.
+ *
+ * <p>
+ * This rule is somewhat suspect. In particular, if the inner plan that it matches against does not produce duplicates,
+ * this rule will then return that plan. This is fine unless the plan is later modified in such a way that it then
+ * <em>can</em> produce duplicates. At the moment, none of the rules modify a {@link RecordQueryPlan} once it has
+ * been produced, but a future rule that does so may cause errors where plans erroneously produce duplicate records.
+ * </p>
+ */
+@API(API.Status.EXPERIMENTAL)
+public class ImplementDistinctRule extends PlannerRule<LogicalDistinctExpression> {
+    @Nonnull
+    private static final ExpressionMatcher<RecordQueryPlan> innerMatcher = TypeMatcher.of(RecordQueryPlan.class, AllChildrenMatcher.allMatching(ReferenceMatcher.anyRef()));
+    @Nonnull
+    private static final ExpressionMatcher<LogicalDistinctExpression> root = TypeMatcher.of(LogicalDistinctExpression.class, innerMatcher);
+
+    public ImplementDistinctRule() {
+        super(root);
+    }
+
+    @Nonnull
+    @Override
+    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+        RecordQueryPlan inner = call.get(innerMatcher);
+        boolean createsDuplicates = CreatesDuplicatesProperty.evaluate(inner);
+        if (createsDuplicates) {
+            call.yield(call.ref(new RecordQueryUnorderedPrimaryKeyDistinctPlan(inner)));
+            return ChangesMade.MADE_CHANGES;
+        } else {
+            call.yield(call.ref(inner));
+            return ChangesMade.MADE_CHANGES;
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
@@ -1,0 +1,59 @@
+/*
+ * ImplementUnorderedUnionRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.rules;
+
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.matchers.AllChildrenMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * A rule that implements an unordered union of its (already implemented) children. This will combine the
+ * {@link RecordQueryPlan}s corresponding to its children.
+ */
+public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnorderedUnionExpression> {
+    @Nonnull
+    private static final ExpressionMatcher<ExpressionRef<RecordQueryPlan>> childMatcher = ReferenceMatcher.anyRef();
+    @Nonnull
+    private static final ExpressionMatcher<LogicalUnorderedUnionExpression> root = TypeMatcher.of(LogicalUnorderedUnionExpression.class,
+            AllChildrenMatcher.allMatching(childMatcher));
+
+    public ImplementUnorderedUnionRule() {
+        super(root);
+    }
+
+    @Nonnull
+    @Override
+    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+        final List<ExpressionRef<RecordQueryPlan>> planChildren = call.getBindings().getAll(childMatcher);
+        call.yield(call.ref(RecordQueryUnorderedUnionPlan.fromRefs(planChildren)));
+        return ChangesMade.MADE_CHANGES;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
@@ -20,9 +20,9 @@
 
 package com.apple.foundationdb.record.query.plan.temp.rules;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
@@ -38,9 +38,10 @@ import java.util.List;
  * A rule that implements an unordered union of its (already implemented) children. This will combine the
  * {@link RecordQueryPlan}s corresponding to its children.
  */
+@API(API.Status.EXPERIMENTAL)
 public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnorderedUnionExpression> {
     @Nonnull
-    private static final ExpressionMatcher<ExpressionRef<RecordQueryPlan>> childMatcher = ReferenceMatcher.anyRef();
+    private static final ExpressionMatcher<RecordQueryPlan> childMatcher = TypeMatcher.of(RecordQueryPlan.class, AllChildrenMatcher.allMatching(ReferenceMatcher.anyRef()));
     @Nonnull
     private static final ExpressionMatcher<LogicalUnorderedUnionExpression> root = TypeMatcher.of(LogicalUnorderedUnionExpression.class,
             AllChildrenMatcher.allMatching(childMatcher));
@@ -52,8 +53,8 @@ public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnorderedUni
     @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
-        final List<ExpressionRef<RecordQueryPlan>> planChildren = call.getBindings().getAll(childMatcher);
-        call.yield(call.ref(RecordQueryUnorderedUnionPlan.fromRefs(planChildren)));
+        final List<RecordQueryPlan> planChildren = call.getBindings().getAll(childMatcher);
+        call.yield(call.ref(RecordQueryUnorderedUnionPlan.from(planChildren)));
         return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
@@ -35,8 +35,9 @@ import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
- * A rule that implements an unordered union of its (already implemented) children. This will combine the
- * {@link RecordQueryPlan}s corresponding to its children.
+ * A rule that implements an unordered union of its (already implemented) children. This will extract the
+ * {@link RecordQueryPlan} from each child of a {@link LogicalUnorderedUnionExpression} and create a
+ * {@link RecordQueryUnorderedUnionPlan} with those plans as children.
  */
 @API(API.Status.EXPERIMENTAL)
 public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnorderedUnionExpression> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
@@ -1,0 +1,74 @@
+/*
+ * OrToUnorderedUnionRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.rules;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.expressions.OrComponent;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
+import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
+import com.apple.foundationdb.record.query.plan.temp.SingleExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalPlannerExpression;
+import com.apple.foundationdb.record.query.plan.temp.matchers.AllChildrenMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convert a filter on an {@linkplain OrComponent or} expression into a plan on the union. In particular, this will
+ * produce a {@link LogicalUnorderedUnionExpression} with simple filter plans on each child. Those plans can then themselves
+ * be planned individually.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class OrToUnorderedUnionRule extends PlannerRule<LogicalFilterExpression> {
+    @Nonnull
+    private static final ReferenceMatcher<QueryComponent> childMatcher = ReferenceMatcher.anyRef();
+    @Nonnull
+    private static final ExpressionMatcher<OrComponent> orMatcher = TypeMatcher.of(OrComponent.class, AllChildrenMatcher.allMatching(childMatcher));
+    @Nonnull
+    private static final ReferenceMatcher<RelationalPlannerExpression> innerMatcher = ReferenceMatcher.anyRef();
+    @Nonnull
+    private static final ExpressionMatcher<LogicalFilterExpression> root = TypeMatcher.of(LogicalFilterExpression.class, orMatcher, innerMatcher);
+
+    public OrToUnorderedUnionRule() {
+        super(root);
+    }
+
+    @Nonnull
+    @Override
+    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+        final ExpressionRef<RelationalPlannerExpression> inner = call.get(innerMatcher);
+        final List<ExpressionRef<QueryComponent>> children = call.getBindings().getAll(childMatcher);
+        List<ExpressionRef<RelationalPlannerExpression>> relationalExpressionRefs = new ArrayList<>(children.size());
+        for (ExpressionRef<QueryComponent> child : children) {
+            relationalExpressionRefs.add(call.ref(new LogicalFilterExpression(child, inner)));
+        }
+        call.yield(SingleExpressionRef.of(new LogicalUnorderedUnionExpression(relationalExpressionRefs)));
+        return ChangesMade.MADE_CHANGES;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
@@ -41,8 +41,7 @@ import java.util.List;
 
 /**
  * Convert a filter on an {@linkplain OrComponent or} expression into a plan on the union. In particular, this will
- * produce a {@link LogicalUnorderedUnionExpression} with simple filter plans on each child. Those plans can then themselves
- * be planned individually.
+ * produce a {@link LogicalUnorderedUnionExpression} with simple filter plans on each child.
  */
 @API(API.Status.EXPERIMENTAL)
 public class OrToUnorderedUnionRule extends PlannerRule<LogicalFilterExpression> {

--- a/fdb-record-layer-core/src/test/java-proto2/com/apple/foundationdb/record/provider/foundationdb/MapsTest.java
+++ b/fdb-record-layer-core/src/test/java-proto2/com/apple/foundationdb/record/provider/foundationdb/MapsTest.java
@@ -24,20 +24,23 @@ import com.apple.foundationdb.record.TestRecordsMapsProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
-import com.apple.foundationdb.record.query.plan.match.PlanMatchers;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTupleString;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.primaryKeyDistinct;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -110,9 +113,9 @@ public class MapsTest extends FDBRecordStoreTestBase {
             RecordQueryPlan plan = planner.plan(query);
             List<Tuple> results = recordStore.executeQuery(plan).map(FDBQueriedRecord::getPrimaryKey).asList().join();
             assertEquals(Collections.singletonList(Tuple.from(2)), results);
-            MatcherAssert.assertThat(plan, PlanMatchers.primaryKeyDistinct(PlanMatchers.indexScan(Matchers.allOf(
+            assertThat(plan, primaryKeyDistinct(indexScan(allOf(
                     indexName("mapKeyValue"),
-                    PlanMatchers.bounds(PlanMatchers.hasTupleString("([num, 1],[num]]"))))));
+                    bounds(hasTupleString("([num, 1],[num]]"))))));
             commit(context);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/QueryPlanCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/QueryPlanCursorTest.java
@@ -216,30 +216,30 @@ public class QueryPlanCursorTest extends FDBRecordStoreTestBase {
 
     @Test
     public void union() throws Exception {
-        final RecordQueryPlan plan = new RecordQueryUnionPlan(
+        final RecordQueryPlan plan = RecordQueryUnionPlan.from(
                 indexPlanEquals("MySimpleRecord$num_value_3_indexed", 2),
                 indexPlanEquals("MySimpleRecord$num_value_3_indexed", 4),
-                primaryKey(), false, false);
+                primaryKey(), false);
         compareSkipsAndCursors(plan);
     }
 
     @Test
     public void unionOneSideAtATime() throws Exception {
-        final RecordQueryPlan plan = new RecordQueryUnionPlan(
+        final RecordQueryPlan plan = RecordQueryUnionPlan.from(
                 indexPlanEquals("MySimpleRecord$num_value_3_indexed", 2),
                 indexPlanEquals("MySimpleRecord$num_value_3_indexed", 4),
                 Key.Expressions.concat(Key.Expressions.field("num_value_3_indexed"),
                         primaryKey()),
-                false, true);
+                true);
         compareSkipsAndCursors(plan);
     }
 
     @Test
     public void intersection() throws Exception {
-        final RecordQueryPlan plan = new RecordQueryIntersectionPlan(
+        final RecordQueryPlan plan = RecordQueryIntersectionPlan.from(
                 indexPlanEquals("MySimpleRecord$num_value_3_indexed", 2),
                 indexPlanEquals("MySimpleRecord$str_value_indexed", "even"),
-                primaryKey(), false);
+                primaryKey());
         compareSkipsAndCursors(plan);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -1991,8 +1991,8 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
                     queryComplexDocumentsWithIndex(Query.field("text").text().containsPrefix("ang"), 0L, -1013515738));
             assertEquals(Arrays.asList(Tuple.from(1L, 3L), Tuple.from(1L, 1L)),
                     queryComplexDocumentsWithIndex(Query.field("text").text().containsPrefix("un"), 1L, -995158140));
-            assertEquals(Arrays.asList(Tuple.from(0L, 0L), Tuple.from(0L, 2L)),
-                    queryComplexDocumentsWithIndex(Query.field("text").text().containsAnyPrefix("ang par nap kin"), 0L, -1089713854));
+            assertEquals(ImmutableSet.of(Tuple.from(0L, 0L), Tuple.from(0L, 2L)),
+                    ImmutableSet.copyOf(queryComplexDocumentsWithIndex(Query.field("text").text().containsAnyPrefix("ang par nap kin"), 0L, -1089713854)));
             assertEquals(Collections.singletonList(Tuple.from(0L, 0L)),
                     queryComplexDocumentsWithIndex(Query.field("text").text().containsAllPrefixes("ang uni name", false), 0L, 646414402));
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreLimitTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreLimitTestBase.java
@@ -109,31 +109,31 @@ public class FDBRecordStoreLimitTestBase extends FDBRecordStoreTestBase {
                 Arguments.of("filter on index plan", fail, new RecordQueryFilterPlan(indexPlan, filter)),
                 Arguments.of("type filter on scan plan", fail, new RecordQueryTypeFilterPlan(scanPlan, Collections.singletonList("MySimpleRecord"))),
                 Arguments.of("type filter on index plan", fail, new RecordQueryTypeFilterPlan(indexPlan, Collections.singletonList("MySimpleRecord"))),
-                Arguments.of("disjoint union", fail, new RecordQueryUnionPlan(
+                Arguments.of("disjoint union", fail, RecordQueryUnionPlan.from(
                         indexPlanEquals("MySimpleRecord$str_value_indexed", "odd"),
                         indexPlanEquals("MySimpleRecord$str_value_indexed", "even"),
-                        primaryKey(), false, false)),
-                Arguments.of("overlapping union", fail, new RecordQueryUnionPlan(firstChild, secondChild, primaryKey(), false, false)),
-                Arguments.of("overlapping union (swapped args)", fail, new RecordQueryUnionPlan(secondChild, firstChild, primaryKey(), false, false)),
-                Arguments.of("overlapping intersection", fail, new RecordQueryIntersectionPlan(firstChild, secondChild, primaryKey(), false)),
-                Arguments.of("overlapping intersection", fail, new RecordQueryIntersectionPlan(secondChild, firstChild, primaryKey(), false)),
-                Arguments.of("union with inner filter", fail, new RecordQueryUnionPlan(
-                        new RecordQueryFilterPlan(firstChild, middleFilter), secondChild, primaryKey(), false, false)),
-                Arguments.of("union with two inner filters", fail, new RecordQueryUnionPlan(
-                        new RecordQueryFilterPlan(firstChild, middleFilter),
-                        new RecordQueryFilterPlan(secondChild, Query.field("rec_no").lessThan(55L)),
-                        primaryKey(), false, false)),
-                Arguments.of("intersection with inner filter", fail, new RecordQueryIntersectionPlan(
+                        primaryKey(), false)),
+                Arguments.of("overlapping union", fail, RecordQueryUnionPlan.from(firstChild, secondChild, primaryKey(), false)),
+                Arguments.of("overlapping union (swapped args)", fail, RecordQueryUnionPlan.from(secondChild, firstChild, primaryKey(), false)),
+                Arguments.of("overlapping intersection", fail, RecordQueryIntersectionPlan.from(firstChild, secondChild, primaryKey())),
+                Arguments.of("overlapping intersection", fail, RecordQueryIntersectionPlan.from(secondChild, firstChild, primaryKey())),
+                Arguments.of("union with inner filter", fail, RecordQueryUnionPlan.from(
                         new RecordQueryFilterPlan(firstChild, middleFilter), secondChild, primaryKey(), false)),
-                Arguments.of("intersection with two inner filters", fail, new RecordQueryIntersectionPlan(
+                Arguments.of("union with two inner filters", fail, RecordQueryUnionPlan.from(
                         new RecordQueryFilterPlan(firstChild, middleFilter),
                         new RecordQueryFilterPlan(secondChild, Query.field("rec_no").lessThan(55L)),
-                        primaryKey(), false)));
+                        primaryKey(), false)),
+                Arguments.of("intersection with inner filter", fail, RecordQueryIntersectionPlan.from(
+                        new RecordQueryFilterPlan(firstChild, middleFilter), secondChild, primaryKey())),
+                Arguments.of("intersection with two inner filters", fail, RecordQueryIntersectionPlan.from(
+                        new RecordQueryFilterPlan(firstChild, middleFilter),
+                        new RecordQueryFilterPlan(secondChild, Query.field("rec_no").lessThan(55L)),
+                        primaryKey())));
     }
 
     public Stream<Arguments> unorderedPlans(boolean fail) {
         return Stream.of(
-                Arguments.of("unordered union", fail, new RecordQueryUnorderedUnionPlan(indexPlanEquals("MySimpleRecord$str_value_indexed", "even"), indexPlanEquals("MySimpleRecord$num_value_3_indexed", 2), false))
+                Arguments.of("unordered union", fail, RecordQueryUnorderedUnionPlan.from(indexPlanEquals("MySimpleRecord$str_value_indexed", "even"), indexPlanEquals("MySimpleRecord$num_value_3_indexed", 2)))
         );
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -74,7 +74,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Tests related to planning a query with an OR clause into a union plan.
@@ -344,7 +343,6 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     @ParameterizedTest(name = "testOrQuery5 [removesDuplicates = {0}]")
     public void testOrQuery5(@Nonnull TestHelpers.BooleanEnum removesDuplicatesEnum) throws Exception {
         final boolean removesDuplicates = removesDuplicatesEnum.toBoolean();
-        assumeFalse(removesDuplicates);
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder()
@@ -398,7 +396,6 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     @ParameterizedTest(name = "testOrQuery5WithLimits [limit = {0}, removesDuplicates = {1}]")
     @DualPlannerTest
     public void testOrQuery5WithLimits(int limit, boolean removesDuplicates) throws Exception {
-        assumeFalse(removesDuplicates);
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder()
@@ -511,7 +508,6 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     @ParameterizedTest
     public void testUnorderableOrQueryWithAnd(@Nonnull TestHelpers.BooleanEnum removesDuplicatesEnum) throws Exception {
         final boolean removesDuplicates = removesDuplicatesEnum.toBoolean();
-        assumeFalse(removesDuplicates);
         RecordMetaDataHook hook = metaDataBuilder -> {
             complexQuerySetupHook().apply(metaDataBuilder);
             metaDataBuilder.addIndex("MySimpleRecord", new Index("multi_index_2", "str_value_indexed", "num_value_3_indexed"));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
@@ -187,7 +187,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
             TestRecords4Proto.RestaurantReviewer reviewer = TestRecords4Proto.RestaurantReviewer.newBuilder()
                     .setId(1L)
                     .setName("Javert")
-                    .setEmail("anton@ego.com")
+                    .setEmail("inspecteur@policier.fr")
                     .setStats(TestRecords4Proto.ReviewerStats.newBuilder()
                             .setStartDate(100L)
                             .setHometown("Toulon")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/QueryPlanStructuralInstrumentationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/QueryPlanStructuralInstrumentationTest.java
@@ -104,10 +104,10 @@ public class QueryPlanStructuralInstrumentationTest {
 
     @Test
     public void unionSameIndex() {
-        final RecordQueryPlan plan = new RecordQueryUnionPlan(
+        final RecordQueryPlan plan = RecordQueryUnionPlan.from(
                 indexPlanEquals("index_1", 2),
                 indexPlanEquals("index_1", 4),
-                EmptyKeyExpression.EMPTY, false, false);
+                EmptyKeyExpression.EMPTY, false);
 
         assertUsesIndexes(plan, Lists.newArrayList("index_1"));
 
@@ -119,10 +119,10 @@ public class QueryPlanStructuralInstrumentationTest {
 
     @Test
     public void unionDifferentIndex() {
-        final RecordQueryPlan plan = new RecordQueryUnionPlan(
+        final RecordQueryPlan plan = RecordQueryUnionPlan.from(
                 indexPlanEquals("index_1", 2),
                 indexPlanEquals("index_2", 4),
-                EmptyKeyExpression.EMPTY, false, false);
+                EmptyKeyExpression.EMPTY, false);
 
         assertUsesIndexes(plan, Lists.newArrayList("index_1", "index_2"));
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/planning/RecordQueryPlanEqualityTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/planning/RecordQueryPlanEqualityTest.java
@@ -64,17 +64,17 @@ public class RecordQueryPlanEqualityTest {
     }
 
     private RecordQueryPlan unionPlan(Object value1, Object value2) {
-        return new RecordQueryUnionPlan(
-                indexPlanEquals("MySimpleRecord$num_value_3_indexed", value1),
-                indexPlanEquals("MySimpleRecord$num_value_3_indexed", value2),
-                Key.Expressions.field("num_value_3_indexed"), false, false);
-    }
-
-    private RecordQueryPlan intersectionPlan(Object value1, Object value2) {
-        return new RecordQueryIntersectionPlan(
+        return RecordQueryUnionPlan.from(
                 indexPlanEquals("MySimpleRecord$num_value_3_indexed", value1),
                 indexPlanEquals("MySimpleRecord$num_value_3_indexed", value2),
                 Key.Expressions.field("num_value_3_indexed"), false);
+    }
+
+    private RecordQueryPlan intersectionPlan(Object value1, Object value2) {
+        return RecordQueryIntersectionPlan.from(
+                indexPlanEquals("MySimpleRecord$num_value_3_indexed", value1),
+                indexPlanEquals("MySimpleRecord$num_value_3_indexed", value2),
+                Key.Expressions.field("num_value_3_indexed"));
     }
 
     private List<Supplier<RecordQueryPlan>> planSuppliers = Arrays.asList(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionMatcherTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionMatcherTest.java
@@ -122,12 +122,12 @@ public class ExpressionMatcherTest {
         ExpressionMatcher<RecordQueryScanPlan> childMatcher2 = TypeMatcher.of(RecordQueryScanPlan.class);
         ExpressionMatcher<RecordQueryUnionPlan> parentMatcher = TypeMatcher.of(RecordQueryUnionPlan.class,
                 childMatcher1, childMatcher2, ReferenceMatcher.anyRef());
-        RecordQueryIndexPlan child1 = new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false);
+        RecordQueryIndexPlan child1 = new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, true);
         RecordQueryScanPlan child2 = new RecordQueryScanPlan(ScanComparisons.EMPTY, true);
 
         // check matches if the children are in the right order
-        ExpressionRef<PlannerExpression> root = SingleExpressionRef.of(new RecordQueryUnionPlan( // union with arbitrary comparison key
-                child1, child2, EmptyKeyExpression.EMPTY, false, false));
+        ExpressionRef<PlannerExpression> root = SingleExpressionRef.of(RecordQueryUnionPlan.from( // union with arbitrary comparison key
+                child1, child2, EmptyKeyExpression.EMPTY, false));
         Optional<PlannerBindings> possibleBindings = root.bindTo(parentMatcher).findFirst();
         assertTrue(possibleBindings.isPresent());
         PlannerBindings allBindings = possibleBindings.get().mergedWith(getExistingBindings());
@@ -137,8 +137,8 @@ public class ExpressionMatcherTest {
         assertEquals(child2, allBindings.get(childMatcher2));
 
         // check that we fail to match if the children are in the wrong order
-        root = SingleExpressionRef.of(new RecordQueryUnionPlan( // union with arbitrary comparison key
-                child2, child1, EmptyKeyExpression.EMPTY, false, false));
+        root = SingleExpressionRef.of(RecordQueryUnionPlan.from( // union with arbitrary comparison key
+                child2, child1, EmptyKeyExpression.EMPTY, false));
         assertFalse(root.bindTo(parentMatcher).findFirst().isPresent());
     }
 
@@ -147,10 +147,10 @@ public class ExpressionMatcherTest {
         ExpressionMatcher<RecordQueryUnionPlan> parentMatcher = TypeMatcher.of(RecordQueryUnionPlan.class,
                 // types are wrong based on ordering of children in getPlannerExpressionChildren()
                 TypeMatcher.of(KeyExpression.class), TypeMatcher.of(RecordQueryIndexPlan.class, TypeMatcher.of(RecordQueryScanPlan.class)));
-        RecordQueryIndexPlan child1 = new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false);
+        RecordQueryIndexPlan child1 = new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, true);
         RecordQueryScanPlan child2 = new RecordQueryScanPlan(ScanComparisons.EMPTY, true);
-        ExpressionRef<PlannerExpression> root = SingleExpressionRef.of(new RecordQueryUnionPlan( // union with arbitrary comparison key
-                child1, child2, EmptyKeyExpression.EMPTY, false, false));
+        ExpressionRef<PlannerExpression> root = SingleExpressionRef.of(RecordQueryUnionPlan.from( // union with arbitrary comparison key
+                child1, child2, EmptyKeyExpression.EMPTY, false));
         assertFalse(root.bindTo(parentMatcher).findFirst().isPresent());
     }
 
@@ -161,10 +161,10 @@ public class ExpressionMatcherTest {
         ExpressionMatcher<ExpressionRef<KeyExpression>> comparisonKeyMatcher = ReferenceMatcher.anyRef();
         ExpressionMatcher<RecordQueryUnionPlan> matcher = TypeMatcher.of(RecordQueryUnionPlan.class,
                 childMatcher1, childMatcher2, comparisonKeyMatcher);
-        RecordQueryIndexPlan child1 = new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false);
+        RecordQueryIndexPlan child1 = new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, true);
         RecordQueryScanPlan child2 = new RecordQueryScanPlan(ScanComparisons.EMPTY, true);
-        ExpressionRef<PlannerExpression> root = SingleExpressionRef.of(new RecordQueryUnionPlan( // union with arbitrary comparison key
-                child1, child2, EmptyKeyExpression.EMPTY, false, false));
+        ExpressionRef<PlannerExpression> root = SingleExpressionRef.of(RecordQueryUnionPlan.from( // union with arbitrary comparison key
+                child1, child2, EmptyKeyExpression.EMPTY, false));
 
         Optional<PlannerBindings> possibleBindings = root.bindTo(matcher).findFirst();
         assertTrue(possibleBindings.isPresent());
@@ -194,11 +194,11 @@ public class ExpressionMatcherTest {
         QueryComponent andBranch1 = Query.field("field1").greaterThan(6);
         QueryComponent andBranch2 = Query.field("field2").equalsParameter("param");
         RecordQueryFilterPlan filterPlan = new RecordQueryFilterPlan(
-                new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, false),
+                new RecordQueryIndexPlan("an_index", IndexScanType.BY_VALUE, ScanComparisons.EMPTY, true),
                 Query.and(andBranch1, andBranch2));
         RecordQueryScanPlan scanPlan = new RecordQueryScanPlan(ScanComparisons.EMPTY, true);
         ExpressionRef<PlannerExpression> root = SingleExpressionRef.of(
-                new RecordQueryUnionPlan(filterPlan, scanPlan, EmptyKeyExpression.EMPTY, false, false));
+                RecordQueryUnionPlan.from(filterPlan, scanPlan, EmptyKeyExpression.EMPTY, false));
 
         // try to bind
         Optional<PlannerBindings> possibleBindings = root.bindTo(matcher).findFirst();


### PR DESCRIPTION
This adds a new logical unordered union expression and then rules to create them from a filter and transform the rule into a union.

Because this rule is the first implemented rule (I think) that might create a plan with duplicates and our tests all eschew setting `removes_duplicates` to true, it also made sense to add a thing to remove duplicates with a primary key distinct plan within this work. This included as a separate commit.

This resolves #359, and this resolves #501.