### PR TITLE
Fixes #418: Sanity checks in KeyValueCursor.build.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava version has been updated to version 27. Users of the [shaded variants]
 ### NEXT_RELEASE
 
 * **Bug fix** `OnlineIndexer.buildEndpoints` should not decrease the scan limits on conflicts [(Issue #511)](https://github.com/FoundationDB/fdb-record-layer/issues/511)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `KeyValueCursor.Builder.build` now requires `subspace`, `context` and `scanProperties` are specifed, throws RecordCoreException if not [(Issue #418)](https://github.com/FoundationDB/fdb-record-layer/issues/418)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -192,7 +192,15 @@ public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements Bas
             return new Builder(subspace);
         }
 
-        public KeyValueCursor build() {
+        public KeyValueCursor build() throws RecordCoreException {
+            if (subspace == null) {
+                throw new RecordCoreException("record subspace must be supplied");
+            }
+
+            if (context == null) {
+                throw new RecordCoreException("record context must be supplied");
+            }
+
             if (lowBytes == null) {
                 lowBytes = subspace.pack();
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -201,6 +201,10 @@ public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements Bas
                 throw new RecordCoreException("record context must be supplied");
             }
 
+            if (scanProperties == null) {
+                throw new RecordCoreException("record scanProperties must be supplied");
+            }
+
             if (lowBytes == null) {
                 lowBytes = subspace.pack();
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -440,7 +440,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     }
 
     @Test
-    public void buildWitRequiredProperties() {
+    public void buildWithRequiredProperties() {
         fdb.run(context -> {
             try {
                 RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.ExecuteState;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -419,4 +420,52 @@ public class KeyValueCursorTest extends FDBTestBase {
             return null;
         });
     }
+
+    @Test
+    public void buildWithoutRequiredProperties() {
+        try {
+            RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
+                                                .build();
+            // Program flow should not reach here.
+            assertTrue(false);
+        } catch (RecordCoreException ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void buildWithoutScanProperties() {
+        fdb.run(context -> {
+            try {
+                RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
+                                                    .setContext(context)
+                                                    .build();
+                // Program flow should not reach here.
+                assertTrue(false);
+            } catch (RecordCoreException ex) {
+                assertTrue(true);
+            }
+
+            return null;
+        });
+    }
+
+    @Test
+    public void buildWitRequiredProperties() {
+        fdb.run(context -> {
+            try {
+                RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
+                                                    .setContext(context)
+                                                    .setScanProperties(ScanProperties.FORWARD_SCAN)
+                                                    .build();
+                assertTrue(true);
+            } catch (RecordCoreException ex) {
+                // Program flow should not reach here.
+                assertTrue(false);
+            }
+
+            return null;
+        });
+    }
+
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -423,28 +424,16 @@ public class KeyValueCursorTest extends FDBTestBase {
 
     @Test
     public void buildWithoutRequiredProperties() {
-        try {
-            RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
-                                                .build();
-            // Program flow should not reach here.
-            assertTrue(false);
-        } catch (RecordCoreException ex) {
-            assertTrue(true);
-        }
+        assertThrows(RecordCoreException.class, () -> KeyValueCursor.Builder.withSubspace(subspace)
+                                                        .build());
     }
 
     @Test
     public void buildWithoutScanProperties() {
         fdb.run(context -> {
-            try {
-                RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
-                                                    .setContext(context)
-                                                    .build();
-                // Program flow should not reach here.
-                assertTrue(false);
-            } catch (RecordCoreException ex) {
-                assertTrue(true);
-            }
+            assertThrows(RecordCoreException.class, () -> KeyValueCursor.Builder.withSubspace(subspace)
+                                                            .setContext(context)
+                                                            .build());
 
             return null;
         });


### PR DESCRIPTION
- This fix adds some sanity checks to the KeyValueCursor.build().
- This change ensures that 'subspace' and 'context' are specified when this
  method is invoked.
- This guarantees that no KeyValueCursors are instantiated without these two
  properties being specified.