### PR TITLE
Resolves #504: Introduce mocked locality API

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Provide a way for `FDBDatabase` to use a non-standard locality API  [(Issue #504)](https://github.com/FoundationDB/fdb-record-layer/issues/504)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -504,7 +504,7 @@ public class FDBDatabaseFactory {
      */
     @Nonnull
     public FDBLocalityProvider getLocalityProvider() {
-        return this.localityProvider;
+        return localityProvider;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -20,9 +20,9 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.NetworkOptions;
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
@@ -59,6 +59,9 @@ public class FDBDatabaseFactory {
 
     @Nonnull
     private static final FDBDatabaseFactory INSTANCE = new FDBDatabaseFactory();
+
+    @Nonnull
+    private FDBLocalityProvider localityProvider = FDBLocalityUtil.instance();
 
     /* Next few null until initFDB is called */
 
@@ -493,5 +496,23 @@ public class FDBDatabaseFactory {
     @Nonnull
     public synchronized FDBDatabase getDatabase() {
         return getDatabase(null);
+    }
+
+    /**
+     * Get the locality provider that is used to discover the server location of the keys.
+     * @return the installed locality provider
+     */
+    @Nonnull
+    public FDBLocalityProvider getLocalityProvider() {
+        return this.localityProvider;
+    }
+
+    /**
+     * Set the locality provider that is used to discover the server location of the keys.
+     * @param localityProvider the locality provider
+     * @see FDBLocalityUtil
+     */
+    public void setLocalityProvider(@Nonnull FDBLocalityProvider localityProvider) {
+        this.localityProvider = localityProvider;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -515,12 +515,4 @@ public class FDBDatabaseFactory {
     public void setLocalityProvider(@Nonnull FDBLocalityProvider localityProvider) {
         this.localityProvider = localityProvider;
     }
-
-    /**
-     * Unset the installed locality provider back to default ({@link FDBLocalityUtil}). The locality provider is used to discover the server location of the keys.
-     * @see FDBLocalityUtil
-     */
-    public void unsetLocalityProvider() {
-        this.localityProvider = FDBLocalityUtil.instance();
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -515,4 +515,12 @@ public class FDBDatabaseFactory {
     public void setLocalityProvider(@Nonnull FDBLocalityProvider localityProvider) {
         this.localityProvider = localityProvider;
     }
+
+    /**
+     * Unset the installed locality provider back to default ({@link FDBLocalityUtil}). The locality provider is used to discover the server location of the keys.
+     * @see FDBLocalityUtil
+     */
+    public void unsetLocalityProvider() {
+        this.localityProvider = FDBLocalityUtil.instance();
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBLocalityProvider.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBLocalityProvider.java
@@ -1,0 +1,50 @@
+/*
+ * FDBLocalityProvider.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.async.CloseableAsyncIterator;
+
+import javax.annotation.Nonnull;
+
+
+/**
+ * An interface containing a set of functions for discovering the location of the keys within a cluster.
+ *
+ * @see FDBLocalityUtil
+ * @see com.apple.foundationdb.LocalityUtil
+ */
+public interface FDBLocalityProvider {
+
+    /**
+     * Return a {@code CloseableAsyncIterator} of keys {@code k} such that {@code begin <= k < end} and {@code k} is
+     * located at the start of a contiguous range stored on a single server.<br>
+     *
+     * @param tr the transaction on which to base the query
+     * @param begin the inclusive start of the range
+     * @param end the exclusive end of the range
+     *
+     * @return a sequence of keys denoting the start of single-server ranges
+     * @see com.apple.foundationdb.LocalityUtil#getBoundaryKeys(Transaction, byte[], byte[])
+     */
+    @Nonnull
+    CloseableAsyncIterator<byte[]> getBoundaryKeys(@Nonnull Transaction tr, @Nonnull byte[] begin, @Nonnull byte[] end);
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBLocalityUtil.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBLocalityUtil.java
@@ -1,0 +1,68 @@
+/*
+ * FDBLocalityUtil.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.LocalityUtil;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.async.CloseableAsyncIterator;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An implementation of the {@link FDBLocalityProvider} interface that uses foundationDB's {@link LocalityUtil} API to
+ * discover the storage locations of keys within a cluster.
+ */
+public class FDBLocalityUtil implements FDBLocalityProvider {
+    private static final FDBLocalityUtil INSTANCE = new FDBLocalityUtil();
+
+    private FDBLocalityUtil() {
+    }
+
+    /**
+     * Get the single instance of this utility class.
+     * @return the only instance of the class
+     */
+    @Nonnull
+    public static FDBLocalityUtil instance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Return an estimate of the keys boundaries within the given range.
+     *
+     * <p>
+     * The method results in a {@code CloseableAsyncIterator} of keys {@code k} such that
+     * {@code begin <= k < end} and {@code k} is located at the start of a contiguous range stored on a single server.
+     * </p>
+     *
+     * @param tr the transaction on which to base the query
+     * @param begin the inclusive start of the range
+     * @param end the exclusive end of the range
+     *
+     * @return a sequence of keys denoting the start of single-server ranges
+     * @see LocalityUtil#getBoundaryKeys(Transaction, byte[], byte[])
+     */
+    @Nonnull
+    @Override
+    public CloseableAsyncIterator<byte[]> getBoundaryKeys(@Nonnull Transaction tr, @Nonnull byte[] begin, @Nonnull byte[] end) {
+        return LocalityUtil.getBoundaryKeys(tr, begin, end);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -20,13 +20,12 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.KeyValue;
-import com.apple.foundationdb.LocalityUtil;
 import com.apple.foundationdb.MutationType;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncIterator;
 import com.apple.foundationdb.async.AsyncUtil;
@@ -2899,7 +2898,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         final Transaction transaction = ensureContextActive();
         byte[] rangeStart = recordsSubspace().pack(low);
         byte[] rangeEnd = recordsSubspace().pack(high);
-        CloseableAsyncIterator<byte[]> cursor = LocalityUtil.getBoundaryKeys(transaction, rangeStart, rangeEnd);
+        CloseableAsyncIterator<byte[]> cursor = context.getDatabase().getLocalityProvider().getBoundaryKeys(transaction, rangeStart, rangeEnd);
         final boolean hasSplitRecordSuffix = hasSplitRecordSuffix();
         DistinctFilterCursorClosure closure = new DistinctFilterCursorClosure();
         return RecordCursor.fromIterator(getExecutor(), cursor)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -138,7 +138,7 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
         }
     }
 
-    public void commit(FDBRecordContext context) throws Exception {
+    public void commit(FDBRecordContext context) {
         try {
             context.commit();
             if (logger.isInfoEnabled()) {
@@ -163,7 +163,7 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
         openSimpleRecordStore(context, NO_HOOK);
     }
 
-    public void openSimpleRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook) throws Exception {
+    public void openSimpleRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook) {
         createOrOpenRecordStore(context, simpleMetaData(hook));
     }
 
@@ -290,7 +290,7 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
         return recBuilder.build();
     }
 
-    protected FDBStoredRecord<Message> saveAndSplitSimpleRecord(long recno, String strValue, int numValue) throws Exception {
+    protected FDBStoredRecord<Message> saveAndSplitSimpleRecord(long recno, String strValue, int numValue) {
         FDBStoredRecord<Message> savedRecord;
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MockedLocalityUtil.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MockedLocalityUtil.java
@@ -1,0 +1,184 @@
+/*
+ * MockedLocalityUtil.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.async.CloseableAsyncIterator;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A mocked implementation of the {@link FDBLocalityProvider} interface.
+ */
+public class MockedLocalityUtil implements FDBLocalityProvider {
+
+    private static class KeyRange {
+        @Nonnull
+        private byte[] key;
+        @Nonnull
+        private Tuple tuple;
+        private int rangeIndex;
+
+        public KeyRange(@Nonnull byte[] key, @Nonnull Tuple tuple, int rangeIndex) {
+            this.key = key;
+            this.tuple = tuple;
+            this.rangeIndex = rangeIndex;
+        }
+    }
+
+    private static final MockedLocalityUtil INSTANCE = new MockedLocalityUtil();
+    @Nonnull
+    private List<KeyRange> keyRanges;
+    @Nonnull
+    private List<Integer> ranges;
+
+    private MockedLocalityUtil() {
+    }
+
+    /**
+     * Get the single instance of this utility class.
+     * @return the only instance of the class
+     */
+    @Nonnull
+    public static MockedLocalityUtil instance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Initialize the {@code MockedLocalityUtil}'s singleton using a random number of ranges.
+     * @param keys a sorted list of keys
+     * @see #init(List, int)
+     */
+    @Nonnull
+    public static void init(@Nonnull List<byte[]> keys) {
+        init(keys, new Random().nextInt(keys.size()) + 1);
+    }
+
+    /**
+     * Initialize the {@code MockedLocalityUtil}'s singleton.
+     *
+     * <p>
+     * This is method randomly partitions the sorted list of {@code keys} among {@code rangeCount} servers as if the keys
+     * were stored contiguously on those servers. The outcome of this partition is later used by {@link #getBoundaryKeys(Transaction, byte[], byte[])}.
+     * Note that {@code getBoundaryKeys} must be called after this method is called, otherwise it will assume no keys exists.
+     * </p>
+     *
+     * @param keys a sorted list of keys
+     * @param rangeCount the number of ranges to return.
+     */
+    @Nonnull
+    public static void init(@Nonnull List<byte[]> keys, int rangeCount) {
+        INSTANCE.ranges = new ArrayList<>(rangeCount);
+        INSTANCE.keyRanges = new ArrayList<>(keys.size());
+
+        // Build the boundaries randomly
+        Random randomGenerator = new Random();
+        int lastBoundaryIndex = 0;
+        for (int i = 0; i < rangeCount; i++) {
+            if (i > 0) {
+                lastBoundaryIndex += randomGenerator.nextInt((keys.size() - INSTANCE.ranges.get(i - 1)) / (rangeCount - i));
+            }
+            INSTANCE.ranges.add(lastBoundaryIndex);
+        }
+
+        // Create a map between keys and their ranges.
+        int rangeIndex = 0;
+        for (int i = 0; INSTANCE.ranges.size() > 0 && i < keys.size(); i++) {
+            while (rangeIndex < INSTANCE.ranges.size() && INSTANCE.ranges.get(rangeIndex) < i) {
+                rangeIndex++;
+            }
+            INSTANCE.keyRanges.add(new KeyRange(keys.get(i), Tuple.fromBytes(keys.get(i)),
+                    rangeIndex == INSTANCE.ranges.size() ? INSTANCE.ranges.get(rangeIndex - 1) /* it's the last range */ : INSTANCE.ranges.get(rangeIndex)));
+        }
+    }
+
+    /**
+     * Return a {@code CloseableAsyncIterator} of keys {@code k} such that {@code begin <= k < end} and {@code k}
+     * represents a location at the start of a contiguous range stored on a single server. Note that this class
+     * fakes the actual locations, and the returned keys are derived from the random boundaries created in {@link #init(List, int)}.
+     *
+     * @param tr the transaction on which to base the query
+     * @param begin the inclusive start of the range
+     * @param end the exclusive end of the range
+     *
+     * @return a sequence of keys denoting the start of the ranges
+     */
+    @Nonnull
+    public CloseableAsyncIterator<byte[]> getBoundaryKeys(@Nonnull Transaction tr, @Nonnull byte[] begin, @Nonnull byte[] end) {
+        // This mocked locality API does not need tr.
+        return new MockedBoundaryIterator(keyRanges, ranges, begin, end);
+    }
+
+    static class MockedBoundaryIterator implements CloseableAsyncIterator<byte[]> {
+        private List<byte[]> ranges;
+        int lastBeginIndex;
+
+        MockedBoundaryIterator(@Nonnull List<KeyRange> keyRanges, @Nonnull List<Integer> ranges, @Nonnull byte[] begin, @Nonnull byte[] end) {
+            this.ranges = new ArrayList<>();
+            Tuple beginTuple = Tuple.fromBytes(begin);
+            Tuple endTuple = Tuple.fromBytes(end);
+            if (beginTuple.compareTo(endTuple) > 0) {
+                return;
+            }
+            int rangeIndex = -1;
+            for (KeyRange keyRange : keyRanges) {
+                if (beginTuple.compareTo(keyRange.tuple) <= 0) {
+                    this.ranges.add(keyRange.key);
+                    rangeIndex = keyRange.rangeIndex;
+                    break;
+                }
+            }
+            while (rangeIndex >= 0 && rangeIndex < ranges.size() && keyRanges.get(ranges.get(rangeIndex)).tuple.compareTo(endTuple) < 0) {
+                this.ranges.add(keyRanges.get(ranges.get(rangeIndex++)).key);
+            }
+        }
+
+        @Override
+        public CompletableFuture<Boolean> onHasNext() {
+            return new CompletableFuture<>().completedFuture(lastBeginIndex < ranges.size());
+        }
+
+        @Override
+        public boolean hasNext() {
+            return lastBeginIndex < ranges.size();
+        }
+
+        @Override
+        public byte[] next() {
+            return ranges.get(lastBeginIndex++);
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("Boundary keys are read-only");
+        }
+
+        @Override
+        public void close() {
+            // does nothing here.
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MockedLocalityUtil.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MockedLocalityUtil.java
@@ -68,6 +68,14 @@ public class MockedLocalityUtil implements FDBLocalityProvider {
     }
 
     /**
+     * Get the key of the last range.
+     * @return the key of the last range
+     */
+    public static byte[] getLastRange() {
+        return INSTANCE.keyRanges.get(MockedLocalityUtil.instance().ranges.get(MockedLocalityUtil.instance().ranges.size() - 1)).key;
+    }
+
+    /**
      * Initialize the {@code MockedLocalityUtil}'s singleton.
      *
      * <p>

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MockedLocalityUtil.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MockedLocalityUtil.java
@@ -68,16 +68,6 @@ public class MockedLocalityUtil implements FDBLocalityProvider {
     }
 
     /**
-     * Initialize the {@code MockedLocalityUtil}'s singleton using a random number of ranges.
-     * @param keys a sorted list of keys
-     * @see #init(List, int)
-     */
-    @Nonnull
-    public static void init(@Nonnull List<byte[]> keys) {
-        init(keys, new Random().nextInt(keys.size()) + 1);
-    }
-
-    /**
      * Initialize the {@code MockedLocalityUtil}'s singleton.
      *
      * <p>
@@ -91,6 +81,9 @@ public class MockedLocalityUtil implements FDBLocalityProvider {
      */
     @Nonnull
     public static void init(@Nonnull List<byte[]> keys, int rangeCount) {
+        if (keys.size() < rangeCount) {
+            throw new IllegalArgumentException("rangeCount must be less than (or equal) the size of keys");
+        }
         INSTANCE.ranges = new ArrayList<>(rangeCount);
         INSTANCE.keyRanges = new ArrayList<>(keys.size());
 
@@ -146,7 +139,6 @@ public class MockedLocalityUtil implements FDBLocalityProvider {
             int rangeIndex = -1;
             for (KeyRange keyRange : keyRanges) {
                 if (beginTuple.compareTo(keyRange.tuple) <= 0) {
-                    this.ranges.add(keyRange.key);
                     rangeIndex = keyRange.rangeIndex;
                     break;
                 }


### PR DESCRIPTION
This change adds an interface for the locality API and implements one class that uses FDB's
LocalityUtil and one that fakes locality API by creating random boundaries. The interface is hooked
to FDBDatabase/FDBDatabaseFactory with a default that uses FDB LocalityUtil.