### PR TITLE
Resolves #696: OnlineIndexer should instrument getting read versions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The transaction priority can be set through the `FDBTransactionPriority` enum, and the `OnlineIndexer` exposes that as an option on index builds [(Issue #697)](https://github.com/FoundationDB/fdb-record-layer/issues/697)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,6 +26,8 @@ Constructors of the `RecordQueryUnionPlan` and `RecordQueryIntersectionPlan` hav
 
 The non-static `RecordCursor::flatMapPipelined()` method has been deprecated because it is easy to mis-use (by mistaken analogy to the `mapPipelined()` method) and cannot be used with continuations. See [Issue #665](https://github.com/FoundationDB/fdb-record-layer/issues/665) for further explanation.
 
+The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecordContext::getReadVersionAsync()` and `FDBRecordContext::getReadVersion()` methods. Though not strictly necessary, users should also replace any uses of `Transaction::getReadVersion()` and `Transaction::setReadVersion()` (on the `Transaction` interface provided by the FoundationDB Java bindings) with `FDBRecordContext::getReadVersionAsync()` and `FDBRecordContext::setReadVersion()` on any transactions created by the Record Layer. This allows the Record Layer to track the version in Java memory which both can then be used to skip a JNI hop if the read version is needed, but it also allows the Record Layer to more accurately track when read versions are retrieved from the database if the user has enabled read version tracking.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -48,7 +50,7 @@ The non-static `RecordCursor::flatMapPipelined()` method has been deprecated bec
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** The `FDBDatabase::getReadVersion` method has been deprecated and replaced with `FDBRecordContext::getReadVersionAsync` [(Issue #698)](https://github.com/FoundationDB/fdb-record-layer/issues/698)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 
 // end next release

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -37,7 +37,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** The `OnlineIndexer` now instruments its read versions so that performance issues that may be linked to high read version latencies can now be better diagnosed [(Issue #696)](https://github.com/FoundationDB/fdb-record-layer/issues/696)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     testCompileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}" // binding
     testCompile "org.apache.logging.log4j:log4j-core:${log4jVersion}" // library

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
@@ -30,6 +30,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+/**
+ * Argument provider for the {@link BooleanSource} annotation for providing booleans to parameterized
+ * tests. Regardless of the source or context, this always returns {@code false} and {@code true} in that order.
+ */
 class BooleanArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<BooleanSource> {
     @Nonnull
     private static final List<Arguments> BOOLEANS = Arrays.asList(Arguments.of(false), Arguments.of(true));

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
@@ -1,0 +1,45 @@
+/*
+ * BooleanArgumentsProvider.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.test;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+class BooleanArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<BooleanSource> {
+    @Nonnull
+    private static final List<Arguments> BOOLEANS = Arrays.asList(Arguments.of(false), Arguments.of(true));
+
+    @Override
+    public void accept(BooleanSource booleanSource) {
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+        return BOOLEANS.stream();
+    }
+}

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
@@ -1,0 +1,41 @@
+/*
+ * BooleanSource.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.test;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for parameterized tests that take a single boolean argument. One might think one could use
+ * {@link org.junit.jupiter.params.provider.ValueSource} for that, but that annotation does not allow
+ * one to set a boolean value.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ArgumentsSource(BooleanArgumentsProvider.class)
+public @interface BooleanSource {
+}

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
@@ -31,7 +31,8 @@ import java.lang.annotation.Target;
 /**
  * An annotation for parameterized tests that take a single boolean argument. One might think one could use
  * {@link org.junit.jupiter.params.provider.ValueSource} for that, but that annotation does not allow
- * one to set a boolean value.
+ * one to set a boolean value. This will always provide {@code false} and {@code true} as the single argument
+ * to parameterized tests that have this annotation in that order.
  */
 @Documented
 @Target(ElementType.METHOD)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -317,12 +317,30 @@ public class FDBDatabase {
      * @see Database#createTransaction
      */
     @Nonnull
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public FDBRecordContext openContext(@Nullable Map<String, String> mdcContext,
                                         @Nullable FDBStoreTimer timer,
                                         @Nullable WeakReadSemantics weakReadSemantics) {
+        return openContext(mdcContext, timer, weakReadSemantics, FDBTransactionPriority.DEFAULT);
+    }
+
+
+    /**
+     * Open a new record context with a new transaction begun on the underlying FDB database.
+     * @param mdcContext logger context to set in running threads
+     * @param timer the timer to use for instrumentation
+     * @param weakReadSemantics allowable staleness information if caching read versions
+     * @param priority the priority of the transaction being created
+     * @return a new record context
+     * @see Database#createTransaction
+     */
+    @Nonnull
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public FDBRecordContext openContext(@Nullable Map<String, String> mdcContext,
+                                        @Nullable FDBStoreTimer timer,
+                                        @Nullable WeakReadSemantics weakReadSemantics,
+                                        @Nonnull FDBTransactionPriority priority) {
         openFDB();
-        FDBRecordContext context = new FDBRecordContext(this, mdcContext, transactionIsTracedSupplier.get(), weakReadSemantics);
+        FDBRecordContext context = new FDBRecordContext(this, mdcContext, transactionIsTracedSupplier.get(), weakReadSemantics, priority);
         if (timer != null) {
             context.setTimer(timer);
             timer.increment(FDBStoreTimer.Counts.OPEN_CONTEXT);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
@@ -119,6 +119,21 @@ public interface FDBDatabaseRunner extends AutoCloseable {
     void setWeakReadSemantics(@Nullable FDBDatabase.WeakReadSemantics weakReadSemantics);
 
     /**
+     * Get the priority of transactions opened by this runner.
+     * @return the priority of transactions opened by this runner
+     * @see FDBRecordContext#getPriority()
+     */
+    @Nonnull
+    FDBTransactionPriority getPriority();
+
+    /**
+     * Set the priority of transactions opened by this runner.
+     * @param priority the priority of transactions by this runner
+     * @see FDBRecordContext#getPriority()
+     */
+    void setPriority(@Nonnull FDBTransactionPriority priority);
+
+    /**
      * Gets the maximum number of attempts for a database to make when running a
      * retriable transactional operation. This is used by {@link #run} and {@link #runAsync} to limit the number of
      * attempts that an operation is retried.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
@@ -65,6 +65,8 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
     private Map<String, String> mdcContext;
     @Nullable
     private FDBDatabase.WeakReadSemantics weakReadSemantics;
+    @Nonnull
+    private FDBTransactionPriority priority;
 
     private int maxAttempts;
     private long maxDelayMillis;
@@ -85,6 +87,7 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
         this.timer = timer;
         this.mdcContext = mdcContext;
         this.weakReadSemantics = weakReadSemantics;
+        this.priority = FDBTransactionPriority.DEFAULT;
 
         final FDBDatabaseFactory factory = database.getFactory();
         this.maxAttempts = factory.getMaxAttempts();
@@ -153,6 +156,17 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
         this.weakReadSemantics = weakReadSemantics;
     }
 
+    @Nonnull
+    @Override
+    public FDBTransactionPriority getPriority() {
+        return priority;
+    }
+
+    @Override
+    public void setPriority(@Nonnull FDBTransactionPriority priority) {
+        this.priority = priority;
+    }
+
     @Override
     public int getMaxAttempts() {
         return maxAttempts;
@@ -207,7 +221,7 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
         if (closed) {
             throw new RunnerClosed();
         }
-        FDBRecordContext context = database.openContext(mdcContext, timer, weakReadSemantics);
+        FDBRecordContext context = database.openContext(mdcContext, timer, weakReadSemantics, priority);
         addContextToClose(context);
         return context;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBLatencySource.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBLatencySource.java
@@ -20,6 +20,9 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+
+import javax.annotation.Nonnull;
 import java.util.function.Function;
 
 /**
@@ -27,13 +30,30 @@ import java.util.function.Function;
  */
 public enum FDBLatencySource {
     /**
-     * See {@link FDBDatabase#getReadVersion(FDBRecordContext)}.
+     * See {@link FDBRecordContext#getReadVersion()}.
      */
-    GET_READ_VERSION,
+    GET_READ_VERSION(FDBStoreTimer.Events.INJECTED_GET_READ_VERSION_LATENCY),
 
     /**
      * See {@link FDBRecordContext#commitAsync()}.
      */
-    COMMIT_ASYNC,
+    COMMIT_ASYNC(FDBStoreTimer.Events.INJECTED_COMMIT_LATENCY),
     ;
+
+    @Nonnull
+    private final StoreTimer.Event event;
+
+    FDBLatencySource(@Nonnull StoreTimer.Event event) {
+        this.event = event;
+    }
+
+    /**
+     * Get the event used to track this latency source by {@link FDBStoreTimer}s.
+     *
+     * @return the event used to instrument injecting this latency source
+     */
+    @Nonnull
+    public StoreTimer.Event getTimerEvent() {
+        return event;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -303,7 +303,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      *
      * <p>
      * Note that this method is {@code synchronized}, but only creating the future (<em>not</em> waiting on
-     * the future) will block other threads. Thus, while it is advised that this method ony be called once
+     * the future) will block other threads. Thus, while it is advised that this method only be called once
      * and by only one caller at a time, if it safe to use this method in asynchronous contexts. If this method is
      * called multiple times, then the same future will be returned each time.
      * </p>

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -326,11 +326,9 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
                     if (database.isTrackLastSeenVersionOnRead()) {
                         database.updateLastSeenFDBVersion(startTimeMillis, newReadVersion);
                     }
-                    if (timer != null) {
-                        timer.record(FDBStoreTimer.Events.GET_READ_VERSION, System.nanoTime() - startTimeNanos);
-                    }
                     return newReadVersion;
                 });
+        localReadVersionFuture = instrument(FDBStoreTimer.Events.GET_READ_VERSION, localReadVersionFuture, startTimeNanos);
         readVersionFuture = localReadVersionFuture;
         return localReadVersionFuture;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -40,6 +40,8 @@ public class FDBStoreTimer extends StoreTimer {
     public enum Events implements Event {
         /** The amount of time taken performing a no-op. */
         PERFORM_NO_OP("perform no-op"),
+        /** The amount of time taken to get a read version when explicitly called. */
+        GET_READ_VERSION("get read version"),
         /** The amount of time taken committing transactions successfully. */
         COMMIT("commit transaction"),
         /** The amount of time taken committing transactions that did not actually have any writes. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -40,10 +40,28 @@ public class FDBStoreTimer extends StoreTimer {
     public enum Events implements Event {
         /** The amount of time taken performing a no-op. */
         PERFORM_NO_OP("perform no-op"),
-        /** The amount of time taken to get a read version when explicitly called. */
+        /**
+         * The amount of time taken to get a read version when explicitly called.
+         * This includes any injected latency added before issuing the request.
+         * @see #INJECTED_GET_READ_VERSION_LATENCY
+         */
         GET_READ_VERSION("get read version"),
-        /** The amount of time taken committing transactions successfully. */
+        /**
+         * The amount of time injected prior to getting a read version.
+         * @see FDBDatabase#injectLatency(FDBLatencySource)
+         */
+        INJECTED_GET_READ_VERSION_LATENCY("injected get read version latency"),
+        /**
+         * The amount of time taken committing transactions successfully.
+         * This includes any injected latency added before issuing the request and any time spent performing pre-commit checks.
+         * @see #INJECTED_COMMIT_LATENCY
+         */
         COMMIT("commit transaction"),
+        /**
+         * The amount of time injected into committing transactions.
+         * @see FDBDatabase#injectLatency(FDBLatencySource)
+         */
+        INJECTED_COMMIT_LATENCY("injected commit latency"),
         /** The amount of time taken committing transactions that did not actually have any writes. */
         COMMIT_READ_ONLY("commit read-only transaction"),
         /** The amount of time taken committing transactions that did not succeed. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionPriority.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionPriority.java
@@ -1,0 +1,56 @@
+/*
+ * FDBTransactionPriority.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+
+/**
+ * An enum indicating the priority of transactions against FoundationDB. This value can then be used to set options on
+ * the transaction to indicate to the database the priority of the transaction's work.
+ *
+ * <p>
+ * This API is {@link API.Status#MAINTAINED MAINTAINED}, but it may add additional values if they become available.
+ * </p>
+ */
+@API(API.Status.MAINTAINED)
+public enum FDBTransactionPriority {
+    /**
+     * The priority level that should be used for batch operations. This should be used for discretionary work
+     * such as background jobs that do not have strict time pressure to complete in the near future. For example
+     * {@linkplain OnlineIndexer index builds} and
+     * {@linkplain com.apple.foundationdb.record.provider.foundationdb.cursors.SizeStatisticsCollectorCursor statistics collection}
+     * should often happen at batch priority. This signals to the database that this work should be rate limited
+     * at a higher rate if it would impact work done at a higher priority.
+     */
+    BATCH,
+    /**
+     * The default priority level for most transactions. This should be used for most work unless {@link #BATCH}
+     * priority is more appropriate. The system will apply normal rate limiting and throttling mechanisms to
+     * the transaction.
+     */
+    DEFAULT,
+    /**
+     * The priority level for system operations. This is used within internally within FoundationDB for operations
+     * that must complete immediately for all operations, and it bypasses any rate limiting. For this reason, it
+     * should generally <em>not</em> be used by users of the system, and it is included mainly for completeness.
+     */
+    SYSTEM_IMMEDIATE
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionPriority.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionPriority.java
@@ -35,7 +35,7 @@ public enum FDBTransactionPriority {
     /**
      * The priority level that should be used for batch operations. This should be used for discretionary work
      * such as background jobs that do not have strict time pressure to complete in the near future. For example
-     * {@linkplain OnlineIndexer index builds} and
+     * {@linkplain OnlineIndexer online index builds} and
      * {@linkplain com.apple.foundationdb.record.provider.foundationdb.cursors.SizeStatisticsCollectorCursor statistics collection}
      * should often happen at batch priority. This signals to the database that this work should be rate limited
      * at a higher rate if it would impact work done at a higher priority.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionPriority.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionPriority.java
@@ -48,9 +48,9 @@ public enum FDBTransactionPriority {
      */
     DEFAULT,
     /**
-     * The priority level for system operations. This is used within internally within FoundationDB for operations
-     * that must complete immediately for all operations, and it bypasses any rate limiting. For this reason, it
-     * should generally <em>not</em> be used by users of the system, and it is included mainly for completeness.
+     * The priority level for system operations. This is used internally within FoundationDB for operations that must
+     * complete immediately for all operations, and it bypasses any rate limiting. For this reason, it should
+     * generally <em>not</em> be used by users of the system, and it is included mainly for completeness.
      */
     SYSTEM_IMMEDIATE
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/ReadVersionRecordStoreStateCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/ReadVersionRecordStoreStateCache.java
@@ -78,7 +78,7 @@ public class ReadVersionRecordStoreStateCache implements FDBRecordStoreStateCach
             context.increment(FDBStoreTimer.Counts.STORE_STATE_CACHE_MISS);
             return FDBRecordStoreStateCacheEntry.load(recordStore, existenceCheck);
         } else {
-            return context.ensureActive().getReadVersion().thenCompose(readVersion -> {
+            return context.getReadVersionAsync().thenCompose(readVersion -> {
                 final SubspaceProvider subspaceProvider = recordStore.getSubspaceProvider();
                 CompletableFuture<FDBRecordStoreStateCacheEntry> storeStateFuture = cache.orElseGet(Pair.of(subspaceProvider, readVersion), () -> {
                     if (LOGGER.isDebugEnabled()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/SynchronizedSessionRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/SynchronizedSessionRunner.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunnerImpl;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTransactionPriority;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.synchronizedsession.SynchronizedSession;
 import org.apache.commons.lang3.tuple.Pair;
@@ -218,6 +219,17 @@ public class SynchronizedSessionRunner implements FDBDatabaseRunner {
     @Override
     public void setWeakReadSemantics(@Nullable FDBDatabase.WeakReadSemantics weakReadSemantics) {
         underlying.setWeakReadSemantics(weakReadSemantics);
+    }
+
+    @Nonnull
+    @Override
+    public FDBTransactionPriority getPriority() {
+        return underlying.getPriority();
+    }
+
+    @Override
+    public void setPriority(@Nonnull FDBTransactionPriority priority) {
+        underlying.setPriority(priority);
     }
 
     @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.cursors.MapCursor;
 import com.apple.foundationdb.record.cursors.RowLimitedCursor;
 import com.apple.foundationdb.record.cursors.SkipCursor;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.test.BooleanSource;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.tuple.Pair;
@@ -36,7 +37,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -425,10 +425,9 @@ public class RecordCursorTest {
         return results;
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "pipelineWithInnerLimits [outOfBand = {0}]")
-    public void pipelineWithInnerLimits(TestHelpers.BooleanEnum outOfBandEnum) {
-        final boolean outOfBand = outOfBandEnum.toBoolean();
+    @BooleanSource
+    public void pipelineWithInnerLimits(boolean outOfBand) {
         final RecordCursor.NoNextReason[] possibleNoNextReasons = new RecordCursor.NoNextReason[]{
                 RecordCursor.NoNextReason.SOURCE_EXHAUSTED,
                 outOfBand ? RecordCursor.NoNextReason.TIME_LIMIT_REACHED : RecordCursor.NoNextReason.RETURN_LIMIT_REACHED
@@ -458,10 +457,9 @@ public class RecordCursorTest {
         assertEquals(ints.size() * ints.size() - expectedResults, timer.getCount(FDBStoreTimer.Counts.QUERY_DISCARDED));
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "pipelineWithOuterLimits [outOfBand = {0}]")
-    public void pipelineWithOuterLimits(TestHelpers.BooleanEnum outOfBandEnum) {
-        final boolean outOfBand = outOfBandEnum.toBoolean();
+    @BooleanSource
+    public void pipelineWithOuterLimits(boolean outOfBand) {
         final RecordCursor.NoNextReason[] possibleNoNextReasons = new RecordCursor.NoNextReason[]{
                 RecordCursor.NoNextReason.SOURCE_EXHAUSTED,
                 outOfBand ? RecordCursor.NoNextReason.TIME_LIMIT_REACHED : RecordCursor.NoNextReason.RETURN_LIMIT_REACHED
@@ -509,10 +507,9 @@ public class RecordCursorTest {
         assertEquals(13, timer.getCount(FDBStoreTimer.Counts.QUERY_DISCARDED));
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "pipelineWithOuterLimitsWithSomeDelay [outOfBand = {0}]")
-    public void pipelineWithOuterLimitsWithSomeDelay(TestHelpers.BooleanEnum outOfBandEnum) {
-        final boolean outOfBand = outOfBandEnum.toBoolean();
+    @BooleanSource
+    public void pipelineWithOuterLimitsWithSomeDelay(boolean outOfBand) {
         final RecordCursor.NoNextReason limitReason = outOfBand ? RecordCursor.NoNextReason.TIME_LIMIT_REACHED : RecordCursor.NoNextReason.RETURN_LIMIT_REACHED;
         final List<Integer> ints = IntStream.range(0, 10).boxed().collect(Collectors.toList());
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
@@ -56,26 +56,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class TestHelpers {
 
-    /**
-     * This enum exists so that tests can use them as an enumeration source in
-     * parameterized tests. JUnit5, for whatever reason, doesn't allow booleans
-     * as values for parameters--only strings, ints, longs, and doubles.
-     */
-    public enum BooleanEnum {
-        FALSE(false),
-        TRUE(true);
-
-        private final boolean value;
-
-        BooleanEnum(boolean value) {
-            this.value = value;
-        }
-
-        public boolean toBoolean() {
-            return value;
-        }
-    }
-
     public static Executable toCallable(DangerousRunnable danger) {
         return () -> {
             try {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
 import org.apache.commons.lang3.tuple.Pair;
@@ -137,10 +138,9 @@ public class FDBDatabaseTest extends FDBTestBase {
         assertTrue(readVersion1 < readVersion2);
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "cachedReadVersionWithRetryLoops [async = {0}]")
-    public void cachedReadVersionWithRetryLoops(TestHelpers.BooleanEnum asyncEnum) throws InterruptedException, ExecutionException {
-        final boolean async = asyncEnum.toBoolean();
+    @BooleanSource
+    public void cachedReadVersionWithRetryLoops(boolean async) throws InterruptedException, ExecutionException {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setTrackLastSeenVersion(true);
         FDBDatabase database = factory.getDatabase();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
 import com.apple.foundationdb.record.RecordMetaDataProto;
-import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestNoUnionEvolvedIllegalProto;
 import com.apple.foundationdb.record.TestNoUnionEvolvedProto;
 import com.apple.foundationdb.record.TestNoUnionEvolvedRenamedRecordTypeProto;
@@ -56,6 +55,7 @@ import com.apple.foundationdb.record.metadata.MetaDataProtoTest;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.DescriptorProtos;
@@ -350,13 +350,13 @@ public class FDBMetaDataStoreTest extends FDBTestBase {
         }
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "indexes [indexCounterBasedSubspaceKey = {0}]")
-    public void indexes(final TestHelpers.BooleanEnum indexCounterBasedSubspaceKey) {
+    @BooleanSource
+    public void indexes(final boolean indexCounterBasedSubspaceKey) {
         try (FDBRecordContext context = fdb.openContext()) {
             openMetaDataStore(context);
             RecordMetaDataBuilder builder = RecordMetaData.newBuilder();
-            if (indexCounterBasedSubspaceKey.toBoolean()) {
+            if (indexCounterBasedSubspaceKey) {
                 builder.enableCounterBasedSubspaceKeys();
             }
             metaDataStore.saveRecordMetaData(builder.setRecords(TestRecords1Proto.getDescriptor()).getRecordMetaData());
@@ -545,10 +545,9 @@ public class FDBMetaDataStoreTest extends FDBTestBase {
         }
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "updateRecordsWithNewUnionField [reorderFields = {0}]")
-    public void updateRecordsWithNewUnionField(TestHelpers.BooleanEnum reorderFieldsEnum) {
-        final boolean reorderFields = reorderFieldsEnum.toBoolean();
+    @BooleanSource
+    public void updateRecordsWithNewUnionField(boolean reorderFields) {
         try (FDBRecordContext context = fdb.openContext()) {
             openMetaDataStore(context);
             RecordMetaData metaData = RecordMetaData.build(TestRecords1Proto.getDescriptor());
@@ -1569,9 +1568,9 @@ public class FDBMetaDataStoreTest extends FDBTestBase {
         }
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "noUnionUpdateRecords [repeatSaveOrDoUpdate = {0}]")
-    public void noUnionUpdateRecords(TestHelpers.BooleanEnum repeatSaveOrDoUpdate) {
+    @BooleanSource
+    public void noUnionUpdateRecords(boolean repeatSaveOrDoUpdate) {
         int version;
         try (FDBRecordContext context = fdb.openContext()) {
             openMetaDataStore(context);
@@ -1584,7 +1583,7 @@ public class FDBMetaDataStoreTest extends FDBTestBase {
         try (FDBRecordContext context = fdb.openContext()) {
             openMetaDataStore(context);
             assertEquals(version, metaDataStore.getRecordMetaData().getVersion());
-            if (repeatSaveOrDoUpdate.toBoolean()) {
+            if (repeatSaveOrDoUpdate) {
                 metaDataStore.updateRecords(TestNoUnionEvolvedProto.getDescriptor());
             } else {
                 metaDataStore.saveRecordMetaData(TestNoUnionEvolvedProto.getDescriptor());
@@ -1602,7 +1601,7 @@ public class FDBMetaDataStoreTest extends FDBTestBase {
             openMetaDataStore(context);
             assertEquals(version + 1, metaDataStore.getRecordMetaData().getVersion());
             MetaDataException e;
-            if (repeatSaveOrDoUpdate.toBoolean()) {
+            if (repeatSaveOrDoUpdate) {
                 e = assertThrows(MetaDataException.class, () -> metaDataStore.updateRecords(TestNoUnionEvolvedRenamedRecordTypeProto.getDescriptor()));
             } else {
                 e = assertThrows(MetaDataException.class, () -> metaDataStore.saveRecordMetaData(TestNoUnionEvolvedRenamedRecordTypeProto.getDescriptor()));
@@ -1612,9 +1611,9 @@ public class FDBMetaDataStoreTest extends FDBTestBase {
         }
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "noUnionImplicitUsage [repeatSaveOrDoUpdate = {0}]")
-    public void noUnionImplicitUsage(TestHelpers.BooleanEnum repeatSaveOrDoUpdate) {
+    @BooleanSource
+    public void noUnionImplicitUsage(boolean repeatSaveOrDoUpdate) {
         int version;
 
         // MyOtherRecord has no explicit usage. The proto file has a union and does not include MyOtherRecord.
@@ -1632,7 +1631,7 @@ public class FDBMetaDataStoreTest extends FDBTestBase {
         try (FDBRecordContext context = fdb.openContext()) {
             openMetaDataStore(context);
             assertEquals(version, metaDataStore.getRecordMetaData().getVersion());
-            if (repeatSaveOrDoUpdate.toBoolean()) {
+            if (repeatSaveOrDoUpdate) {
                 metaDataStore.updateRecords(TestRecordsImplicitUsageNoUnionProto.getDescriptor());
             } else {
                 metaDataStore.saveRecordMetaData(TestRecordsImplicitUsageNoUnionProto.getDescriptor());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -24,13 +24,12 @@ import com.apple.foundationdb.FDBException;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCoreStorageException;
-import com.apple.foundationdb.record.TestHelpers;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.annotation.Nonnull;
 
@@ -140,17 +139,18 @@ public class FDBRecordContextTest extends FDBTestBase {
     }
 
     @ParameterizedTest(name = "closeWithOutstandingGetReadVersion [inject latency = {0}]")
-    @EnumSource(TestHelpers.BooleanEnum.class)
-    public void closeWithOutstandingGetReadVersion(@Nonnull TestHelpers.BooleanEnum injectLatency) throws InterruptedException, ExecutionException {
+    @BooleanSource
+    public void closeWithOutstandingGetReadVersion(boolean injectLatency) throws InterruptedException, ExecutionException {
         FDBDatabaseFactory factory = fdb.getFactory();
         Function<FDBLatencySource, Long> oldLatencyInjector = factory.getLatencyInjector();
-        if (injectLatency.toBoolean()) {
+        if (injectLatency) {
             factory.setLatencyInjector(latencySource -> 5L);
         } else {
             factory.setLatencyInjector(latencySource -> 0L);
         }
         factory.clear();
         fdb = factory.getDatabase(fdb.getClusterFile());
+
 
         FDBRecordContext context = null;
         try {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -1,0 +1,176 @@
+/*
+ * FDBRecordContextTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.FDBException;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests of the {@link FDBRecordContext} class.
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBRecordContextTest extends FDBTestBase {
+    private static final int ERR_CODE_READ_VERSION_ALREADY_SET = 2010;
+    @Nonnull
+    private static final FDBDatabase.WeakReadSemantics UNLIMITED_STALE_READ = new FDBDatabase.WeakReadSemantics(0L, Long.MAX_VALUE, true);
+    protected FDBDatabase fdb;
+
+    @BeforeEach
+    public void getFDB() {
+        fdb = FDBDatabaseFactory.instance().getDatabase();
+    }
+
+    /**
+     * Validate that if the {@link FDBRecordContext#getReadVersion()} is called twice that the
+     * same value is returned each time and that the second time does not actually call the
+     * FDB method.
+     */
+    @Test
+    public void getReadVersionTwice() {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            long readVersion1 = context.getReadVersion();
+            assertEquals(1, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+            long grvNanos = timer.getTimeNanos(FDBStoreTimer.Events.GET_READ_VERSION);
+            long readVersion2 = context.getReadVersion();
+            assertEquals(readVersion1, readVersion2);
+            assertEquals(1, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+            assertEquals(grvNanos, timer.getTimeNanos(FDBStoreTimer.Events.GET_READ_VERSION));
+        }
+    }
+
+    @Test
+    public void manyParallelReadVersions() throws InterruptedException, ExecutionException {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            List<CompletableFuture<Long>> futures = Stream.generate(context::getReadVersionAsync)
+                    .limit(10)
+                    .collect(Collectors.toList());
+            List<Long> readVersions = AsyncUtil.getAll(futures).get();
+            long firstReadVersion = readVersions.get(0);
+            for (long readVersion : readVersions) {
+                assertEquals(firstReadVersion, readVersion);
+            }
+            assertEquals(1, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+        }
+    }
+
+    @Test
+    public void concurrentGetAndSet() throws InterruptedException, ExecutionException {
+        for (int i = 0; i < 10; i++) {
+            final FDBStoreTimer timer = new FDBStoreTimer();
+            try (FDBRecordContext context = fdb.openContext(null, timer)) {
+                context.ensureActive().setReadVersion(1459L); // to increase the probability of getReadVersion completing first
+                CompletableFuture<Long> readVersionFuture = context.getReadVersionAsync();
+                // Setting a read version with an outstanding read version request may or not succeed
+                // depending on whether the future is completed by the time the set request is called.
+                try {
+                    long readVersionSet = context.setReadVersion(1066);
+                    assertEquals(readVersionSet, (long)readVersionFuture.get());
+                } catch (RecordCoreException e) {
+                    assertEquals("Cannot set read version as read version request is outstanding", e.getMessage());
+                }
+                assertEquals(1459L, (long)readVersionFuture.get());
+                assertEquals(1459L, context.getReadVersion());
+            }
+        }
+    }
+
+    @Test
+    public void setReadVersionTwice() {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            assertEquals(1066L, context.setReadVersion(1066L));
+            assertEquals(1066L, context.setReadVersion(1459L));
+            assertEquals(1066L, context.getReadVersion());
+            assertEquals(0, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+            context.commit();
+        }
+    }
+
+    @Test
+    public void setReadVersionAfterGet() {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            long readVersion = context.getReadVersion();
+            assertEquals(readVersion, context.setReadVersion(1066L));
+            assertEquals(readVersion, context.getReadVersion());
+            assertEquals(1, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+        }
+    }
+
+    @Test
+    public void setReadVersionOutOfBandThenGet() {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            context.ensureActive().setReadVersion(1066L);
+            assertEquals(1066L, context.getReadVersion());
+            assertEquals(1, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+        }
+    }
+
+    @Test
+    public void setReadVersionOutOfBandThenSet() {
+        try (FDBRecordContext context = fdb.openContext()) {
+            context.ensureActive().setReadVersion(1066L);
+            assertEquals(1459L, context.setReadVersion(1459L));
+            assertEquals(1459L, context.getReadVersion());
+            FDBExceptions.FDBStoreException err = assertThrows(FDBExceptions.FDBStoreException.class, context::commit);
+            assertNotNull(err.getCause());
+            assertThat(err.getCause(), instanceOf(FDBException.class));
+            FDBException fdbE = (FDBException)err.getCause();
+            assertEquals(ERR_CODE_READ_VERSION_ALREADY_SET, fdbE.getCode());
+        }
+    }
+
+    @Test
+    public void getReadVersionWithWeakReadSemantics() {
+        fdb.setTrackLastSeenVersion(true);
+        long firstReadVersion;
+        try (FDBRecordContext context = fdb.openContext()) {
+            firstReadVersion = context.getReadVersion();
+        }
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer, UNLIMITED_STALE_READ)) {
+            assertEquals(firstReadVersion, context.getReadVersion());
+            assertEquals(0, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -143,17 +143,16 @@ public class FDBRecordContextTest extends FDBTestBase {
     public void closeWithOutstandingGetReadVersion(boolean injectLatency) throws InterruptedException, ExecutionException {
         FDBDatabaseFactory factory = fdb.getFactory();
         Function<FDBLatencySource, Long> oldLatencyInjector = factory.getLatencyInjector();
-        if (injectLatency) {
-            factory.setLatencyInjector(latencySource -> 5L);
-        } else {
-            factory.setLatencyInjector(latencySource -> 0L);
-        }
-        factory.clear();
-        fdb = factory.getDatabase(fdb.getClusterFile());
-
 
         FDBRecordContext context = null;
         try {
+            if (injectLatency) {
+                factory.setLatencyInjector(latencySource -> 5L);
+            } else {
+                factory.setLatencyInjector(latencySource -> 0L);
+            }
+            factory.clear();
+            fdb = factory.getDatabase(fdb.getClusterFile());
             context = fdb.openContext();
             CompletableFuture<Long> readVersionFuture = context.getReadVersionAsync();
             context.close();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -132,7 +132,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     private static final Logger logger = LoggerFactory.getLogger(FDBRecordStoreTest.class);
 
-    private void openLongRecordStore(FDBRecordContext context) throws Exception {
+    private void openLongRecordStore(FDBRecordContext context) {
         createOrOpenRecordStore(context, RecordMetaData.build(TestRecords2Proto.getDescriptor()));
     }
 
@@ -884,7 +884,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testDeleteWhereMissingIndex() throws Exception {
+    public void testDeleteWhereMissingIndex() {
         try (FDBRecordContext context = openContext()) {
             RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecordsWithHeaderProto.getDescriptor());
             builder.getRecordType("MyRecord")
@@ -899,7 +899,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testOverlappingPrimaryKey() throws Exception {
+    public void testOverlappingPrimaryKey() {
         try (FDBRecordContext context = openContext()) {
             RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecordsWithHeaderProto.getDescriptor());
             builder.getRecordType("MyRecord")
@@ -941,7 +941,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testIndexKeyTooLarge() throws Exception {
+    public void testIndexKeyTooLarge() {
         assertThrows(FDBExceptions.FDBStoreKeySizeException.class, () -> {
             try (FDBRecordContext context = openContext()) {
                 openSimpleRecordStore(context);
@@ -957,7 +957,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testIndexValueTooLarge() throws Exception {
+    public void testIndexValueTooLarge() {
         assertThrows(FDBExceptions.FDBStoreValueSizeException.class, () -> {
             try (FDBRecordContext context = openContext()) {
                 openSimpleRecordStore(context, md -> {
@@ -982,7 +982,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testStoredRecordSizeIsPlausible() throws Exception {
+    public void testStoredRecordSizeIsPlausible() {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
 
@@ -1017,7 +1017,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testStoredRecordSizeIsConsistent() throws Exception {
+    public void testStoredRecordSizeIsConsistent() {
         final RecordMetaDataHook hook = md -> {
             md.setSplitLongRecords(true);
         };
@@ -1060,7 +1060,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testSplitContinuation() throws Exception {
+    public void testSplitContinuation() {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
             commit(context);
@@ -1148,7 +1148,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         deleteAndCheckSplitSimpleRecord(recno);
     }
 
-    private void saveAndCheckSplitSimpleRecord(long recno, String strValue, int numValue) throws Exception {
+    private void saveAndCheckSplitSimpleRecord(long recno, String strValue, int numValue) {
         FDBStoredRecord<Message> savedRecord = saveAndSplitSimpleRecord(recno, strValue, numValue);
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
@@ -1194,7 +1194,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         }
     }
 
-    private void saveAndCheckCorruptSplitSimpleRecord(long recno, String strValue, int numValue) throws Exception {
+    private void saveAndCheckCorruptSplitSimpleRecord(long recno, String strValue, int numValue) {
         FDBStoredRecord<Message> savedRecord = saveAndSplitSimpleRecord(recno, strValue, numValue);
         if (!savedRecord.isSplit()) {
             return;
@@ -1270,7 +1270,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         }
     }
 
-    private void deleteAndCheckSplitSimpleRecord(long recno) throws Exception {
+    private void deleteAndCheckSplitSimpleRecord(long recno) {
         FDBStoredRecord<Message> savedRecord;
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, TEST_SPLIT_HOOK);
@@ -1454,7 +1454,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         countRecords(false);
     }
 
-    private void countRecords(boolean useIndex) throws Exception {
+    private void countRecords(boolean useIndex) {
         final RecordMetaDataHook hook = countKeyHook(EmptyKeyExpression.EMPTY, useIndex, 0);
         HashMap<Integer, Integer> expectedCountBuckets = new HashMap<>();
 
@@ -1593,7 +1593,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         countRecordsKeyed(false);
     }
 
-    private void countRecordsKeyed(boolean useIndex) throws Exception {
+    private void countRecordsKeyed(boolean useIndex) {
         final KeyExpression key = field("num_value_3_indexed");
         final RecordMetaDataHook hook = countKeyHook(key, useIndex, 0);
 
@@ -2183,7 +2183,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     @Test
     public void testCommittedVersion() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            final long readVersion = context.ensureActive().getReadVersion().get();
+            final long readVersion = context.getReadVersion();
 
             openSimpleRecordStore(context);
 
@@ -2196,7 +2196,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testCommittedVersionReadOnly() throws Exception {
+    public void testCommittedVersionReadOnly() {
         try (FDBRecordContext context = openContext()) {
             commit(context);
             assertThat(context.getCommittedVersion(), equalTo(-1L));
@@ -2222,7 +2222,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void testVersionStampReadOnly() throws Exception {
+    public void testVersionStampReadOnly() {
         try (FDBRecordContext context = openContext()) {
             commit(context);
             assertNull(context.getVersionStamp());
@@ -2962,7 +2962,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void invalidMetaData() throws Exception {
+    public void invalidMetaData() {
         RecordMetaDataHook invalid = metaData -> {
             metaData.addIndex("MySimpleRecord", "no_such_field");
         };
@@ -3193,7 +3193,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void metaDataVersionZero() throws Exception {
+    public void metaDataVersionZero() {
         final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestNoIndexesProto.getDescriptor());
         metaData.setVersion(0);
 
@@ -3267,7 +3267,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
 
     @EnumSource(ClearOmitUnsplitRecordSuffixMode.class)
     @ParameterizedTest(name = "clearOmitUnsplitRecordSuffix [mode = {0}]")
-    public void clearOmitUnsplitRecordSuffix(ClearOmitUnsplitRecordSuffixMode mode) throws Exception {
+    public void clearOmitUnsplitRecordSuffix(ClearOmitUnsplitRecordSuffixMode mode) {
         final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
         FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
@@ -3306,7 +3306,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void clearOmitUnsplitRecordSuffixTyped() throws Exception {
+    public void clearOmitUnsplitRecordSuffixTyped() {
         final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         final KeyExpression pkey = concat(Key.Expressions.recordType(), field("rec_no"));
         metaData.getRecordType("MySimpleRecord").setPrimaryKey(pkey);
@@ -3340,7 +3340,7 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void clearOmitUnsplitRecordSuffixOverlapping() throws Exception {
+    public void clearOmitUnsplitRecordSuffixOverlapping() {
         final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
         FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -1721,9 +1721,9 @@ public class OnlineIndexerTest extends FDBTestBase {
                 .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
                 .build()) {
             try (FDBRecordContext context = openContext()) {
-                context.ensureActive().getReadVersion().join();
+                context.getReadVersion();
                 try (FDBRecordContext context2 = fdb.openContext()) {
-                    context2.ensureActive().getReadVersion().join();
+                    context2.getReadVersion();
                     FDBRecordStore recordStore2 = recordStore.asBuilder().setContext(context2).build();
 
                     indexBuilder.buildUnbuiltRange(recordStore, null, Key.Evaluated.scalar(5L)).join();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -44,7 +44,6 @@ import com.apple.foundationdb.record.metadata.IndexRecordFunction;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase.RecordMetaDataHook;
@@ -74,7 +73,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -89,6 +87,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -115,6 +114,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -335,6 +335,14 @@ public class OnlineIndexerTest extends FDBTestBase {
             // or otherwise disrupt the build.
             LOGGER.info("Setting progress log interval");
             builder.setProgressLogIntervalMillis(0);
+        }
+        if (ThreadLocalRandom.current().nextBoolean()) {
+            LOGGER.info("Setting priority to DEFAULT");
+            builder.setPriority(FDBTransactionPriority.DEFAULT);
+        }
+        if (fdb.isTrackLastSeenVersion()) {
+            LOGGER.info("Setting weak read semantics");
+            builder.setWeakReadSemantics(new FDBDatabase.WeakReadSemantics(0L, Long.MAX_VALUE, true));
         }
 
         try (OnlineIndexer indexBuilder = builder.build()) {
@@ -955,12 +963,48 @@ public class OnlineIndexerTest extends FDBTestBase {
 
     @Test
     @Tag(Tags.Slow)
+    public void oneHundredElementsWithWeakReads() {
+        boolean dbTracksReadVersionOnRead = fdb.isTrackLastSeenVersionOnRead();
+        boolean dbTracksReadVersionOnCommit = fdb.isTrackLastSeenVersionOnCommit();
+        try {
+            fdb.setTrackLastSeenVersion(true);
+            Random r = new Random(0x5ca1ab1e);
+            List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
+                    TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
+            ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
+            valueRebuild(records);
+        } finally {
+            fdb.setTrackLastSeenVersionOnRead(dbTracksReadVersionOnRead);
+            fdb.setTrackLastSeenVersionOnCommit(dbTracksReadVersionOnCommit);
+        }
+    }
+
+    @Test
+    @Tag(Tags.Slow)
     public void oneHundredElementsParallel() {
         Random r = new Random(0x5ca1ab1e);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         valueRebuild(records, null, 5, false);
+    }
+
+    @Test
+    @Tag(Tags.Slow)
+    public void oneHundredElementsParallelWithWeakReads() {
+        boolean dbTracksReadVersionOnRead = fdb.isTrackLastSeenVersionOnRead();
+        boolean dbTracksReadVersionOnCommit = fdb.isTrackLastSeenVersionOnCommit();
+        try {
+            fdb.setTrackLastSeenVersion(true);
+            Random r = new Random(0x5ca1ab1e);
+            List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
+                    TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
+            ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
+            valueRebuild(records, null, 5, false);
+        } finally {
+            fdb.setTrackLastSeenVersionOnRead(dbTracksReadVersionOnRead);
+            fdb.setTrackLastSeenVersionOnCommit(dbTracksReadVersionOnCommit);
+        }
     }
 
     @Test
@@ -2393,6 +2437,59 @@ public class OnlineIndexerTest extends FDBTestBase {
         }
     }
 
+    @Test
+    public void runWithWeakReadSemantics() throws InterruptedException, ExecutionException {
+        boolean dbTracksReadVersionOnRead = fdb.isTrackLastSeenVersionOnRead();
+        boolean dbTracksReadVersionOnCommit = fdb.isTrackLastSeenVersionOnCommit();
+        try {
+            fdb.setTrackLastSeenVersion(true);
+            Index index = runAsyncSetup();
+
+            FDBDatabase.WeakReadSemantics weakReadSemantics = new FDBDatabase.WeakReadSemantics(0L, Long.MAX_VALUE, true);
+            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
+                    .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                    .setWeakReadSemantics(weakReadSemantics)
+                    .build()) {
+                long readVersion = runAndHandleLessenWorkCodes(indexBuilder, recordStore -> {
+                    assertSame(weakReadSemantics, recordStore.getContext().getWeakReadSemantics());
+                    assertTrue(recordStore.getContext().hasReadVersion());
+                    return recordStore.getContext().getReadVersionAsync();
+                }).get();
+                long readVersion2 = runAndHandleLessenWorkCodes(indexBuilder, recordStore -> {
+                    assertTrue(recordStore.getContext().hasReadVersion());
+                    return recordStore.getContext().getReadVersionAsync();
+                }).get();
+                assertEquals(readVersion, readVersion2, "weak read semantics did not preserve read version");
+            }
+        } finally {
+            fdb.setTrackLastSeenVersionOnRead(dbTracksReadVersionOnRead);
+            fdb.setTrackLastSeenVersionOnRead(dbTracksReadVersionOnCommit);
+        }
+    }
+
+    @Test
+    public void runWithPriorities() throws InterruptedException, ExecutionException {
+        Index index = runAsyncSetup();
+        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
+                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                .build()) {
+            runAndHandleLessenWorkCodes(indexBuilder, recordStore -> {
+                assertEquals(FDBTransactionPriority.BATCH, recordStore.getContext().getPriority());
+                return AsyncUtil.DONE;
+            }).get();
+        }
+        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
+                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                .setPriority(FDBTransactionPriority.DEFAULT)
+                .build()) {
+            runAndHandleLessenWorkCodes(indexBuilder, recordStore -> {
+                assertEquals(FDBTransactionPriority.DEFAULT, recordStore.getContext().getPriority());
+                return AsyncUtil.DONE;
+            }).get();
+        }
+    }
+
+    @Nonnull
     private Index runAsyncSetup() {
         Index index = new Index("newIndex", field("num_value_2"));
         openSimpleMetaData(metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index));
@@ -2410,55 +2507,49 @@ public class OnlineIndexerTest extends FDBTestBase {
         Index newIndex = new Index("newIndex", field("num_value_2"));
         openSimpleMetaData(metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", newIndex));
         Index indexPrime = metaData.getIndex("newIndex");
-        Collection<RecordType> recordTypes = metaData.recordTypesForIndex(indexPrime);
         // Absent index
-        try {
+        RecordCoreException e = assertThrows(MetaDataException.class, () -> {
             Index absentIndex = new Index("absent", field("num_value_2"));
             OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(absentIndex).setSubspace(subspace).build();
-            fail("Did not catch absent index.");
-        } catch (MetaDataException e) {
-            assertEquals("Index absent not contained within specified metadata", e.getMessage());
-        }
+        });
+        assertEquals("Index absent not contained within specified metadata", e.getMessage());
         // Limit
-        try {
-            OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setLimit(-1).build();
-            fail("Did not catch negative limit.");
-        } catch (RecordCoreException e) {
-            assertEquals("Non-positive value -1 given for record limit", e.getMessage());
-        }
-        try {
-            OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setLimit(0).build();
-            fail("Did not catch zero limit.");
-        } catch (RecordCoreException e) {
-            assertEquals("Non-positive value 0 given for record limit", e.getMessage());
-        }
+        e = assertThrows(RecordCoreException.class, () ->
+                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setLimit(-1).build()
+        );
+        assertEquals("Non-positive value -1 given for record limit", e.getMessage());
+        e = assertThrows(RecordCoreException.class, () ->
+                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setLimit(0).build()
+        );
+        assertEquals("Non-positive value 0 given for record limit", e.getMessage());
         // Retries
-        try {
-            OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setMaxRetries(-1).build();
-            fail("Did not catch negative retries.");
-        } catch (RecordCoreException e) {
-            assertEquals("Non-positive value -1 given for maximum retries", e.getMessage());
-        }
-        try {
-            OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setMaxRetries(0).build();
-            fail("Did not catch zero retries.");
-        } catch (RecordCoreException e) {
-            assertEquals("Non-positive value 0 given for maximum retries", e.getMessage());
-        }
+        e = assertThrows(RecordCoreException.class, () ->
+                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setMaxRetries(-1).build()
+        );
+        assertEquals("Non-positive value -1 given for maximum retries", e.getMessage());
+        e = assertThrows(RecordCoreException.class, () ->
+                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setMaxRetries(0).build()
+        );
+        assertEquals("Non-positive value 0 given for maximum retries", e.getMessage());
         // Records per second
-        try {
-            OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setRecordsPerSecond(-1).build();
-            fail("Did not catch negative RPS");
-        } catch (RecordCoreException e) {
-            assertEquals("Non-positive value -1 given for records per second value", e.getMessage());
-        }
-        try {
-            OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setRecordsPerSecond(0).build();
-
-            fail("Did not catch zero RPS");
-        } catch (RecordCoreException e) {
-            assertEquals("Non-positive value 0 given for records per second value", e.getMessage());
-        }
+        e = assertThrows(RecordCoreException.class, () ->
+                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setRecordsPerSecond(-1).build()
+        );
+        assertEquals("Non-positive value -1 given for records per second value", e.getMessage());
+        e = assertThrows(RecordCoreException.class, () ->
+                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setRecordsPerSecond(0).build()
+        );
+        assertEquals("Non-positive value 0 given for records per second value", e.getMessage());
+        // WeakReadSemantics before runner
+        e = assertThrows(MetaDataException.class, () ->
+                OnlineIndexer.newBuilder().setWeakReadSemantics(new FDBDatabase.WeakReadSemantics(Long.MAX_VALUE, 0L, true))
+        );
+        assertEquals("weak read semantics can only be set after runner has been set", e.getMessage());
+        // priority before runner
+        e = assertThrows(MetaDataException.class, () ->
+                OnlineIndexer.newBuilder().setPriority(FDBTransactionPriority.DEFAULT)
+        );
+        assertEquals("transaction priority can only be set after runner has been set", e.getMessage());
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollectorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SizeStatisticsCollectorTest.java
@@ -224,7 +224,7 @@ public class SizeStatisticsCollectorTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             // Somewhat leaky, but should get transaction_too_old.
             // One can set knob_max_read_transaction_life_versions up to max_versions_in_flight, which is 100000000.
-            context.ensureActive().setReadVersion(commitVersion - 101_000_000);
+            context.setReadVersion(commitVersion - 101_000_000);
             assertThat(statisticsCollector.collect(context, ExecuteProperties.SERIAL_EXECUTE), is(false));
             assertThrows(FDBExceptions.FDBStoreTransactionIsTooOldException.class, context::commit);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
@@ -30,11 +30,11 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.ScanProperties;
-import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
@@ -461,10 +460,9 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
         }
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "deleteWithSplitAndVersion [splitLongRecords = {0}]")
-    public void deleteWithSplitAndVersion(TestHelpers.BooleanEnum splitLongRecordsEnum) throws Exception {
-        final boolean splitLongRecords = splitLongRecordsEnum.toBoolean();
+    @BooleanSource
+    public void deleteWithSplitAndVersion(boolean splitLongRecords) throws Exception {
         final byte[] globalVersion = "chrysan_th".getBytes(Charsets.US_ASCII);
         try (FDBRecordContext context = openContext()) {
             // Delete unsplit with size info
@@ -685,10 +683,9 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
         }
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "scan [reverse = {0}]")
-    public void scanSingleRecords(final TestHelpers.BooleanEnum reverseEnum) throws Exception {
-        final boolean reverse = reverseEnum.toBoolean();
+    @BooleanSource
+    public void scanSingleRecords(boolean reverse) throws Exception {
         loadSingleRecords(true, false,
                 (context, key, expectedSizes, expectedContents, version) -> scanSingleRecord(context, reverse, key, expectedSizes, expectedContents, version));
     }
@@ -719,10 +716,9 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
         return rawRecords;
     }
 
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest(name = "scanMultipleRecords [reverse = {0}]")
-    public void scanMultipleRecords(final TestHelpers.BooleanEnum reverseEnum) throws Exception {
-        final boolean reverse = reverseEnum.toBoolean();
+    @BooleanSource
+    public void scanMultipleRecords(boolean reverse) throws Exception {
         final ScanProperties scanProperties = reverse ? ScanProperties.REVERSE_SCAN : ScanProperties.FORWARD_SCAN;
         List<FDBRawRecord> rawRecords = writeDummyRecords();
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/VersionIndexTest.java
@@ -552,7 +552,7 @@ public class VersionIndexTest extends FDBTestBase {
         FDBRecordVersion manualVersion;
         byte[] versionstamp;
         try (FDBRecordContext context = openContext(functionVersionHook)) {
-            long readVersion = context.ensureActive().getReadVersion().get();
+            long readVersion = context.getReadVersion();
             manualVersion = FDBRecordVersion.firstInDBVersion(readVersion);
             FDBStoredRecord<Message> storedCommitWithDummy =  recordStore.saveRecord(recordCommitWithDummy);
             assertEquals(FDBRecordVersion.incomplete(0), storedCommitWithDummy.getVersion());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreScanLimitTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/limits/FDBRecordStoreScanLimitTest.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.ScanLimitReachedException;
 import com.apple.foundationdb.record.ScanProperties;
-import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.cursors.BaseCursor;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
@@ -53,6 +52,7 @@ import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithNoChildren;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.common.base.Strings;
 import com.google.protobuf.Message;
@@ -63,7 +63,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
@@ -273,10 +272,9 @@ public class FDBRecordStoreScanLimitTest extends FDBRecordStoreLimitTestBase {
     }
 
     @ParameterizedTest(name = "unorderedIntersectionWithScanLimit [fail = {0}]")
-    @EnumSource(TestHelpers.BooleanEnum.class)
-    public void unorderedIntersectionWithScanLimit(TestHelpers.BooleanEnum failEnum) throws Exception {
+    @BooleanSource
+    public void unorderedIntersectionWithScanLimit(boolean fail) throws Exception {
         // TODO: When there is an UnorderedIntersectionPlan (or whatever) add that to the unordered plans stream
-        final boolean fail = failEnum.toBoolean();
         RecordQueryPlanner planner = new RecordQueryPlanner(simpleMetaData(NO_HOOK), new RecordStoreState(null, null));
         RecordQueryPlan leftPlan = planner.plan(RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.provider.foundationdb.query;
 
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.RecordCursorIterator;
-import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
@@ -33,6 +32,7 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Message;
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
@@ -338,11 +337,10 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that an OR of inequalities on different fields uses an unordered union, since there is no compatible ordering.
      */
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @DualPlannerTest
     @ParameterizedTest(name = "testOrQuery5 [removesDuplicates = {0}]")
-    public void testOrQuery5(@Nonnull TestHelpers.BooleanEnum removesDuplicatesEnum) throws Exception {
-        final boolean removesDuplicates = removesDuplicatesEnum.toBoolean();
+    @BooleanSource
+    public void testOrQuery5(boolean removesDuplicates) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder()
@@ -504,10 +502,9 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * Unlike {@link #testOrQuery6()}, the legs of the union are not compatibly ordered, so this will revert to using
      * an unordered union.
      */
-    @EnumSource(TestHelpers.BooleanEnum.class)
     @ParameterizedTest
-    public void testUnorderableOrQueryWithAnd(@Nonnull TestHelpers.BooleanEnum removesDuplicatesEnum) throws Exception {
-        final boolean removesDuplicates = removesDuplicatesEnum.toBoolean();
+    @BooleanSource
+    public void testUnorderableOrQueryWithAnd(boolean removesDuplicates) throws Exception {
         RecordMetaDataHook hook = metaDataBuilder -> {
             complexQuerySetupHook().apply(metaDataBuilder);
             metaDataBuilder.addIndex("MySimpleRecord", new Index("multi_index_2", "str_value_indexed", "num_value_3_indexed"));

--- a/fdb-record-layer-core/src/test/resources/log4j2-test.properties
+++ b/fdb-record-layer-core/src/test/resources/log4j2-test.properties
@@ -26,9 +26,10 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d [%level] %logger{1.} - %m%n%ex{full}
 
+# Enable trace logging on the split helper by setting level to "trace"
 loggers = splithelper
 logger.splithelper.name = com.apple.foundationdb.record.provider.foundationdb.SplitHelper
-logger.splithelper.level = trace
+logger.splithelper.level = debug
 
 rootLogger.level = debug
 rootLogger.appenderRefs = stdout


### PR DESCRIPTION
This combines three related issues mainly because I found the second one trivial after doing the first one, and the third actually used methods that were added in the first and conflicted with the second.

The first one deprecates `FDBDatabase::getReadVersion`, which called `Transaction::getReadVersion` and then added tracking for it in the record context. This is replaced with `FDBRecordContext::getReadVersionAsync` (and a synchronous version). This will then cache the result of the future within the context, which means that we can distinguish between read versions that have come from actually going to the database from those that have come from read version tracking, which is kind of nice. (There's still a way to get around this (i.e., by directly calling `setReadVersion` on the transaction), but I think it's almost impossible to get around that.) This also adds tracking of the call through a new event, `GET_READ_VERSION`. (This is distinguished from the existing *wait*, `WAIT_GET_READ_VERSION`.)

The second change then edits the `OnlineIndexer`'s runner to explicitly call `getReadVersion` on the transaction's it gets. This then uses the instrumentation that was added in the first change, which makes the second change trivial. I also inspected the logs emitted from the `OnlineIndexer` tests to make sure that the value was actually getting tracked.

The third change then allows the user to specify the priority of transactions for the `OnlineIndexer`. In actuality, it allows the user to set the priority on any transaction, and then it exposes a `setPriority` on `FDBDatabaseRunner`s and `OnlineIndexer.Builder`. It also exposes the weak read semantics through `OnlineIndexer.Builder`, which already existed. This feels like a more natural way for the user to specify the priority in general, and it made the problem of setting it for `OnlinIndexer`s less "special case"-y.

This resolves #696, this resolves #697, and this resolves #698. I can break this out into more PRs if necessary, as they aren't super intertwined, but they are a little intertwined, tbh.