### PR TITLE
Resolves #636: It should be possible for different time-window leaderboard groups to have different orders

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
@@ -47,13 +47,29 @@ import static com.apple.foundationdb.async.AsyncUtil.DONE;
 import static com.apple.foundationdb.async.AsyncUtil.READY_FALSE;
 
 /**
- * RankedSet supports the efficient retrieval of elements by their rank as
- * defined by lexiographic order.
+ * <code>RankedSet</code> supports the efficient retrieval of elements by their rank as
+ * defined by lexicographic order.
  *
  * <p>
- * Elements are added or removed from the set by key. The rank of any element
- * can then be quickly determined, and an element can be quickly retrieved by
- * its rank.
+ * Elements are added or removed from the set as byte-array keys.
+ * </p>
+ *
+ * <p>
+ * The fundamental operations are:
+ * </p>
+ * <ul>
+ * <li><b>rank</b>: the ordinal position of an element of the set ({@link #rank}).</li>
+ * <li><b>select</b>: the element at a given ordinal position in the set ({@link #getNth}).</li>
+ * </ul>
+ *
+ * <p>
+ * The set is implemented as a skip-list with a specified number of levels. Level zero has one entry for each element.
+ * Coarser levels have a sampling of values, determined by bits the hash code of their key.
+ * </p>
+ *
+ * <p>
+ * The skip-list is stored as key-value pairs within a given subspace, where the key is a tuple of the form <code>[<i>level</i>, <i>key</i>]</code>
+ * and the value is the number of elements between this key and the previous key at the same level, encoded as a little-endian long.
  * </p>
  */
 @API(API.Status.MAINTAINED)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -149,7 +149,11 @@ public class FDBStoreTimer extends StoreTimer {
         /** The amount of time spent in {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardWindowUpdate}. */
         TIME_WINDOW_LEADERBOARD_UPDATE_DIRECTORY("leaderboard update directory"),
         /** The amount of time spent in {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardScoreTrim}. */
-        TIME_WINDOW_LEADERBOARD_TRIM_SCORES("leaderboard trim scores");
+        TIME_WINDOW_LEADERBOARD_TRIM_SCORES("leaderboard trim scores"),
+        /** The amount of time spent in {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardSubDirectoryOperation}. */
+        TIME_WINDOW_LEADERBOARD_GET_SUB_DIRECTORY("leaderboard get sub-directory"),
+        /** The amount of time spent in {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardSaveSubDirectory}. */
+        TIME_WINDOW_LEADERBOARD_SAVE_SUB_DIRECTORY("leaderboard save sub-directory");
 
         private final String title;
         Events(String title) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
@@ -63,8 +63,18 @@ import java.util.concurrent.CompletableFuture;
  * <li><b>select</b>: Given a range of ranks, return (the primary keys for) the records with values in that range.</li>
  * </ul>
  *
+ * <p>
  * Any number of fields in the index can optionally separate records into non-overlapping <i>groups</i>.
  * Each group, determined by the values of those fields, has separate ranking.
+ * </p>
+ *
+ * <p>
+ * Physical layout:
+ * </p>
+ * <ul>
+ * <li><b>primary subspace</b>: an ordinary B-tree index by <code>[<i>group</i>, ..., <i>score</i>, ...]</code>.</li>
+ * <li><b>secondary subspace</b>: a ranked set per group, that is, with any group key as a prefix.</li>
+ * </ul>
  */
 @API(API.Status.MAINTAINED)
 public class RankIndexMaintainer extends StandardIndexMaintainer {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboard.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboard.java
@@ -67,10 +67,6 @@ public class TimeWindowLeaderboard implements Comparable<TimeWindowLeaderboard> 
         return directory;
     }
 
-    public boolean isHighScoreFirst() {
-        return directory.isHighScoreFirst();
-    }
-
     public int getType() {
         return type;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardDirectory.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The persisted set of active leaderboard ranked sets.
@@ -40,6 +41,7 @@ public class TimeWindowLeaderboardDirectory {
     private long updateTimestamp;
     private int nextKey;
     private Map<Integer, Collection<TimeWindowLeaderboard>> leaderboards = new TreeMap<>();
+    private Map<Tuple, TimeWindowLeaderboardSubDirectory> subdirectories = new ConcurrentHashMap<>();
 
     public TimeWindowLeaderboardDirectory(boolean highScoreFirst) {
         this.highScoreFirst = highScoreFirst;
@@ -111,6 +113,15 @@ public class TimeWindowLeaderboardDirectory {
             collection.add(leaderboard);
             return collection;
         });
+    }
+
+    @Nullable
+    public TimeWindowLeaderboardSubDirectory getSubDirectory(@Nonnull Tuple subdir) {
+        return subdirectories.get(subdir);
+    }
+
+    public void addSubDirectory(@Nonnull TimeWindowLeaderboardSubDirectory subdir) {
+        subdirectories.put(subdir.getGroup(), subdir);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSaveSubDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSaveSubDirectory.java
@@ -1,0 +1,44 @@
+/*
+ * TimeWindowLeaderboardSaveSubDirectory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.leaderboard;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperation;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Save a subdirectory to specify direction.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class TimeWindowLeaderboardSaveSubDirectory extends IndexOperation {
+    @Nonnull
+    private final TimeWindowLeaderboardSubDirectory subDirectory;
+
+    public TimeWindowLeaderboardSaveSubDirectory(@Nonnull TimeWindowLeaderboardSubDirectory subDirectory) {
+        this.subDirectory = subDirectory;
+    }
+
+    @Nonnull
+    public TimeWindowLeaderboardSubDirectory getSubDirectory() {
+        return subDirectory;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardScoreTrim.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardScoreTrim.java
@@ -28,6 +28,11 @@ import java.util.Collection;
 
 /**
  * Retain only scores that would be indexed by active time windows.
+ *
+ * Scores are specified as a collection of {@link Tuple}. A sub-collection is returned in {@link TimeWindowLeaderboardScoreTrimResult}.
+ *
+ * Score tuples can include their group key as well. If they do not, then all groups must have the default setting for whether high scores come first, which is needed
+ * to keep only the best score for a given time window.
  */
 @API(API.Status.EXPERIMENTAL)
 public class TimeWindowLeaderboardScoreTrim extends IndexOperation {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSubDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSubDirectory.java
@@ -1,0 +1,64 @@
+/*
+ * TimeWindowLeaderboardSubDirectory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.leaderboard;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.TimeWindowLeaderboardProto;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Persisted per-group information for leaderboard ranked sets.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class TimeWindowLeaderboardSubDirectory {
+    @Nonnull
+    private final Tuple group;
+    private final boolean highScoreFirst;
+
+    public TimeWindowLeaderboardSubDirectory(@Nonnull Tuple group, boolean highScoreFirst) {
+        this.group = group;
+        this.highScoreFirst = highScoreFirst;
+    }
+
+    protected TimeWindowLeaderboardSubDirectory(@Nonnull Tuple group, @Nonnull TimeWindowLeaderboardProto.TimeWindowLeaderboardSubDirectory proto) {
+        this.group = group;
+        highScoreFirst = proto.getHighScoreFirst();
+    }
+
+    @Nonnull
+    public Tuple getGroup() {
+        return group;
+    }
+
+    public boolean isHighScoreFirst() {
+        return highScoreFirst;
+    }
+
+    @Nonnull
+    public TimeWindowLeaderboardProto.TimeWindowLeaderboardSubDirectory toProto() {
+        TimeWindowLeaderboardProto.TimeWindowLeaderboardSubDirectory.Builder builder = TimeWindowLeaderboardProto.TimeWindowLeaderboardSubDirectory.newBuilder();
+        builder.setHighScoreFirst(highScoreFirst);
+        return builder.build();
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSubDirectoryOperation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSubDirectoryOperation.java
@@ -1,0 +1,45 @@
+/*
+ * TimeWindowLeaderboardSubDirectoryOperation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.leaderboard;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperation;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Get a sub-directory, which presently only contains information about direction.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class TimeWindowLeaderboardSubDirectoryOperation extends IndexOperation {
+    @Nonnull
+    private final Tuple group;
+
+    public TimeWindowLeaderboardSubDirectoryOperation(@Nonnull Tuple group) {
+        this.group = group;
+    }
+
+    @Nonnull
+    public Tuple getGroup() {
+        return group;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSubDirectoryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardSubDirectoryResult.java
@@ -1,0 +1,44 @@
+/*
+ * TimeWindowLeaderboardSubDirectoryResult.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.leaderboard;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperationResult;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A sub-directory, which presently only contains information about direction.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class TimeWindowLeaderboardSubDirectoryResult extends IndexOperationResult {
+    @Nonnull
+    private final TimeWindowLeaderboardSubDirectory subDirectory;
+
+    public TimeWindowLeaderboardSubDirectoryResult(@Nonnull TimeWindowLeaderboardSubDirectory subDirectory) {
+        this.subDirectory = subDirectory;
+    }
+
+    @Nonnull
+    public TimeWindowLeaderboardSubDirectory getSubDirectory() {
+        return subDirectory;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/package-info.java
@@ -21,35 +21,67 @@
 /**
  * Maintain leaderboard as multiple time-windowed ranked sets (so that old scores fall off).
  *
+ * <p>
  * The time windows are grouped by type, a client-supplied positive integer. For example, daily and weekly.
  * The built-in <code>ALL_TIME_WINDOW_LEADERBOARD_TYPE</code> type has the value 0.
+ * </p>
  *
+ * <p>
  * Each time window has a start and (exclusive) end timestamp, using a client-supplied timebase.
+ * </p>
  *
+ * <p>
  * A record is expected to contain multiple timestamped scored. The leaderboard enters the record's best score
  * (client specifies whether this is lowest or highest numerical value) in each time window. This determines
  * the record's rank (leaderboard position) at that time.
+ * </p>
  *
  * <h3>Index Representation</h3>
  *
- * The expected index keys are <code>group_fields..., score, timestamp, more_fields...</code>. A single B-tree stores these for all time windows.
+ * The expected index keys are <code>group_fields..., score, timestamp, more_fields...</code>.
+ * A single B-tree in the <em>primary</em> index subspace stores these once for all time windows.
  *
+ * <p>
  * The ideal root expression is therefore <code>field(scores_field, fanOut).nest(concat(score, timestamp, context))</code>.
+ * </p>
  *
+ * <p>
  * For the sake of simpler type systems, {@link com.apple.foundationdb.record.metadata.expressions.SplitKeyExpression} can be used to store
  * timestamped scores in the record in a repeated long field, along with zero or more opaque context values.
+ * </p>
  *
+ * <p>
  * The index root expression is then <code>split(list_field/fanOut, n)</code> or <code>concat(group_fields..., split(list_field/fanOut, n), more_fields...)</code>.
+ * </p>
  *
+ * <p>
  * The primary index entries are <code>group_fields..., score, timestamp, more_fields..., primary_key</code> &rarr; <code>context_values</code>.
+ * </p>
  *
- * The root of the secondary index is a directory, {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardDirectory}, serialized as Protobuf.
+ * <p>
+ * The root of the <em>secondary</em> index subspace is a directory, {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardDirectory}, serialized as Protobuf.
+ * </p>
  *
- * There is a {@link com.apple.foundationdb.async.RankedSet} stored for each directory entry for each group.
+ * <p>
+ * For each directory entry, there is a leaderboard subspace using the entry's {@linkplain com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboard#getSubspaceKey() subspace key}.
+ * </p>
  *
+ * <p>
+ * There is a {@link com.apple.foundationdb.async.RankedSet} within the leaderboard subspace for each group, that is, with any grouping keys as a prefix.
+ * </p>
+ *
+ * <p>
  * The ranked set entries are for <code>score, timestamp, more_fields</code>.
  * When scores match, the timestamp can break the tie: earlier is better (even when high scores come first).
  * <code>more_fields</code> can be used to further break ties at the same timestamp.
+ * </p>
+ *
+ * <p>
+ * A group can have an optional {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardSubDirectory}.
+ * A sub-directory allows individual groups to have different settings for whether high scores come first.
+ * Sub-directories are serialized as Protobuf in the <em>secondary</em> index subspace with key <code>[null, group_fields...]</code>.
+ * This does not conflict with leaderboards because <code>null</code> is not a valid leaderboard subspace key (they are automatically assigned integers).
+ * </p>
  *
  * <h3>Operations</h3>
  *
@@ -62,21 +94,27 @@
  * <li>A timestamp before which expired time windows can be removed from the database</li>
  * <li>A set of per-type specifications for regularly spaced windows, giving a base timestamp, duration and repeat count</li>
  * </ul>
- * 
+ *
+ * <p>
  * A good practice is to probabilistically add time windows in the future, with the chances increasing to certainty
  * as the time when a new window would be needed approaches.
+ * </p>
  *
  * <h3>Scanning</h3>
  *
  * The leaderboard index can be scanned <code>BY_VALUE</code>, like an ordinary index, provided the all-time time window
  * is maintained. This means by score ranges, or score matches for time ranges.
  *
+ * <p>
  * Scanning <code>BY_RANK</code> means a range of ranks rather than scores, as with a rankset index.
  * For this, too, the <code>ALL_TIME_LEADERBOARD_TYPE</code> time window is used.
+ * </p>
  *
+ * <p>
  * Scanning <code>BY_TIME_WINDOW</code> adds to tuple items at the beginning of the range representing the time window type and target timestamp.
  * The oldest ranked set of the given type containing the timestamp will be used.
  * For example,
+ * </p>
  * <code>
  *     final TupleRange top_10_type_2 = new TupleRange(Tuple.from(2, now, 0), Tuple.from(2, now, 9), EndpointType.RANGE_INCLUSIVE, EndpointType.RANGE_INCLUSIVE);
  *     final RecordCursor&lt;Message&gt; cursor = &lt;Message&gt;recordStore.scanIndexRecords("LeaderboardIndex", IndexScanType.BY_TIME_WINDOW, top_2_type_2, ScanProperties.FORWARD_SCAN);
@@ -87,10 +125,12 @@
  * The index can be used to match predicates / sorting for <code>Query.rank(expr)</code>.
  * Again, the <code>ALL_TIME_LEADERBOARD_TYPE</code> time window is used.
  *
+ * <p>
  * It can also match <code>Query.timeWindowRank(leaderboardType, leaderboardTimestamp, expr)</code>.
  * <code>leaderboardType</code> and <code>leaderboardTimestamp</code> can be strings, in which case
  * they specify the names of runtime parameters containing those values. The rank(s) will be taken from
  * the oldest leaderboard of the specified type containing the specified timestamp.
+ * </p>
  *
  */
 

--- a/fdb-record-layer-core/src/main/proto/time_window_leaderboard.proto
+++ b/fdb-record-layer-core/src/main/proto/time_window_leaderboard.proto
@@ -31,6 +31,10 @@ message TimeWindowLeaderboardDirectory {
   repeated TimeWindowLeaderboard leaderboards = 4;
 }
 
+message TimeWindowLeaderboardSubDirectory {
+  optional bool high_score_first = 1;
+}
+
 message TimeWindowLeaderboard {
    optional uint32 type = 1;
    optional uint64 start_timestamp = 2;


### PR DESCRIPTION
Mostly this consists of making the `isHighScoreFirst` asynchronous and based on group.