### PR TITLE
Resolves #646: Key comparison in checkPossiblyRebuildRecordCounts confused …

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix key comparison in `checkPossiblyRebuildRecordCounts` [(Issue #646)](https://github.com/FoundationDB/fdb-record-layer/issues/646)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -54,9 +54,10 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
     private final String fieldName;
     @Nonnull
     private final FanType fanType;
+    @Nonnull
     private final Key.Evaluated.NullStandin nullStandin;
 
-    public FieldKeyExpression(@Nonnull String fieldName, @Nonnull FanType fanType, Key.Evaluated.NullStandin nullStandin) {
+    public FieldKeyExpression(@Nonnull String fieldName, @Nonnull FanType fanType, @Nonnull Key.Evaluated.NullStandin nullStandin) {
         this.fieldName = fieldName;
         this.fanType = fanType;
         this.nullStandin = nullStandin;
@@ -298,6 +299,7 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         return fanType;
     }
 
+    @Nonnull
     public Key.Evaluated.NullStandin getNullStandin() {
         return nullStandin;
     }
@@ -318,12 +320,14 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         }
 
         FieldKeyExpression that = (FieldKeyExpression)o;
-        return this.fieldName.equals(that.fieldName) && (this.fanType == that.fanType);
+        return this.fieldName.equals(that.fieldName) &&
+               this.fanType == that.fanType &&
+               this.nullStandin == that.nullStandin;
     }
 
     @Override
     public int hashCode() {
-        return fieldName.hashCode() + fanType.hashCode();
+        return fieldName.hashCode() + fanType.hashCode() + nullStandin.hashCode();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -90,6 +90,7 @@ import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
 import com.apple.foundationdb.util.LoggableException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
@@ -1715,7 +1716,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return readStoreFirstKey(context, getSubspace(), isolationLevel).thenApply(keyValue -> checkAndParseStoreHeader(keyValue, existenceCheck));
     }
 
-    private void saveStoreHeader(@Nonnull RecordMetaDataProto.DataStoreInfo storeHeader) {
+    @VisibleForTesting
+    protected void saveStoreHeader(@Nonnull RecordMetaDataProto.DataStoreInfo storeHeader) {
         if (recordStoreStateRef.get() == null) {
             throw new RecordCoreException("cannot update store header with a null record store state");
         }
@@ -2922,18 +2924,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                                        @Nonnull RecordMetaDataProto.DataStoreInfo.Builder info,
                                                        @Nonnull List<CompletableFuture<Void>> work,
                                                        int oldFormatVersion) {
-        RecordMetaDataProto.KeyExpression countKeyExpression = null;
-        if (metaData.getRecordCountKey() != null) {
-            try {
-                countKeyExpression = metaData.getRecordCountKey().toKeyExpression();
-            } catch (KeyExpression.SerializationException e) {
-                throw new RecordCoreException("Error converting count key expression to protobuf", e);
-            }
-        }
+        KeyExpression countKeyExpression = metaData.getRecordCountKey();
         boolean rebuildRecordCounts =
                 (oldFormatVersion > 0 && oldFormatVersion < RECORD_COUNT_ADDED_FORMAT_VERSION) ||
                         (countKeyExpression != null && formatVersion >= RECORD_COUNT_KEY_ADDED_FORMAT_VERSION &&
-                                (!info.hasRecordCountKey() || !info.getRecordCountKey().equals(countKeyExpression)));
+                                (!info.hasRecordCountKey() || !KeyExpression.fromProto(info.getRecordCountKey()).equals(countKeyExpression)));
         if (rebuildRecordCounts) {
             // We want to clear all record counts.
             final Transaction tr = ensureContextActive();
@@ -2942,7 +2937,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             // Set the new record count key if we have one.
             if (formatVersion >= RECORD_COUNT_KEY_ADDED_FORMAT_VERSION) {
                 if (countKeyExpression != null) {
-                    info.setRecordCountKey(countKeyExpression);
+                    info.setRecordCountKey(countKeyExpression.toKeyExpression());
                 } else {
                     info.clearRecordCountKey();
                 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
+import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestHelpers;
@@ -96,6 +97,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
@@ -1802,6 +1804,64 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             openSimpleRecordStore(context, hook);
             Index countIndex = recordStore.getRecordMetaData().getIndex("record_count");
             assertThat(recordStore.getRecordStoreState().isWriteOnly(countIndex), is(false));
+            assertEquals(10L, recordStore.getSnapshotRecordCount().get().longValue());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void addCountKey() throws Exception {
+        RecordMetaDataHook removeCountHook = metaData -> {
+            metaData.removeIndex(COUNT_INDEX.getName());
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, removeCountHook);
+
+            for (int i = 0; i < 10; i++) {
+                recordStore.saveRecord(makeRecord(i, 1066, i % 5));
+            }
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, removeCountHook);
+            recordStore.getSnapshotRecordCount().get();
+            fail("evaluated count without index or key");
+        } catch (RecordCoreException e) {
+            assertThat(e.getMessage(), containsString("requires appropriate index"));
+        }
+
+        AtomicInteger versionCounter = new AtomicInteger(recordStore.getRecordMetaData().getVersion());
+        RecordMetaDataHook hook = md -> {
+            md.setRecordCountKey(Key.Expressions.field("num_value_3_indexed"));
+            md.setVersion(md.getVersion() + versionCounter.incrementAndGet());
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(timer.getCount(FDBStoreTimer.Events.RECOUNT_RECORDS), equalTo(1));
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(timer.getCount(FDBStoreTimer.Events.RECOUNT_RECORDS), equalTo(0));
+            assertEquals(10L, recordStore.getSnapshotRecordCount().get().longValue());
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            // Before it was deprecated, this is how a key would have been written.
+            RecordMetaDataProto.DataStoreInfo.Builder infoBuilder = recordStore.getRecordStoreState().getStoreHeader().toBuilder();
+            infoBuilder.getRecordCountKeyBuilder().getFieldBuilder().clearNullInterpretation();
+            recordStore.saveStoreHeader(infoBuilder.build());
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(timer.getCount(FDBStoreTimer.Events.RECOUNT_RECORDS), equalTo(0));
             assertEquals(10L, recordStore.getSnapshotRecordCount().get().longValue());
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -305,7 +305,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
             assertThat(executeQuery(RecordQuery.newBuilder()
                     .setRecordType("MyNullRecord")
-                    .setSort(Key.Expressions.field("int_value"))
+                    .setSort(scalarFieldsNotNull ? Key.Expressions.field("int_value", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NOT_NULL) : Key.Expressions.field("int_value"))
                     .build()),
                     is(scalarFieldsNotNull ?
                                 Arrays.asList("minus", "default", "empty", "one", "two") :
@@ -359,7 +359,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
             assertThat(executeQuery(RecordQuery.newBuilder()
                             .setRecordType("MyNullRecord")
-                            .setSort(Key.Expressions.field("nullable_int_value").nest("value"))
+                            .setSort(Key.Expressions.field("nullable_int_value").nest(Key.Expressions.field("value", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NOT_NULL)))
                             .build()),
                     is(Arrays.asList("empty", "minus", "default", "one", "two")));
         }


### PR DESCRIPTION
… in difference in nullInterpretation

Add a test that reproduces the problem by simulating how things were once written.
Use `KeyExpression.equals` instead of comparing protobuf, so that any compatible evolution is applied.
Make `FieldKeyExpression.equals` and `hashCode` take `nullStandin` into account. Keep `planHash` the same so as not to be disruptive.

Note that some tests need to change now, since sorting must agree in null behavior with index. I believe that this is required, since, for instance, an index that treats missing as default sorts numbers at zero, whereas missing as null sorts before negative infinity, so the queries aren't equivalent. (You could even define both indexes and issue alternative queries.)