### PR TITLE
Fixes #628: Ergonomic improvements to Hamcrest matchers.

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -215,7 +215,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreTestBase {
 
             assertEquals(recs.subList(0, 2), recordStore.executeQuery(query)
                     .map(FDBQueriedRecord::getStoredRecord).asList().join());
-            assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(unbounded()))));
+            assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), unbounded())));
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
@@ -1183,7 +1183,7 @@ public class VersionIndexTest extends FDBTestBase {
             assertEquals(version1, loadedRecord.getVersion());
 
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, indexScan(indexName("globalVersion")));
+            assertThat(plan, indexScan("globalVersion"));
             List<FDBQueriedRecord<Message>> records = recordStore.executeQuery(plan).asList().join();
             assertEquals(1, records.size());
             FDBQueriedRecord<Message> queriedRecord = records.get(0);
@@ -1229,7 +1229,7 @@ public class VersionIndexTest extends FDBTestBase {
             assertEquals(version3, loadedRecord3.getVersion());
 
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, indexScan(indexName("globalVersion2")));
+            assertThat(plan, indexScan("globalVersion2"));
             List<FDBQueriedRecord<Message>> records = recordStore.executeQuery(plan).asList().join();
             assertEquals(3, records.size());
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -1285,7 +1285,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     @Nonnull
     private List<Long> querySimpleDocumentsWithScan(@Nonnull QueryComponent filter, int planHash) throws InterruptedException, ExecutionException {
         return queryDocuments(Collections.singletonList(SIMPLE_DOC), Collections.singletonList(field("doc_id")), filter, planHash,
-                    filter(equalTo(BooleanNormalizer.getDefaultInstance().normalize(filter)), typeFilter(contains(SIMPLE_DOC), PlanMatchers.scan(bounds(unbounded())))))
+                    filter(equalTo(BooleanNormalizer.getDefaultInstance().normalize(filter)), typeFilter(contains(SIMPLE_DOC), PlanMatchers.scan(unbounded()))))
                 .map(t -> t.getLong(0))
                 .asList()
                 .get();
@@ -2264,7 +2264,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     @Nonnull
     private List<Long> queryMapDocumentsWithScan(@Nonnull QueryComponent filter, int planHash) throws InterruptedException, ExecutionException {
         return queryDocuments(Collections.singletonList(MAP_DOC), Collections.singletonList(field("doc_id")), filter, planHash,
-                filter(equalTo(filter), typeFilter(equalTo(Collections.singleton(MAP_DOC)), PlanMatchers.scan(bounds(unbounded())))))
+                filter(equalTo(filter), typeFilter(equalTo(Collections.singleton(MAP_DOC)), PlanMatchers.scan(unbounded()))))
                 .map(t -> t.getLong(0))
                 .asList()
                 .get();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
@@ -263,7 +263,7 @@ public class FDBAndQueryToIntersectionTest extends FDBRecordStoreQueryTestBase {
         planner.setIndexScanPreference(QueryPlanner.IndexScanPreference.PREFER_SCAN);
         RecordQueryPlan plan = planner.plan(query);
         // Would get Intersection didn't have identical continuations if it did
-        assertThat("Should not use grouped index", plan, hasNoDescendant(indexScan(indexName("grouped_index"))));
+        assertThat("Should not use grouped index", plan, hasNoDescendant(indexScan("grouped_index")));
         assertEquals(622816289, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -387,7 +387,7 @@ public class FDBAndQueryToIntersectionTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_3_indexed").lessThanOrEquals(3)))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat("should have range scan in " + plan, plan, descendant(indexScan(indexName("index_2_3"))));
+        assertThat("should have range scan in " + plan, plan, descendant(indexScan("index_2_3")));
         assertFalse(plan.hasRecordScan(), "should not use record scan");
         assertEquals(1840965325, plan.planHash());
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCollateQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCollateQueryTest.java
@@ -183,7 +183,7 @@ public abstract class FDBCollateQueryTest extends FDBRecordStoreQueryTestBase {
         final List<String> expected = Arrays.asList("Ørsted", "Ångström");
         assertEquals(expected, actual);
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, indexScan(indexName("collated_name")));
+        assertThat(plan, indexScan("collated_name"));
     }
 
     @Test
@@ -206,7 +206,7 @@ public abstract class FDBCollateQueryTest extends FDBRecordStoreQueryTestBase {
         final List<String> expected = Arrays.asList("Ampère");
         assertEquals(expected, actual);
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(indexScan(indexName("collated_name"))));
+        assertThat(plan, coveringIndexScan(indexScan("collated_name")));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
@@ -120,7 +120,7 @@ public class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setRequiredResults(Collections.singletonList(field("num_value_3_indexed")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(unbounded())))));
+        assertThat(plan, coveringIndexScan(indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), unbounded()))));
         assertEquals(413789395, plan.planHash());
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
@@ -87,7 +87,7 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
                 .setSort(field("etag"))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        MatcherAssert.assertThat(plan, indexScan(allOf(indexName("versions"), bounds(unbounded()))));
+        MatcherAssert.assertThat(plan, indexScan(allOf(indexName("versions"), unbounded())));
         assertEquals(1555932709, plan.planHash());
 
         List<String> names = new ArrayList<>();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
@@ -102,7 +102,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("num_value_2").in(asList(0, 2)))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(bounds(unbounded())))));
+        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(unbounded()))));
         assertEquals(-1139367309, plan.planHash());
         assertEquals(67, querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty,
                 record -> assertThat(record.getNumValue2(), anyOf(is(0), is(2))),
@@ -120,7 +120,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("num_value_2").in("valuesThree"))    // num_value_2 is i%3
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(bounds(unbounded())))));
+        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(unbounded()))));
         assertEquals(-1677754243, plan.planHash());
         assertEquals(33, querySimpleRecordStore(NO_HOOK, plan,
                 () -> EvaluationContext.forBinding("valuesThree", asList(1, 3)),
@@ -207,7 +207,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.not(Query.field("num_value_3_indexed").in("valueThrees")))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(bounds(unbounded())))));
+        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(unbounded()))));
         assertEquals(1667070459, plan.planHash());
         assertEquals(100, querySimpleRecordStore(NO_HOOK, plan,
                 () -> EvaluationContext.forBinding("valueThrees", Collections.emptyList()),
@@ -254,7 +254,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .build();
         RecordQueryPlan plan = planner.plan(query);
         // IN join is cancelled on account of incompatible sorting.
-        assertThat(plan, filter(equalTo(query.getFilter()), indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(unbounded())))));
+        assertThat(plan, filter(equalTo(query.getFilter()), indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), unbounded()))));
         assertEquals(1775865786, plan.planHash());
         assertEquals(60, querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty,
                 record -> assertThat(record.getNumValue3Indexed(), anyOf(is(1), is(2), is(4))),
@@ -771,7 +771,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("num_value_2").in(ls))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(bounds(unbounded())))));
+        assertThat(plan, filter(equalTo(query.getFilter()), descendant(scan(unbounded()))));
         assertEquals(-1139440926, plan.planHash());
         assertEquals(0, querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty, (rec) -> {
         }));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
@@ -586,7 +586,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .build();
         RecordQueryPlan plan = planner.plan(query);
         assertThat(plan, union(
-                indexScan(indexName("MySimpleRecord$num_value_unique")),
+                indexScan("MySimpleRecord$num_value_unique"),
                 inValues(equalTo(Arrays.asList(901, 903, 905)),
                         indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), bounds(hasTupleString("[EQUALS $__in_num_value_unique__0]"))))),
                 equalTo(concat(field("num_value_unique"), primaryKey("MySimpleRecord")))));
@@ -738,7 +738,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                         TestRecordsEnumProto.MyShapeRecord.Color.BLUE)))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, descendant(indexScan(indexName("color"))));
+        assertThat(plan, descendant(indexScan("color")));
         assertFalse(plan.hasRecordScan(), "should not use record scan");
         assertEquals(-520431454, plan.planHash());
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreIndexScanPreferenceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreIndexScanPreferenceTest.java
@@ -58,7 +58,7 @@ public class FDBRecordStoreIndexScanPreferenceTest extends FDBRecordStoreQueryTe
         for (QueryPlanner.IndexScanPreference indexScanPreference : QueryPlanner.IndexScanPreference.values()) {
             planner.setIndexScanPreference(indexScanPreference);
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, scan(bounds(unbounded())));
+            assertThat(plan, scan(unbounded()));
         }
     }
 
@@ -76,8 +76,8 @@ public class FDBRecordStoreIndexScanPreferenceTest extends FDBRecordStoreQueryTe
             planner.setIndexScanPreference(indexScanPreference);
             RecordQueryPlan plan = planner.plan(query);
             assertThat(plan, indexScanPreference == QueryPlanner.IndexScanPreference.PREFER_INDEX ?
-                             indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(unbounded()))) :
-                             typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))));
+                             indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), unbounded())) :
+                             typeFilter(contains("MySimpleRecord"), scan(unbounded())));
         }
     }
 
@@ -97,8 +97,8 @@ public class FDBRecordStoreIndexScanPreferenceTest extends FDBRecordStoreQueryTe
             planner.setIndexScanPreference(indexScanPreference);
             RecordQueryPlan plan = planner.plan(query);
             assertThat(plan, indexScanPreference == QueryPlanner.IndexScanPreference.PREFER_SCAN ?
-                             typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))) :
-                             indexScan(allOf(indexName("pkey"), bounds(unbounded()))));
+                             typeFilter(contains("MySimpleRecord"), scan(unbounded())) :
+                             indexScan(allOf(indexName("pkey"), unbounded())));
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreIndexScanPreferenceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreIndexScanPreferenceTest.java
@@ -29,7 +29,6 @@ import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scan;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
@@ -221,7 +221,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
 
             RecordQuery query = RecordQuery.newBuilder().setRecordType("MySimpleRecord").setAllowedIndexes(Collections.emptyList()).build();
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))));
+            assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(unbounded())));
             assertEquals(1623132305, plan.planHash());
             byte[] continuation = null;
             List<TestRecords1Proto.MySimpleRecord> retrieved = new ArrayList<>(100);
@@ -283,7 +283,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
                     .setFilter(Query.field("num_value_2").equalsValue(0))
                     .build();
             plan = planner.plan(query);
-            assertThat(plan, filter(equalTo(query.getFilter()), typeFilter(anything(), scan(bounds(unbounded())))));
+            assertThat(plan, filter(equalTo(query.getFilter()), typeFilter(anything(), scan(unbounded()))));
             assertEquals(913370491, plan.planHash());
             continuation = null;
             retrieved = new ArrayList<>(50);
@@ -601,7 +601,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
                     .build();
             RecordQueryPlan plan = planner.plan(query);
             assertThat(plan, filter(equalTo(query.getFilter()),
-                    typeFilter(containsInAnyOrder("MultiRecordTwo", "MultiRecordThree"), scan(bounds(unbounded())))));
+                    typeFilter(containsInAnyOrder("MultiRecordTwo", "MultiRecordThree"), scan(unbounded()))));
             assertEquals(1808059644, plan.planHash());
             assertEquals(Arrays.asList(800L, 1776L),
                     recordStore.executeQuery(plan)
@@ -617,7 +617,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
                     .build();
             plan = planner.plan(query);
             assertThat(plan, filter(equalTo(query.getFilter()),
-                    typeFilter(containsInAnyOrder("MultiRecordOne", "MultiRecordTwo"), scan(bounds(unbounded())))));
+                    typeFilter(containsInAnyOrder("MultiRecordOne", "MultiRecordTwo"), scan(unbounded()))));
             assertEquals(-663593392, plan.planHash());
             assertEquals(Arrays.asList(948L, 1066L, 1776L),
                     recordStore.executeQuery(plan)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
@@ -454,7 +454,7 @@ public class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("color").equalsValue(TestRecordsEnumProto.MyShapeRecord.Color.RED))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, indexScan(indexName("color")));
+        assertThat(plan, indexScan("color"));
         assertFalse(plan.hasRecordScan(), "should not use record scan");
         assertEquals(1393755963, plan.planHash());
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
@@ -151,7 +151,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("s1").oneOfThem().greaterThan("b"))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, filter(equalTo(query.getFilter()), scan(bounds(unbounded()))));
+        assertThat(plan, filter(equalTo(query.getFilter()), scan(unbounded())));
         assertEquals(972152650, plan.planHash());
         assertEquals(Arrays.asList(1L), fetchResultValues(plan, TestRecords6Proto.MyRepeatedRecord.REC_NO_FIELD_NUMBER,
                 this::openDoublyRepeatedRecordStore,
@@ -272,7 +272,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                     .setSort(field("reviews", FanType.FanOut).nest("rating"));
             RecordQuery query = builder.setRemoveDuplicates(false).build();
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, indexScan(allOf(indexName("review_rating"), bounds(unbounded()))));
+            assertThat(plan, indexScan(allOf(indexName("review_rating"), unbounded())));
             assertEquals(406416366, plan.planHash());
             assertEquals(Arrays.asList(1000L, 1001L, 1000L, 1001L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
                     this::openNestedRecordStore,
@@ -280,7 +280,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
 
             query = builder.setRemoveDuplicates(true).build();
             plan = planner.plan(query);
-            assertThat(plan, primaryKeyDistinct(indexScan(allOf(indexName("review_rating"), bounds(unbounded())))));
+            assertThat(plan, primaryKeyDistinct(indexScan(allOf(indexName("review_rating"), unbounded()))));
             assertEquals(406416367, plan.planHash());
             assertEquals(Arrays.asList(1000L, 1001L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
                     this::openNestedRecordStore,
@@ -292,7 +292,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                     .setSort(field("reviews", FanType.FanOut).nest("rating"), true);
             RecordQuery query = builder.setRemoveDuplicates(false).build();
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, indexScan(allOf(indexName("review_rating"), bounds(unbounded()))));
+            assertThat(plan, indexScan(allOf(indexName("review_rating"), unbounded())));
             assertTrue(plan.isReverse());
             assertEquals(406416367, plan.planHash());
             assertEquals(Arrays.asList(1001L, 1000L, 1001L, 1000L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
@@ -301,7 +301,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
 
             query = builder.setRemoveDuplicates(true).build();
             plan = planner.plan(query);
-            assertThat(plan, primaryKeyDistinct(indexScan(allOf(indexName("review_rating"), bounds(unbounded())))));
+            assertThat(plan, primaryKeyDistinct(indexScan(allOf(indexName("review_rating"), unbounded()))));
             assertTrue(plan.isReverse());
             assertEquals(406416368, plan.planHash());
             assertEquals(Arrays.asList(1001L, 1000L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
@@ -315,7 +315,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                     .setFilter(Query.field("name").greaterThan("A"));
             RecordQuery query = builder.setRemoveDuplicates(false).build();
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, filter(equalTo(query.getFilter()), indexScan(allOf(indexName("review_rating"), bounds(unbounded())))));
+            assertThat(plan, filter(equalTo(query.getFilter()), indexScan(allOf(indexName("review_rating"), unbounded()))));
             assertEquals(1381942688, plan.planHash());
             assertEquals(Arrays.asList(1000L, 1001L, 1000L, 1001L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
                     this::openNestedRecordStore,
@@ -324,7 +324,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
             query = builder.setRemoveDuplicates(true).build();
             plan = planner.plan(query);
             assertThat(plan, filter(equalTo(query.getFilter()), primaryKeyDistinct(
-                    indexScan(allOf(indexName("review_rating"), bounds(unbounded()))))));
+                    indexScan(allOf(indexName("review_rating"), unbounded())))));
             assertEquals(1381942689, plan.planHash());
             assertEquals(Arrays.asList(1000L, 1001L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
                     this::openNestedRecordStore,
@@ -337,7 +337,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                     .setFilter(Query.field("name").greaterThan("A"));
             RecordQuery query = builder.setRemoveDuplicates(false).build();
             RecordQueryPlan plan = planner.plan(query);
-            assertThat(plan, filter(equalTo(query.getFilter()), indexScan(allOf(indexName("customers"), bounds(unbounded())))));
+            assertThat(plan, filter(equalTo(query.getFilter()), indexScan(allOf(indexName("customers"), unbounded()))));
             assertEquals(1833106833, plan.planHash());
             assertEquals(Arrays.asList(1000L, 1001L, 1000L, 1001L, 1000L, 1000L, 1001L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
                     this::openNestedRecordStore,
@@ -346,7 +346,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
             query = builder.setRemoveDuplicates(true).build();
             plan = planner.plan(query);
             assertThat(plan, filter(equalTo(query.getFilter()), primaryKeyDistinct(
-                    indexScan(allOf(indexName("customers"), bounds(unbounded()))))));
+                    indexScan(allOf(indexName("customers"), unbounded())))));
             assertEquals(1833106834, plan.planHash());
             assertEquals(Arrays.asList(1000L, 1001L), fetchResultValues(plan, TestRecords4Proto.RestaurantRecord.REST_NO_FIELD_NUMBER,
                     this::openNestedRecordStore,
@@ -482,7 +482,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("num_value_2").equalsValue(1))
                 .build();
         RecordQueryPlan plan1 = planner.plan(query1);
-        assertThat(plan1, filter(anything(), typeFilter(anything(), scan(bounds(unbounded())))));
+        assertThat(plan1, filter(anything(), typeFilter(anything(), scan(unbounded()))));
         assertEquals(913370492, plan1.planHash());
 
         RecordQuery query2 = RecordQuery.newBuilder()
@@ -539,7 +539,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                 .setRecordType("MySimpleRecord")
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))));
+        assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(unbounded())));
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
@@ -603,7 +603,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(filter)
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, filter(equalTo(filter), scan(bounds(unbounded()))));
+        assertThat(plan, filter(equalTo(filter), scan(unbounded())));
 
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeader(context, hook);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRestrictedIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRestrictedIndexQueryTest.java
@@ -390,7 +390,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("str_value_indexed").equalsValue("abc"))
                 .build();
         RecordQueryPlan plan1 = planner.plan(query1);
-        assertThat("should not use prohibited index", plan1, hasNoDescendant(indexScan(indexName("limited_str_value_index"))));
+        assertThat("should not use prohibited index", plan1, hasNoDescendant(indexScan("limited_str_value_index")));
         assertTrue(plan1.hasFullRecordScan(), "should use full record scan");
         assertEquals(-223683769, plan1.planHash());
 
@@ -413,7 +413,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setAllowedIndex("limited_str_value_index")
                 .build();
         RecordQueryPlan plan2 = planner.plan(query2);
-        assertThat("explicitly use prohibited index", plan2, descendant(indexScan(indexName("limited_str_value_index"))));
+        assertThat("explicitly use prohibited index", plan2, descendant(indexScan("limited_str_value_index")));
         assertFalse(plan2.hasRecordScan(), "should not use record scan");
         assertEquals(-1573180774, plan2.planHash());
 
@@ -451,7 +451,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.field("num_value_2").equalsValue(123))
                 .build();
         RecordQueryPlan plan1 = planner.plan(query1);
-        assertThat("should not use prohibited index", plan1, hasNoDescendant(indexScan(indexName("universal_num_value_2"))));
+        assertThat("should not use prohibited index", plan1, hasNoDescendant(indexScan("universal_num_value_2")));
         assertTrue(plan1.hasFullRecordScan(), "should use full record scan");
         assertEquals(-709761689, plan1.planHash());
 
@@ -460,7 +460,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 .setAllowedIndex("universal_num_value_2")
                 .build();
         RecordQueryPlan plan2 = planner.plan(query2);
-        assertThat("explicitly use prohibited index", plan2, descendant(indexScan(indexName("universal_num_value_2"))));
+        assertThat("explicitly use prohibited index", plan2, descendant(indexScan("universal_num_value_2")));
         assertFalse(plan2.hasRecordScan(), "should not use record scan");
         assertEquals(-1692774119, plan2.planHash());
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBReturnedRecordLimitQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBReturnedRecordLimitQueryTest.java
@@ -77,7 +77,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
                 .build();
         RecordQueryPlan plan = planner.plan(query);
         assertThat(plan, filter(equalTo(query.getFilter()),
-                indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(unbounded())))));
+                indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), unbounded()))));
         assertTrue(plan.isReverse());
         assertEquals(-384998859, plan.planHash());
 
@@ -111,7 +111,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
                 .setFilter(Query.field("num_value_2").equalsValue(0))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, descendant(scan(bounds(unbounded()))));
+        assertThat(plan, descendant(scan(unbounded())));
         assertEquals(913370491, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -140,7 +140,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder().setRecordType("MySimpleRecord").setAllowedIndexes(Collections.emptyList()).build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))));
+        assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(unbounded())));
         assertEquals(1623132305, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -169,7 +169,7 @@ public class FDBReturnedRecordLimitQueryTest extends FDBRecordStoreQueryTestBase
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder().setRecordTypes(Arrays.asList("MySimpleRecord", "MyOtherRecord")).build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, scan(bounds(unbounded())));
+        assertThat(plan, scan(unbounded()));
         assertEquals(2, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
@@ -141,7 +141,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 .setSort(field("num_value_unique"))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), bounds(unbounded()))));
+        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), unbounded())));
         assertEquals(-1130465929, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -210,7 +210,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
         setupPlanner(indexTypes);
         RecordQueryPlan plan = planner.plan(query);
         assertThat(plan, filter(equalTo(query.getFilter()),
-                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(unbounded())))));
+                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), unbounded()))));
         assertEquals(-799849347, plan.planHash());
 
         AtomicInteger lastNumValue3 = new AtomicInteger(Integer.MIN_VALUE);
@@ -245,7 +245,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
         setupPlanner(indexTypes);
         RecordQueryPlan plan = planner.plan(query);
         assertThat(plan, filter(equalTo(query.getFilter()),
-                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(unbounded())))));
+                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), unbounded()))));
         assertEquals(735933204, plan.planHash());
 
         AtomicInteger lastNumValue3 = new AtomicInteger(Integer.MIN_VALUE);
@@ -275,7 +275,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 .setSort(field("rec_no"), reverse.toBoolean())
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded()))));
+        assertThat(plan, typeFilter(contains("MySimpleRecord"), scan(unbounded())));
 
         AtomicLong lastId = new AtomicLong(reverse.toBoolean() ? 99L : 0L);
         int returned = querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty,
@@ -326,7 +326,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 planHash,
                 expectedReturn,
                 100 - expectedReturn,
-                filter(equalTo(filter), typeFilter(contains("MySimpleRecord"), scan(bounds(unbounded())))),
+                filter(equalTo(filter), typeFilter(contains("MySimpleRecord"), scan(unbounded()))),
                 checkRecord
         );
     }
@@ -441,7 +441,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 .setSort(field("num_value_unique"))
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), bounds(unbounded()))));
+        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), unbounded())));
         assertEquals(-1130465929, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -473,7 +473,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 .setSort(field("num_value_unique"), true)
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), bounds(unbounded()))));
+        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), unbounded())));
         assertTrue(plan.isReverse(), "plan should have reversal");
         assertEquals(-1130465928, plan.planHash());
 
@@ -509,7 +509,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 .build();
         RecordQueryPlan plan = planner.plan(query);
         assertThat(plan, filter(equalTo(query.getFilter()),
-                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(unbounded())))));
+                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), unbounded()))));
         assertEquals(-1429997503, plan.planHash());
 
         try (FDBRecordContext context = openContext()) {
@@ -541,7 +541,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 .setSort(field("str_value_indexed"), true)
                 .build();
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(unbounded()))));
+        assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), unbounded())));
         assertTrue(plan.isReverse(), "plan is reversed");
         assertEquals(324762955, plan.planHash());
 
@@ -592,7 +592,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                         .setSort(field("header").nest("num"))
                         .build();
                 RecordQueryPlan plan = planner.plan(query);
-                assertThat(plan, indexScan(allOf(indexName("MyRecord$header_num"), bounds(unbounded()))));
+                assertThat(plan, indexScan(allOf(indexName("MyRecord$header_num"), unbounded())));
                 assertEquals(-1173952475, plan.planHash());
 
                 int i = 0;
@@ -672,7 +672,7 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                         .build();
                 RecordQueryPlan plan = planner.plan(query);
                 assertThat(plan, filter(equalTo(query.getFilter()),
-                        indexScan(allOf(indexName("MyRecord$header_num"), bounds(unbounded())))));
+                        indexScan(allOf(indexName("MyRecord$header_num"), unbounded()))));
                 assertEquals(1936972136, plan.planHash());
 
                 try (RecordCursorIterator<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan).asIterator()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
@@ -93,16 +93,16 @@ public class PlanMatchers {
         return new IndexMatcher.BoundsMatcher(boundsMatcher);
     }
 
+    public static Matcher<RecordQueryPlanWithComparisons> unbounded() {
+        return new IndexMatcher.BoundsMatcher(new ScanComparisonsEmptyMatcher());
+    }
+
     public static Matcher<ScanComparisons> hasTupleString(@Nonnull Matcher<String> stringMatcher) {
         return new ScanComparisonsStringMatcher(stringMatcher);
     }
 
     public static Matcher<ScanComparisons> hasTupleString(@Nonnull String string) {
         return hasTupleString(equalTo(string));
-    }
-
-    public static Matcher<ScanComparisons> unbounded() {
-        return new ScanComparisonsEmptyMatcher();
     }
 
     public static Matcher<RecordQueryPlan> coveringIndexScan(@Nonnull Matcher<? super RecordQueryPlan> childMatcher) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
@@ -57,6 +57,10 @@ public class PlanMatchers {
         return new IndexMatcher(planMatcher);
     }
 
+    public static Matcher<RecordQueryPlan> indexScan(@Nonnull final String indexName) {
+        return indexScan(indexName(indexName));
+    }
+
     public static Matcher<RecordQueryPlan> textIndexScan(@Nonnull Matcher<? super RecordQueryTextIndexPlan> planMatcher) {
         return new TextIndexMatcher(planMatcher);
     }


### PR DESCRIPTION
- Added 'PlanMatchers.unbounded' thats returns
  'Matcher<RecordQueryPlanWithComparisons>'.
- Using this overload in all instances where 'bounds(unbounded())' was used.
- Next commit will simplify 'PlanMatchers.nextScan' usage.