### PR TITLE
Fix release note that was mistakenly added to the template

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,6 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* All changes from version [2.5.54.17](#255417)
 
 // end template
 -->
@@ -83,13 +82,13 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* All changes from version [2.5.54.17](#255417)
 
 // end next release
 -->
 
 ### 2.6.56.0
 
+* All changes from version [2.5.54.17](#255417)
 
 ### 2.6.55.0
 


### PR DESCRIPTION
This removes it from the template and puts it under the appropriate release.