### PR TITLE
Resolves #524: Invalidation callbacks in the AsyncLoadingCache can build up

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -70,7 +70,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Cached futures in the `AsyncLoadingCache` should produce smaller chains of `whenComplete` futures [(Issue #524)](https://github.com/FoundationDB/fdb-record-layer/issues/524)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
This makes the async loading cache only add the call back if necessary. In particular, it eschews adding the call back if the future is already in the cache or if the supplied future is already completed without error. This still allows for the same callback to be added multiple times to the same future (in particular, if the same key is accessed concurrently from a blank cache, then they both might add the callback), but it will add the call back in many fewer places. Hopefully, this reduces contention around the cache key and also reduces the number of these classes that are chained up together.

This resolves #524. Note that it is against the 2.5.54 patch branch. In theory, this could probably wait to be put onto 2.6 as the performance benefit here is probably something but not too much, though I haven't done the science.