### PR TITLE
Fixes #682: Remove NullStandIn checking from the equality check for fields

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ The non-static `RecordCursor::flatMapPipelined()` method has been deprecated bec
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fields no longer compare their `NullStandIn` value in their equality check [(Issue #682)](https://github.com/FoundationDB/fdb-record-layer/issues/682)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
@@ -66,9 +66,13 @@ public class Key {
         private Expressions() {}
 
         /**
-         * Create an expression of a single scalar (i.e. not repeated) field.
+         * Create an expression of a single scalar (i.e. not repeated) field. This sets the {@link Evaluated.NullStandin}
+         * to {@link Evaluated.NullStandin#NULL}. See {@link #field(String, KeyExpression.FanType, com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin)}
+         * for more details.
+         *
          * @param name the name of the field to evaluate
          * @return a new Field expression, which can further be nested if the associated field is of the Message type.
+         * @see #field(String, KeyExpression.FanType, com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin)
          */
         @Nonnull
         public static FieldKeyExpression field(@Nonnull String name) {
@@ -78,10 +82,14 @@ public class Key {
         /**
          * Creates an expression of a field. This field can be repeated or not, depending on the fanType.
          * If fanType is Concatenate or None, this expression will only create 1 index entry. If it is FanOut it will
-         * create 1 index entry per value of the field.
+         * create 1 index entry per value of the field. This sets the {@link Evaluated.NullStandin} to
+         * {@link Evaluated.NullStandin#NULL}. See {@link #field(String, KeyExpression.FanType, com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin)}
+         * for more details.
+         *
          * @param name the name of the field to evaluate
          * @param fanType the way that repeated fields should be handled
          * @return a new Field expression which can further be nested if the associated field is of the Message type.
+         * @see #field(String, KeyExpression.FanType, com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin)
          */
         @Nonnull
         public static FieldKeyExpression field(@Nonnull String name, @Nonnull KeyExpression.FanType fanType) {
@@ -92,6 +100,21 @@ public class Key {
          * Creates an expression of a field. This field can be repeated or not, depending on the fanType.
          * If fanType is Concatenate or None, this expression will only create 1 index entry. If it is FanOut it will
          * create 1 index entry per value of the field.
+         *
+         * <p>
+         * This also takes a {@link Evaluated.NullStandin} value to describe the field's behavior when it encounters an
+         * unset field. If the value is {@link Evaluated.NullStandin#NOT_NULL NOT_NULL}, it will use the field's default
+         * value instead of {@code null}. If the value is {@link Evaluated.NullStandin#NULL NULL}, it will return the
+         * value {@code null} and disable any uniqueness checks (if the index is a {@linkplain IndexOptions#UNIQUE_OPTION unique}
+         * index). If the value is {@link Evaluated.NullStandin#NULL_UNIQUE NULL_UNIQUE}, it will return {@code null}
+         * and not disable any uniqueness checks. (In other words, it will treat {@code null} just like any other value.)
+         * Note that for most use cases, the same value should be used for the {@code nullStandIn} every time the field
+         * is referenced by any key expression or different indexes may have different ideas as to, for example,
+         * whether a field can be {@code null} or not. For this reason, there are plans to move this expression from
+         * the field to meta-data on the {@link RecordType}. See <a href="https://github.com/FoundationDB/fdb-record-layer/issues/677">Issue #677</a>
+         * for more details.
+         * </p>
+         *
          * @param name the name of the field to evaluate
          * @param fanType the way that repeated fields should be handled
          * @param nullStandin value to use in place of missing values,
@@ -99,7 +122,7 @@ public class Key {
          * @return a new Field expression which can further be nested if the associated field is of the Message type.
          */
         @Nonnull
-        public static FieldKeyExpression field(@Nonnull String name, @Nonnull KeyExpression.FanType fanType, Evaluated.NullStandin nullStandin) {
+        public static FieldKeyExpression field(@Nonnull String name, @Nonnull KeyExpression.FanType fanType, @Nonnull Evaluated.NullStandin nullStandin) {
             return new FieldKeyExpression(name, fanType, nullStandin);
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -319,41 +319,29 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
             return false;
         }
 
+        // Note that the NullStandIn value is NOT checked here. It will be replaced with
+        // https://github.com/FoundationDB/fdb-record-layer/issues/677
         FieldKeyExpression that = (FieldKeyExpression)o;
         return this.fieldName.equals(that.fieldName) &&
-               this.fanType == that.fanType &&
-               this.nullStandin == that.nullStandin;
+               this.fanType == that.fanType;
     }
 
     @Override
     public int hashCode() {
-        return fieldName.hashCode() + fanType.hashCode() + nullStandin.hashCode();
+        // Note that the NullStandIn is NOT included in the hash code. It will be replaced with
+        // https://github.com/FoundationDB/fdb-record-layer/issues/677
+        return fieldName.hashCode() + fanType.hashCode();
     }
 
     @Override
     public int planHash() {
-        int hash = fieldName.hashCode() + fanType.name().hashCode();
-        if (nullStandin == Key.Evaluated.NullStandin.NOT_NULL) {
-            // NULL and NULL_UNIQUE have the same hash, which is also the same as before.
-            hash++;
-        }
-        return hash;
+        // Note that the NullStandIn is NOT included in the hash code. It will be replaced with
+        // https://github.com/FoundationDB/fdb-record-layer/issues/677
+        return fieldName.hashCode() + fanType.name().hashCode();
     }
 
     @Override
     public boolean equalsAtomic(AtomKeyExpression other) {
-        return equivalentForSort(other);
-    }
-
-    @Override
-    public boolean equivalentForSort(@Nonnull KeyExpression other) {
-        if (getClass() != other.getClass()) {
-            return false;
-        }
-
-        FieldKeyExpression that = (FieldKeyExpression)other;
-        return this.fieldName.equals(that.fieldName) &&
-               this.fanType == that.fanType &&
-               (this.nullStandin == Key.Evaluated.NullStandin.NOT_NULL) == (that.nullStandin == Key.Evaluated.NullStandin.NOT_NULL);
+        return equals(other);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
@@ -371,18 +371,4 @@ public abstract class FunctionKeyExpression extends BaseKeyExpression implements
             return functions;
         }
     }
-
-    @Override
-    public boolean equivalentForSort(@Nonnull KeyExpression other) {
-        if (getClass() != other.getClass()) {
-            return false;
-        }
-
-        FunctionKeyExpression that = (FunctionKeyExpression) other;
-        if (!this.getName().equals(that.getName())) {
-            return false;
-        }
-
-        return this.getArguments().equivalentForSort(that.getArguments());
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupingKeyExpression.java
@@ -199,14 +199,4 @@ public class GroupingKeyExpression extends BaseKeyExpression implements KeyExpre
     public int planHash() {
         return getWholeKey().planHash() + groupedCount;
     }
-
-    @Override
-    public boolean equivalentForSort(@Nonnull KeyExpression other) {
-        if (getClass() != other.getClass()) {
-            return false;
-        }
-
-        GroupingKeyExpression that = (GroupingKeyExpression)other;
-        return this.getWholeKey().equivalentForSort(that.getWholeKey()) && (this.groupedCount == that.groupedCount);
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -226,16 +226,7 @@ public interface KeyExpression extends PlanHashable, PlannerExpression {
         return this instanceof KeyExpressionWithChildren || this instanceof KeyExpressionWithoutChildren;
     }
 
-    /**
-     * Check whether a key expression is the same for purposes of determining sort order.
-     * @param other another key expression
-     * @return {@code true} if this key expression sorts entries in the same order
-     */
-    @API(API.Status.INTERNAL)
-    default boolean equivalentForSort(@Nonnull KeyExpression other) {
-        return equals(other);
-    }
-
+    @Nonnull
     static KeyExpression fromProto(RecordMetaDataProto.KeyExpression expression)
             throws DeserializationException {
         KeyExpression root = null;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
@@ -234,14 +234,4 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
     public int planHash() {
         return getInnerKey().planHash() + splitPoint;
     }
-
-    @Override
-    public boolean equivalentForSort(@Nonnull KeyExpression other) {
-        if (getClass() != other.getClass()) {
-            return false;
-        }
-
-        KeyWithValueExpression that = (KeyWithValueExpression)other;
-        return this.getInnerKey().equivalentForSort(that.getInnerKey()) && (this.splitPoint == that.splitPoint);
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
@@ -201,15 +201,4 @@ public class NestingKeyExpression extends BaseKeyExpression implements KeyExpres
     public boolean equalsAtomic(AtomKeyExpression other) {
         return this.getClass() == other.getClass() && parent.equals(((NestingKeyExpression) other).parent);
     }
-
-    @Override
-    public boolean equivalentForSort(@Nonnull KeyExpression other) {
-        if (getClass() != other.getClass()) {
-            return false;
-        }
-
-        NestingKeyExpression that = (NestingKeyExpression)other;
-        // Parent does not contribute to sorting, so just use equals.
-        return this.parent.equals(that.parent) && this.getChild().equivalentForSort(that.getChild());
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
@@ -196,14 +196,4 @@ public class SplitKeyExpression extends BaseKeyExpression implements AtomKeyExpr
     public boolean equalsAtomic(AtomKeyExpression other) {
         return equals(other);
     }
-
-    @Override
-    public boolean equivalentForSort(@Nonnull KeyExpression other) {
-        if (getClass() != other.getClass()) {
-            return false;
-        }
-
-        SplitKeyExpression that = (SplitKeyExpression)other;
-        return this.getJoined().equivalentForSort(that.getJoined()) && (this.splitSize == that.splitSize);
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
@@ -302,24 +302,5 @@ public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressio
         }
         return i;
     }
-
-    @Override
-    public boolean equivalentForSort(@Nonnull KeyExpression other) {
-        if (getClass() != other.getClass()) {
-            return false;
-        }
-
-        List<KeyExpression> children = getChildren();
-        List<KeyExpression> otherChildren = ((ThenKeyExpression)other).getChildren();
-        if (children.size() != otherChildren.size()) {
-            return false;
-        }
-        for (int i = 0; i < children.size(); i++) {
-            if (!children.get(i).equivalentForSort(otherChildren.get(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
 }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -687,7 +687,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             return new AndWithThenPlanner(candidateScan, then, Collections.singletonList(filter), sort).plan();
         }
         ScoredPlan plan = planNestedField(candidateScan, then.getChildren().get(0), filter, sort);
-        if (plan == null && sort != null && sort.equivalentForSort(then.getChildren().get(1))) {
+        if (plan == null && sort != null && sort.equals(then.getChildren().get(1))) {
             ScoredPlan sortlessPlan = planNestedField(candidateScan, then.getChildren().get(0), filter, null);
             ScanComparisons sortlessComparisons = getPlanComparisons(sortlessPlan);
             if (sortlessComparisons != null && sortlessComparisons.isEquality()) {
@@ -920,7 +920,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             return null;
         } else if (index instanceof ThenKeyExpression) {
             ThenKeyExpression then = (ThenKeyExpression) index;
-            if ((sort == null || sort.equivalentForSort(then.getChildren().get(0))) &&
+            if ((sort == null || sort.equals(then.getChildren().get(0))) &&
                     !then.createsDuplicates() &&
                     !(then.getChildren().get(0) instanceof RecordTypeKeyExpression)) {
                 // First column will do it all or not.
@@ -938,7 +938,7 @@ public class RecordQueryPlanner implements QueryPlanner {
                                                             @Nonnull KeyExpression index,
                                                             @Nonnull QueryKeyExpressionWithComparison queryKeyExpressionWithComparison,
                                                             @Nullable KeyExpression sort) {
-        if (index.equals(queryKeyExpressionWithComparison.getKeyExpression()) && (sort == null || sort.equivalentForSort(index))) {
+        if (index.equals(queryKeyExpressionWithComparison.getKeyExpression()) && (sort == null || sort.equals(index))) {
             final Comparisons.Comparison comparison = queryKeyExpressionWithComparison.getComparison();
             final ScanComparisons scanComparisons = ScanComparisons.from(comparison);
             if (scanComparisons == null) {
@@ -1003,7 +1003,7 @@ public class RecordQueryPlanner implements QueryPlanner {
         if (index instanceof VersionKeyExpression) {
             final Comparisons.Comparison comparison = filter.getComparison();
             final ScanComparisons comparisons = ScanComparisons.from(comparison);
-            if (sort == null || sort.equivalentForSort(VersionKeyExpression.VERSION)) {
+            if (sort == null || sort.equals(VersionKeyExpression.VERSION)) {
                 RecordQueryPlan plan = new RecordQueryIndexPlan(candidateScan.index.getName(), IndexScanType.BY_VALUE, comparisons, candidateScan.reverse);
                 return new ScoredPlan(1, plan, Collections.emptyList(), false);
             }
@@ -1747,7 +1747,7 @@ public class RecordQueryPlanner implements QueryPlanner {
 
         private boolean currentSortMatches(@Nonnull KeyExpression child) {
             if (currentSort != null) {
-                if (currentSort.equivalentForSort(child)) {
+                if (currentSort.equals(child)) {
                     return true;
                 }
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreNullQueryTest.java
@@ -305,7 +305,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
             assertThat(executeQuery(RecordQuery.newBuilder()
                     .setRecordType("MyNullRecord")
-                    .setSort(scalarFieldsNotNull ? Key.Expressions.field("int_value", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NOT_NULL) : Key.Expressions.field("int_value"))
+                    .setSort(Key.Expressions.field("int_value"))
                     .build()),
                     is(scalarFieldsNotNull ?
                                 Arrays.asList("minus", "default", "empty", "one", "two") :
@@ -359,7 +359,7 @@ public class FDBRecordStoreNullQueryTest extends FDBRecordStoreQueryTestBase {
 
             assertThat(executeQuery(RecordQuery.newBuilder()
                             .setRecordType("MyNullRecord")
-                            .setSort(Key.Expressions.field("nullable_int_value").nest(Key.Expressions.field("value", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NOT_NULL)))
+                            .setSort(Key.Expressions.field("nullable_int_value").nest(Key.Expressions.field("value")))
                             .build()),
                     is(Arrays.asList("empty", "minus", "default", "one", "two")));
         }


### PR DESCRIPTION
This removes the `NullStandIn` checking in the `.equals` method from the `FieldKeyExpression`. It also removes it from that fields hash code methods, and it removes the `equivalentForSort` method from all key expressions, as it was only used to check for the `NullStandIn` anyway. It references #677 in a few places, which is the issue to move this into meta-data that is stored at the `RecordType` level, as having mixed values for different indexes does not really make sense.

This fixes #682.