### PR TITLE
Fixes #573: FilterCursors can shuffle off work to the wrong executor

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FilterCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FilterCursor.java
@@ -69,7 +69,7 @@ public class FilterCursor<T> implements RecordCursor<T> {
             nextResult = innerResult;
             hasNext = innerResult.hasNext() && (Boolean.TRUE.equals(pred.apply(innerResult.get()))); // relies on short circuiting
             return innerResult.hasNext() && !hasNext; // keep looping only if we might find more records and we filtered a record out
-        })).thenApply(vignore -> {
+        }), getExecutor()).thenApply(vignore -> {
             mayGetContinuation = !hasNext;
             return nextResult;
         });

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicator.java
@@ -155,7 +155,7 @@ public class ResolverMappingReplicator implements AutoCloseable {
                 .whenComplete((vignore, eignore) -> cursor.close())
                 .thenApply(vignore -> Objects.nonNull(continuation.get()));
             });
-        });
+        }, runner.getExecutor());
     }
 
     @Override


### PR DESCRIPTION
This now feeds the executor in properly in a `FilterCursor`. I didn't add a test for this, because I'm not quite sure what the right way to test it is. In theory, one could imagine a test that, like, checked what thread it was in, but I don't know if we have anywhere else that does that. Though maybe doing more of that would be a good idea. I went ahead and looked for all instances of us calling `AsyncUtil.whileTrue(Supplier)` instead of `AsyncUtil.whileTrue(Supplier, Executor)`, and there was only one other instance (in a non-test setting), so I went and fixed that one, too.

This fixes #573.