### PR TITLE
Fixes #399: FDBRecordStore.deleteAllRecords enables disabled indexes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -68,7 +68,7 @@ The `RecordStoreState` constructors have been deprecated or marked [`INTERNAL`](
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Deleting all records no longer resets all index states to `READABLE` [(Issue #399)](https://github.com/FoundationDB/fdb-record-layer/issues/399)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Rebuilding all indexes with `FDBRecordStore::rebuildAllIndexes` now updates the local cache of index states [(Issue #597)](https://github.com/FoundationDB/fdb-record-layer/issues/597)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -67,7 +67,7 @@ The `RecordStoreState` constructors have been deprecated or marked [`INTERNAL`](
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Deleting all records no longer resets all index states to `READABLE` [(Issue #399)](https://github.com/FoundationDB/fdb-record-layer/issues/399)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1121,8 +1121,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     public void deleteAllRecords() {
         preloadCache.invalidateAll();
         Transaction tr = ensureContextActive();
-        tr.clear(recordsSubspace().getKey(),
-                 getSubspace().range().end);
+
+        // Clear out all data except for the store header key and the index state space.
+        // Those two subspaces are determined by the configuration of the record store rather then
+        // the records.
+        Range indexStateRange = indexStateSubspace().range();
+        tr.clear(recordsSubspace().getKey(), indexStateRange.begin);
+        tr.clear(indexStateRange.end, getSubspace().range().end);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1705,13 +1705,22 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 iterator.onHasNext().thenApply(hasNext -> hasNext ? iterator.next() : null));
     }
 
+    /**
+     * Rebuild all of this store's indexes. All indexes will then be marked as {@linkplain IndexState#READABLE readable}
+     * when this function completes. Note that this will attempt to read all of the records within
+     * this store in a single transaction, so for large record stores, this can run up against transaction
+     * time and size limits. For larger stores, one should use the {@link OnlineIndexer} to build
+     * each index instead.
+     *
+     * @return a future that will complete when all of the indexes are built
+     */
     @Nonnull
     public CompletableFuture<Void> rebuildAllIndexes() {
         Transaction tr = ensureContextActive();
+        // Note that index states are *not* cleared, as rebuilding the indexes resets each state
         tr.clear(getSubspace().range(Tuple.from(INDEX_KEY)));
         tr.clear(getSubspace().range(Tuple.from(INDEX_SECONDARY_SPACE_KEY)));
         tr.clear(getSubspace().range(Tuple.from(INDEX_RANGE_SPACE_KEY)));
-        tr.clear(getSubspace().range(Tuple.from(INDEX_STATE_SPACE_KEY)));
         tr.clear(getSubspace().range(Tuple.from(INDEX_UNIQUENESS_VIOLATIONS_KEY)));
         List<CompletableFuture<Void>> work = new LinkedList<>();
         addRebuildRecordCountsJob(work);
@@ -2438,6 +2447,24 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return markIndexReadable(index).thenApply(b -> null);
     }
 
+    /**
+     * Rebuild an index. This clears the index and attempts to build it within a single transaction. Upon
+     * successful completion, the index is marked as {@linkplain IndexState#READABLE readable} and can
+     * be used to satisfy queries.
+     *
+     * <p>
+     * Because the operations all occur within a single transaction, for larger record stores,
+     * this operation can run into transaction size and time limits. (See:
+     * <a href="https://apple.github.io/foundationdb/known-limitations.html">FoundationDB Known Limitations</a>.)
+     * To build an index on such a record store, the user should use the {@link OnlineIndexer}, which
+     * breaks up work across multiple transactions to avoid those limits.
+     * </p>
+     *
+     * @param index the index to rebuild
+     * @return a future that will complete when the index build has finished
+     * @see OnlineIndexer
+     */
+    @Nonnull
     public CompletableFuture<Void> rebuildIndex(@Nonnull Index index) {
         return rebuildIndex(index, getRecordMetaData().recordTypesForIndex(index), RebuildIndexReason.EXPLICIT);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1255,7 +1255,16 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
      * Delete all the data in the record store.
      * <p>
      * Everything except the store header and index state information is cleared from the database.
-     * This is an efficient operation, since all the data is contiguous.
+     * This is is an efficient operation as all data are contiguous.
+     * This means that any {@linkplain IndexState#DISABLED disabled} or {@linkplain IndexState#WRITE_ONLY write-only}
+     * index will remain in its disabled or write-only state after all of the data are cleared. If one also wants
+     * to reset all index states, one can call {@link FDBRecordStore#rebuildAllIndexes()}, which should complete
+     * quickly on an empty record store. If one wants to remove the record store entirely (including the store
+     * header and all index states), one should call {@link FDBRecordStore#deleteStore(FDBRecordContext, KeySpacePath)}
+     * instead of this method.
+     *
+     * @see FDBRecordStore#deleteStore(FDBRecordContext, KeySpacePath)
+     * @see FDBRecordStore#deleteStore(FDBRecordContext, Subspace)
      */
     void deleteAllRecords();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1254,7 +1254,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
     /**
      * Delete all the data in the record store.
      * <p>
-     * Everything except the store header is cleared from the database.
+     * Everything except the store header and index state information is cleared from the database.
      * This is an efficient operation, since all the data is contiguous.
      */
     void deleteAllRecords();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -1009,6 +1009,25 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
             assertFalse(recordStore.recordExists(Tuple.from(1066L)));
         }
+
+        // Rebuild all indexes to reset the index states.
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            assertTrue(recordStore.isIndexDisabled(disabledIndex));
+            assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
+            recordStore.rebuildAllIndexes().get();
+            assertTrue(recordStore.isIndexReadable(disabledIndex));
+            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            commit(context);
+        }
+
+        // Verify that the index states are, in fact, updated.
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            assertTrue(recordStore.isIndexReadable(disabledIndex));
+            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            commit(context);
+        }
     }
 
     @Test
@@ -1228,30 +1247,84 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(false));
+            assertFalse(recordStore.isIndexWriteOnly(indexName));
             recordStore.markIndexWriteOnly(indexName).get();
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(true));
-            context.commit();
+            assertTrue(recordStore.isIndexWriteOnly(indexName));
+            commit(context);
         }
 
-        RecordMetaData metaData;
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            metaData = recordStore.getRecordMetaData();
             assertTrue(recordStore.isIndexWriteOnly(indexName));
         }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.rebuildIndex(recordStore.getRecordMetaData().getIndex(indexName), null, FDBRecordStore.RebuildIndexReason.TEST).get();
-            assertThat(recordStore.isIndexReadable(indexName), is(true));
-            context.commit();
+            assertTrue(recordStore.isIndexReadable(indexName));
+            commit(context);
         }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertTrue(recordStore.getRecordStoreState().compatibleWith(recordStore.getRecordStoreState()));
+        }
+    }
+
+    @Test
+    public void rebuildAll() throws Exception {
+        final String disabledIndex = "MySimpleRecord$str_value_indexed";
+        final String writeOnlyIndex = "MySimpleRecord$num_value_3_indexed";
+
+        TestRecords1Proto.MySimpleRecord record = TestRecords1Proto.MySimpleRecord.newBuilder()
+                .setRecNo(1066)
+                .setStrValueIndexed("indexed_string")
+                .setNumValue3Indexed(42)
+                .build();
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            assertTrue(recordStore.isIndexReadable(disabledIndex));
+            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            recordStore.markIndexDisabled(disabledIndex).get();
+            recordStore.markIndexWriteOnly(writeOnlyIndex).get();
+            assertTrue(recordStore.isIndexDisabled(disabledIndex));
+            assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
+            recordStore.saveRecord(record);
+            commit(context);
+        }
+
+        // Verify the write-only index was updated and the disabled one was not
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            recordStore.uncheckedMarkIndexReadable(disabledIndex).get();
+            recordStore.uncheckedMarkIndexReadable(writeOnlyIndex).get();
+            assertEquals(Collections.emptyList(),
+                    recordStore.scanIndexRecords(disabledIndex).map(FDBIndexedRecord::getRecord).asList().get());
+            assertEquals(Collections.singletonList(record),
+                    recordStore.scanIndexRecords(writeOnlyIndex).map(FDBIndexedRecord::getRecord).asList().get());
+            // do not commit
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            recordStore.rebuildAllIndexes().get();
+            assertTrue(recordStore.isIndexReadable(disabledIndex));
+            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            assertEquals(Collections.singletonList(record),
+                    recordStore.scanIndexRecords(disabledIndex).map(FDBIndexedRecord::getRecord).asList().get());
+            assertEquals(Collections.singletonList(record),
+                    recordStore.scanIndexRecords(writeOnlyIndex).map(FDBIndexedRecord::getRecord).asList().get());
+            commit(context);
+        }
+
+        // Validate that the index state updates carry over into the next transaction
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            assertTrue(recordStore.isIndexReadable(disabledIndex));
+            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
         }
     }
 


### PR DESCRIPTION
The index state space is now excluded from `deleteAllRecords`. This means that the index state information is preserved after all records are deleted. The issue, #399, mentioned that in theory, this was the "right" thing to do for write-only indexes (under the assumption that they are write only just because no one has finished building them, and now that the store is empty, there isn't need to keep them write-only). I decided to keep it simple in this fix and have it just preserve all index states, which is easier to reason about.

@amouehsan, IIRC, I was under that impression that some of the index meta-data changes (in #520?) will end up using a different subspace or something within the Record Store keyspace. I think you'll also need to update this to also exclude that region if I understand how that is supposed to work.

This fixes #399.