### PR TITLE
Resolves #584: Expose trace log format option through FDBDatabaseFactory

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -35,7 +35,7 @@ This version of the Record Layer requires a FoundationDB server version of at le
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Store state information can now be cached using the meta-data key added in FoundationDB 6.1 [(Issue #537)](https://github.com/FoundationDB/fdb-record-layer/issues/537)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Trace log format can be set in the `FDBDatabaseFactory` [(Issue #584)](https://github.com/FoundationDB/fdb-record-layer/issues/584)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTraceFormat.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTraceFormat.java
@@ -1,0 +1,92 @@
+/*
+ * FDBTraceFormat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+
+/**
+ * The FoundationDB native client can be configured to emit its trace logs (containing important
+ * metrics and instrumentation information) in one of several different formats. This enum can be
+ * passed to the {@link FDBDatabaseFactory#setTraceFormat(FDBTraceFormat)} method in order to
+ * control the client's behavior.
+ *
+ * <p>
+ * This class is {@link API.Status#MAINTAINED}. However, additional values to this enum may be added
+ * if more trace format options become available.
+ * </p>
+ */
+@API(API.Status.MAINTAINED)
+public enum FDBTraceFormat {
+
+    /**
+     * Use the system default. If the {@code FDB_NETWORK_OPTION_TRACE_FORMAT} environment variable
+     * is set or if one has already called {@link com.apple.foundationdb.NetworkOptions#setTraceFormat(String)},
+     * then the client trace logs will follow whatever format was already specified. If neither of
+     * those are set, then the logs will used the default format, which is {@link #XML}.
+     */
+    DEFAULT("", true),
+
+    /**
+     * Format the trace logs as XML. The full logs are contained within {@code Trace} tags, and each
+     * log entry is a single-line {@code TraceEvent} XML element. Each {@code TraceEvent} will associate
+     * log keys and values as attributes of the element (<em>not</em> as child elements). Logs will
+     * be written to files with a {@code .xml} extension.
+     */
+    XML("xml", false),
+
+    /**
+     * Format the trace logs as JSON. Each log entry is a single-line JSON document. Each entry will associate
+     * log keys and values as fields of the JSON document. Logs will be written to files with a {@code .json}
+     * extension.
+     */
+    JSON("json", false);
+
+    @Nonnull
+    private final String optionValue;
+    private final boolean defaultValue;
+
+    FDBTraceFormat(@Nonnull String optionValue, boolean defaultValue) {
+        this.optionValue = optionValue;
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+     * Get the value to supply to {@link com.apple.foundationdb.NetworkOptions#setTraceFormat(String) setTraceFormat()}.
+     * The exception here is the default value which can be achieved by not supplying any value to that option.
+     *
+     * @return the value to pass to {@link com.apple.foundationdb.NetworkOptions#setTraceFormat(String) setTraceFormat()}
+     */
+    @Nonnull
+    public String getOptionValue() {
+        return optionValue;
+    }
+
+    /**
+     * Get whether this is the default trace format. See {@link #DEFAULT} for more details.
+     *
+     * @return whether this indicates the client should use the default trace format
+     */
+    public boolean isDefaultValue() {
+        return defaultValue;
+    }
+}


### PR DESCRIPTION
The `FDBTraceFormat` enum can be used to specify whether the trace logs should be emitted in XML or JSON format. It allows includes a "default" option that follows the system default. This means this change backwards compatible with anyone who has used the `FDB_NETWORK_OPTION_TRACE_FORMAT` environment variable to do the same thing. If both the environment variable and a (non-`DEFAULT`) log format are set through the new interface, the new interface wins.

It's somewhat difficult to write tests for this (and none are checked in), but I did verify locally that setting this option did, in fact, change the format of the log files produced, and I verified that setting it to `DEFAULT` did follow the format set in the `FDB_NETWORK_OPTION_TRACE_FORMAT` variable.

Note that this requires FDB 6.1, so this is on the 2.8 branch. This resolves #584.