### PR TITLE
Resolves #670: Add a MAX_VERSION index type

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The new `MAX_EVER_VERSION` index type tracks the maximum ever value for key expressions including a record's version [(Issue #670)](https://github.com/FoundationDB/fdb-record-layer/issues/670)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexTypes.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexTypes.java
@@ -102,6 +102,27 @@ public class IndexTypes {
     public static final String MAX_EVER_LONG = FunctionNames.MAX_EVER + "_long";
 
     /**
+     * An index remembering the maximum ever value stored where one column is the
+     * {@linkplain com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion record version}.
+     * This can be used to detect if there have been any changes to the record store or to subsections
+     * of the record store (if there are grouping columns included in the index definition).
+     *
+     * <p>
+     * This index is like {@link #MAX_EVER_TUPLE} except that the expression may contain exactly
+     * one aggregated column that contains a
+     * {@link com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression VersionKeyExpression}
+     * with one caveat. If a record is written with an incomplete version-stamp, then the aggregate index
+     * entry is guaranteed to be updated to include the value from that record. For example, if there
+     * are two columns defined as part of the index, and the first corresponds to an integer field while the
+     * second corresponds to the record version, then the value stored by this index may go backwards
+     * if, for example, one stores a record where the first field has value 2 and has an incomplete
+     * version-stamp and then, in a separate transaction, one stores a record with the first field has
+     * value 1 and has an incomplete version-stamp.
+     * </p>
+     */
+    public static final String MAX_EVER_VERSION = FunctionNames.MAX_EVER + "_version";
+
+    /**
      * A ranked set index, allowing efficient rank and select operations.
      */
     public static final String RANK = "rank";

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidator.java
@@ -107,6 +107,30 @@ public class IndexValidator {
         }
     }
 
+    protected void validateVersionInGroupedKeys() {
+        KeyExpression key = index.getRootExpression();
+        validateGrouping(1);
+        if (key instanceof GroupingKeyExpression) {
+            GroupingKeyExpression grouping = (GroupingKeyExpression)key;
+            KeyExpression groupingKey = grouping.getGroupingSubKey();
+            if (groupingKey.versionColumns() != 0) {
+                throw new KeyExpression.InvalidExpressionException(
+                        String.format("there must be no version entries in grouping key in %s index",
+                                index.getType()),
+                        LogMessageKeys.INDEX_NAME, index.getName(),
+                        LogMessageKeys.INDEX_KEY, key);
+            }
+            final KeyExpression groupedKey = grouping.getGroupedSubKey();
+            if (groupedKey.versionColumns() != 1) {
+                throw new KeyExpression.InvalidExpressionException(
+                        String.format("there must be exactly 1 version entry in grouped key in %s index",
+                                index.getType()),
+                        LogMessageKeys.INDEX_NAME, index.getName(),
+                        LogMessageKeys.INDEX_KEY, key);
+            }
+        }
+    }
+
     protected void validateNotUnique() {
         if (index.isUnique()) {
             throw new MetaDataException(String.format(

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/VersionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/VersionKeyExpression.java
@@ -47,7 +47,7 @@ public class VersionKeyExpression extends BaseKeyExpression implements AtomKeyEx
     public static final RecordMetaDataProto.KeyExpression VERSION_PROTO =
             RecordMetaDataProto.KeyExpression.newBuilder().setVersion(VERSION.toProto()).build();
 
-    private static final GroupingKeyExpression UNGROUPED = new GroupingKeyExpression(new VersionKeyExpression(), 0);
+    private static final GroupingKeyExpression UNGROUPED = new GroupingKeyExpression(new VersionKeyExpression(), 1);
 
     private VersionKeyExpression() {
         // nothing to initialize
@@ -84,6 +84,10 @@ public class VersionKeyExpression extends BaseKeyExpression implements AtomKeyEx
         return UNGROUPED;
     }
 
+    @Nonnull
+    public GroupingKeyExpression groupBy(@Nonnull KeyExpression groupByFirst, @Nonnull KeyExpression... groupByRest) {
+        return GroupingKeyExpression.of(this, groupByFirst, groupByRest);
+    }
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -55,6 +55,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -851,6 +852,19 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     public byte[] removeVersionMutation(@Nonnull byte[] key) {
         Pair<MutationType, byte[]> existingValue = versionMutationCache.remove(key);
         return existingValue != null ? existingValue.getRight() : null;
+    }
+
+    public byte[] updateVersionMutation(@Nonnull MutationType mutationType, @Nonnull byte[] key, @Nonnull byte[] value,
+                                        @Nonnull BiFunction<byte[], byte[], byte[]> remappingFunction) {
+        Pair<MutationType, byte[]> valuePair = Pair.of(mutationType, value);
+        return versionMutationCache.merge(key, valuePair, (origPair, newPair) -> {
+            if (origPair.getLeft().equals(newPair.getLeft())) {
+                byte[] newValue = remappingFunction.apply(origPair.getRight(), newPair.getRight());
+                return newValue == null ? null : Pair.of(origPair.getLeft(), newValue);
+            } else {
+                throw new RecordCoreArgumentException("cannot update mutation type for versionstamp operation");
+            }
+        }).getRight();
     }
 
     public FDBDatabase.WeakReadSemantics getWeakReadSemantics() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -44,14 +44,15 @@ import java.util.List;
  *
  * Implements the following index types:
  * <ul>
- * <li><code>COUNT</code></li>
- * <li><code>COUNT_UPDATES</code></li>
- * <li><code>COUNT_NOT_NULL</code></li>
- * <li><code>SUM</code></li>
- * <li><code>MIN_EVER_TUPLE</code></li>
- * <li><code>MAX_EVER_TUPLE</code></li>
- * <li><code>MIN_EVER_LONG</code></li>
- * <li><code>MAX_EVER_LONG</code></li>
+ *     <li>{@link IndexTypes#COUNT COUNT}</li>
+ *     <li>{@link IndexTypes#COUNT_UPDATES COUNT_UPDATES}</li>
+ *     <li>{@link IndexTypes#COUNT_NOT_NULL COUNT_NOT_NULL}</li>
+ *     <li>{@link IndexTypes#SUM SUM}</li>
+ *     <li>{@link IndexTypes#MIN_EVER_TUPLE MIN_EVER_TUPLE}</li>
+ *     <li>{@link IndexTypes#MAX_EVER_TUPLE MAX_EVER_TUPLE}</li>
+ *     <li>{@link IndexTypes#MIN_EVER_LONG MIN_EVER_LONG}</li>
+ *     <li>{@link IndexTypes#MAX_EVER_LONG MAX_EVER_LONG}</li>
+ *     <li>{@link IndexTypes#MAX_EVER_VERSION MAX_EVER_VERSION}</li>
  * </ul>
  */
 @AutoService(IndexMaintainerFactory.class)
@@ -59,8 +60,11 @@ import java.util.List;
 public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFactory {
     @SuppressWarnings({"deprecation","squid:CallToDeprecatedMethod"}) // Support the deprecated names for compatibility.
     static final String[] TYPES = {
-        IndexTypes.COUNT, IndexTypes.COUNT_UPDATES, IndexTypes.COUNT_NOT_NULL, IndexTypes.SUM,
-        IndexTypes.MIN_EVER_TUPLE, IndexTypes.MAX_EVER_TUPLE, IndexTypes.MIN_EVER_LONG, IndexTypes.MAX_EVER_LONG, IndexTypes.MIN_EVER, IndexTypes.MAX_EVER
+            IndexTypes.COUNT, IndexTypes.COUNT_UPDATES, IndexTypes.COUNT_NOT_NULL, IndexTypes.SUM,
+            IndexTypes.MIN_EVER_TUPLE, IndexTypes.MAX_EVER_TUPLE,
+            IndexTypes.MIN_EVER_LONG, IndexTypes.MAX_EVER_LONG,
+            IndexTypes.MAX_EVER_VERSION,
+            IndexTypes.MIN_EVER, IndexTypes.MAX_EVER
     };
 
     @Override
@@ -82,7 +86,6 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
             @Override
             public void validate(@Nonnull MetaDataValidator metaDataValidator) {
                 super.validate(metaDataValidator);
-                validateNotVersion();
                 if (!mutation.hasValues()) {
                     validateGrouping(0);
                     if (getGroupedCount() != 0) {
@@ -99,6 +102,11 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
                                 LogMessageKeys.INDEX_NAME, index.getName(),
                                 LogMessageKeys.INDEX_KEY, index.getRootExpression());
                     }
+                }
+                if (AtomicMutation.Standard.MAX_EVER_VERSION.equals(mutation)) {
+                    validateVersionInGroupedKeys();
+                } else {
+                    validateNotVersion();
                 }
             }
 


### PR DESCRIPTION
The new `MAX_EVER_VERSION` index type allows for expressions with a `VersionKeyExpression` within it to be tracked. It uses the same machinery as the `MAX_EVER` atomic mutation index, though there is some special casing needed to handle the fact that sometimes, one wants to use the `SET_VERSIONSTAMPED_VALUE` mutation, and sometimes, one wants to use the `BYTES_MAX` expression.

There are two other weird things about this index:

* It does not (at the moment) support read your writes insofar as asking for the max version from the index will not include incomplete versions from the same transaction. The version index also has this property, and the way to solve it is to introduce a new special kind of intersection cursor for scanning those two indexes that reads from the in-memory structure with version information for both types. That could be added fairly straightforwardly.
* It can theoretically "go backwards". This is because it always assumes that with incomplete versions, the version it is saving is greater than any version of any record in the record store, which may not be true if there are records saved with versions not chosen by the database. (A non-contrived example of this might be data copied from another cluster where the versions from that cluster are copied over with the data.) It can also go backwards if there is a column in the expression being maxed by the index prior to the version column (not counting grouping columns), and then one saves a new record where the value of that column goes down but the version included is incomplete. These both stem from the fact that the `SET_VERSIONSTAMPED_VALUE` mutation is used in the case of incomplete versionstamps, so that can result in existing expressions being overwritten. This, theoretically, could be fixed, but it would require reading from the database, and it would either require serializing all updates to the index or still allowing gaps where the index could go backwards. For that reason, it seemed better to keep the index performant and then document the behavior, but I could be wrong. Another approach would be to push for a new mutation type from the key-value store that did the `MAX_VERSIONSTAMPED_VALUE`, i.e., it transforms the value like `SET_VERSIONSTAMPED_VALUE`, but then it calls `BYTES_MAX` instead of `SET`.

This resolves #670.