### PR TITLE
Fixes #526: ProbableIntersection and UnorderedUnion cursors can become stuck if one child completes with a limit and another an error

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -46,7 +46,7 @@ The `asyncToSync` method of the `OnlineIndexer` has been marked as `INTERNAL`. U
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `ProbableIntersectionCursor`s and `UnorderedUnionCursor`s should no longer get stuck in a loop when one child completes exceptionally and another with a limit [(Issue #526)](https://github.com/FoundationDB/fdb-record-layer/issues/526)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
@@ -78,8 +78,13 @@ class MergeCursorState<T> implements AutoCloseable {
         continuation = result.getContinuation();
     }
 
-    public boolean isExhausted() {
-        return result != null && !result.hasNext() && result.getNoNextReason().isSourceExhausted();
+    /**
+     * Return whether this cursor may return a result in the future. In particular, this will return {@code true}
+     * if this cursor has either not returned its first result or if the most recent result had a next element.
+     * @return whether the cursor might have more results
+     */
+    public boolean mightHaveNext() {
+        return result == null || result.hasNext();
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptionsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptionsTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.logging.CompletionExceptionLogHelper;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
@@ -106,7 +107,7 @@ public class FDBExceptionsTest {
             suppressedExceptions = base.getSuppressed();
             assertEquals(3, suppressedExceptions.length);
             assertThat(Arrays.asList(suppressedExceptions), hasItems(e0, e1));
-            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(hasItem(e2), hasItem(e3))));
+            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(Matchers.<Throwable>hasItem(e2), hasItem(e3))));
             countException = suppressedExceptions[2];
             assertThat(countException, instanceOf(CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount.class));
             assertEquals(2, ((CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount)countException).getCount());
@@ -126,7 +127,7 @@ public class FDBExceptionsTest {
             assertEquals(base, FDBExceptions.wrapException(e1));
             Throwable[] suppressedExceptions = base.getSuppressed();
             assertEquals(1, suppressedExceptions.length);
-            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(hasItem(e0), hasItem(e1))));
+            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(Matchers.<Throwable>hasItem(e0), hasItem(e1))));
             Throwable countException = suppressedExceptions[0];
             assertThat(countException, instanceOf(CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount.class));
             assertEquals(2, ((CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount)countException).getCount());


### PR DESCRIPTION
This makes it so that `whenAny` only looks at cursors that might return a next value, so if the cursor has hit a limit, it is now excluded from the list of cursors to investigate. This actually can also cause an infinite loop if there is a cursor that hit a limit and another cursor who has not yet completed in which case it would spin loop waiting for that cursor to complete. Note that this could end up blocking the thread that asked for the future if the other future completed instantaneously.

Hopefully this will stop cursors becoming unstuck in time.

This fixes #526.