### PR TITLE
Fixes #602: Several tests define potentially overlapping KeySpacePaths

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerTest.java
@@ -60,8 +60,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag(Tags.RequiresFDB)
 public class FDBDatabaseRunnerTest extends FDBTestBase {
 
-    private static final Object[] PATH_OBJECTS = {"record-test", "unit"};
-
     private FDBDatabase database;
 
     @BeforeEach
@@ -158,7 +156,7 @@ public class FDBDatabaseRunnerTest extends FDBTestBase {
 
             runner.run(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(FDBRecordStoreTestBase.PATH_OBJECTS))
                         .build();
                 store.deleteRecord(Tuple.from(1066L));
                 return null;
@@ -166,7 +164,7 @@ public class FDBDatabaseRunnerTest extends FDBTestBase {
 
             FDBStoredRecord<Message> retrieved2 = runner.run(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(FDBRecordStoreTestBase.PATH_OBJECTS))
                         .build();
                 return store.loadRecord(Tuple.from(1066L));
             });
@@ -295,14 +293,14 @@ public class FDBDatabaseRunnerTest extends FDBTestBase {
         try (FDBDatabaseRunner runner = database.newRunner()) {
             runner.runAsync(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(FDBRecordStoreTestBase.PATH_OBJECTS))
                         .build();
                 return store.deleteRecordAsync(Tuple.from(1066L));
             }).join();
 
             FDBStoredRecord<Message> retrieved2 = runner.runAsync(context -> {
                 FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                        .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
+                        .setKeySpacePath(TestKeySpace.getKeyspacePath(FDBRecordStoreTestBase.PATH_OBJECTS))
                         .build();
                 return store.loadRecordAsync(Tuple.from(1066L));
             }).join();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -58,8 +58,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag(Tags.RequiresFDB)
 public class FDBDatabaseTest extends FDBTestBase {
 
-    private static final Object[] PATH_OBJECTS = {"record-test", "unit"};
-
     @Test
     public void cachedVersionMaintenanceOnReadsTest() throws Exception {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
@@ -330,7 +328,7 @@ public class FDBDatabaseTest extends FDBTestBase {
 
         database.run(context -> {
             FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                    .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
+                    .setKeySpacePath(TestKeySpace.getKeyspacePath(FDBRecordStoreTestBase.PATH_OBJECTS))
                     .build();
             store.deleteAllRecords();
             store.saveRecord(simpleRecord);
@@ -343,7 +341,7 @@ public class FDBDatabaseTest extends FDBTestBase {
         // Tests to make sure the database operations are run and committed.
         TestRecords1Proto.MySimpleRecord retrieved = database.run(context -> {
             FDBRecordStore store = FDBRecordStore.newBuilder().setMetaDataProvider(metaData).setContext(context)
-                    .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH_OBJECTS))
+                    .setKeySpacePath(TestKeySpace.getKeyspacePath(FDBRecordStoreTestBase.PATH_OBJECTS))
                     .build();
             TestRecords1Proto.MySimpleRecord.Builder builder = TestRecords1Proto.MySimpleRecord.newBuilder();
             FDBStoredRecord<Message> rec = store.loadRecord(Tuple.from(recordNumber));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -62,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public abstract class FDBRecordStoreTestBase extends FDBTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBRecordStoreTestBase.class);
 
-    private static final Object[] PATH_OBJECTS = new Object[]{"record-test", "unit", "recordStore"};
+    protected static final Object[] PATH_OBJECTS = new Object[]{"record-test", "unit", "recordStore"};
 
     protected FDBDatabase fdb;
     protected FDBRecordStore recordStore;


### PR DESCRIPTION
This arranges the tests so that they all use the `PATH_OBJECTS` defined in one place so that none of them use a prefix of the usual path as their main path.

No release notes added as this is a test-only fix. This fixes #602.