### PR TITLE
Fixes #665: Deprecate non-static RecordCursor.flatMapPipelinedCursor().

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,6 +12,10 @@ The Guava version has been updated to version 27. Users of the [shaded variants]
 
 Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` have been marked as deprecated in favor of static initializers. This will allow for more flexibility as work on the new planner develops.
 
+# Newly Deprecated 
+
+The non-static `RecordCursor::flatMapPipelined()` method has been deprecated because it is easy to mis-use (by mistaken analogy to the `mapPipelined()` method) and cannot be used with continuations. See [Issue #665](https://github.com/FoundationDB/fdb-record-layer/issues/665) for further explanation.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -36,6 +40,7 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Deprecated** The non-static `RecordCursor::flatMapPipelined()` method has been deprecated [(Issue #665)](https://github.com/FoundationDB/fdb-record-layer/issues/665)
 * All changes from version [2.7.73.21](#277321)
 
 // end next release

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursor.java
@@ -556,7 +556,11 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
      * @param pipelineSize the number of cursors from applications of the mapping function to open ahead of time
      * @param <V> the result type of the mapping function
      * @return a new cursor that applies the given function to produce a cursor of records that gets flattened
+     * @deprecated because it does not support continuations and is easy to misuse.
+     *             Use {@link #flatMapPipelined(Function, BiFunction, byte[], int)} instead.
      */
+    @Deprecated
+    @API(API.Status.DEPRECATED)
     @Nonnull
     default <V> RecordCursor<V> flatMapPipelined(@Nonnull Function<T, ? extends RecordCursor<V>> func, int pipelineSize) {
         return new FlatMapPipelinedCursor<>(this, (t, cignore) -> func.apply(t),
@@ -572,7 +576,6 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
         return flatMapPipelined(outerFunc, innerFunc, null, continuation, pipelineSize);
     }
 
-    @Nonnull
     /**
      * Resume a nested cursor with the given continuation or start if <code>null</code>.
      * @param outerFunc a function that takes the outer continuation and returns the outer cursor.
@@ -586,7 +589,11 @@ public interface RecordCursor<T> extends AutoCloseable, Iterator<T> {
      * or a new record being inserted right before it (do full inner cursor, not partial based on previous).
      * @param continuation the continuation returned from a previous instance of this pipeline or <code>null</code> at start.
      * @param pipelineSize the number of outer items to work ahead; inner cursors for these will be started in parallel.
+     * @param <T> the result type of the outer cursor
+     * @param <V> the result type of the inner cursor produced by the mapping function
+     * @return a {@link FlatMapPipelinedCursor} that maps the inner function across the results of the outer function
      */
+    @Nonnull
     static <T, V> RecordCursor<V> flatMapPipelined(@Nonnull Function<byte[], ? extends RecordCursor<T>> outerFunc,
                                                           @Nonnull BiFunction<T, byte[], ? extends RecordCursor<V>> innerFunc,
                                                           @Nullable Function<T, byte[]> checker,


### PR DESCRIPTION
As described in #665, it is very easy to misuse and impossible to use with a continuation. It's not used in very many places, and most of the places where it's used are tests. This change also migrates all the Record Layer's internal uses of this method to the static forms instead.