### PR TITLE
Resolves #575: UnorderedUnion and ProbableIntersectionCursors should return deterministically ordered results

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -51,6 +51,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Results from `ProbableIntersectionCursor`s and `UnorderedUnionCursor`s are returned in a predictable order which makes using their continuations safer [(Issue #575)](https://github.com/FoundationDB/fdb-record-layer/issues/575)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
@@ -134,6 +134,16 @@ abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implements Recor
         }
     }
 
+    /**
+     * Fire off futures for each state in the list. This allows for the cursor to pipeline
+     * work from each of its children.
+     */
+    static <T, S extends MergeCursorState<T>> void startAllStates(@Nonnull List<S> curorStates) {
+        for (MergeCursorState<T> cursorState : curorStates) {
+            cursorState.getOnNextFuture();
+        }
+    }
+
     void checkNextStateTimeout(long startTime) {
         long checkStateTime = System.currentTimeMillis();
         if (checkStateTime - startTime > MAX_NEXT_STATE_MILLIS) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/RoundRobinCursorChooser.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/RoundRobinCursorChooser.java
@@ -1,0 +1,82 @@
+/*
+ * RoundRobinCursorChooser.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.async.MoreAsyncUtil;
+import com.apple.foundationdb.record.RecordCursorResult;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Given a list of cursor states, this keeps track of the state necessary to go through the list of cursors
+ * in a round-robin fashion. This abstracts some of the common logic shared by the {@link UnorderedUnionCursor}
+ * and the {@link ProbableIntersectionCursor}, both of which choose cursors this way.
+ */
+class RoundRobinCursorChooser<T> {
+    @Nonnull
+    private final List<? extends MergeCursorState<T>> cursorStates;
+    private int nextStatePos;
+
+    RoundRobinCursorChooser(@Nonnull List<? extends MergeCursorState<T>> cursorStates, int nextStatePos) {
+        this.cursorStates = cursorStates;
+        this.nextStatePos = nextStatePos;
+    }
+
+    /**
+     * Move the round-robin cursor forward. This should be called after consuming a child and returning it.
+     */
+    void advance() {
+        nextStatePos = (nextStatePos + 1) % cursorStates.size();
+    }
+
+    int getNextStatePos() {
+        return nextStatePos;
+    }
+
+    /**
+     * Choose the next state (using the round-robin policy). It will skip over any states that it
+     * knows are exhausted (though the future itself may correspond to an exhausted state if incomplete).
+     *
+     * @return a future from the next cursor state or {@code null} if all cursors are known to be exhausted
+     */
+    @Nullable
+    CompletableFuture<RecordCursorResult<T>> getFutureFromNextState() {
+        int initialPos = nextStatePos;
+        MergeCursorState<T> nextState = cursorStates.get(nextStatePos);
+        while (MoreAsyncUtil.isCompletedNormally(nextState.getOnNextFuture())) {
+            final RecordCursorResult<T> resultState = nextState.getResult();
+            if (!resultState.hasNext() && resultState.getNoNextReason().isSourceExhausted()) {
+                advance();
+                if (nextStatePos == initialPos) {
+                    // We went through all of them, so return null here to indicate that we're exhausted.
+                    return null;
+                }
+                nextState = cursorStates.get(nextStatePos);
+            } else {
+                break;
+            }
+        }
+        return nextState.getOnNextFuture();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursorContinuation.java
@@ -1,0 +1,75 @@
+/*
+ * UnorderedUnionCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorProto;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+class UnorderedUnionCursorContinuation extends UnionCursorContinuation {
+    private final int currentChild;
+
+    private UnorderedUnionCursorContinuation(@Nonnull List<RecordCursorContinuation> continuations,
+                                             @Nullable RecordCursorProto.UnionContinuation originalProto,
+                                             int currentChild) {
+        super(continuations, originalProto);
+        this.currentChild = currentChild;
+    }
+
+    private UnorderedUnionCursorContinuation(@Nonnull List<RecordCursorContinuation> continuations,
+                                             int currentChild) {
+        this(continuations, null, currentChild);
+    }
+
+    @Override
+    @Nonnull
+    RecordCursorProto.UnionContinuation.Builder newProtoBuilder() {
+        return RecordCursorProto.UnionContinuation.newBuilder()
+                .setCurrentChild(currentChild);
+    }
+
+    int getCurrentChild() {
+        return currentChild;
+    }
+
+    @Nonnull
+    static UnorderedUnionCursorContinuation from(@Nonnull UnorderedUnionCursor<?> cursor) {
+        return new UnorderedUnionCursorContinuation(cursor.getChildContinuations(), cursor.getCurrentChildPos());
+    }
+
+    @Nonnull
+    static UnorderedUnionCursorContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
+        if (bytes == null) {
+            return new UnorderedUnionCursorContinuation(Collections.nCopies(numberOfChildren, RecordCursorStartContinuation.START), 0);
+        }
+        return UnorderedUnionCursorContinuation.from(parseProto(bytes), numberOfChildren);
+    }
+
+    @Nonnull
+    static UnorderedUnionCursorContinuation from(@Nonnull RecordCursorProto.UnionContinuation parsed, int numberOfChildren) {
+        return new UnorderedUnionCursorContinuation(getChildContinuations(parsed, numberOfChildren), parsed, parsed.getCurrentChild());
+    }
+}

--- a/fdb-record-layer-core/src/main/proto/record_cursor.proto
+++ b/fdb-record-layer-core/src/main/proto/record_cursor.proto
@@ -55,6 +55,7 @@ message UnionContinuation {
     optional bool first_exhausted = 3;
     optional bool second_exhausted = 4;
     repeated CursorState other_child_state = 5;
+    optional int32 current_child = 6;
 }
 
 message ProbableIntersectionContinuation {
@@ -64,6 +65,7 @@ message ProbableIntersectionContinuation {
         optional bytes bloom_filter = 3;
     }
     repeated CursorState child_state = 1;
+    optional int32 current_child = 2;
 }
 
 message ConcatContinuation {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/CursorTestUtils.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/CursorTestUtils.java
@@ -1,0 +1,119 @@
+/*
+ * CursorTestUtils.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.cursors;
+
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Some utility functions for working with cursors that are useful for the various cursor tests.
+ */
+public class CursorTestUtils {
+
+    /**
+     * Create a list of functions for turning lists into {@link RecordCursor}s. This can then be used as
+     * input into higher-level cursors. Each function will thread through the continuation its given to the
+     * cursor it produces, so it can be used to correctly construct resumable cursors over multiple lists of input.
+     *
+     * @param lists a list of lists of items
+     * @param <T> the type of element returned by each cursor and each list
+     * @return a list of functions producing cursors over the original lists
+     */
+    @Nonnull
+    public static <T> List<Function<byte[], RecordCursor<T>>> cursorFunctionsFromLists(@Nonnull List<List<T>> lists) {
+        return lists.stream()
+                .map(list -> (Function<byte[], RecordCursor<T>>)((byte[] continuation) -> RecordCursor.fromList(list, continuation)))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Create a list of functions wrapping existing cursors. This can then be used as input into higher-level
+     * cursors. <em>Warning:</em> this method ignores the continuation completely, so care must be taken
+     * to make sure that the continuations given to the cursors given as input into this function match the
+     * continuation that will eventually be provided to the function.
+     *
+     * @param cursors a list of cursors
+     * @param <T> the type of element returned by each cursor
+     * @return a list of functions wrapping the given cursors
+     */
+    @Nonnull
+    public static <T> List<Function<byte[], RecordCursor<T>>> cursorFunctionsFromCursors(@Nonnull List<? extends RecordCursor<T>> cursors) {
+        return cursors.stream()
+                .map(cursor -> (Function<byte[], RecordCursor<T>>)((byte[] ignore) -> cursor))
+                .collect(Collectors.toList());
+    }
+
+    @Nonnull
+    private static <T> RecordCursorContinuation consumeFirstN(@Nonnull RecordCursor<T> cursor, @Nonnull List<T> dest, int n) {
+        if (n <= 0) {
+            throw new RecordCoreArgumentException("cannot consume a non-positive number of elements from a cursor");
+        }
+        RecordCursorContinuation continuation = null;
+        for (int i = 0; i < n; i++) {
+            RecordCursorResult<T> result = cursor.getNext();
+            continuation = result.getContinuation();
+            if (result.hasNext()) {
+                dest.add(result.get());
+            } else {
+                break;
+            }
+        }
+        return continuation;
+    }
+
+    /**
+     * Make a cursor a list while consuming a given number of elements at a time. This will attempt to consume up
+     * to {@code batchSize} elements of the cursor, after which it will discard that cursor and then resume from
+     * the final result's continuation. If the cursor hits a limit during execution before returning {@code batchSize}
+     * results, then the cursor will be likewise resumed using the continuation from the last result (i.e., the
+     * result that did not have an element associated with it). The results from all of these cursors will be
+     * returned as a list, with the elements of the list in the same order as returned by the cursors.
+     *
+     * @param cursorFunction a function for producing a cursor (resumed from a continuation)
+     * @param batchSize the number of elements to consume between stopping and resuming the cursor
+     * @param <T> the type of elements returned by the cursor
+     * @return a list of elements returned by the cursor (possibly across multiple invocations)
+     */
+    @Nonnull
+    public static <T> List<T> toListInBatches(@Nonnull Function<byte[], ? extends RecordCursor<T>> cursorFunction, int batchSize) {
+        RecordCursorContinuation continuation = RecordCursorStartContinuation.START;
+        List<T> dest = new ArrayList<>();
+        while (!continuation.isEnd()) {
+            try (RecordCursor<T> cursor = cursorFunction.apply(continuation.toBytes())) {
+                continuation = consumeFirstN(cursor, dest, batchSize);
+            }
+        }
+        return dest;
+    }
+
+    // Static utility class
+    private CursorTestUtils() {
+    }
+}


### PR DESCRIPTION
The `UnorderedUnionCursor` and `ProbableIntersectionCursor` now choose to use a "round robin" strategy for going through its children. The continuation then includes the child to use when the cursor is resumed.

In theory, I could see one or two more tests to validate that the order is exactly as specified in the (updated!) comments, but I also wanted to get the code out here for this.

This resolves #575.