### PR TITLE
Resolves #641: Add a "get now" method to blocking in async detection

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Blocking on a future that should already be complete can now be detected and logged [(Issue #641)](https://github.com/FoundationDB/fdb-record-layer/issues/641)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -601,9 +601,25 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      * @param future the future to be completed
      * @param <T> the type of the value produced by the future
      * @return the result value
+     * @see FDBDatabase#join(CompletableFuture)
      */
     public <T> T join(CompletableFuture<T> future) {
         return database.join(future);
+    }
+
+    /**
+     * Join a future but validate that the future is already completed. This can be used to unwrap a completed
+     * future while allowing for bugs caused by inadvertently waiting on incomplete futures to be caught.
+     * In particular, this will throw an exception if the {@link BlockingInAsyncDetection} behavior is set
+     * to throw an exception on incomplete futures and otherwise just log that future was waited on.
+     *
+     * @param future the future that should already be completed
+     * @param <T> the type of the value produced by the future
+     * @return the result value
+     * @see FDBDatabase#joinNow(CompletableFuture)
+     */
+    public <T> T joinNow(CompletableFuture<T> future) {
+        return database.joinNow(future);
     }
 
     /**
@@ -613,6 +629,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      * @param future the future to be completed
      * @param <T> the type of the value produced by the future
      * @return the result value
+     * @see FDBDatabase#get(CompletableFuture)
      *
      * @throws java.util.concurrent.CancellationException if the future was cancelled
      * @throws ExecutionException if the future completed exceptionally

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -701,7 +701,7 @@ public class SplitHelper {
         @Deprecated
         public boolean hasNext() {
             try {
-                return onHasNext().join();
+                return context.join(onHasNext());
             } catch (Exception e) {
                 throw FDBExceptions.wrapException(e);
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
@@ -78,7 +78,7 @@ public class QueryRecordFunctionWithComparison implements ComponentWithCompariso
     @Nullable
     public <M extends Message> Boolean evalMessage(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context,
                                                    @Nullable FDBRecord<M> record, @Nullable Message message) {
-        return evalMessageAsync(store, context, record, message).join();
+        return store.getContext().join(evalMessageAsync(store, context, record, message));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -85,7 +85,7 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
             EvaluationContextBuilder builder = context.childBuilder();
             for (int i = 0; i < scores.size(); i++) {
                 final ScoreForRank rank = ranks.get(i);
-                final Tuple score = scores.get(i).join();
+                final Tuple score = store.getContext().joinNow(scores.get(i));
                 final Object binding;
                 if (score == null) {
                     binding = null;


### PR DESCRIPTION
This adds a `joinNow` method to `FDBDatabase` and to `FDBRecordContext` (the latter just calling the former). It then piggy backs off of the behavior of the `BlockingInAsyncDetection` specified for the database to also determine the behavior for this new method. I then went through the code base and tried to identify places that might `join`. I think I got all of them where there was a convenient `FDBDatabase` or `FDBRecordContext` lying around, but that might not quite be all of them.

This resolves #641.