### PR TITLE
Resolves #529: TracedTransaction could give a little more context

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -67,7 +67,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* Traced transactions restore MDC context [(Issue #529)](https://github.com/FoundationDB/fdb-record-layer/issues/529)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -468,10 +468,10 @@ public class FDBDatabase {
         return factory.getExecutor();
     }
 
-    public Transaction createTransaction(Executor executor, boolean transactionIsTraced) {
+    public Transaction createTransaction(Executor executor, @Nullable Map<String, String> mdcContext, boolean transactionIsTraced) {
         Transaction transaction = database.createTransaction(executor);
         if (transactionIsTraced) {
-            return new TracedTransaction(transaction);
+            return new TracedTransaction(transaction, mdcContext);
         } else {
             return transaction;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -95,7 +95,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
 
     protected FDBRecordContext(@Nonnull FDBDatabase fdb, @Nullable Map<String, String> mdcContext,
                                boolean transactionIsTraced, @Nullable FDBDatabase.WeakReadSemantics weakReadSemantics) {
-        super(fdb, fdb.createTransaction(initExecutor(fdb, mdcContext), transactionIsTraced));
+        super(fdb, fdb.createTransaction(initExecutor(fdb, mdcContext), mdcContext, transactionIsTraced));
         this.transactionCreateTime = System.currentTimeMillis();
         this.localVersion = new AtomicInteger(0);
         this.localVersionCache = new ConcurrentSkipListMap<>();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -306,7 +306,9 @@ public class FDBDatabaseTest extends FDBTestBase {
 
     private long getReadVersion(FDBDatabase database, Long minVersion, Long stalenessBoundMillis) {
         FDBDatabase.WeakReadSemantics weakReadSemantics = minVersion == null ? null : new FDBDatabase.WeakReadSemantics(minVersion, stalenessBoundMillis, false);
-        return database.getReadVersion(database.openContext(Collections.emptyMap(), null, weakReadSemantics)).join();
+        try (FDBRecordContext context = database.openContext(Collections.emptyMap(), null, weakReadSemantics)) {
+            return database.getReadVersion(context).join();
+        }
     }
 
     public static void testStoreAndRetrieveSimpleRecord(FDBDatabase database, RecordMetaData metaData) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -652,8 +652,10 @@ public class FDBReverseDirectoryCacheTest extends FDBTestBase {
     private LocatableResolver createRandomDirectoryScope() {
         final String name = String.format("name-%d", Math.abs(random.nextLong()));
         KeySpace keySpace = new KeySpace(new KeySpaceDirectory(name, KeySpaceDirectory.KeyType.STRING, name));
-        FDBRecordContext context = fdb.openContext();
-        ResolvedKeySpacePath path = keySpace.resolveFromKey(context, Tuple.from(name));
+        ResolvedKeySpacePath path;
+        try (FDBRecordContext context = fdb.openContext()) {
+            path = keySpace.resolveFromKey(context, Tuple.from(name));
+        }
         return new ScopedDirectoryLayer(fdb, path);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
@@ -128,21 +128,25 @@ public class ScopedDirectoryLayerTest extends LocatableResolverTest {
                         )
         );
 
-        FDBRecordContext context = database.openContext();
-        ResolvedKeySpacePath path = keySpace.resolveFromKey(context, Tuple.from("path", "to", "dirLayer"));
+        ResolvedKeySpacePath path;
+        try (FDBRecordContext context = database.openContext()) {
+            path = keySpace.resolveFromKey(context, Tuple.from("path", "to", "dirLayer"));
+        }
 
         LocatableResolver resolver = scopedDirectoryGenerator.apply(database, path);
-        Long value = resolver.resolve(context.getTimer(), "foo").join();
+        Long value = resolver.resolve(null, "foo").join();
 
         DirectoryLayer directoryLayer = new DirectoryLayer(
                 new Subspace(Bytes.concat(path.toTuple().pack(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())),
                 path.toSubspace());
-        context = database.openContext();
-        validate(context, resolver, directoryLayer, "foo", value);
 
-        DirectoryLayer defaultDirectoryLayer = DirectoryLayer.getDefault();
-        List<String> defaultDirectories = defaultDirectoryLayer.list(context.ensureActive()).join();
-        assertThat("entry is not in the default directory layer", defaultDirectories, not(hasItem("foo")));
+        try (FDBRecordContext context = database.openContext()) {
+            validate(context, resolver, directoryLayer, "foo", value);
+
+            DirectoryLayer defaultDirectoryLayer = DirectoryLayer.getDefault();
+            List<String> defaultDirectories = defaultDirectoryLayer.list(context.ensureActive()).join();
+            assertThat("entry is not in the default directory layer", defaultDirectories, not(hasItem("foo")));
+        }
     }
 
     @Test


### PR DESCRIPTION
Use any provided MDC and restore when logging the leak warning.

Also clean up some tests that didn't close their context but weren't detected in previous runs because they have the wipes-FDB annotation and so don't run by default.