### PR TITLE
Fixes #512: Put a limit on the number of suppressed exceptions.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -46,7 +46,7 @@ The `asyncToSync` method of the `OnlineIndexer` has been marked as `INTERNAL`. U
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Added an optional limit on the number of suppressed exceptions [(Issue #512)](https://github.com/FoundationDB/fdb-record-layer/issues/512)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
This adds an optional limit on the number of suppressed exceptions that can be added to a given exception. After the limit is reached, we start incrementing a special exception which holds a counter of the number of ignored exceptions that we were supposed to suppress.

The semantics of changing the limit are a bit odd. I didn't want to deal with exceptions that have a different limit, so I ended up permitting a single change from the default (unlimited) value. I don't think that @alecgrieser especially likes this but I think it suffices for most use cases while keeping the suppression-adding code pretty simple.