### PR TITLE
 Fixes #655: Planner's sort matching needs to understand null interpretation equivalence classes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ The non-static `RecordCursor::flatMapPipelined()` method has been deprecated bec
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `NullStandin` should be set in `FieldKeyExpression::toProto` [(Issue #626)](https://github.com/FoundationDB/fdb-record-layer/issues/626)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,9 +20,9 @@ The non-static `RecordCursor::flatMapPipelined()` method has been deprecated bec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Work around SpotBugs bug [(Issue #659)](https://github.com/FoundationDB/fdb-record-layer/issues/659)
+* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix sorting with null-is-unique indexes [(Issue #655)](https://github.com/FoundationDB/fdb-record-layer/issues/655)
 * **Bug fix** `NullStandin` should be set in `FieldKeyExpression::toProto` [(Issue #626)](https://github.com/FoundationDB/fdb-record-layer/issues/626)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ The non-static `RecordCursor::flatMapPipelined()` method has been deprecated bec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Work around SpotBugs bug [(Issue #659)](https://github.com/FoundationDB/fdb-record-layer/issues/659)
 * **Bug fix** `NullStandin` should be set in `FieldKeyExpression::toProto` [(Issue #626)](https://github.com/FoundationDB/fdb-record-layer/issues/626)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
@@ -375,7 +375,7 @@ public class Key {
                 proto = nullInterpretation;
             }
 
-            RecordMetaDataProto.Field.NullInterpretation toProto() {
+            public RecordMetaDataProto.Field.NullInterpretation toProto() {
                 return proto;
             }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -54,9 +54,10 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
     private final String fieldName;
     @Nonnull
     private final FanType fanType;
+    @Nonnull
     private final Key.Evaluated.NullStandin nullStandin;
 
-    public FieldKeyExpression(@Nonnull String fieldName, @Nonnull FanType fanType, Key.Evaluated.NullStandin nullStandin) {
+    public FieldKeyExpression(@Nonnull String fieldName, @Nonnull FanType fanType, @Nonnull Key.Evaluated.NullStandin nullStandin) {
         this.fieldName = fieldName;
         this.fanType = fanType;
         this.nullStandin = nullStandin;
@@ -298,6 +299,7 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         return fanType;
     }
 
+    @Nonnull
     public Key.Evaluated.NullStandin getNullStandin() {
         return nullStandin;
     }
@@ -318,12 +320,14 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         }
 
         FieldKeyExpression that = (FieldKeyExpression)o;
-        return this.fieldName.equals(that.fieldName) && (this.fanType == that.fanType);
+        return this.fieldName.equals(that.fieldName) &&
+               this.fanType == that.fanType &&
+               this.nullStandin == that.nullStandin;
     }
 
     @Override
     public int hashCode() {
-        return fieldName.hashCode() + fanType.hashCode();
+        return fieldName.hashCode() + fanType.hashCode() + nullStandin.hashCode();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -188,6 +188,7 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         return RecordMetaDataProto.Field.newBuilder()
                 .setFieldName(fieldName)
                 .setFanType(fanType.toProto())
+                .setNullInterpretation(nullStandin.toProto())
                 .build();
     }
 
@@ -295,6 +296,10 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
     @Nonnull
     public FanType getFanType() {
         return fanType;
+    }
+
+    public Key.Evaluated.NullStandin getNullStandin() {
+        return nullStandin;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -332,11 +332,28 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
 
     @Override
     public int planHash() {
-        return fieldName.hashCode() + fanType.name().hashCode();
+        int hash = fieldName.hashCode() + fanType.name().hashCode();
+        if (nullStandin == Key.Evaluated.NullStandin.NOT_NULL) {
+            // NULL and NULL_UNIQUE have the same hash, which is also the same as before.
+            hash++;
+        }
+        return hash;
     }
 
     @Override
     public boolean equalsAtomic(AtomKeyExpression other) {
-        return equals(other);
+        return equivalentForSort(other);
+    }
+
+    @Override
+    public boolean equivalentForSort(@Nonnull KeyExpression other) {
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        FieldKeyExpression that = (FieldKeyExpression)other;
+        return this.fieldName.equals(that.fieldName) &&
+               this.fanType == that.fanType &&
+               (this.nullStandin == Key.Evaluated.NullStandin.NOT_NULL) == (that.nullStandin == Key.Evaluated.NullStandin.NOT_NULL);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
@@ -371,4 +371,18 @@ public abstract class FunctionKeyExpression extends BaseKeyExpression implements
             return functions;
         }
     }
+
+    @Override
+    public boolean equivalentForSort(@Nonnull KeyExpression other) {
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        FunctionKeyExpression that = (FunctionKeyExpression) other;
+        if (!this.getName().equals(that.getName())) {
+            return false;
+        }
+
+        return this.getArguments().equivalentForSort(that.getArguments());
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupingKeyExpression.java
@@ -199,4 +199,14 @@ public class GroupingKeyExpression extends BaseKeyExpression implements KeyExpre
     public int planHash() {
         return getWholeKey().planHash() + groupedCount;
     }
+
+    @Override
+    public boolean equivalentForSort(@Nonnull KeyExpression other) {
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        GroupingKeyExpression that = (GroupingKeyExpression)other;
+        return this.getWholeKey().equivalentForSort(that.getWholeKey()) && (this.groupedCount == that.groupedCount);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -226,6 +226,16 @@ public interface KeyExpression extends PlanHashable, PlannerExpression {
         return this instanceof KeyExpressionWithChildren || this instanceof KeyExpressionWithoutChildren;
     }
 
+    /**
+     * Check whether a key expression is the same for purposes of determining sort order.
+     * @param other another key expression
+     * @return {@code true} if this key expression sorts entries in the same order
+     */
+    @API(API.Status.INTERNAL)
+    default boolean equivalentForSort(@Nonnull KeyExpression other) {
+        return equals(other);
+    }
+
     static KeyExpression fromProto(RecordMetaDataProto.KeyExpression expression)
             throws DeserializationException {
         KeyExpression root = null;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
@@ -234,4 +234,14 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
     public int planHash() {
         return getInnerKey().planHash() + splitPoint;
     }
+
+    @Override
+    public boolean equivalentForSort(@Nonnull KeyExpression other) {
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        KeyWithValueExpression that = (KeyWithValueExpression)other;
+        return this.getInnerKey().equivalentForSort(that.getInnerKey()) && (this.splitPoint == that.splitPoint);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
@@ -201,4 +201,15 @@ public class NestingKeyExpression extends BaseKeyExpression implements KeyExpres
     public boolean equalsAtomic(AtomKeyExpression other) {
         return this.getClass() == other.getClass() && parent.equals(((NestingKeyExpression) other).parent);
     }
+
+    @Override
+    public boolean equivalentForSort(@Nonnull KeyExpression other) {
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        NestingKeyExpression that = (NestingKeyExpression)other;
+        // Parent does not contribute to sorting, so just use equals.
+        return this.parent.equals(that.parent) && this.getChild().equivalentForSort(that.getChild());
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
@@ -196,4 +196,14 @@ public class SplitKeyExpression extends BaseKeyExpression implements AtomKeyExpr
     public boolean equalsAtomic(AtomKeyExpression other) {
         return equals(other);
     }
+
+    @Override
+    public boolean equivalentForSort(@Nonnull KeyExpression other) {
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        SplitKeyExpression that = (SplitKeyExpression)other;
+        return this.getJoined().equivalentForSort(that.getJoined()) && (this.splitSize == that.splitSize);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
@@ -303,5 +303,23 @@ public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressio
         return i;
     }
 
+    @Override
+    public boolean equivalentForSort(@Nonnull KeyExpression other) {
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+
+        List<KeyExpression> children = getChildren();
+        List<KeyExpression> otherChildren = ((ThenKeyExpression)other).getChildren();
+        if (children.size() != otherChildren.size()) {
+            return false;
+        }
+        for (int i = 0; i < children.size(); i++) {
+            if (!children.get(i).equivalentForSort(otherChildren.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -93,6 +93,7 @@ import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
 import com.apple.foundationdb.util.LoggableException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
@@ -1846,7 +1847,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return readStoreFirstKey(context, getSubspace(), isolationLevel).thenApply(keyValue -> checkAndParseStoreHeader(keyValue, existenceCheck));
     }
 
-    private void saveStoreHeader(@Nonnull RecordMetaDataProto.DataStoreInfo storeHeader) {
+    @VisibleForTesting
+    protected void saveStoreHeader(@Nonnull RecordMetaDataProto.DataStoreInfo storeHeader) {
         if (recordStoreStateRef.get() == null) {
             throw new RecordCoreException("cannot update store header with a null record store state");
         }
@@ -3053,18 +3055,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                                        @Nonnull RecordMetaDataProto.DataStoreInfo.Builder info,
                                                        @Nonnull List<CompletableFuture<Void>> work,
                                                        int oldFormatVersion) {
-        RecordMetaDataProto.KeyExpression countKeyExpression = null;
-        if (metaData.getRecordCountKey() != null) {
-            try {
-                countKeyExpression = metaData.getRecordCountKey().toKeyExpression();
-            } catch (KeyExpression.SerializationException e) {
-                throw new RecordCoreException("Error converting count key expression to protobuf", e);
-            }
-        }
+        KeyExpression countKeyExpression = metaData.getRecordCountKey();
         boolean rebuildRecordCounts =
                 (oldFormatVersion > 0 && oldFormatVersion < RECORD_COUNT_ADDED_FORMAT_VERSION) ||
                         (countKeyExpression != null && formatVersion >= RECORD_COUNT_KEY_ADDED_FORMAT_VERSION &&
-                                (!info.hasRecordCountKey() || !info.getRecordCountKey().equals(countKeyExpression)));
+                                (!info.hasRecordCountKey() || !KeyExpression.fromProto(info.getRecordCountKey()).equals(countKeyExpression)));
         if (rebuildRecordCounts) {
             // We want to clear all record counts.
             final Transaction tr = ensureContextActive();
@@ -3073,7 +3068,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             // Set the new record count key if we have one.
             if (formatVersion >= RECORD_COUNT_KEY_ADDED_FORMAT_VERSION) {
                 if (countKeyExpression != null) {
-                    info.setRecordCountKey(countKeyExpression);
+                    info.setRecordCountKey(countKeyExpression.toKeyExpression());
                 } else {
                     info.clearRecordCountKey();
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -687,7 +687,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             return new AndWithThenPlanner(candidateScan, then, Collections.singletonList(filter), sort).plan();
         }
         ScoredPlan plan = planNestedField(candidateScan, then.getChildren().get(0), filter, sort);
-        if (plan == null && sort != null && sort.equals(then.getChildren().get(1))) {
+        if (plan == null && sort != null && sort.equivalentForSort(then.getChildren().get(1))) {
             ScoredPlan sortlessPlan = planNestedField(candidateScan, then.getChildren().get(0), filter, null);
             ScanComparisons sortlessComparisons = getPlanComparisons(sortlessPlan);
             if (sortlessComparisons != null && sortlessComparisons.isEquality()) {
@@ -920,7 +920,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             return null;
         } else if (index instanceof ThenKeyExpression) {
             ThenKeyExpression then = (ThenKeyExpression) index;
-            if ((sort == null || sort.equals(then.getChildren().get(0))) &&
+            if ((sort == null || sort.equivalentForSort(then.getChildren().get(0))) &&
                     !then.createsDuplicates() &&
                     !(then.getChildren().get(0) instanceof RecordTypeKeyExpression)) {
                 // First column will do it all or not.
@@ -938,7 +938,7 @@ public class RecordQueryPlanner implements QueryPlanner {
                                                             @Nonnull KeyExpression index,
                                                             @Nonnull QueryKeyExpressionWithComparison queryKeyExpressionWithComparison,
                                                             @Nullable KeyExpression sort) {
-        if (index.equals(queryKeyExpressionWithComparison.getKeyExpression()) && (sort == null || sort.equals(index))) {
+        if (index.equals(queryKeyExpressionWithComparison.getKeyExpression()) && (sort == null || sort.equivalentForSort(index))) {
             final Comparisons.Comparison comparison = queryKeyExpressionWithComparison.getComparison();
             final ScanComparisons scanComparisons = ScanComparisons.from(comparison);
             if (scanComparisons == null) {
@@ -1003,7 +1003,7 @@ public class RecordQueryPlanner implements QueryPlanner {
         if (index instanceof VersionKeyExpression) {
             final Comparisons.Comparison comparison = filter.getComparison();
             final ScanComparisons comparisons = ScanComparisons.from(comparison);
-            if (sort == null || sort.equals(VersionKeyExpression.VERSION)) {
+            if (sort == null || sort.equivalentForSort(VersionKeyExpression.VERSION)) {
                 RecordQueryPlan plan = new RecordQueryIndexPlan(candidateScan.index.getName(), IndexScanType.BY_VALUE, comparisons, candidateScan.reverse);
                 return new ScoredPlan(1, plan, Collections.emptyList(), false);
             }
@@ -1747,7 +1747,7 @@ public class RecordQueryPlanner implements QueryPlanner {
 
         private boolean currentSortMatches(@Nonnull KeyExpression child) {
             if (currentSort != null) {
-                if (currentSort.equals(child)) {
+                if (currentSort.equivalentForSort(child)) {
                     return true;
                 }
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -685,10 +685,11 @@ public class KeyExpressionTest {
 
     @Test
     public void testSerializeField() throws Exception {
-        final FieldKeyExpression f1 = field("f1", FanType.FanOut);
+        final FieldKeyExpression f1 = field("f1", FanType.FanOut, Key.Evaluated.NullStandin.NULL_UNIQUE);
         final FieldKeyExpression f1Deserialized = new FieldKeyExpression(f1.toProto());
         assertEquals("f1", f1Deserialized.getFieldName());
         assertEquals(FanType.FanOut, f1Deserialized.getFanType());
+        assertEquals(Key.Evaluated.NullStandin.NULL_UNIQUE, f1Deserialized.getNullStandin());
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
+import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestHelpers;
@@ -96,6 +97,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
@@ -1802,6 +1804,64 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             openSimpleRecordStore(context, hook);
             Index countIndex = recordStore.getRecordMetaData().getIndex("record_count");
             assertThat(recordStore.getRecordStoreState().isWriteOnly(countIndex), is(false));
+            assertEquals(10L, recordStore.getSnapshotRecordCount().get().longValue());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void addCountKey() throws Exception {
+        RecordMetaDataHook removeCountHook = metaData -> {
+            metaData.removeIndex(COUNT_INDEX.getName());
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, removeCountHook);
+
+            for (int i = 0; i < 10; i++) {
+                recordStore.saveRecord(makeRecord(i, 1066, i % 5));
+            }
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, removeCountHook);
+            recordStore.getSnapshotRecordCount().get();
+            fail("evaluated count without index or key");
+        } catch (RecordCoreException e) {
+            assertThat(e.getMessage(), containsString("requires appropriate index"));
+        }
+
+        AtomicInteger versionCounter = new AtomicInteger(recordStore.getRecordMetaData().getVersion());
+        RecordMetaDataHook hook = md -> {
+            md.setRecordCountKey(Key.Expressions.field("num_value_3_indexed"));
+            md.setVersion(md.getVersion() + versionCounter.incrementAndGet());
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(timer.getCount(FDBStoreTimer.Events.RECOUNT_RECORDS), equalTo(1));
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(timer.getCount(FDBStoreTimer.Events.RECOUNT_RECORDS), equalTo(0));
+            assertEquals(10L, recordStore.getSnapshotRecordCount().get().longValue());
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            // Before it was deprecated, this is how a key would have been written.
+            RecordMetaDataProto.DataStoreInfo.Builder infoBuilder = recordStore.getRecordStoreState().getStoreHeader().toBuilder();
+            infoBuilder.getRecordCountKeyBuilder().getFieldBuilder().clearNullInterpretation();
+            recordStore.saveStoreHeader(infoBuilder.build());
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(timer.getCount(FDBStoreTimer.Events.RECOUNT_RECORDS), equalTo(0));
             assertEquals(10L, recordStore.getSnapshotRecordCount().get().longValue());
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -305,7 +305,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
             assertThat(executeQuery(RecordQuery.newBuilder()
                     .setRecordType("MyNullRecord")
-                    .setSort(Key.Expressions.field("int_value"))
+                    .setSort(scalarFieldsNotNull ? Key.Expressions.field("int_value", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NOT_NULL) : Key.Expressions.field("int_value"))
                     .build()),
                     is(scalarFieldsNotNull ?
                                 Arrays.asList("minus", "default", "empty", "one", "two") :
@@ -359,7 +359,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
             assertThat(executeQuery(RecordQuery.newBuilder()
                             .setRecordType("MyNullRecord")
-                            .setSort(Key.Expressions.field("nullable_int_value").nest("value"))
+                            .setSort(Key.Expressions.field("nullable_int_value").nest(Key.Expressions.field("value", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NOT_NULL)))
                             .build()),
                     is(Arrays.asList("empty", "minus", "default", "one", "two")));
         }


### PR DESCRIPTION
Restores 85b09f13ebe3c5e9c70bb23cc824dda03ebc0111 and 9f6f5663a4e1484acadf2465badc420b59244d97 to get back to 7401456d855955ab7f439b5a47ea5ea550eda288.

Adds a comparison predicate on `KeyExpression` for the purpose of sort ordering, defaulting to `equals`.
Make the planner use this.
It might be better, as part of the new planner, to rethink how unique nulls are handled as part of the index definition so that key expression comparison could be simpler again.
Also address `planHash` as noted in https://github.com/FoundationDB/fdb-record-layer/pull/647#discussion_r303114366.