### PR TITLE
Fixes #616: Javadoc build on Java 11 fails complaining about modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ subprojects {
                 exclude "**/*ProtoV3.java"
                 // warnings are errors
                 options.addBooleanOption('Xwerror', true)
+                options.addStringOption('source', '8')
                 options.with {
                     overview "src/main/javadoc/overview.html"
 


### PR DESCRIPTION
This was fixed by telling Javadoc to assume that it was looking at Java 8 source...which it is.

No release notes as this only affects the build system and not the published artifacts. This fixes #616.