### PR TITLE
Resolves #537: Invalidate store state caches using the meta-data version key in FDB 6.1

### DIFF
--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,8 +1,8 @@
 FROM centos:7
-LABEL version=0.0.10
+LABEL version=0.0.11
 
 RUN yum install -y java-1.8.0-openjdk-devel python git unzip wget which time
-RUN yum install -y https://www.foundationdb.org/downloads/6.0.15/rhel6/installers/foundationdb-clients-6.0.15-1.el6.x86_64.rpm nmap
+RUN yum install -y https://www.foundationdb.org/downloads/6.1.8/rhel6/installers/foundationdb-clients-6.1.8-1.el6.x86_64.rpm nmap
 
 RUN mkdir -p /usr/local/bin
 COPY fdb_create_cluster_file.bash /usr/local/bin/fdb_create_cluster_file.bash

--- a/build/Dockerfile.fdbserver
+++ b/build/Dockerfile.fdbserver
@@ -1,7 +1,7 @@
 FROM centos:7
-LABEL version=6.0.15
+LABEL version=6.1.8
 
-RUN yum install -y which initscripts rsync net-tools passwd https://www.foundationdb.org/downloads/6.0.15/rhel6/installers/foundationdb-clients-6.0.15-1.el6.x86_64.rpm https://www.foundationdb.org/downloads/6.0.15/rhel6/installers/foundationdb-server-6.0.15-1.el6.x86_64.rpm
+RUN yum install -y which initscripts rsync net-tools passwd https://www.foundationdb.org/downloads/6.1.8/rhel6/installers/foundationdb-clients-6.1.8-1.el6.x86_64.rpm https://www.foundationdb.org/downloads/6.1.8/rhel6/installers/foundationdb-server-6.1.8-1.el6.x86_64.rpm
 
 USER root
 

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: fdb-record-layer-build:0.0.10
+    image: fdb-record-layer-build:0.0.11
     build:
       context: .
       dockerfile: Dockerfile.build
@@ -17,7 +17,7 @@ services:
       - FDBHOSTNAME=fdbserver
 
   fdbserver:
-    image: foundationdb-server:6.0.15
+    image: foundationdb-server:6.1.8
     environment:
       - FDBSTARTOPT=2
       - HOST_IP=0.0.0.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,6 +6,10 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ## 2.8
 
+### Breaking Changes
+
+This version of the Record Layer requires a FoundationDB server version of at least version 6.1. Attempting to connect to older versions may result in the client hanging when attempting to connect to the database.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -29,7 +33,7 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** The Record Layer now requires a minimum FoundationDB version of 6.1 [(Issue #551)](https://github.com/FoundationDB/fdb-record-layer/issues/551)
 
 // end next release
 -->

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
@@ -112,7 +112,7 @@ public class RangeSetTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        db = FDB.selectAPIVersion(600).open();
+        db = FDB.selectAPIVersion(610).open();
         rsSubspace = DirectoryLayer.getDefault().createOrOpen(db, PathUtil.from(getClass().getSimpleName())).get();
         rs = new RangeSet(rsSubspace);
         rs.clear(db).join();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
@@ -61,7 +61,7 @@ public class RankedSetTest
 
     @BeforeEach
     public void setUp() throws Exception {
-        FDB fdb = FDB.selectAPIVersion(600);
+        FDB fdb = FDB.selectAPIVersion(610);
         if (TRACE) {
             NetworkOptions options = fdb.options();
             options.setTraceEnable("/tmp");
@@ -109,11 +109,13 @@ public class RankedSetTest
         });
         Transaction tr1 = db.createTransaction();
         if (TRACE) {
-            tr1.options().setTransactionLoggingEnable("tr1");
+            tr1.options().setDebugTransactionIdentifier("tr1");
+            tr1.options().setLogTransaction();
         }
         Transaction tr2 = db.createTransaction();
         if (TRACE) {
-            tr2.options().setTransactionLoggingEnable("tr2");
+            tr2.options().setDebugTransactionIdentifier("tr2");
+            tr2.options().setLogTransaction();
         }
         rs.add(tr1, Tuple.from(30).pack()).join();
         rs.add(tr2, Tuple.from(40).pack()).join();
@@ -137,11 +139,13 @@ public class RankedSetTest
         });
         Transaction tr1 = db.createTransaction();
         if (TRACE) {
-            tr1.options().setTransactionLoggingEnable("tr1");
+            tr1.options().setDebugTransactionIdentifier("tr1");
+            tr1.options().setLogTransaction();
         }
         Transaction tr2 = db.createTransaction();
         if (TRACE) {
-            tr2.options().setTransactionLoggingEnable("tr2");
+            tr2.options().setDebugTransactionIdentifier("tr2");
+            tr2.options().setLogTransaction();
         }
         // Will remove from all levels.
         rs.remove(tr1, Tuple.from(20).pack()).join();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
@@ -104,7 +104,7 @@ public class BunchedMapScanTest {
 
     @BeforeAll
     public static void setup() throws InterruptedException, ExecutionException {
-        FDB fdb = FDB.selectAPIVersion(600);
+        FDB fdb = FDB.selectAPIVersion(610);
         fdb.setUnclosedWarning(true);
         db = fdb.open();
         bmSubspace = DirectoryLayer.getDefault().createOrOpen(db, PathUtil.from(BunchedMapIterator.class.getSimpleName())).get();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -55,7 +55,7 @@ public class FDBDatabaseFactory {
      * {@link com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver} retrieval requests.
      */
     public static final int DEFAULT_DIRECTORY_CACHE_SIZE = 5000;
-    private static final int API_VERSION = 600;
+    private static final int API_VERSION = 610;
 
     @Nonnull
     private static final FDBDatabaseFactory INSTANCE = new FDBDatabaseFactory();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
@@ -188,4 +188,16 @@ public class FDBExceptions {
         }
         return false;
     }
+
+    @Nullable
+    public static FDBException getFDBCause(@Nullable Throwable ex) {
+        Throwable current = ex;
+        while (current != null) {
+            if (current instanceof FDBException) {
+                return (FDBException)current;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -116,7 +116,8 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         if (transactionIsTraced) {
             final String uuid = mdcContext == null ? null : mdcContext.get("uuid");
             if (uuid != null) {
-                transaction.options().setTransactionLoggingEnable(uuid);
+                transaction.options().setDebugTransactionIdentifier(uuid);
+                transaction.options().setLogTransaction();
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -117,6 +117,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -170,9 +171,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     public static final int SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION = 5;
     // 6 - store record version at a split point within the record
     public static final int SAVE_VERSION_WITH_RECORD_FORMAT_VERSION = 6;
+    // 7 - allow the record store state to be cached and invalidated with the meta-data version key
+    public static final int CACHEABLE_STATE_FORMAT_VERSION = 7;
 
     // The current code can read and write up to the format version below
-    public static final int MAX_SUPPORTED_FORMAT_VERSION = SAVE_VERSION_WITH_RECORD_FORMAT_VERSION;
+    public static final int MAX_SUPPORTED_FORMAT_VERSION = CACHEABLE_STATE_FORMAT_VERSION;
 
     // Record stores attempt to upgrade to this version
     public static final int DEFAULT_FORMAT_VERSION = MAX_SUPPORTED_FORMAT_VERSION;
@@ -1105,15 +1108,44 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return context.instrument(FDBStoreTimer.Events.DELETE_RECORD, result);
     }
 
+    /**
+     * Delete the record store at the given {@link KeySpacePath}. This behaves like
+     * {@link #deleteStore(FDBRecordContext, Subspace)} on the record store saved
+     * at {@link KeySpacePath#toSubspace(FDBRecordContext)}.
+     *
+     * @param context the transactional context in which to delete the record store
+     * @param path the path to the record store
+     * @see #deleteStore(FDBRecordContext, Subspace)
+     */
     public static void deleteStore(FDBRecordContext context, KeySpacePath path) {
-        final Subspace subspace = new Subspace(path.toTuple(context));
+        final Subspace subspace = path.toSubspace(context);
         deleteStore(context, subspace);
     }
 
+    /**
+     * Delete the record store at the given {@link Subspace}. In addition to the store's
+     * data this will delete the store's header and therefore will remove any evidence that
+     * the store existed.
+     *
+     * <p>
+     * This method does not read the underlying record store, so it does not validate
+     * that a record store exists in the given subspace. As it might be the case that
+     * this record store has a cacheable store state (see {@link #setStateCacheability(boolean)}),
+     * this method resets the database's
+     * {@linkplain FDBRecordContext#getMetaDataVersionStamp(IsolationLevel) meta-data version-stamp}.
+     * As a result, calling this method may cause other clients to invalidate their caches needlessly.
+     * </p>
+     *
+     * @param context the transactional context in which to delete the record store
+     * @param subspace the subspace containing the record store
+     */
     public static void deleteStore(FDBRecordContext context, Subspace subspace) {
+        // In theory, we only need to set the meta-data version stamp if the record store's
+        // meta-data is cacheable, but we can't know that from here.
+        context.setMetaDataVersionStamp();
+        context.setDirtyStoreState(true);
         final Transaction transaction = context.ensureActive();
         transaction.clear(subspace.range());
-        context.setDirtyStoreState(true);
     }
 
     @Override
@@ -1538,12 +1570,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         final boolean[] dirty = new boolean[1];
         final CompletableFuture<Void> checkedUserVersion = checkUserVersion(userVersionChecker, oldUserVersion, oldMetaDataVersion, info, dirty);
         final CompletableFuture<Void> checkedRebuild = checkedUserVersion.thenCompose(vignore -> checkPossiblyRebuild(userVersionChecker, info, dirty));
-        return checkedRebuild.thenApply(vignore -> {
+        return checkedRebuild.thenCompose(vignore -> {
             if (dirty[0]) {
-                info.setLastUpdateTime(System.currentTimeMillis());
-                saveStoreHeader(info.build());
+                RecordMetaDataProto.DataStoreInfo newStoreHeader = info.setLastUpdateTime(System.currentTimeMillis()).build();
+                return updateStoreHeaderAsync(ignore -> newStoreHeader).thenApply(vignore2 -> true);
+            } else {
+                return AsyncUtil.READY_FALSE;
             }
-            return dirty[0];
         });
     }
 
@@ -1681,19 +1714,44 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return readStoreFirstKey(context, getSubspace(), isolationLevel).thenApply(keyValue -> checkAndParseStoreHeader(keyValue, existenceCheck));
     }
 
-    private void saveStoreHeader(@Nonnull RecordMetaDataProto.DataStoreInfo storeHeader) {
+
+    @Nonnull
+    private CompletableFuture<Void> updateStoreHeaderAsync(@Nonnull UnaryOperator<RecordMetaDataProto.DataStoreInfo> storeHeaderOperator) {
         if (recordStoreState == null) {
-            throw new RecordCoreException("cannot update store header with a null record store state");
+            return preloadRecordStoreStateAsync().thenCompose(vignore -> updateStoreHeaderAsync(storeHeaderOperator));
         }
+        RecordMetaDataProto.DataStoreInfo oldStoreHeader;
+        RecordMetaDataProto.DataStoreInfo newStoreHeader;
         recordStoreState.beginWrite();
         try {
             context.setDirtyStoreState(true);
             synchronized (recordStoreState) {
-                recordStoreState.setStoreHeader(storeHeader);
-                ensureContextActive().set(getSubspace().pack(STORE_INFO_KEY), storeHeader.toByteArray());
+                oldStoreHeader = recordStoreState.getStoreHeader();
+                newStoreHeader = storeHeaderOperator.apply(oldStoreHeader);
+                recordStoreState.setStoreHeader(newStoreHeader);
+                ensureContextActive().set(getSubspace().pack(STORE_INFO_KEY), newStoreHeader.toByteArray());
             }
         } finally {
             recordStoreState.endWrite();
+        }
+
+        // Update the meta-data version-stamp key as appropriate.
+        if (oldStoreHeader.getCacheable()) {
+            // The old store header had a cacheable store header, so update the database's meta-data version-stamp
+            // so that anything that has the old cached value knows to invalidate its cache.
+            context.setMetaDataVersionStamp();
+            return AsyncUtil.DONE;
+        } else if (newStoreHeader.getCacheable()) {
+            // The old header did not have a cacheable store header, but the new header does. As long as someone
+            // has set the meta-data version stamp ever, there is no need to update it here.
+            return context.getMetaDataVersionStampAsync(IsolationLevel.SNAPSHOT).thenAccept(metaDataVersionStamp -> {
+                if (metaDataVersionStamp == null) {
+                    context.setMetaDataVersionStamp();
+                }
+            });
+        } else {
+            // Neither header was cacheable meta-data, so there is no need to update the key.
+            return AsyncUtil.DONE;
         }
     }
 
@@ -1744,6 +1802,48 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         });
     }
 
+    /**
+     * Set whether the store state is cacheable. In particular, this flag determines whether the
+     * {@linkplain FDBRecordContext#getMetaDataVersionStampAsync(IsolationLevel) meta-data version-stamp} key
+     * is changed whenever the {@link RecordStoreState} is changed. By default, record store state information is
+     * <em>not</em> cacheable. This is because for deployments in which there are many record stores sharing the same
+     * cluster, updating the meta-data version key every time any store changes its state could lead to performance
+     * problems, so (at least for now), this is a feature the user must opt-in to on each record store.
+     *
+     * @param cacheable whether the meta-data version-stamp should be invalidated upon store state change
+     * @return a future that will complete to {@code true} if the store state's cacheability has changed
+     */
+    @Nonnull
+    public CompletableFuture<Boolean> setStateCacheabilityAsync(boolean cacheable) {
+        if (recordStoreState == null) {
+            return preloadRecordStoreStateAsync().thenCompose(vignore -> setStateCacheabilityAsync(cacheable));
+        }
+        if (formatVersion < CACHEABLE_STATE_FORMAT_VERSION) {
+            throw new RecordCoreException("cannot mark record store state cacheable at format version " + formatVersion);
+        }
+        if (recordStoreState.getStoreHeader().getCacheable() == cacheable) {
+            return AsyncUtil.READY_FALSE;
+        } else {
+            return updateStoreHeaderAsync(oldHeader -> oldHeader.toBuilder()
+                    .setCacheable(cacheable)
+                    .setLastUpdateTime(System.currentTimeMillis())
+                    .build()
+            ).thenApply(ignore -> true);
+        }
+    }
+
+    /**
+     * Set whether the store state is cacheable. This operation might block if the record store state has
+     * not yet been loaded. Use {@link #setStateCacheabilityAsync(boolean)} in asychronous contexts.
+     *
+     * @param cacheable whether this store's state should be cacheable
+     * @return whether the record store state cacheability has changed
+     * @see #setStateCacheabilityAsync(boolean)
+     */
+    public boolean setStateCacheability(boolean cacheable) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_SET_STATE_CACHEABILITY, setStateCacheabilityAsync(cacheable));
+    }
+
     // Actually (1) writes the index state to the database and (2) updates the cached state with the new state
     private void updateIndexState(@Nonnull String indexName, byte[] indexKey, @Nonnull IndexState indexState) {
         // This is generally called by someone who should already have a write lock, but adding them here
@@ -1751,6 +1851,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         recordStoreState.beginWrite();
         try {
             context.setDirtyStoreState(true);
+            if (recordStoreState.getStoreHeader().getCacheable()) {
+                context.setMetaDataVersionStamp();
+            }
             Transaction tr = context.ensureActive();
             if (IndexState.READABLE.equals(indexState)) {
                 tr.clear(indexKey);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1263,6 +1263,13 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
      * header and all index states), one should call {@link FDBRecordStore#deleteStore(FDBRecordContext, KeySpacePath)}
      * instead of this method.
      *
+     * <p>
+     * Note that, at the moment, this operation also has the side effect of resetting
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#MAX_EVER_TUPLE MAX_EVER} and
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#MIN_EVER_TUPLE MIN_EVER} indexes.
+     * See: <a href="https://github.com/FoundationDB/fdb-record-layer/issues/398">Issue #398</a>.
+     * </p>
+     *
      * @see FDBRecordStore#deleteStore(FDBRecordContext, KeySpacePath)
      * @see FDBRecordStore#deleteStore(FDBRecordContext, Subspace)
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -269,6 +269,8 @@ public class FDBStoreTimer extends StoreTimer {
          * This future should normally be completed already, so this is mainly for error checking.
          */
         WAIT_VERSION_STAMP("wait for version stamp"),
+        /** Wait to load the the cluster's meta-data version stamp. */
+        WAIT_META_DATA_VERSION_STAMP("wait for meta-data version stamp"),
         /** Wait for a synchronous {@link com.apple.foundationdb.record.RecordCursor#next}. */
         WAIT_ADVANCE_CURSOR("wait for advance cursor"),
         /** Wait for scanning a {@link com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpace} to see whether it has data.*/
@@ -289,6 +291,8 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_COLLECT_STATISTICS("wait for statistics to be collected of a record store or index"),
         /** Wait for getting boundaries. */
         WAIT_GET_BOUNDARY("wait for boundary result from locality api"),
+        /** Wait for setting the store state cacheability. */
+        WAIT_SET_STATE_CACHEABILITY("wait to set state cacheability"),
         ;
 
         private final String title;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
@@ -93,13 +93,28 @@ public class TracedTransaction implements Transaction {
     }
 
     @Override
+    public boolean isSnapshot() {
+        return transaction.isSnapshot();
+    }
+
+    @Override
     public void addReadConflictRange(byte[] keyBegin, byte[] keyEnd) {
         transaction.addReadConflictRange(keyBegin, keyEnd);
     }
 
     @Override
+    public boolean addReadConflictRangeIfNotSnapshot(byte[] keyBegin, byte[] keyEnd) {
+        return transaction.addReadConflictRangeIfNotSnapshot(keyBegin, keyEnd);
+    }
+
+    @Override
     public void addReadConflictKey(byte[] key) {
         transaction.addReadConflictKey(key);
+    }
+
+    @Override
+    public boolean addReadConflictKeyIfNotSnapshot(byte[] key) {
+        return transaction.addReadConflictKeyIfNotSnapshot(key);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePath.java
@@ -260,6 +260,13 @@ public interface KeySpacePath {
     /**
      * Delete all data from this path. Use with care.
      *
+     * <p>
+     * Note that as it is possible that one or more record stores saved underneath this path
+     * might have cacheable meta-data, this method will reset the database's
+     * {@linkplain FDBRecordContext#getMetaDataVersionStampAsync(com.apple.foundationdb.record.IsolationLevel)}  meta-data version-stamp}.
+     * This can result in clients which are caching store state having to invalidate their caches.
+     * </p>
+     *
      * @param context the context in which the path is resolved and the delete operation takes place
      * @return a future that will delete all data underneath of this path
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathImpl.java
@@ -255,6 +255,7 @@ class KeySpacePathImpl implements KeySpacePath {
     @Override
     public CompletableFuture<Void> deleteAllDataAsync(@Nonnull FDBRecordContext context) {
         context.setDirtyStoreState(true);
+        context.setMetaDataVersionStamp();
         return toTupleAsync(context).thenApply( tuple -> {
             final byte[] rangeStart = tuple.pack();
             final byte[] rangeEnd = ByteArrayUtil.strinc(rangeStart);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/MetaDataVersionStampStoreStateCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/MetaDataVersionStampStoreStateCache.java
@@ -1,0 +1,143 @@
+/*
+ * MetaDataVersionStampStoreStateCache.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.storestate;
+
+import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.SubspaceProvider;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.google.common.cache.Cache;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An implementation of the {@link FDBRecordStoreStateCache} that uses the database's
+ * {@linkplain FDBRecordContext#getMetaDataVersionStampAsync(IsolationLevel) meta-data version-stamp} key as the
+ * cache invalidation key. This will only cache the meta-data if it is "safe", that is, if the record store
+ * has marked its state as cacheable. This means that one should first set the state cacheability to {@code true}
+ * on any record store whose state one would want cached by calling {@link FDBRecordStore#setStateCacheability(boolean)}.
+ * Then only those stores will be cached by this store state cache.
+ *
+ * @see FDBRecordStore#setStateCacheabilityAsync(boolean)
+ * @see FDBRecordContext#getMetaDataVersionStamp(IsolationLevel)
+ */
+public class MetaDataVersionStampStoreStateCache implements FDBRecordStoreStateCache {
+    @Nonnull
+    private final FDBDatabase database;
+    @Nonnull
+    private final Cache<SubspaceProvider, FDBRecordStoreStateCacheEntry> cache;
+
+    MetaDataVersionStampStoreStateCache(@Nonnull FDBDatabase database, @Nonnull Cache<SubspaceProvider, FDBRecordStoreStateCacheEntry> cache) {
+        this.database = database;
+        this.cache = cache;
+    }
+
+    @Nonnull
+    private FDBRecordStoreStateCacheEntry getNewerEntry(@Nonnull FDBRecordStoreStateCacheEntry entry1, @Nonnull FDBRecordStoreStateCacheEntry entry2) {
+        if (entry1.getMetaDataVersionStamp() == null) {
+            return entry2;
+        } else if (entry2.getMetaDataVersionStamp() == null) {
+            return entry1;
+        } else {
+            return ByteArrayUtil.compareUnsigned(entry1.getMetaDataVersionStamp(), entry2.getMetaDataVersionStamp()) >= 0 ? entry1 : entry2;
+        }
+    }
+
+    private void addToCache(@Nonnull SubspaceProvider subspaceProvider, @Nonnull FDBRecordStoreStateCacheEntry cacheEntry) {
+        cache.asMap().merge(subspaceProvider, cacheEntry, (entry1, entry2) -> {
+            final FDBRecordStoreStateCacheEntry newerEntry = getNewerEntry(entry1, entry2);
+            if (newerEntry.getRecordStoreState().getStoreHeader().getCacheable()) {
+                return newerEntry;
+            } else {
+                return null;
+            }
+        });
+    }
+
+    private void invalidateOlderEntry(@Nonnull SubspaceProvider subspaceProvider, @Nonnull byte[] metaDataVersionStamp) {
+        cache.asMap().computeIfPresent(subspaceProvider, (ignore, existingEntry) -> {
+            // Invalidate the key unless the cached meta-data is newer than or matches this meta-data version stamp
+            if (existingEntry.getMetaDataVersionStamp() == null || ByteArrayUtil.compareUnsigned(metaDataVersionStamp, existingEntry.getMetaDataVersionStamp()) > 0) {
+                return null;
+            } else {
+                return existingEntry;
+            }
+        });
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<FDBRecordStoreStateCacheEntry> get(@Nonnull FDBRecordStore recordStore, @Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck) {
+        final FDBRecordContext context = recordStore.getContext();
+        validateContext(context);
+        if (context.hasDirtyStoreState()) {
+            recordStore.increment(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS);
+            return FDBRecordStoreStateCacheEntry.load(recordStore, existenceCheck);
+        }
+        final SubspaceProvider subspaceProvider = recordStore.getSubspaceProvider();
+        final FDBRecordStoreStateCacheEntry existingEntry = cache.getIfPresent(subspaceProvider);
+        if (existingEntry == null) {
+            recordStore.increment(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS);
+            return FDBRecordStoreStateCacheEntry.load(recordStore, existenceCheck).whenComplete((cacheEntry, err) -> {
+                if (err == null && cacheEntry.getRecordStoreState().getStoreHeader().getCacheable()) {
+                    addToCache(subspaceProvider, cacheEntry);
+                }
+            });
+        } else {
+            return recordStore.getContext().getMetaDataVersionStampAsync(IsolationLevel.SNAPSHOT).thenCompose(metaDataVersionStamp -> {
+                if (metaDataVersionStamp == null || existingEntry.getMetaDataVersionStamp() == null ||
+                        ByteArrayUtil.compareUnsigned(metaDataVersionStamp, existingEntry.getMetaDataVersionStamp()) != 0) {
+                    recordStore.increment(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS);
+                    return FDBRecordStoreStateCacheEntry.load(recordStore, existenceCheck).whenComplete((cacheEntry, err) -> {
+                        if (err == null && metaDataVersionStamp != null) {
+                            if (cacheEntry.getRecordStoreState().getStoreHeader().getCacheable()) {
+                                addToCache(subspaceProvider, cacheEntry);
+                            } else {
+                                invalidateOlderEntry(subspaceProvider, metaDataVersionStamp);
+                            }
+                        }
+                    });
+                } else {
+                    recordStore.increment(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT);
+                    return existingEntry.handleCachedState(context, existenceCheck).thenApply(ignore -> existingEntry);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void validateDatabase(@Nonnull FDBDatabase database) {
+        if (database != this.database) {
+            throw new RecordCoreArgumentException("record store state cache used with different database than the one it was initialized with");
+        }
+    }
+
+    @Override
+    public void clear() {
+        cache.invalidateAll();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/MetaDataVersionStampStoreStateCacheFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/MetaDataVersionStampStoreStateCacheFactory.java
@@ -1,0 +1,119 @@
+/*
+ * MetaDataVersionStampStoreStateCacheFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.storestate;
+
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.SubspaceProvider;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A factory for creating {@link MetaDataVersionStampStoreStateCache}s.
+ */
+public class MetaDataVersionStampStoreStateCacheFactory implements FDBRecordStoreStateCacheFactory {
+    /**
+     * A constant indicating that the cache should be of unlimited size or keep items for an unlimited time.
+     */
+    public static final long UNLIMITED = Long.MAX_VALUE;
+    /**
+     * The default maximum number of items to include in the cache.
+     */
+    public static final long DEFAULT_MAX_SIZE = 500;
+    /**
+     * The default amount of time in milliseconds after last access that cache entries should start to be expired.
+     */
+    public static final long DEFAULT_EXPIRE_AFTER_ACCESS_MILLIS = TimeUnit.MINUTES.toMillis(1L);
+
+    private long maxSize = DEFAULT_MAX_SIZE;
+    private long expireAfterAccessMillis = DEFAULT_EXPIRE_AFTER_ACCESS_MILLIS;
+
+    @Nonnull
+    @Override
+    public FDBRecordStoreStateCache getCache(@Nonnull FDBDatabase database) {
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (maxSize != UNLIMITED) {
+            cacheBuilder.maximumSize(maxSize);
+        }
+        if (expireAfterAccessMillis != UNLIMITED) {
+            cacheBuilder.expireAfterAccess(expireAfterAccessMillis, TimeUnit.MILLISECONDS);
+        }
+        Cache<SubspaceProvider, FDBRecordStoreStateCacheEntry> cache = cacheBuilder.build();
+        return new MetaDataVersionStampStoreStateCache(database, cache);
+    }
+
+    /**
+     * Set the number of milliseconds to keep an item in produced caches after it has been accessed.
+     * This value can be set to {@link #UNLIMITED} to indicate that the items in caches produced
+     * by this factory should not be limited by time.
+     *
+     * @param expireAfterAccessMillis the amount of time to keep the item in each cache after last access
+     * @return this factory
+     */
+    @Nonnull
+    public MetaDataVersionStampStoreStateCacheFactory setExpireAfterAccessMillis(long expireAfterAccessMillis) {
+        this.expireAfterAccessMillis = expireAfterAccessMillis;
+        return this;
+    }
+
+    /**
+     * Get the amount of time in milliseconds that each entry is kept in each cache after its last access.
+     *
+     * @return the amount of time to keep the item in each cache after last access
+     */
+    public long getDefaultExpireAfterAccessMillis() {
+        return expireAfterAccessMillis;
+    }
+
+    /**
+     * Set the maximum number of elements to keep in produced caches. This value can be set to {@link #UNLIMITED} to
+     * indicate that no maximum size should be imposed on the number of items in each cache.
+     *
+     * @param maxSize the maximum number of elements to keep in each cache
+     * @return this factory
+     */
+    @Nonnull
+    public MetaDataVersionStampStoreStateCacheFactory setMaxSize(long maxSize) {
+        this.maxSize = maxSize;
+        return this;
+    }
+
+    /**
+     * Get the maximum number of elements to keep in produced caches.
+     *
+     * @return the maximum number of elements to keep in each cache
+     */
+    public long getMaxSize() {
+        return maxSize;
+    }
+
+    /**
+     * Create a new factory.
+     *
+     * @return a new factory of {@link MetaDataVersionStampStoreStateCache}s
+     */
+    @Nonnull
+    public static MetaDataVersionStampStoreStateCacheFactory newInstance() {
+        return new MetaDataVersionStampStoreStateCacheFactory();
+    }
+}

--- a/fdb-record-layer-core/src/main/proto/record_metadata.proto
+++ b/fdb-record-layer-core/src/main/proto/record_metadata.proto
@@ -31,6 +31,7 @@ message DataStoreInfo {
   optional KeyExpression record_count_key = 4;
   optional uint64 lastUpdateTime = 5;
   optional bool omit_unsplit_record_suffix = 6;
+  optional bool cacheable = 7;
 }
 
 message Index {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -1160,13 +1160,15 @@ public class LeaderboardIndexTest extends FDBTestBase {
 
         FDBRecordContext context1 = openContext();
         if (TRACE) {
-            context1.ensureActive().options().setTransactionLoggingEnable("tr1");
+            context1.ensureActive().options().setDebugTransactionIdentifier("tr1");
+            context1.ensureActive().options().setLogTransaction();
         }
         Leaderboards leaderboards1 = new FlatLeaderboards();
         leaderboards1.recordStore = leaderboards.recordStore.asBuilder().setContext(context1).build();
         FDBRecordContext context2 = openContext();
         if (TRACE) {
-            context2.ensureActive().options().setTransactionLoggingEnable("tr2");
+            context2.ensureActive().options().setDebugTransactionIdentifier("tr2");
+            context2.ensureActive().options().setLogTransaction();
         }
         Leaderboards leaderboards2 = new FlatLeaderboards();
         leaderboards2.recordStore = leaderboards.recordStore.asBuilder().setContext(context2).build();
@@ -1218,7 +1220,8 @@ public class LeaderboardIndexTest extends FDBTestBase {
                 int score = r.nextInt(1000000);
                 int pass = i;
                 fdb.run(metrics, null, context -> {
-                    context.ensureActive().options().setTransactionLoggingEnable(String.format("t-%d-%d", n, pass));
+                    context.ensureActive().options().setDebugTransactionIdentifier(String.format("t-%d-%d", n, pass));
+                    context.ensureActive().options().setLogTransaction();
                     privateLeaderboards.recordStore = builder.setContext(context).build();
                     privateLeaderboards.addScores(player, "game-1", score, 10100, 0);
                     return null;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
@@ -20,7 +20,9 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.storestate;
 
+import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestRecords1Proto;
@@ -34,14 +36,18 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreKeyspac
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.RecordStoreAlreadyExistsException;
-import com.apple.foundationdb.record.provider.foundationdb.RecordStoreDoesNotExistException;
 import com.apple.foundationdb.record.provider.foundationdb.RecordStoreNoInfoAndNotEmptyException;
 import com.apple.foundationdb.record.provider.foundationdb.RecordStoreStaleMetaDataVersionException;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 
@@ -50,14 +56,19 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -70,7 +81,118 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
     @Nonnull
     private static final ReadVersionRecordStoreStateCacheFactory readVersionCacheFactory = ReadVersionRecordStoreStateCacheFactory.newInstance();
     @Nonnull
+    private static final MetaDataVersionStampStoreStateCacheFactory metaDataVersionStampCacheFactory = MetaDataVersionStampStoreStateCacheFactory.newInstance();
+    @Nonnull
     private KeySpacePath multiStorePath = TestKeySpace.getKeyspacePath(new Object[]{"record-test", "unit", "multiRecordStore"});
+
+    @Nonnull
+    public static Stream<FDBRecordStoreStateCacheFactory> factorySource() {
+        return Stream.of(readVersionCacheFactory, metaDataVersionStampCacheFactory);
+    }
+
+    @Nonnull
+    public static Stream<StateCacheTestContext> testContextSource() {
+        return Stream.of(new ReadVersionStateCacheTestContext(), new MetaDataVersionStampStateCacheTestContext());
+    }
+
+    /**
+     * A wrapper interface for dealing with the differences between the different {@link FDBRecordStoreStateCache}
+     * implementations.
+     */
+    public interface StateCacheTestContext {
+        @Nonnull
+        FDBRecordStoreStateCache getCache(@Nonnull FDBDatabase database);
+
+        @Nonnull
+        default FDBRecordContext getCachedContext(@Nonnull FDBDatabase fdb, @Nonnull FDBRecordStore.Builder storeBuilder) {
+            return getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NO_INFO_AND_NOT_EMPTY);
+        }
+
+        @Nonnull
+        FDBRecordContext getCachedContext(@Nonnull FDBDatabase fdb, @Nonnull FDBRecordStore.Builder storeBuilder,
+                                          @Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck);
+
+        void invalidateCache(@Nonnull FDBDatabase fdb);
+    }
+
+    /**
+     * An implementation of the {@link StateCacheTestContext} that handles caching by read version.
+     */
+    public static class ReadVersionStateCacheTestContext implements StateCacheTestContext {
+        @Nonnull
+        @Override
+        public FDBRecordStoreStateCache getCache(@Nonnull FDBDatabase database) {
+            return readVersionCacheFactory.getCache(database);
+        }
+
+        @Nonnull
+        @Override
+        public FDBRecordContext getCachedContext(@Nonnull FDBDatabase fdb, @Nonnull FDBRecordStore.Builder storeBuilder,
+                                                 @Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck) {
+            long readVersion;
+            try (FDBRecordContext context = fdb.openContext()) {
+                storeBuilder.copyBuilder().setContext(context).createOrOpen(existenceCheck);
+                readVersion = context.ensureActive().getReadVersion().join();
+            }
+            FDBRecordContext context = fdb.openContext(null, new FDBStoreTimer());
+            context.ensureActive().setReadVersion(readVersion);
+            return context;
+        }
+
+        @Override
+        public void invalidateCache(@Nonnull FDBDatabase fdb) {
+            // Ensure that the next read version includes at least one new commit.
+            try (FDBRecordContext context = fdb.openContext()) {
+                context.ensureActive().addWriteConflictKey(Tuple.from(UUID.randomUUID()).pack());
+                context.commit();
+            }
+        }
+    }
+
+    /**
+     * An implementation of the {@link StateCacheTestContext} that handles caching by the meta-data version-stamp.
+     */
+    public static class MetaDataVersionStampStateCacheTestContext implements StateCacheTestContext {
+
+        @Nonnull
+        @Override
+        public FDBRecordStoreStateCache getCache(@Nonnull FDBDatabase database) {
+            return metaDataVersionStampCacheFactory.getCache(database);
+        }
+
+        @Nonnull
+        @Override
+        public FDBRecordContext getCachedContext(@Nonnull FDBDatabase fdb, @Nonnull FDBRecordStore.Builder storeBuilder,
+                                                 @Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck) {
+            boolean cacheable = true;
+            try (FDBRecordContext context = fdb.openContext()) {
+                FDBRecordStore store = storeBuilder.copyBuilder().setContext(context).createOrOpen(existenceCheck);
+                if (!store.getRecordStoreState().getStoreHeader().getCacheable()) {
+                    cacheable = false;
+                    assertTrue(store.setStateCacheability(true));
+                    context.commit();
+                }
+            }
+            if (!cacheable) {
+                try (FDBRecordContext context = fdb.openContext()) {
+                    storeBuilder.copyBuilder().setContext(context).createOrOpen(existenceCheck);
+                    context.commit();
+                }
+            }
+            FDBRecordContext context = fdb.openContext(null, new FDBStoreTimer());
+            context.getMetaDataVersionStampAsync(IsolationLevel.SNAPSHOT).join();
+            return context;
+        }
+
+        @Override
+        public void invalidateCache(@Nonnull FDBDatabase fdb) {
+            // Ensure that the next read version includes at least one new commit.
+            try (FDBRecordContext context = fdb.openContext()) {
+                context.setMetaDataVersionStamp();
+                context.commit();
+            }
+        }
+    }
 
     /**
      * Validate that caching by read version works.
@@ -185,20 +307,223 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
     }
 
     /**
+     * Validate that caching by the meta-data version works.
+     */
+    @Test
+    public void cacheByMetaDataVersion() throws Exception {
+        FDBRecordStoreStateCache origStoreStateCache = fdb.getStoreStateCache();
+        try {
+            fdb.setStoreStateCache(metaDataVersionStampCacheFactory.getCache(fdb));
+            byte[] metaDataVersionStamp;
+
+            // Open the store; save the meta-data
+            try (FDBRecordContext context = openContext()) {
+                openSimpleRecordStore(context);
+                context.setMetaDataVersionStamp();
+                commit(context);
+            }
+
+            // Load the meta-data. It should not be cached as the store meta-data are not cacheable.
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                metaDataVersionStamp = context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT);
+                assertNotNull(metaDataVersionStamp);
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+                recordStore.markIndexWriteOnly("MySimpleRecord$str_value_indexed").get();
+                assertTrue(context.hasDirtyStoreState());
+                assertNotNull(context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+                commit(context);
+            }
+
+            // Note that the meta-data version has not been updated
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+                assertTrue(recordStore.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
+                commit(context);
+            }
+
+            // Mark the meta-data as cacheable
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertTrue(recordStore.setStateCacheability(true));
+                assertTrue(context.hasDirtyStoreState());
+                assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+                commit(context);
+            }
+
+            // Load the store state into cache
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertTrue(recordStore.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
+                // don't need to commit
+            }
+
+            // The first meta-data cache hit!
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                assertTrue(recordStore.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
+                recordStore.markIndexReadable("MySimpleRecord$str_value_indexed").get();
+                assertTrue(context.hasDirtyStoreState());
+                assertNull(context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+                commit(context);
+            }
+
+            // Load the updated the meta-data into cache
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertTrue(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+                byte[] trMetaDataVersionStamp = context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT);
+                assertNotNull(trMetaDataVersionStamp);
+                assertThat(ByteArrayUtil.compareUnsigned(metaDataVersionStamp, trMetaDataVersionStamp), lessThan(0));
+                metaDataVersionStamp = trMetaDataVersionStamp;
+            }
+
+            // The updated meta-data should now be in cache
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                assertTrue(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+                assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+            }
+
+            // Changing the meta-data to a non-cacheable state should increment the meta-data version stamp
+            long readVersion;
+            byte[] commitVersionStamp;
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                readVersion = context.ensureActive().getReadVersion().get();
+                assertTrue(recordStore.setStateCacheability(false));
+                assertTrue(context.hasDirtyStoreState());
+                assertNull(context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+                commit(context);
+                commitVersionStamp = context.getVersionStamp();
+                assertNotNull(commitVersionStamp);
+            }
+
+            // This should hit the cache because it uses an older read version where the meta-data versionstamp is good.
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                context.ensureActive().setReadVersion(readVersion);
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                assertTrue(recordStore.getRecordStoreState().getStoreHeader().getCacheable());
+            }
+
+            // These should both miss the cache
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                byte[] trMetaDataVersionStamp = context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT);
+                assertNotNull(trMetaDataVersionStamp);
+                assertThat(ByteArrayUtil.compareUnsigned(metaDataVersionStamp, trMetaDataVersionStamp), lessThan(0));
+                assertArrayEquals(commitVersionStamp, trMetaDataVersionStamp);
+                metaDataVersionStamp = trMetaDataVersionStamp;
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                byte[] trMetaDataVersionStamp = context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT);
+                assertNotNull(trMetaDataVersionStamp);
+                assertArrayEquals(metaDataVersionStamp, trMetaDataVersionStamp);
+            }
+        } finally {
+            fdb.setStoreStateCache(origStoreStateCache);
+        }
+    }
+
+    @Test
+    public void cacheByMetaDataVersionFirstTimeEver() throws Exception {
+        FDBRecordStoreStateCache origStoreStateCache = fdb.getStoreStateCache();
+        try {
+            fdb.setStoreStateCache(metaDataVersionStampCacheFactory.getCache(fdb));
+
+            // Clear out the meta-data version-stamp key
+            try (FDBRecordContext context = openContext()) {
+                openSimpleRecordStore(context);
+                byte[] metaDataVersionStampKey = ByteArrayUtil2.unprint("\\xff/metadataVersion");
+                context.ensureActive().options().setAccessSystemKeys();
+                context.ensureActive().clear(metaDataVersionStampKey);
+                commit(context);
+            }
+
+            byte[] commitVersionStamp;
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertNull(context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+
+                recordStore.setStateCacheability(true);
+                commit(context);
+                commitVersionStamp = context.getVersionStamp();
+                assertNotNull(commitVersionStamp);
+            }
+
+            // Usually, marking the store state as cacheable from a non-cacheable state won't update the
+            // meta-data version. However, in the case where the key is initially unset, to make sure that
+            // caching actually happens, the meta-data version *is* updated.
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertArrayEquals(commitVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                context.getTimer().reset();
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                assertArrayEquals(commitVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
+            }
+        } finally {
+            fdb.setStoreStateCache(origStoreStateCache);
+        }
+    }
+
+    /**
      * Make sure that if one transaction changes the store header then an open store in another transaction that
      * loaded the store state from cache will fail at commit time with conflict.
      */
-    @Test
-    public void readVersionConflictWhenCachedChanged() throws Exception {
+    @ParameterizedTest(name = "conflictWhenCachedChanged (test context = [0])")
+    @MethodSource("testContextSource")
+    public void conflictWhenCachedChanged(@Nonnull StateCacheTestContext testContext) throws Exception {
         FDBRecordStoreStateCache origStoreStateCache = fdb.getStoreStateCache();
         try {
-            fdb.setStoreStateCache(readVersionCacheFactory.getCache(fdb));
+            fdb.setStoreStateCache(testContext.getCache(fdb));
 
             RecordMetaData metaData1 = RecordMetaData.build(TestRecords1Proto.getDescriptor());
             RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
             metaDataBuilder.addIndex("MySimpleRecord", "num_value_2");
             RecordMetaData metaData2 = metaDataBuilder.getRecordMetaData();
             assertThat(metaData1.getVersion(), lessThan(metaData2.getVersion()));
+
+            FDBRecordStore.Builder storeBuilder;
 
             // Initialize the record store with a meta-data store
             try (FDBRecordContext context = openContext()) {
@@ -212,43 +537,27 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
                 assertEquals(metaData1.getVersion(), recordStore.getRecordStoreState().getStoreHeader().getMetaDataversion());
                 commit(context);
+
+                storeBuilder = recordStore.asBuilder();
             }
 
             // Load the record store state into the cache.
-            long readVersion;
-            try (FDBRecordContext context = openContext()) {
-                readVersion = context.ensureActive().getReadVersion().get();
-                FDBRecordStore recordStore = FDBRecordStore.newBuilder()
-                        .setContext(context)
-                        .setMetaDataProvider(metaData1)
-                        .setKeySpacePath(path)
-                        .open();
-                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
-                assertEquals(metaData1.getVersion(), recordStore.getRecordMetaData().getVersion());
-                assertEquals(metaData1.getVersion(), recordStore.getRecordStoreState().getStoreHeader().getMetaDataversion());
-            }
-
-            // Use the cache to load the record store states
-            try (FDBRecordContext context1 = openContext(); FDBRecordContext context2 = openContext()) {
+            try (FDBRecordContext context1 = testContext.getCachedContext(fdb, storeBuilder); FDBRecordContext context2 = testContext.getCachedContext(fdb, storeBuilder)) {
                 context1.setTimer(new FDBStoreTimer());
-                context1.ensureActive().setReadVersion(readVersion);
                 context2.setTimer(new FDBStoreTimer());
-                context2.ensureActive().setReadVersion(readVersion);
 
-                FDBRecordStore recordStore1 = FDBRecordStore.newBuilder()
+                FDBRecordStore recordStore1 = storeBuilder.copyBuilder()
                         .setContext(context1)
                         .setMetaDataProvider(metaData1)
-                        .setKeySpacePath(path)
                         .open();
                 assertEquals(1, context1.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 assertEquals(metaData1.getVersion(), recordStore1.getRecordMetaData().getVersion());
                 assertEquals(metaData1.getVersion(), recordStore1.getRecordStoreState().getStoreHeader().getMetaDataversion());
 
                 // Update the meta-data in the second transaction
-                FDBRecordStore recordStore2 = FDBRecordStore.newBuilder()
+                FDBRecordStore recordStore2 = storeBuilder.copyBuilder()
                         .setContext(context2)
                         .setMetaDataProvider(metaData2)
-                        .setKeySpacePath(path)
                         .open();
                 assertEquals(1, context2.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 assertEquals(Collections.singletonList(recordStore2.getRecordMetaData().getRecordType("MySimpleRecord")),
@@ -272,18 +581,16 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
                 context.getTimer().reset();
 
                 // Trying to load with the old meta-data should fail
-                assertThrows(RecordStoreStaleMetaDataVersionException.class, () -> FDBRecordStore.newBuilder()
+                assertThrows(RecordStoreStaleMetaDataVersionException.class, () -> storeBuilder.copyBuilder()
                         .setContext(context)
                         .setMetaDataProvider(metaData1)
-                        .setKeySpacePath(path)
                         .open());
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
 
                 // Trying to load with the new meta-data should succeed
-                FDBRecordStore recordStore = FDBRecordStore.newBuilder()
+                FDBRecordStore recordStore = storeBuilder.copyBuilder()
                         .setContext(context)
                         .setMetaDataProvider(metaData2)
-                        .setKeySpacePath(path)
                         .open();
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 assertEquals(metaData2.getVersion(), recordStore.getRecordStoreState().getStoreHeader().getMetaDataversion());
@@ -297,67 +604,44 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
     /**
      * Validate that the store existence check is still performed on the cached store info.
      */
-    @Test
-    public void existenceCheckOnCachedStoreStates() throws Exception {
+    @ParameterizedTest(name = "existenceCheckOnCachedStoreStates (test context = [0])")
+    @MethodSource("testContextSource")
+    public void existenceCheckOnCachedStoreStates(@Nonnull StateCacheTestContext testContext) throws Exception {
         FDBRecordStoreStateCache origStoreStateCache = fdb.getStoreStateCache();
         try {
-            fdb.setStoreStateCache(readVersionCacheFactory.getCache(fdb));
+            fdb.setStoreStateCache(testContext.getCache(fdb));
 
             // Create a record store
-            long readVersion;
             FDBRecordStore.Builder storeBuilder;
             try (FDBRecordContext context = openContext()) {
                 openSimpleRecordStore(context);
-                readVersion = context.ensureActive().getReadVersion().get();
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
                 assertTrue(context.hasDirtyStoreState());
                 storeBuilder = recordStore.asBuilder();
                 commit(context);
             }
 
-            try (FDBRecordContext context = openContext()) {
-                context.ensureActive().setReadVersion(readVersion);
-                storeBuilder.setContext(context);
-                assertThrows(RecordStoreDoesNotExistException.class, storeBuilder::open);
-            }
-
-            // Load the record store state into the cache
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                openSimpleRecordStore(context);
-                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
-                readVersion = context.ensureActive().getReadVersion().get();
-                storeBuilder = recordStore.asBuilder();
-            }
-
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                context.ensureActive().setReadVersion(readVersion);
+            byte[] storeInfoKey;
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder)) {
                 storeBuilder.setContext(context);
                 assertThrows(RecordStoreAlreadyExistsException.class, storeBuilder::create);
+                context.getTimer().reset();
                 FDBRecordStore store = storeBuilder.open();
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
 
                 // Delete the store header
-                context.ensureActive().clear(store.getSubspace().pack(FDBRecordStoreKeyspace.STORE_INFO.key()));
+                storeInfoKey = store.getSubspace().pack(FDBRecordStoreKeyspace.STORE_INFO.key());
+                context.ensureActive().clear(storeInfoKey);
                 commit(context);
             }
 
-            // Load the record store state into cache
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                storeBuilder.setContext(context);
-                assertThrows(RecordStoreNoInfoAndNotEmptyException.class, storeBuilder::createOrOpen);
-                storeBuilder.createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-                readVersion = context.ensureActive().getReadVersion().get();
-            }
+            // The caches have dirty information from the out-of-band "clear".
+            testContext.invalidateCache(fdb);
+            assertThrows(RecordStoreNoInfoAndNotEmptyException.class, () -> testContext.getCachedContext(fdb, storeBuilder));
 
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                context.ensureActive().setReadVersion(readVersion);
-                storeBuilder.setContext(context);
-                assertThrows(RecordStoreNoInfoAndNotEmptyException.class, storeBuilder::createOrOpen);
-                storeBuilder.createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
+            // Ensure the store info key is still empty
+            try (FDBRecordContext context = fdb.openContext()) {
+                assertNull(context.readTransaction(true).get(storeInfoKey).get());
             }
         } finally {
             fdb.setStoreStateCache(origStoreStateCache);
@@ -368,28 +652,21 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
      * Validate that deleting a record store causes the record store to go back to the database as it's possible the
      * cached stuff is what was deleted.
      */
-    @Test
-    public void storeDeletionInSameContext() throws Exception {
+    @ParameterizedTest(name = "storeDeletionInSameContext (test context = [0])")
+    @MethodSource("testContextSource")
+    public void storeDeletionInSameContext(@Nonnull StateCacheTestContext testContext) throws Exception {
         FDBRecordStoreStateCache storeStateCache = fdb.getStoreStateCache();
         try {
-            fdb.setStoreStateCache(readVersionCacheFactory.getCache(fdb));
+            fdb.setStoreStateCache(testContext.getCache(fdb));
 
+            FDBRecordStore.Builder storeBuilder;
             try (FDBRecordContext context = openContext()) {
                 openSimpleRecordStore(context);
+                storeBuilder = recordStore.asBuilder();
                 commit(context);
             }
 
-            // Load the record store state into the cache
-            long readVersion;
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                openSimpleRecordStore(context);
-                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
-                readVersion = context.ensureActive().getReadVersion().get();
-            }
-
-            try (FDBRecordContext context = openContext()) {
-                context.ensureActive().setReadVersion(readVersion);
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder)) {
                 openSimpleRecordStore(context);
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
 
@@ -401,16 +678,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
                 commit(context);
             }
 
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                openSimpleRecordStore(context);
-                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
-                readVersion = context.ensureActive().getReadVersion().get();
-            }
-
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                context.ensureActive().setReadVersion(readVersion);
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder)) {
                 openSimpleRecordStore(context);
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 path.deleteAllData(context);
@@ -419,6 +687,104 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
                 recordStore.asBuilder().create();
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
             }
+
+            // Deleting all records should not disable the index, so the result should still be cacheable.
+            // See: https://github.com/FoundationDB/fdb-record-layer/issues/399
+            final String disabledIndex = "MySimpleRecord$str_value_indexed";
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                recordStore.markIndexDisabled(disabledIndex).get();
+                commit(context);
+            }
+
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                assertTrue(recordStore.isIndexDisabled(disabledIndex));
+                recordStore.deleteAllRecords();
+
+                context.getTimer().reset();
+                recordStore = recordStore.asBuilder().open();
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                assertTrue(recordStore.isIndexDisabled(disabledIndex));
+                commit(context);
+            }
+        } finally {
+            fdb.setStoreStateCache(storeStateCache);
+        }
+    }
+
+    /**
+     * After a store is deleted, validate that future transactions need to reload it from cache.
+     */
+    @ParameterizedTest(name = "storeDeletionAcrossContexts (test context = [0])")
+    @MethodSource("testContextSource")
+    public void storeDeletionAcrossContexts(@Nonnull StateCacheTestContext testContext) throws Exception {
+        FDBRecordStoreStateCache storeStateCache = fdb.getStoreStateCache();
+        try {
+            fdb.setStoreStateCache(testContext.getCache(fdb));
+
+            FDBRecordStore.Builder storeBuilder;
+            try (FDBRecordContext context = openContext()) {
+                openSimpleRecordStore(context);
+                assertTrue(recordStore.setStateCacheability(true));
+                storeBuilder = recordStore.asBuilder();
+                commit(context);
+            }
+
+            // Delete by calling deleteStore.
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                FDBRecordStore.deleteStore(context, recordStore.getSubspace());
+                commit(context);
+            }
+
+            // After deleting it, when opening the same store again, it shouldn't be cached.
+            try (FDBRecordContext context = fdb.openContext(null, new FDBStoreTimer())) {
+                FDBRecordStore store = storeBuilder.setContext(context).create();
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                assertTrue(store.setStateCacheability(true));
+                commit(context);
+            }
+
+            // Delete by calling path.deleteAllData
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                openSimpleRecordStore(context);
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                path.deleteAllData(context);
+                commit(context);
+            }
+
+            try (FDBRecordContext context = fdb.openContext(null, new FDBStoreTimer())) {
+                FDBRecordStore store = storeBuilder.setContext(context).create();
+                store.setStateCacheabilityAsync(true).get();
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                commit(context);
+            }
+
+            // Deleting all records should not disable the index state.
+            final String disabledIndex = "MySimpleRecord$str_value_indexed";
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                openSimpleRecordStore(context);
+                recordStore.markIndexDisabled(disabledIndex).get();
+                commit(context);
+            }
+
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                openSimpleRecordStore(context);
+                assertTrue(recordStore.isIndexDisabled(disabledIndex));
+                recordStore.deleteAllRecords();
+                commit(context);
+            }
+
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                openSimpleRecordStore(context);
+                assertTrue(recordStore.isIndexDisabled(disabledIndex));
+                commit(context);
+            }
+
         } finally {
             fdb.setStoreStateCache(storeStateCache);
         }
@@ -427,13 +793,17 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
     /**
      * Make sure that caching two different subspaces are both cached but with separate entries.
      */
-    @Test
-    public void cacheTwoSubspacesByReadVersion() throws Exception {
+    @ParameterizedTest(name = "cacheTwoSubspaces (test context = [0])")
+    @MethodSource("testContextSource")
+    public void cacheTwoSubspaces(@Nonnull StateCacheTestContext testContext) throws Exception {
         FDBRecordStoreStateCache origStoreStateCache = fdb.getStoreStateCache();
         try {
-            fdb.setStoreStateCache(readVersionCacheFactory.getCache(fdb));
+            fdb.setStoreStateCache(testContext.getCache(fdb));
             final KeySpacePath path1 = multiStorePath.add("storePath", "path1");
             final KeySpacePath path2 = multiStorePath.add("storePath", "path2");
+
+            final FDBRecordStore.Builder storeBuilder1;
+            final FDBRecordStore.Builder storeBuilder2;
 
             try (FDBRecordContext context = openContext()) {
                 context.getTimer().reset();
@@ -442,51 +812,43 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
 
                 openSimpleRecordStore(context);
                 FDBRecordStore store1 = recordStore.asBuilder().setKeySpacePath(path1).create();
+                store1.setStateCacheabilityAsync(true).get();
+                storeBuilder1 = store1.asBuilder();
                 store1.markIndexWriteOnly("MySimpleRecord$str_value_indexed").get();
+
                 FDBRecordStore store2 = recordStore.asBuilder().setKeySpacePath(path2).create();
+                store2.setStateCacheabilityAsync(true).get();
+                storeBuilder2 = store2.asBuilder();
                 store2.markIndexDisabled("MySimpleRecord$num_value_3_indexed").get();
 
                 commit(context);
             }
 
-            // Get a read version and load one of the record store's info into cache
-            long readVersion;
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                openSimpleRecordStore(context);
-                readVersion = context.ensureActive().getReadVersion().get();
-                FDBRecordStore store1 = recordStore.asBuilder().setKeySpacePath(path1).open();
-                assertTrue(store1.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
-                assertTrue(store1.isIndexReadable("MySimpleRecord$num_value_3_indexed"));
-                assertEquals(2, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
-            }
-
             // Open both paths. Only the one in path1 should be cached.
-            try (FDBRecordContext context = openContext()) {
-                context.getTimer().reset();
-                context.ensureActive().setReadVersion(readVersion);
-                openSimpleRecordStore(context);
-                FDBRecordStore store1 = recordStore.asBuilder().setKeySpacePath(path1).open();
-                assertEquals(2, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+            long readVersion;
+            try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder1, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
+                FDBRecordStore store1 = storeBuilder1.setContext(context).open();
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 assertTrue(store1.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
                 assertTrue(store1.isIndexReadable("MySimpleRecord$num_value_3_indexed"));
-                FDBRecordStore store2 = recordStore.asBuilder().setKeySpacePath(path2).open();
+                FDBRecordStore store2 = storeBuilder2.setContext(context).open();
                 assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
                 assertTrue(store2.isIndexReadable("MySimpleRecord$str_value_indexed"));
                 assertTrue(store2.isIndexDisabled("MySimpleRecord$num_value_3_indexed"));
+
+                readVersion = context.ensureActive().getReadVersion().get();
             }
 
             // Open both paths. Now they are both cached.
             try (FDBRecordContext context = openContext()) {
                 context.getTimer().reset();
                 context.ensureActive().setReadVersion(readVersion);
-                openSimpleRecordStore(context);
-                FDBRecordStore store1 = recordStore.asBuilder().setKeySpacePath(path1).open();
-                assertEquals(2, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                FDBRecordStore store1 = storeBuilder1.setContext(context).open();
+                assertEquals(1, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 assertTrue(store1.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
                 assertTrue(store1.isIndexReadable("MySimpleRecord$num_value_3_indexed"));
-                FDBRecordStore store2 = recordStore.asBuilder().setKeySpacePath(path2).open();
-                assertEquals(3, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                FDBRecordStore store2 = storeBuilder2.setContext(context).open();
+                assertEquals(2, context.getTimer().getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 assertTrue(store2.isIndexReadable("MySimpleRecord$str_value_indexed"));
                 assertTrue(store2.isIndexDisabled("MySimpleRecord$num_value_3_indexed"));
             }
@@ -498,13 +860,14 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
     /**
      * Validate that caching just naturally works.
      */
-    @Test
-    public void cacheByReadWithVersionTracking() throws Exception {
+    @ParameterizedTest(name = "cacheWithVersionTracking (test context = [0])")
+    @MethodSource("testContextSource")
+    public void cacheWithVersionTracking(@Nonnull StateCacheTestContext testContext) throws Exception {
         boolean trackCommitVersions = fdb.isTrackLastSeenVersionOnCommit();
         boolean trackReadVersion = fdb.isTrackLastSeenVersionOnCommit();
         FDBRecordStoreStateCache currentCache = fdb.getStoreStateCache();
         try {
-            fdb.setStoreStateCache(readVersionCacheFactory.getCache(fdb));
+            fdb.setStoreStateCache(testContext.getCache(fdb));
             fdb.setTrackLastSeenVersion(true);
             FDBStoreTimer timer = new FDBStoreTimer();
             final FDBDatabase.WeakReadSemantics readSemantics = new FDBDatabase.WeakReadSemantics(0L, 5000, false);
@@ -516,10 +879,11 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             }
 
             // Commit a new meta-data
-            final long commitVersion;
+            long commitVersion;
             timer.reset();
             try (FDBRecordContext context = fdb.openContext(null, timer, readSemantics)) {
                 openSimpleRecordStore(context);
+                recordStore.setStateCacheabilityAsync(true).get();
                 assertEquals(1, timer.getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
                 recordStore.markIndexDisabled("MySimpleRecord$str_value_indexed").get();
                 commit(context);
@@ -536,34 +900,57 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
                 commit(context); // should be read only-so won't change commit version
             }
 
-            // Version caching will still use the commit version, but now it is in cache
+            // Version caching will still use the commit version from the first (non read-only commit), but now it is in cache
             timer.reset();
             try (FDBRecordContext context = fdb.openContext(null, timer, readSemantics)) {
                 assertEquals(commitVersion, (long)context.ensureActive().getReadVersion().get());
                 openSimpleRecordStore(context);
                 assertEquals(1, timer.getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
                 assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
-                commit(context);
-            }
 
-            // Make a (no-op) commit to ensure that the db version is increased.
-            try (FDBRecordContext context = fdb.openContext(null, timer, readSemantics)) {
-                openSimpleRecordStore(context);
+                // Add a dummy write to increase the DB version
                 context.ensureActive().addWriteConflictKey(recordStore.recordsSubspace().pack(UUID.randomUUID()));
                 commit(context);
+                assertThat(context.getCommittedVersion(), greaterThan(commitVersion));
+                commitVersion = context.getCommittedVersion();
             }
 
-            // Load a new read version
+            // The commit version will be from the commit above. This should invalidate the
+            // read-version cache, but not the meta-data version cache.
+            timer.reset();
+            try (FDBRecordContext context = fdb.openContext(null, timer, readSemantics)) {
+                assertEquals(commitVersion, (long)context.ensureActive().getReadVersion().get());
+                openSimpleRecordStore(context);
+                if (testContext instanceof ReadVersionStateCacheTestContext) {
+                    assertEquals(1, timer.getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                } else {
+                    assertEquals(1, timer.getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                }
+                assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
+
+                // Add a dummy write to increase the DB version
+                context.ensureActive().addWriteConflictKey(recordStore.recordsSubspace().pack(UUID.randomUUID()));
+                commit(context);
+                assertThat(context.getCommittedVersion(), greaterThan(commitVersion));
+                commitVersion = context.getCommittedVersion();
+            }
+
+            // Load a new read version.
             timer.reset();
             final long readVersion;
             try (FDBRecordContext context = fdb.openContext(null, timer, null)) {
                 readVersion = fdb.getReadVersion(context).get();
+                assertThat(readVersion, greaterThanOrEqualTo(commitVersion));
                 openSimpleRecordStore(context);
-                assertEquals(1, timer.getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                if (testContext instanceof ReadVersionStateCacheTestContext) {
+                    assertEquals(1, timer.getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS));
+                } else {
+                    assertEquals(1, timer.getCount(FDBStoreTimer.Counts.STORE_STATE_CACHE_HIT));
+                }
                 assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
             }
 
-            // Load the meta-data using the cached read version
+            // Load the meta-data using the cached read version.
             timer.reset();
             try (FDBRecordContext context = fdb.openContext(null, timer, readSemantics)) {
                 assertEquals(readVersion, (long)context.ensureActive().getReadVersion().get());
@@ -578,15 +965,16 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
         }
     }
 
-    @Test
-    public void useWithDifferentDatabase() throws Exception {
+    @ParameterizedTest(name = "useWithDifferentDatabase (factory = [0])")
+    @MethodSource("factorySource")
+    public void useWithDifferentDatabase(FDBRecordStoreStateCacheFactory storeStateCacheFactory) throws Exception {
         FDBRecordStoreStateCacheFactory currentCacheFactory = FDBDatabaseFactory.instance().getStoreStateCacheFactory();
         try {
             File clusterFile = File.createTempFile("record_store_cache_", ".cluster");
             try (BufferedWriter writer = new BufferedWriter(new FileWriter(clusterFile))) {
                 writer.write("fake:fdbcluster@127.0.0.1:65537\n");
             }
-            FDBDatabaseFactory.instance().setStoreStateCacheFactory(readVersionCacheFactory);
+            FDBDatabaseFactory.instance().setStoreStateCacheFactory(storeStateCacheFactory);
             FDBDatabase secondDatabase = FDBDatabaseFactory.instance().getDatabase(clusterFile.getAbsolutePath());
 
             // Using the cache with a context from the wrong database shouldn't work
@@ -605,6 +993,57 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             assertSame(originalCache, fdb.getStoreStateCache());
         } finally {
             FDBDatabaseFactory.instance().setStoreStateCacheFactory(currentCacheFactory);
+        }
+    }
+
+    @Test
+    public void setCacheableAtWrongFormatVersion() throws Exception {
+        FDBRecordStoreStateCache currentCache = fdb.getStoreStateCache();
+        try {
+            fdb.setStoreStateCache(metaDataVersionStampCacheFactory.getCache(fdb));
+
+            // Initialize the store at the format version prior to the cacheable state version
+            FDBRecordStore.Builder storeBuilder = FDBRecordStore.newBuilder()
+                    .setKeySpacePath(path)
+                    .setMetaDataProvider(RecordMetaData.build(TestRecords1Proto.getDescriptor()))
+                    .setFormatVersion(FDBRecordStore.CACHEABLE_STATE_FORMAT_VERSION - 1);
+            try (FDBRecordContext context = openContext()) {
+                storeBuilder.copyBuilder().setContext(context).create();
+                commit(context);
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                FDBRecordStore recordStore = storeBuilder.copyBuilder()
+                        .setContext(context)
+                        .open();
+                assertEquals(FDBRecordStore.CACHEABLE_STATE_FORMAT_VERSION - 1, recordStore.getFormatVersion());
+                RecordCoreException e = assertThrows(RecordCoreException.class, () -> recordStore.setStateCacheability(true));
+                assertThat(e.getMessage(), containsString("cannot mark record store state cacheable at format version"));
+                commit(context);
+            }
+
+            // Update the format version
+            try (FDBRecordContext context = openContext()) {
+                storeBuilder.copyBuilder()
+                        .setContext(context)
+                        .setFormatVersion(FDBRecordStore.CACHEABLE_STATE_FORMAT_VERSION)
+                        .open();
+                commit(context);
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                // Assert that format version happens because of the upgrade behind the scenes
+                assertEquals(FDBRecordStore.CACHEABLE_STATE_FORMAT_VERSION - 1, storeBuilder.getFormatVersion());
+                FDBRecordStore recordStore = storeBuilder.copyBuilder()
+                        .setContext(context)
+                        .open();
+                assertEquals(FDBRecordStore.CACHEABLE_STATE_FORMAT_VERSION, recordStore.getFormatVersion());
+                assertTrue(recordStore.setStateCacheability(true));
+                commit(context);
+            }
+
+        } finally {
+            fdb.setStoreStateCache(currentCache);
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ group=org.foundationdb
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation
 
-fdbVersion=6.0.15
+fdbVersion=6.1.8
 jsr305Version=3.0.1
 slf4jVersion=1.7.14
 commonsLang3Version=3.9


### PR DESCRIPTION
This adds a new implementation of the `FDBRecordStoreStateCache` that caches by the meta-data version-stamp key made available in FDB 6.1. Actually using the new cache requires both setting the database to use the new cache as well as marking any record store whose state should be cached as "cacheable" in its store state.

As this feature requires 6.1, this PR also bumps the FDB version to 6.1 (in a separate commit: 10112f8). This resolves #551. Because the 6.1 client is not compatible with the 6.0 client, this is probably best conceived of as a breaking change.

It kind of seems like this could use more documentation somewhere. I updated the release notes to include the most basic usage, but a more worked out example somewhere might be good.

This resolves #537. Note that this is against the 2.8 branch rather than master.