### PR TITLE
Resolves #690: Ignore exceptionally completed futures in  checks

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -1008,7 +1008,7 @@ public class FDBDatabase {
             return;
         }
 
-        final boolean isComplete = future.isDone();
+        final boolean isComplete = future.isDone() || future.isCompletedExceptionally();
         if (isComplete && behavior.ignoreComplete()) {
             return;
         }


### PR DESCRIPTION
This change adds the support of ignoring futures that are completed exceptionally in the `asyncToSync` blocking detection technology.