### PR TITLE
Fixes #580: FDBDatabaseRunnerTest.testRestoreMdc is somewhat flaky

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
@@ -371,7 +371,7 @@ public class FDBDatabaseRunnerTest extends FDBTestBase {
         try {
             ThreadContext.clearAll();
             ThreadContext.put("outer", "Echidna");
-            Map<String, String> outer = ThreadContext.getContext();
+            final Map<String, String> outer = ThreadContext.getContext();
             final ImmutableMap<String, String> restored = ImmutableMap.of("restored", "Platypus");
 
             FDBDatabaseFactory.instance().setExecutor(new FDBRecordContext.ContextRestoringExecutor(
@@ -384,9 +384,13 @@ public class FDBDatabaseRunnerTest extends FDBTestBase {
             final String runnerRunAsyncName = "runner runAsync";
             final String supplyAsyncName = "supplyAsync";
             final String handleName = "handle";
-            assertNull(runner.runAsync(recordContext -> {
+
+            // Delay starting the future until all callbacks have been set up so that the handle lambda
+            // runs in the context-restoring executor.
+            CompletableFuture<Void> signal = new CompletableFuture<>();
+            CompletableFuture<?> task = runner.runAsync(recordContext -> {
                 saveThreadContext.accept(runnerRunAsyncName);
-                return CompletableFuture.supplyAsync(() -> {
+                return signal.thenCompose(vignore -> CompletableFuture.supplyAsync(() -> {
                     saveThreadContext.accept(supplyAsyncName);
                     if (attempts.getAndIncrement() == 0) {
                         throw new RecordCoreRetriableTransactionException("Retriable and lessener",
@@ -394,11 +398,14 @@ public class FDBDatabaseRunnerTest extends FDBTestBase {
                     } else {
                         return null;
                     }
-                }, recordContext.getExecutor());
+                }, recordContext.getExecutor()));
             }).handle((result, exception) -> {
                 saveThreadContext.accept(handleName);
                 return exception;
-            }).join());
+
+            });
+            signal.complete(null);
+            assertNull(task.join());
             List<Map<String, String>> expected = ImmutableList.of(
                     // first attempt:
                     // it is known behavior that the first will be run in the current context


### PR DESCRIPTION
This adds a new `signal` future that is fired only after the `handle` callback has been added, which I think plugs the gap I found.

I'm not sure I totally like it. I think this is what needs to be done if we don't want to weaken the test by just not checking the `handle` lambda's context.