### PR TITLE
Resolves #650: Create no-op operation to test network thread liveness/responsiveness

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Blocking on a future that should already be complete can now be detected and logged [(Issue #641)](https://github.com/FoundationDB/fdb-record-layer/issues/641)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** The `performNoOp` method on `FDBDatabase` allows for instrumenting the delay from queuing work onto the network thread [(Issue #650)](https://github.com/FoundationDB/fdb-record-layer/issues/650)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -38,6 +38,8 @@ public class FDBStoreTimer extends StoreTimer {
      * Ordinary top-level events which surround a single body of code.
      */
     public enum Events implements Event {
+        /** The amount of time taken performing a no-op. */
+        PERFORM_NO_OP("perform no-op"),
         /** The amount of time taken committing transactions successfully. */
         COMMIT("commit transaction"),
         /** The amount of time taken committing transactions that did not actually have any writes. */
@@ -214,6 +216,8 @@ public class FDBStoreTimer extends StoreTimer {
          * The purpose of passing this is to get standard error handling for futures that have completed exceptionally.
          */
         WAIT_ERROR_CHECK("check for error completion"),
+        /** Wait for performing a no-op operation.*/
+        WAIT_PERFORM_NO_OP("wait for performing a no-op"),
         /** Wait for explicit call to {@link FDBDatabase#getReadVersion}. */
         WAIT_GET_READ_VERSION("get_read_version"),
         /** Wait for a transaction to commit. */

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
@@ -24,6 +24,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
 /**
  * Base class from which all FDB tests should be derived.
  */
@@ -54,5 +60,14 @@ public abstract class FDBTestBase {
                 LOGGER.info("Blocking-in-async is " + detection);
             }
         }
+    }
+
+    @Nonnull
+    public static String createFakeClusterFile(String prefix) throws IOException {
+        File clusterFile = File.createTempFile(prefix, ".cluster");
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(clusterFile))) {
+            writer.write("fake:fdbcluster@127.0.0.1:65537\n");
+        }
+        return clusterFile.getAbsolutePath();
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreKeyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.RecordStoreAlreadyExistsException;
 import com.apple.foundationdb.record.provider.foundationdb.RecordStoreDoesNotExistException;
 import com.apple.foundationdb.record.provider.foundationdb.RecordStoreNoInfoAndNotEmptyException;
@@ -45,9 +46,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -582,12 +580,9 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
     public void useWithDifferentDatabase() throws Exception {
         FDBRecordStoreStateCacheFactory currentCacheFactory = FDBDatabaseFactory.instance().getStoreStateCacheFactory();
         try {
-            File clusterFile = File.createTempFile("record_store_cache_", ".cluster");
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(clusterFile))) {
-                writer.write("fake:fdbcluster@127.0.0.1:65537\n");
-            }
+            String clusterFile = FDBTestBase.createFakeClusterFile("record_store_cache_");
             FDBDatabaseFactory.instance().setStoreStateCacheFactory(readVersionCacheFactory);
-            FDBDatabase secondDatabase = FDBDatabaseFactory.instance().getDatabase(clusterFile.getAbsolutePath());
+            FDBDatabase secondDatabase = FDBDatabaseFactory.instance().getDatabase(clusterFile);
 
             // Using the cache with a context from the wrong database shouldn't work
             try (FDBRecordContext context = openContext()) {


### PR DESCRIPTION
This adds the `performNoOp` and its async variants to the `FDBDatabase` class. This also adds events and waits for that which can be instrumented.

The exact no-op thing that is done is to create a new transaction, set its read version, and then attempt to read it. That requires performing no I/O (as verified by trying to run against a fake cluster). It is also harder to test, but if one calls `stopNetwork`, this will catch the fact that the network thread is down. I have not been able to reproduce the network thread just being really, really slow, but alas.

This resolves #650.