### PR TITLE
Fixes #705: Truncate transaction IDs to 100 characters

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -35,7 +35,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Transaction IDs that would exceed the maximum FDB limit are now truncated or ignored instead of throwing an error [(Issue #705)](https://github.com/FoundationDB/fdb-record-layer/issues/705)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
@@ -40,8 +40,9 @@ public abstract class FDBTestBase {
 
     @BeforeAll
     public static void initFDB() {
-        FDBDatabaseFactory.instance().setUnclosedWarning(true);
-        FDBDatabaseFactory.instance().initFDB();
+        FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
+        factory.setUnclosedWarning(true);
+        factory.initFDB();
     }
 
     @BeforeAll


### PR DESCRIPTION
This adds a "sanitization" step to `FDBRecordContext` before it will set the transaction identifier. If the identifier exceeds 100 characters, it will truncate or drop the string. This operates on the assumption that the ID here is less important to most users than actually executing the operation. I think this assumption is correct, especially as we are currently passing the ID through the MDC rather than as a proper argument. I could see an argument being made that if we exposed the ID as something more like "setTransactionID", then we would want that function to throw an error or something, but this seems like the proper couse of action in this case.

This fixes #705.