### PR TITLE
Revert "Fixes #626: NullStandin should be set in FieldKeyExpression::toProto"

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Revert #627 until a complete version of #647 is worked out. [(Issue #646)](https://github.com/FoundationDB/fdb-record-layer/issues/646)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
@@ -353,7 +353,7 @@ public class Key {
                 proto = nullInterpretation;
             }
 
-            public RecordMetaDataProto.Field.NullInterpretation toProto() {
+            RecordMetaDataProto.Field.NullInterpretation toProto() {
                 return proto;
             }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -188,7 +188,6 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         return RecordMetaDataProto.Field.newBuilder()
                 .setFieldName(fieldName)
                 .setFanType(fanType.toProto())
-                .setNullInterpretation(nullStandin.toProto())
                 .build();
     }
 
@@ -296,10 +295,6 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
     @Nonnull
     public FanType getFanType() {
         return fanType;
-    }
-
-    public Key.Evaluated.NullStandin getNullStandin() {
-        return nullStandin;
     }
 
     @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -673,11 +673,10 @@ public class KeyExpressionTest {
 
     @Test
     public void testSerializeField() throws Exception {
-        final FieldKeyExpression f1 = field("f1", FanType.FanOut, Key.Evaluated.NullStandin.NULL_UNIQUE);
+        final FieldKeyExpression f1 = field("f1", FanType.FanOut);
         final FieldKeyExpression f1Deserialized = new FieldKeyExpression(f1.toProto());
         assertEquals("f1", f1Deserialized.getFieldName());
         assertEquals(FanType.FanOut, f1Deserialized.getFanType());
-        assertEquals(Key.Evaluated.NullStandin.NULL_UNIQUE, f1Deserialized.getNullStandin());
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 85b09f13ebe3c5e9c70bb23cc824dda03ebc0111.

This is a temporary fix until all the issues with #647 can be worked through.