### PR TITLE
Merge 2.5.54.18 into master

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -82,6 +82,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* All changes from version [2.5.54.18](#255418)
 
 // end next release
 -->
@@ -127,6 +128,10 @@ In order to simplify typed record stores, the `FDBRecordStoreBase` class was tur
 ### Newly Deprecated
 
 The `asyncToSync` method of the `OnlineIndexer` has been marked as `INTERNAL`. Users should transition to using one of the `asyncToSync` methods defined on either `FDBDatabase`, `FDBRecordContext`, or `FDBDatabaseRunner`. This method may be removed from our public API in a later release (see [Issue # 473](https://github.com/FoundationDB/fdb-record-layer/issues/473)).
+
+### 2.5.54.18
+
+* **Bug fix** `ProbableIntersectionCursor`s and `UnorderedUnionCursor`s should no longer get stuck in a loop when one child completes exceptionally and another with a limit [(Issue #526)](https://github.com/FoundationDB/fdb-record-layer/issues/526)
 
 ### 2.5.54.17
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
@@ -78,8 +78,13 @@ class MergeCursorState<T> implements AutoCloseable {
         continuation = result.getContinuation();
     }
 
-    public boolean isExhausted() {
-        return result != null && !result.hasNext() && result.getNoNextReason().isSourceExhausted();
+    /**
+     * Return whether this cursor may return a result in the future. In particular, this will return {@code true}
+     * if this cursor has either not returned its first result or if the most recent result had a next element.
+     * @return whether the cursor might have more results
+     */
+    public boolean mightHaveNext() {
+        return result == null || result.hasNext();
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptionsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptionsTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.logging.CompletionExceptionLogHelper;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
@@ -106,7 +107,7 @@ public class FDBExceptionsTest {
             suppressedExceptions = base.getSuppressed();
             assertEquals(3, suppressedExceptions.length);
             assertThat(Arrays.asList(suppressedExceptions), hasItems(e0, e1));
-            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(hasItem(e2), hasItem(e3))));
+            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(Matchers.<Throwable>hasItem(e2), hasItem(e3))));
             countException = suppressedExceptions[2];
             assertThat(countException, instanceOf(CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount.class));
             assertEquals(2, ((CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount)countException).getCount());
@@ -126,7 +127,7 @@ public class FDBExceptionsTest {
             assertEquals(base, FDBExceptions.wrapException(e1));
             Throwable[] suppressedExceptions = base.getSuppressed();
             assertEquals(1, suppressedExceptions.length);
-            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(hasItem(e0), hasItem(e1))));
+            assertThat(Arrays.asList(suppressedExceptions), not(anyOf(Matchers.<Throwable>hasItem(e0), hasItem(e1))));
             Throwable countException = suppressedExceptions[0];
             assertThat(countException, instanceOf(CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount.class));
             assertEquals(2, ((CompletionExceptionLogHelper.IgnoredSuppressedExceptionCount)countException).getCount());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -55,9 +56,13 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests of the {@link ProbableIntersectionCursor} class. This class is somewhat difficult to test because of its
@@ -322,5 +327,59 @@ public class ProbableIntersectionCursorTest {
                 null,
                 null);
         verifyResults(cursor, RecordCursor.NoNextReason.SOURCE_EXHAUSTED, 3, 7, 4, 1);
+    }
+
+    @Test
+    public void errorInChild() {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        RecordCursor<Integer> cursor = ProbableIntersectionCursor.create(Collections::singletonList, Arrays.asList(
+                continuation -> RecordCursor.fromList(Arrays.asList(1, 2), continuation),
+                continuation -> RecordCursor.fromFuture(future)
+        ), null, null);
+
+        CompletableFuture<RecordCursorResult<Integer>> cursorResultFuture = cursor.onNext();
+        final RecordCoreException ex = new RecordCoreException("something bad happened!");
+        future.completeExceptionally(ex);
+        ExecutionException executionException = assertThrows(ExecutionException.class, cursorResultFuture::get);
+        assertNotNull(executionException.getCause());
+        assertSame(ex, executionException.getCause());
+    }
+
+    @Test
+    public void errorAndLimitInChild() {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        RecordCursor<Integer> cursor = ProbableIntersectionCursor.create(Collections::singletonList, Arrays.asList(
+                continuation -> RecordCursor.fromList(Arrays.asList(1, 2), continuation).limitRowsTo(1),
+                continuation -> RecordCursor.fromFuture(future)
+        ), null, null);
+
+        CompletableFuture<RecordCursorResult<Integer>> cursorResultFuture = cursor.onNext();
+        final RecordCoreException ex = new RecordCoreException("something bad happened!");
+        future.completeExceptionally(ex);
+        ExecutionException executionException = assertThrows(ExecutionException.class, cursorResultFuture::get);
+        assertNotNull(executionException.getCause());
+        assertSame(ex, executionException.getCause());
+    }
+
+    @Test
+    public void loopIterationWithLimit() throws ExecutionException, InterruptedException {
+        FDBStoreTimer timer = new FDBStoreTimer();
+        FirableCursor<Integer> secondCursor = new FirableCursor<>(RecordCursor.fromList(Arrays.asList(2, 1)));
+        RecordCursor<Integer> cursor = ProbableIntersectionCursor.create(Collections::singletonList, Arrays.asList(
+                continuation -> RecordCursor.fromList(Arrays.asList(1, 2), continuation).limitRowsTo(1),
+                continuation -> secondCursor
+        ), null, timer);
+
+        CompletableFuture<RecordCursorResult<Integer>> cursorResultFuture = cursor.onNext();
+        secondCursor.fire();
+        assertFalse(cursorResultFuture.isDone());
+        secondCursor.fire();
+        RecordCursorResult<Integer> cursorResult = cursorResultFuture.get();
+        assertEquals(1, (int)cursorResult.get());
+
+        secondCursor.fire();
+        cursorResult = cursor.getNext();
+        assertEquals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, cursorResult.getNoNextReason());
+        assertThat(timer.getCount(FDBStoreTimer.Events.QUERY_INTERSECTION), lessThanOrEqualTo(5));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorTest.java
@@ -20,11 +20,13 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorTest;
 import com.apple.foundationdb.record.cursors.FirableCursor;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
@@ -39,13 +41,19 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for the {@link UnorderedUnionCursor} class. This cursor is somewhat unique in that it
@@ -246,5 +254,78 @@ public class UnorderedUnionCursorTest extends FDBTestBase {
         }
         assertEquals(elems.stream().mapToInt(List::size).sum(), results.size());
         assertEquals(elems.stream().flatMap(List::stream).collect(Collectors.toSet()), new HashSet<>(results));
+    }
+
+    @Test
+    public void errorInChild() {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        RecordCursor<Integer> cursor = UnorderedUnionCursor.create(Arrays.asList(
+                continuation -> RecordCursor.fromList(Arrays.asList(1, 2), continuation),
+                continuation -> RecordCursor.fromFuture(future)
+        ), null, null);
+
+        RecordCursorResult<Integer> cursorResult = cursor.getNext();
+        assertEquals(1, (int)cursorResult.get());
+        cursorResult = cursor.getNext();
+        assertEquals(2, (int)cursorResult.get());
+
+        CompletableFuture<RecordCursorResult<Integer>> cursorResultFuture = cursor.onNext();
+        final RecordCoreException ex = new RecordCoreException("something bad happened!");
+        future.completeExceptionally(ex);
+        ExecutionException executionException = assertThrows(ExecutionException.class, cursorResultFuture::get);
+        assertNotNull(executionException.getCause());
+        assertSame(ex, executionException.getCause());
+    }
+
+    @Test
+    public void errorAndLimitInChild() {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        RecordCursor<Integer> cursor = UnorderedUnionCursor.create(Arrays.asList(
+                continuation -> RecordCursor.fromList(Arrays.asList(1, 2), continuation).limitRowsTo(1),
+                continuation -> RecordCursor.fromFuture(future)
+        ), null, null);
+
+        RecordCursorResult<Integer> cursorResult = cursor.getNext();
+        assertEquals(1, (int)cursorResult.get());
+
+        CompletableFuture<RecordCursorResult<Integer>> cursorResultFuture = cursor.onNext();
+        final RecordCoreException ex = new RecordCoreException("something bad happened!");
+        future.completeExceptionally(ex);
+        ExecutionException executionException = assertThrows(ExecutionException.class, cursorResultFuture::get);
+        assertNotNull(executionException.getCause());
+        assertSame(ex, executionException.getCause());
+    }
+
+    @Test
+    public void loopIterationWithLimit() throws ExecutionException, InterruptedException {
+        FDBStoreTimer timer = new FDBStoreTimer();
+        FirableCursor<Integer> secondCursor = new FirableCursor<>(RecordCursor.fromList(Arrays.asList(3, 4)));
+        RecordCursor<Integer> cursor = UnorderedUnionCursor.create(Arrays.asList(
+                continuation -> RecordCursor.fromList(Arrays.asList(1, 2), continuation).limitRowsTo(1),
+                continuation -> secondCursor
+        ), null, timer);
+
+        RecordCursorResult<Integer> cursorResult = cursor.getNext();
+        assertEquals(1, (int)cursorResult.get());
+
+        CompletableFuture<RecordCursorResult<Integer>> cursorResultFuture = cursor.onNext();
+        assertFalse(cursorResultFuture.isDone());
+        secondCursor.fire();
+        cursorResult = cursorResultFuture.get();
+        assertEquals(3, (int)cursorResult.get());
+
+        cursorResultFuture = cursor.onNext();
+        assertFalse(cursorResultFuture.isDone());
+        secondCursor.fire();
+        cursorResult = cursorResultFuture.get();
+        assertEquals(4, (int)cursorResult.get());
+
+        cursorResultFuture = cursor.onNext();
+        assertFalse(cursorResultFuture.isDone());
+        secondCursor.fire();
+        cursorResult = cursorResultFuture.get();
+        assertFalse(cursorResult.hasNext());
+        assertEquals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED, cursorResult.getNoNextReason());
+        assertThat(timer.getCount(FDBStoreTimer.Events.QUERY_INTERSECTION), lessThanOrEqualTo(5));
     }
 }


### PR DESCRIPTION
In addition to fixing merge conflicts, this updates the release notes and also changes some `onNext().get()`s to `getNext()`s.