### PR TITLE
Fixes #659: SpotBugs bug tickled by leaderboards.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Work around SpotBugs bug [(Issue #659)](https://github.com/FoundationDB/fdb-record-layer/issues/659)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -743,10 +743,11 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
         if (directory == null) {
             return CompletableFuture.completedFuture(scores);
         }
+        final Map<Integer, Collection<TimeWindowLeaderboard>> leaderboards = directory.getLeaderboards();
         final List<IndexEntry> indexEntries = scores.stream().map(score -> new IndexEntry(state.index, score, TupleHelpers.EMPTY)).collect(Collectors.toList());
         return groupOrderedScoreIndexKeys(indexEntries, directory, includesGroup).thenApply(groupedScores -> {
             final Set<OrderedScoreIndexKey> trimmed = new TreeSet<>();
-            for (Iterable<TimeWindowLeaderboard> directoryEntry : directory.getLeaderboards().values()) {
+            for (Iterable<TimeWindowLeaderboard> directoryEntry : leaderboards.values()) {
                 for (TimeWindowLeaderboard leaderboard : directoryEntry) {
                     for (Collection<OrderedScoreIndexKey> entry : groupedScores.values()) {
                         Optional<OrderedScoreIndexKey> bestContainedScore = entry.stream()


### PR DESCRIPTION
Remove the @Nullable parameter from the capture by taking getting something out of it outside the lambda.

I'm not quite sure why this doesn't happen in Jenkins. But it does locally every time.