### PR TITLE
Resolves #534: Deprecate static loadRecordStoreStateAsync methods

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -58,6 +58,8 @@ Methods for retrieving a record from a record store based on an index entry gene
 
 While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundationdb/fdb-record-layer-core/latest/com/apple/foundationdb/record/provider/foundationdb/MetaDataCache.html) interface's stability has been lessened from [`MAINTAINED`](https://javadoc.io/page/org.foundationdb/fdb-extensions/latest/com/apple/foundationdb/annotation/API.Status.html#MAINTAINED) to [`EXPERIMENTAL`](https://javadoc.io/page/org.foundationdb/fdb-extensions/latest/com/apple/foundationdb/annotation/API.Status.html#EXPERIMENTAL). That interface may undergo further changes as work progresses on [Issue #280](https://github.com/FoundationDB/fdb-record-layer/issues/280). Clients are discouraged from using that interface until work evolving that API has progressed.
 
+The static `loadRecordStoreStateAsync` methods on `FDBRecordStore` have been deprecated. Users are encouraged to use `getRecordStoreState` instead. The deprecated methods will be removed soon.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -77,7 +79,7 @@ While not deprecated, the [`MetaDataCache`](https://javadoc.io/page/org.foundati
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Deprecate the static `loadRecordStoreStateAsync` methods from `FDBRecordStore` [(Issue #534)](https://github.com/FoundationDB/fdb-record-layer/issues/534)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -315,7 +315,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     public RecordStoreState getRecordStoreState() {
         if (recordStoreState == null) {
             recordStoreState = context.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_RECORD_STORE_STATE,
-                    preloadSubspaceAsync().thenCompose(vignore -> loadRecordStoreStateAsync(context, getSubspace())));
+                    preloadSubspaceAsync().thenCompose(vignore -> loadRecordStoreStateAsync(context)));
         }
         return recordStoreState;
     }
@@ -1924,7 +1924,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @Nonnull
     @API(API.Status.INTERNAL)
     protected CompletableFuture<Void> preloadRecordStoreStateAsync() {
-        return loadRecordStoreStateAsync(context, getSubspace()).thenAccept(state -> this.recordStoreState = state);
+        return loadRecordStoreStateAsync(context).thenAccept(state -> this.recordStoreState = state);
     }
 
     /**
@@ -1942,6 +1942,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @param subspace the subspace of the record store
      * @return a future that will contain the state of the record state located at the given subspace
      */
+    @Deprecated
     @Nonnull
     public static CompletableFuture<MutableRecordStoreState> loadRecordStoreStateAsync(@Nonnull FDBRecordContext context,
                                                                                        @Nonnull Subspace subspace) {
@@ -1957,6 +1958,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @param isolationLevel the isolation level to use when reading
      * @return a future that will contain the state of the record store located at the given subspace
      */
+    @Deprecated
     @Nonnull
     public static CompletableFuture<MutableRecordStoreState> loadRecordStoreStateAsync(@Nonnull FDBRecordContext context,
                                                                                        @Nonnull Subspace subspace,
@@ -1995,6 +1997,18 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             result = timer.instrument(FDBStoreTimer.Events.LOAD_RECORD_STORE_STATE, result, context.getExecutor());
         }
         return result;
+    }
+
+    /**
+     * Loads the current state of the record store asynchronously.
+     * @param context the record context in which to retrieve the record store state
+     * @return a future that will contain the state of the record store located at the given subspace
+     */
+    @Nonnull
+    @SuppressWarnings("deprecation")
+    @API(API.Status.UNSTABLE)
+    CompletableFuture<MutableRecordStoreState> loadRecordStoreStateAsync(@Nonnull FDBRecordContext context) {
+        return loadRecordStoreStateAsync(context, getSubspace(), IsolationLevel.SNAPSHOT);
     }
 
     // add a read conflict key so that the transaction will fail if the index

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -2086,7 +2086,7 @@ public class OnlineIndexerTest extends FDBTestBase {
         }
 
         try (FDBRecordContext context = fdb.openContext()) {
-            assertEquals(RecordStoreState.EMPTY, FDBRecordStore.loadRecordStoreStateAsync(context, subspace).join());
+            assertEquals(RecordStoreState.EMPTY, recordStore.loadRecordStoreStateAsync(context).join());
         }
     }
 


### PR DESCRIPTION
loadRecordStoreStateAsync was static because it used to be called by
different versions of static open methods. However, it's no longer used
that way, and users should really call getRecordStoreState instead. This
change deprecates them and instead introduces a non-static version of
them.