### PR TITLE
Fixes #586: Several ProbableIntersectionCursor tests require FDB but are not marked as such

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
@@ -139,7 +139,7 @@ public class ProbableIntersectionCursorTest {
                 assertNull(result.getContinuation().toBytes());
             }
             return result.hasNext();
-        })).join();
+        }), intersectionCursor.getExecutor()).join();
 
         assertThat(falsePositives.get(), lessThan(5));
         assertEquals(50 + falsePositives.get(), timer.getCount(FDBStoreTimer.Counts.QUERY_INTERSECTION_PLAN_MATCHES));
@@ -227,7 +227,7 @@ public class ProbableIntersectionCursorTest {
                         found.add(value);
                     }
                     return result.hasNext();
-                })).join();
+                }), intersectionCursor.getExecutor()).join();
                 RecordCursorResult<Integer> result = intersectionCursor.getNext();
                 assertThat(result.hasNext(), is(false));
                 if (result.getNoNextReason().isSourceExhausted()) {


### PR DESCRIPTION
This was somewhat subtle, but there were some tests of the probable intersection cursor that relied on `AsyncUtil.whileTrue(Supplier)`. That will then run its tasks on the default FDB executor (instead of the default Record Layer executor or something like that). That executor, `FDB.DEFAULT_EXECUTOR`, requires the `FDB` class to be initialized, which because of reasons, is the thing that actually loads the native library. So if the native library is not present, then that class initialization fails.

The reason the `prb-sonar` task is passing is that this is only problematic in places where the native library is not installed. The `prb-sonar` task runs within an environment where the native library is present, but the server is not started. Running this test in a place with neither the server nor the client produces the bug.

This fixes #586.