### PR TITLE
Resolves #538: AsyncLoadingCache should cache values instead of futures

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -72,7 +72,7 @@ The static `loadRecordStoreStateAsync` methods on `FDBRecordStore` have been dep
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** `OnlineIndexer` inherits `WeakReadSemantics` [(Issue #519)](https://github.com/FoundationDB/fdb-record-layer/issues/519)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Values are cached by the `AsyncLoadingCache` instead of futures to avoid futures sharing errors or timeouts [(Issue #538)](https://github.com/FoundationDB/fdb-record-layer/issues/538)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -810,7 +810,9 @@ public class MoreAsyncUtil {
 
     /**
      * Get a completable future that will either complete within the specified deadline time or complete exceptionally
-     * with {@link DeadlineExceededException}.
+     * with {@link DeadlineExceededException}. If {@code deadlineTimeMillis} is set to {@link Long#MAX_VALUE}, then
+     * no deadline is imposed on the future.
+     *
      * @param deadlineTimeMillis the maximum time to wait for the asynchronous operation to complete, specified in milliseconds
      * @param supplier the {@link Supplier} of the asynchronous result
      * @param <T> the return type for the get operation
@@ -821,7 +823,9 @@ public class MoreAsyncUtil {
     public static <T> CompletableFuture<T> getWithDeadline(long deadlineTimeMillis,
                                                            @Nonnull Supplier<CompletableFuture<T>> supplier) {
         final CompletableFuture<T> valueFuture = supplier.get();
-
+        if (deadlineTimeMillis == Long.MAX_VALUE) {
+            return valueFuture;
+        }
         return CompletableFuture.anyOf(MoreAsyncUtil.delayedFuture(deadlineTimeMillis, TimeUnit.MILLISECONDS), valueFuture)
                 .thenCompose(ignore -> {
                     if (!valueFuture.isDone()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AsyncLoadingCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AsyncLoadingCache.java
@@ -38,7 +38,7 @@ import java.util.function.Supplier;
 @API(API.Status.UNSTABLE)
 public class AsyncLoadingCache<K, V> {
     @Nonnull
-    private final Cache<K, CompletableFuture<V>> cache;
+    private final Cache<K, V> cache;
     private final long refreshTimeMillis;
     private final long deadlineTimeMillis;
 
@@ -54,22 +54,31 @@ public class AsyncLoadingCache<K, V> {
 
     /**
      * If the cache does not contain an entry for <code>key</code>, retrieve the value using the provided asynchronous
-     * {@link Supplier}. The future returned by the supplier is cached immediately, this is to prevent concurrent
-     * attempts to get the value from doing unnecessary (and potentially expensive) work. If the returned asynchronous
-     * operation completes exceptionally, the key will be cleared.
+     * {@link Supplier}. If the value is not currently cached, then the {@code Supplier} is used to load the value
+     * asynchronously. If multiple callers ask for the same key at the same time, then they might duplicate
+     * each other's work in that both callers will result in a future being created. Whichever future completes first
+     * will insert its value into the cache, and all callers that then complete successfully are guaranteed to see that
+     * object until such time as the value is expired from the cache.
      *
      * @param key the key in the cache to lookup
      * @param supplier an asynchronous operation to retrieve the desired value if the cache is empty
      *
      * @return a future containing either the cached value or the result from the supplier
      */
+    @Nonnull
     public CompletableFuture<V> orElseGet(@Nonnull K key, @Nonnull Supplier<CompletableFuture<V>> supplier) {
         try {
-            return cache.get(key, () -> MoreAsyncUtil.getWithDeadline(deadlineTimeMillis, supplier)).whenComplete((ignored, e) -> {
-                if (e != null) {
-                    cache.invalidate(key);
-                }
-            });
+            V cachedValue = cache.getIfPresent(key);
+            if (cachedValue == null) {
+                return MoreAsyncUtil.getWithDeadline(deadlineTimeMillis, supplier).thenApply(value -> {
+                    // Only insert the computed value into the cache if a concurrent caller hasn't.
+                    // Return the value that wound up in the cache.
+                    final V existingValue = cache.asMap().putIfAbsent(key, value);
+                    return existingValue == null ? value : existingValue;
+                });
+            } else {
+                return CompletableFuture.completedFuture(cachedValue);
+            }
         } catch (Exception e) {
             throw new RecordCoreException("failed getting value", e).addLogInfo("cacheKey", key);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/AsyncLoadingCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/AsyncLoadingCacheTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil.DeadlineExceededException;
 import com.google.common.collect.ImmutableList;
@@ -43,6 +44,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class AsyncLoadingCacheTest {
@@ -184,9 +186,10 @@ class AsyncLoadingCacheTest {
     public void testParallelGets() {
         AsyncLoadingCache<String, Boolean> cachedResult = new AsyncLoadingCache<>(100);
         final AtomicInteger counter = new AtomicInteger();
+        CompletableFuture<Void> signal = new CompletableFuture<>();
         final Supplier<CompletableFuture<Boolean>> supplier = () -> {
             counter.incrementAndGet();
-            return MoreAsyncUtil.delayedFuture(200 + random.nextInt(1000), TimeUnit.MICROSECONDS).thenApply(ignored -> true);
+            return signal.thenApply(ignored -> true);
         };
 
         List<String> keys = ImmutableList.of("key-1", "key-2", "key-3");
@@ -197,8 +200,24 @@ class AsyncLoadingCacheTest {
             }
         }
 
-        CompletableFuture.allOf(parallelOperations.toArray(new CompletableFuture<?>[0])).join();
-        assertThat("supplier is only called once per key", counter.get(), is(keys.size()));
+        signal.complete(null);
+        List<Boolean> values = AsyncUtil.getAll(parallelOperations).join();
+        for (Boolean value : values) {
+            assertTrue(value);
+        }
+
+        // Don't increment after futures have already completed
+        List<CompletableFuture<Boolean>> afterCompleteOperations = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            for (String key : keys) {
+                afterCompleteOperations.add(cachedResult.orElseGet(key, supplier));
+            }
+        }
+        values = AsyncUtil.getAll(afterCompleteOperations).join();
+        for (Boolean value : values) {
+            assertTrue(value);
+        }
+        assertThat("supplier is called once per incomplete access", counter.get(), is(parallelOperations.size()));
     }
 
     @Test


### PR DESCRIPTION
The `AsyncLoadingCache` is now backed by a `Cache<K, V>` instead of a `Cache<K, CompletableFuture<V>>`, and if the value is not cached, then each caller creates their own future. This produces duplicate work, but it also creates more failure indepdendence (hopefully). The first future to complete is the one whose value is cached, and all completing futures get that value.

Some of the discussion related to this change also suggested removing the deadline. I elected to keep it (in the name of preserving semantics), but it is also now explicitly the case that the caller can provide a deadline of `Long.MAX_VALUE` to indicate that there should be no deadline imposed on the futures.

This resolves #538.