### PR TITLE
Resolves #544: ExecuteProperties should expose the bytes- and record scan-limits

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -76,7 +76,7 @@ The static `loadRecordStoreStateAsync` methods on `FDBRecordStore` have been dep
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The bytes and record scanned query limits can now be retrieved through the `ExecuteProperties` object [(Issue #544)](https://github.com/FoundationDB/fdb-record-layer/issues/544)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Deprecate the static `loadRecordStoreStateAsync` methods from `FDBRecordStore` [(Issue #534)](https://github.com/FoundationDB/fdb-record-layer/issues/534)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteScanLimiter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteScanLimiter.java
@@ -66,6 +66,16 @@ public class ByteScanLimiter {
         bytesRemaining.addAndGet(-bytes);
     }
 
+    /**
+     * Get the byte scan limit. In particular, this will return the target
+     * number of bytes that this limiter is being used to enforce.
+     *
+     * @return the byte scan limit being enforced
+     */
+    public long getLimit() {
+        return originalLimit;
+    }
+
     @Override
     public String toString() {
         return String.format("ByteScanLimiter(%d limit, %d left)", originalLimit, bytesRemaining.get());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
@@ -123,8 +123,36 @@ public class ExecuteProperties {
         return copy(skip, newLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
     }
 
+    /**
+     * Get the time limit for query execution. This will return {@link #UNLIMITED_TIME} if there is no time-limit
+     * imposed on a query.
+     *
+     * @return the maximum time for query execution
+     */
     public long getTimeLimit() {
         return timeLimit;
+    }
+
+    /**
+     * Get the maximum number of records a query with this execute properties will scan. This will return
+     * {@link Integer#MAX_VALUE} if there is no limit to the number of records scanned by a query.
+     *
+     * @return the maximum number of records a query will scan
+     */
+    public int getScannedRecordsLimit() {
+        final RecordScanLimiter recordScanLimiter = getState().getRecordScanLimiter();
+        return recordScanLimiter == null ? Integer.MAX_VALUE : recordScanLimiter.getLimit();
+    }
+
+    /**
+     * Get the maximum number of bytes a query with this execute properties will scan. This will return
+     * {@link Long#MAX_VALUE} if there is no limit to the number of bytes scanned by a query.
+     *
+     * @return the maximum number of bytes a query will scan
+     */
+    public long getScannedBytesLimit() {
+        final ByteScanLimiter byteScanLimiter = getState().getByteScanLimiter();
+        return byteScanLimiter == null ? Long.MAX_VALUE : byteScanLimiter.getLimit();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiter.java
@@ -57,6 +57,16 @@ public class RecordScanLimiter {
         return allowedRecordScansRemaining.getAndDecrement() > 0;
     }
 
+    /**
+     * Get the record scan limit. In particular, this will return the target
+     * number of records that this limiter is being used to enforce.
+     *
+     * @return the record scan limit being enforced
+     */
+    public int getLimit() {
+        return originalLimit;
+    }
+
     @Override
     public String toString() {
         return String.format("RecordScanLimiter(%d limit, %d left)", originalLimit, allowedRecordScansRemaining.get());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/ExecutePropertiesTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/ExecutePropertiesTest.java
@@ -20,11 +20,13 @@
 
 package com.apple.foundationdb.record;
 
+import com.apple.foundationdb.Transaction;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -70,5 +72,37 @@ public class ExecutePropertiesTest {
         }
         // verify that the record scan limit really is RECORD_SCAN_LIMIT + 1
         assertFalse(merge3.getState().getRecordScanLimiter().tryRecordScan());
+    }
+
+    /**
+     * Validate the values returned by an {@link ExecuteProperties} object when no limit is imposed.
+     * These are helpfully a mix of 0 and the maximum value for their return type.
+     */
+    @Test
+    public void testGetNoLimits() {
+        assertEquals(ExecuteProperties.UNLIMITED_TIME, ExecuteProperties.SERIAL_EXECUTE.getTimeLimit());
+        assertEquals(Integer.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getScannedRecordsLimit());
+        assertNull(ExecuteProperties.SERIAL_EXECUTE.getState().getRecordScanLimiter());
+        assertEquals(Long.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getScannedBytesLimit());
+        assertNull(ExecuteProperties.SERIAL_EXECUTE.getState().getByteScanLimiter());
+        assertEquals(Transaction.ROW_LIMIT_UNLIMITED, ExecuteProperties.SERIAL_EXECUTE.getReturnedRowLimit());
+        assertEquals(Integer.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getReturnedRowLimitOrMax());
+    }
+
+    /**
+     * Validate that getting the limits set on an {@link ExecuteProperties} can then be retrieved back.
+     */
+    @Test
+    public void testGetLimits() {
+        ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                .setTimeLimit(100L)
+                .setScannedBytesLimit(1000L)
+                .setScannedRecordsLimit(1000)
+                .setReturnedRowLimit(200)
+                .build();
+        assertEquals(100L, executeProperties.getTimeLimit());
+        assertEquals(1000L, executeProperties.getScannedBytesLimit());
+        assertEquals(1000, executeProperties.getScannedRecordsLimit());
+        assertEquals(200, executeProperties.getReturnedRowLimit());
     }
 }


### PR DESCRIPTION
This adds getters for the additional limits to the `ExecuteProperties`.