### PR TITLE
Resolves #606: Update commons-lang3 version

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** The version of the `commons-lang3` dependency has been upgraded to version 3.9 [(Issue #606)](https://github.com/FoundationDB/fdb-record-layer/issues/606)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 fdbVersion=6.0.15
 jsr305Version=3.0.1
 slf4jVersion=1.7.14
-commonsLang3Version=3.1
+commonsLang3Version=3.9
 log4jVersion=2.4.1
 guavaVersion=27.0.1-jre
 autoServiceVersion=1.0-rc4


### PR DESCRIPTION
This updates it to 3.9, which is the most recent release. According to the release notes of that dependency, this is the first version to support Java 11, so if we want the Record Layer to support Java 11, I think this is the version we want. (There were some fixes to the `SystemUtil.IS_JAVA_XX` thing for versions newer than 8, but we weren't using that feature anyway.)

Note that this is against the 2.8 branch instead of master. I think that this might be overkill, as it's not clear if there's anything so different between 3.9 and 3.1 in the dependency (based on its release notes), but I felt like it would be safer so that people who are pinned to a minor release (e.g., 2.7) don't see their dependencies change without notice.

This resolves #606.