### PR TITLE
Fixes #723: Shorter metric keys for logging.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
@@ -115,13 +115,24 @@ public interface RecordSerializer<M extends Message> {
         DECRYPT_SERIALIZED_RECORD("decrypt serialized record");
 
         private final String title;
+        private String logKey;
         Events(String title) {
             this.title = title;
+        }
+
+        Events(String title, String logKey) {
+            this.title = title;
+            this.logKey = logKey;
         }
 
         @Override
         public String title() {
             return title;
+        }
+
+        @Override
+        public String logKey() {
+            return logKey;
         }
     }
 
@@ -135,6 +146,7 @@ public interface RecordSerializer<M extends Message> {
 
         private final String title;
         private final boolean isSize;
+        private String logKey;
 
         Counts(String title) {
             this(title, false);
@@ -145,9 +157,20 @@ public interface RecordSerializer<M extends Message> {
             this.isSize = false;
         }
 
+        Counts(String title, boolean isSize, String logKey) {
+            this.title = title;
+            this.isSize = false;
+            this.logKey = logKey;
+        }
+
         @Override
         public String title() {
             return title;
+        }
+
+        @Override
+        public String logKey() {
+            return logKey;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
@@ -115,9 +115,10 @@ public interface RecordSerializer<M extends Message> {
         DECRYPT_SERIALIZED_RECORD("decrypt serialized record");
 
         private final String title;
-        private String logKey;
+        private final String logKey;
         Events(String title) {
             this.title = title;
+            this.logKey = this.name();
         }
 
         Events(String title, String logKey) {
@@ -131,8 +132,9 @@ public interface RecordSerializer<M extends Message> {
         }
 
         @Override
+        @Nonnull
         public String logKey() {
-            return logKey;
+            return this.logKey;
         }
     }
 
@@ -146,7 +148,7 @@ public interface RecordSerializer<M extends Message> {
 
         private final String title;
         private final boolean isSize;
-        private String logKey;
+        private final String logKey;
 
         Counts(String title) {
             this(title, false);
@@ -155,6 +157,7 @@ public interface RecordSerializer<M extends Message> {
         Counts(String title, boolean isSize) {
             this.title = title;
             this.isSize = false;
+            this.logKey = this.name();
         }
 
         Counts(String title, boolean isSize, String logKey) {
@@ -169,8 +172,9 @@ public interface RecordSerializer<M extends Message> {
         }
 
         @Override
+        @Nonnull
         public String logKey() {
-            return logKey;
+            return this.logKey;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
@@ -119,7 +119,7 @@ public interface RecordSerializer<M extends Message> {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = (logKey != null) ? logKey : StoreTimer.DetailEvent.super.logKey();
         }
 
         Events(String title) {
@@ -135,7 +135,7 @@ public interface RecordSerializer<M extends Message> {
         @Override
         @Nonnull
         public String logKey() {
-            return (this.logKey != null) ? this.logKey : StoreTimer.DetailEvent.super.logKey();
+            return this.logKey;
         }
     }
 
@@ -154,7 +154,7 @@ public interface RecordSerializer<M extends Message> {
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = false;
-            this.logKey = logKey;
+            this.logKey = (logKey != null) ? logKey : StoreTimer.Count.super.logKey();
         }
 
         Counts(String title, boolean isSize) {
@@ -173,7 +173,7 @@ public interface RecordSerializer<M extends Message> {
         @Override
         @Nonnull
         public String logKey() {
-            return (this.logKey != null) ? this.logKey : StoreTimer.Count.super.logKey();
+            return this.logKey;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
@@ -28,7 +28,6 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Locale;
 
 /**
  * A converter between a Protobuf record and a byte string stored in one or more values in the FDB key-value store.
@@ -120,7 +119,7 @@ public interface RecordSerializer<M extends Message> {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
+            this.logKey = logKey;
         }
 
         Events(String title) {
@@ -136,7 +135,7 @@ public interface RecordSerializer<M extends Message> {
         @Override
         @Nonnull
         public String logKey() {
-            return this.logKey;
+            return (this.logKey != null) ? this.logKey : StoreTimer.DetailEvent.super.logKey();
         }
     }
 
@@ -155,7 +154,7 @@ public interface RecordSerializer<M extends Message> {
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = false;
-            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
+            this.logKey = logKey;
         }
 
         Counts(String title, boolean isSize) {
@@ -174,7 +173,7 @@ public interface RecordSerializer<M extends Message> {
         @Override
         @Nonnull
         public String logKey() {
-            return this.logKey;
+            return (this.logKey != null) ? this.logKey : StoreTimer.Count.super.logKey();
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
@@ -28,6 +28,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Locale;
 
 /**
  * A converter between a Protobuf record and a byte string stored in one or more values in the FDB key-value store.
@@ -116,15 +117,16 @@ public interface RecordSerializer<M extends Message> {
 
         private final String title;
         private final String logKey;
-        Events(String title) {
-            this.title = title;
-            this.logKey = this.name();
-        }
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
         }
+
+        Events(String title) {
+            this(title, null);
+        }
+
 
         @Override
         public String title() {
@@ -150,20 +152,18 @@ public interface RecordSerializer<M extends Message> {
         private final boolean isSize;
         private final String logKey;
 
-        Counts(String title) {
-            this(title, false);
-        }
-
-        Counts(String title, boolean isSize) {
-            this.title = title;
-            this.isSize = false;
-            this.logKey = this.name();
-        }
-
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = false;
-            this.logKey = logKey;
+            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+        }
+
+        Counts(String title, boolean isSize) {
+            this(title, isSize, null);
+        }
+
+        Counts(String title) {
+            this(title, false, null);
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
@@ -120,7 +120,7 @@ public interface RecordSerializer<M extends Message> {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
         }
 
         Events(String title) {
@@ -155,7 +155,7 @@ public interface RecordSerializer<M extends Message> {
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = false;
-            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
         }
 
         Counts(String title, boolean isSize) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -169,7 +169,10 @@ public class StoreTimer {
         String title();
 
         /**
-         * Get the logKey of this event for logging purposes.
+         * Get the key of this event for logging. This should be used with
+         * KeyValueLogMessages and other key-value based logging systems to
+         * log the values from instrumented events. These keys are not
+         * expected to change frequently.
          *
          * @return the key to use for logging
          */
@@ -445,7 +448,7 @@ public class StoreTimer {
         for (Map.Entry<Event, Counter> entry : counters.entrySet()) {
             Event event = entry.getKey();
             Counter counter = entry.getValue();
-            String prefix = event.name().toLowerCase(Locale.ROOT);
+            String prefix = event.logKey().toLowerCase(Locale.ROOT);
             result.put(prefix + "_count", counter.count.get());
             if (!(event instanceof Count)) {
                 result.put(prefix + "_micros", counter.timeNanos.get() / 1000);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -448,15 +447,16 @@ public class StoreTimer {
         for (Map.Entry<Event, Counter> entry : counters.entrySet()) {
             Event event = entry.getKey();
             Counter counter = entry.getValue();
-            String prefix = event.logKey().toLowerCase(Locale.ROOT);
+            String prefix = event.logKey();
             result.put(prefix + "_count", counter.count.get());
             if (!(event instanceof Count)) {
                 result.put(prefix + "_micros", counter.timeNanos.get() / 1000);
             }
         }
+
         // now add recorded timeout events to map
         for (Event timeoutEvent : timeoutEvents) {
-            String timeoutPrefix = timeoutEvent.name().toLowerCase(Locale.ROOT);
+            String timeoutPrefix = timeoutEvent.logKey();
             result.put(timeoutPrefix + "_timeout_micros", getTimeoutTimeNanos(timeoutEvent) / 1000);
             result.put(timeoutPrefix + "_timeout_count", getTimeoutCount(timeoutEvent));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -177,7 +178,9 @@ public class StoreTimer {
          *
          * @return the key to use for logging
          */
-        String logKey();
+        default String logKey() {
+            return this.name().toLowerCase(Locale.ROOT);
+        }
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -167,6 +167,13 @@ public class StoreTimer {
          * @return the user-visible title
          */
         String title();
+
+        /**
+         * Get the logKey of this event for logging purposes.
+         *
+         * @return the key to use for logging
+         */
+        String logKey();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -169,9 +169,35 @@ public class StoreTimer {
 
         /**
          * Get the key of this event for logging. This should be used with
-         * KeyValueLogMessages and other key-value based logging systems to
-         * log the values from instrumented events. These keys are not
-         * expected to change frequently.
+         * {@link KeyValueLogMessage}s and other key-value based logging
+         * systems to log the values from instrumented events. These keys are
+         * not expected to change frequently. They may, however, change
+         * outside of any minor version change. Their values, therefore,
+         * should not be relied upon, other that for the logging purposes.
+         *
+         * By convention, the following abbreviations are recommended:
+         * build        : bld
+         * check        : chk
+         * count        : cnt
+         * create       : cr
+         * directory    : dir
+         * duplicate    : dup
+         * error        : err
+         * extended     : ext
+         * header       : hdr
+         * index        : idx
+         * keyspace     : ks
+         * leaderboard  : lbrd
+         * load         : ld
+         * mutate       : mut
+         * operation    : op
+         * query        : qry
+         * read         : rd
+         * record       : rec
+         * record_store : rs
+         * reverse      : rev
+         * statistics   : stats
+         * version      : ver
          *
          * @return the key to use for logging
          */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -173,31 +173,7 @@ public class StoreTimer {
          * systems to log the values from instrumented events. These keys are
          * not expected to change frequently. They may, however, change
          * outside of any minor version change. Their values, therefore,
-         * should not be relied upon, other that for the logging purposes.
-         *
-         * By convention, the following abbreviations are recommended:
-         * build        : bld
-         * check        : chk
-         * count        : cnt
-         * create       : cr
-         * directory    : dir
-         * duplicate    : dup
-         * error        : err
-         * extended     : ext
-         * header       : hdr
-         * index        : idx
-         * keyspace     : ks
-         * leaderboard  : lbrd
-         * load         : ld
-         * mutate       : mut
-         * operation    : op
-         * query        : qry
-         * read         : rd
-         * record       : rec
-         * record_store : rs
-         * reverse      : rev
-         * statistics   : stats
-         * version      : ver
+         * should not be relied upon, other than for the logging purposes.
          *
          * @return the key to use for logging
          */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.provider.common.RecordSerializer;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ExtendedDirectoryLayer;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -178,9 +179,10 @@ public class FDBStoreTimer extends StoreTimer {
         TIME_WINDOW_LEADERBOARD_SAVE_SUB_DIRECTORY("leaderboard save sub-directory");
 
         private final String title;
-        private String logKey;
+        private final String logKey;
         Events(String title) {
             this.title = title;
+            this.logKey = this.name();
         }
 
         Events(String title, String logKey) {
@@ -194,6 +196,7 @@ public class FDBStoreTimer extends StoreTimer {
         }
 
         @Override
+        @Nonnull
         public String logKey() {
             return this.logKey;
         }
@@ -223,9 +226,10 @@ public class FDBStoreTimer extends StoreTimer {
         RD_CACHE_DIRECTORY_SCAN("reverse directory cache hard miss, scanning directory subspace");
 
         private final String title;
-        private String logKey;
+        private final String logKey;
         DetailEvents(String title) {
             this.title = title;
+            this.logKey = this.name();
         }
 
         DetailEvents(String title, String logKey) {
@@ -239,8 +243,9 @@ public class FDBStoreTimer extends StoreTimer {
         }
 
         @Override
+        @Nonnull
         public String logKey() {
-            return logKey;
+            return this.logKey;
         }
 
     }
@@ -355,9 +360,10 @@ public class FDBStoreTimer extends StoreTimer {
         ;
 
         private final String title;
-        private String logKey;
+        private final String logKey;
         Waits(String title) {
             this.title = title;
+            this.logKey = this.name();
         }
 
         Waits(String title, String logKey) {
@@ -371,8 +377,9 @@ public class FDBStoreTimer extends StoreTimer {
         }
 
         @Override
+        @Nonnull
         public String logKey() {
-            return logKey;
+            return this.logKey;
         }
     }
 
@@ -532,10 +539,11 @@ public class FDBStoreTimer extends StoreTimer {
 
         private final String title;
         private final boolean isSize;
-        private String logKey;
+        private final String logKey;
         Counts(String title, boolean isSize) {
             this.title = title;
             this.isSize = isSize;
+            this.logKey = this.name();
         }
 
         Counts(String title, boolean isSize, String logKey) {
@@ -550,8 +558,9 @@ public class FDBStoreTimer extends StoreTimer {
         }
 
         @Override
+        @Nonnull
         public String logKey() {
-            return logKey;
+            return this.logKey;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -76,7 +76,7 @@ public class FDBStoreTimer extends StoreTimer {
         /** The amount of time taken loading a record store's {@code DataStoreInfo} header.*/
         LOAD_RECORD_STORE_INFO("load record store info"),
         /** The amount of time taken loading a record store's index meta-data. */
-        LOAD_RECORD_STORE_INDEX_META_DATA("load record store index meta-data", "ld_rs_idx_meta"),
+        LOAD_RECORD_STORE_INDEX_META_DATA("load record store index meta-data"),
         /** The amount of time taken getting the current version from a {@link MetaDataCache}. */
         GET_META_DATA_CACHE_VERSION("get meta-data cache version"),
         /** The amount of time taken getting cached meta-data from a {@link MetaDataCache}. */
@@ -183,7 +183,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = (logKey != null) ? logKey : Event.super.logKey();
         }
 
         Events(String title) {
@@ -199,7 +199,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return (this.logKey != null) ? this.logKey : Event.super.logKey();
+            return this.logKey;
         }
     }
 
@@ -231,7 +231,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         DetailEvents(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = (logKey != null) ? logKey : StoreTimer.DetailEvent.super.logKey();
         }
 
         DetailEvents(String title) {
@@ -247,7 +247,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return (this.logKey != null) ? this.logKey : StoreTimer.DetailEvent.super.logKey();
+            return this.logKey;
         }
 
     }
@@ -366,7 +366,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         Waits(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = (logKey != null) ? logKey : Wait.super.logKey();
         }
 
         Waits(String title) {
@@ -381,7 +381,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return (this.logKey != null) ? this.logKey : Wait.super.logKey();
+            return this.logKey;
         }
     }
 
@@ -546,7 +546,7 @@ public class FDBStoreTimer extends StoreTimer {
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = isSize;
-            this.logKey = logKey;
+            this.logKey = (logKey != null) ? logKey : Count.super.logKey();
         }
 
         Counts(String title, boolean isSize) {
@@ -561,7 +561,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return (this.logKey != null) ? this.logKey : Count.super.logKey();
+            return this.logKey;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.record.provider.foundationdb.keyspace.ExtendedDire
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.stream.Stream;
 
 /**
@@ -184,7 +183,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
+            this.logKey = logKey;
         }
 
         Events(String title) {
@@ -200,7 +199,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return this.logKey;
+            return (this.logKey != null) ? this.logKey : Event.super.logKey();
         }
     }
 
@@ -232,7 +231,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         DetailEvents(String title, String logKey) {
             this.title = title;
-            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
+            this.logKey = logKey;
         }
 
         DetailEvents(String title) {
@@ -248,7 +247,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return this.logKey;
+            return (this.logKey != null) ? this.logKey : StoreTimer.DetailEvent.super.logKey();
         }
 
     }
@@ -367,7 +366,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         Waits(String title, String logKey) {
             this.title = title;
-            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
+            this.logKey = logKey;
         }
 
         Waits(String title) {
@@ -382,7 +381,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return this.logKey;
+            return (this.logKey != null) ? this.logKey : Wait.super.logKey();
         }
     }
 
@@ -547,7 +546,7 @@ public class FDBStoreTimer extends StoreTimer {
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = isSize;
-            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
+            this.logKey = logKey;
         }
 
         Counts(String title, boolean isSize) {
@@ -562,7 +561,7 @@ public class FDBStoreTimer extends StoreTimer {
         @Override
         @Nonnull
         public String logKey() {
-            return this.logKey;
+            return (this.logKey != null) ? this.logKey : Count.super.logKey();
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -184,7 +184,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
         }
 
         Events(String title) {
@@ -232,7 +232,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         DetailEvents(String title, String logKey) {
             this.title = title;
-            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
         }
 
         DetailEvents(String title) {
@@ -367,7 +367,7 @@ public class FDBStoreTimer extends StoreTimer {
 
         Waits(String title, String logKey) {
             this.title = title;
-            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
         }
 
         Waits(String title) {
@@ -547,7 +547,7 @@ public class FDBStoreTimer extends StoreTimer {
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = isSize;
-            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
         }
 
         Counts(String title, boolean isSize) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.provider.foundationdb.keyspace.ExtendedDire
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 /**
@@ -180,15 +181,16 @@ public class FDBStoreTimer extends StoreTimer {
 
         private final String title;
         private final String logKey;
-        Events(String title) {
-            this.title = title;
-            this.logKey = this.name();
-        }
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
         }
+
+        Events(String title) {
+            this(title, null);
+        }
+
 
         @Override
         public String title() {
@@ -227,15 +229,16 @@ public class FDBStoreTimer extends StoreTimer {
 
         private final String title;
         private final String logKey;
-        DetailEvents(String title) {
-            this.title = title;
-            this.logKey = this.name();
-        }
 
         DetailEvents(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
         }
+
+        DetailEvents(String title) {
+            this(title, null);
+        }
+
 
         @Override
         public String title() {
@@ -361,14 +364,14 @@ public class FDBStoreTimer extends StoreTimer {
 
         private final String title;
         private final String logKey;
-        Waits(String title) {
-            this.title = title;
-            this.logKey = this.name();
-        }
 
         Waits(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+        }
+
+        Waits(String title) {
+            this(title, null);
         }
 
         @Override
@@ -540,16 +543,15 @@ public class FDBStoreTimer extends StoreTimer {
         private final String title;
         private final boolean isSize;
         private final String logKey;
-        Counts(String title, boolean isSize) {
-            this.title = title;
-            this.isSize = isSize;
-            this.logKey = this.name();
-        }
 
         Counts(String title, boolean isSize, String logKey) {
             this.title = title;
             this.isSize = isSize;
-            this.logKey = logKey;
+            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+        }
+
+        Counts(String title, boolean isSize) {
+            this(title, isSize, null);
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -75,7 +75,7 @@ public class FDBStoreTimer extends StoreTimer {
         /** The amount of time taken loading a record store's {@code DataStoreInfo} header.*/
         LOAD_RECORD_STORE_INFO("load record store info"),
         /** The amount of time taken loading a record store's index meta-data. */
-        LOAD_RECORD_STORE_INDEX_META_DATA("load record store index meta-data"),
+        LOAD_RECORD_STORE_INDEX_META_DATA("load record store index meta-data", "ld_rs_idx_meta"),
         /** The amount of time taken getting the current version from a {@link MetaDataCache}. */
         GET_META_DATA_CACHE_VERSION("get meta-data cache version"),
         /** The amount of time taken getting cached meta-data from a {@link MetaDataCache}. */
@@ -178,13 +178,24 @@ public class FDBStoreTimer extends StoreTimer {
         TIME_WINDOW_LEADERBOARD_SAVE_SUB_DIRECTORY("leaderboard save sub-directory");
 
         private final String title;
+        private String logKey;
         Events(String title) {
             this.title = title;
+        }
+
+        Events(String title, String logKey) {
+            this.title = title;
+            this.logKey = logKey;
         }
 
         @Override
         public String title() {
             return title;
+        }
+
+        @Override
+        public String logKey() {
+            return this.logKey;
         }
     }
 
@@ -212,14 +223,26 @@ public class FDBStoreTimer extends StoreTimer {
         RD_CACHE_DIRECTORY_SCAN("reverse directory cache hard miss, scanning directory subspace");
 
         private final String title;
+        private String logKey;
         DetailEvents(String title) {
             this.title = title;
+        }
+
+        DetailEvents(String title, String logKey) {
+            this.title = title;
+            this.logKey = logKey;
         }
 
         @Override
         public String title() {
             return title;
         }
+
+        @Override
+        public String logKey() {
+            return logKey;
+        }
+
     }
 
     /**
@@ -332,13 +355,24 @@ public class FDBStoreTimer extends StoreTimer {
         ;
 
         private final String title;
+        private String logKey;
         Waits(String title) {
             this.title = title;
+        }
+
+        Waits(String title, String logKey) {
+            this.title = title;
+            this.logKey = logKey;
         }
 
         @Override
         public String title() {
             return title;
+        }
+
+        @Override
+        public String logKey() {
+            return logKey;
         }
     }
 
@@ -498,14 +532,26 @@ public class FDBStoreTimer extends StoreTimer {
 
         private final String title;
         private final boolean isSize;
+        private String logKey;
         Counts(String title, boolean isSize) {
             this.title = title;
             this.isSize = isSize;
         }
 
+        Counts(String title, boolean isSize, String logKey) {
+            this.title = title;
+            this.isSize = isSize;
+            this.logKey = logKey;
+        }
+
         @Override
         public String title() {
             return title;
+        }
+
+        @Override
+        public String logKey() {
+            return logKey;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.tuple.Tuple;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -59,14 +60,14 @@ public class RankedSetIndexHelper {
 
         private final String title;
         private final String logKey;
-        Events(String title) {
-            this.title = title;
-            this.logKey = this.name();
-        }
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+        }
+
+        Events(String title) {
+            this(title, null);
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -58,13 +58,24 @@ public class RankedSetIndexHelper {
         RANKED_SET_UPDATE("ranked set update");
 
         private final String title;
+        private String logKey;
         Events(String title) {
             this.title = title;
+        }
+
+        Events(String title, String logKey) {
+            this.title = title;
+            this.logKey = logKey;
         }
 
         @Override
         public String title() {
             return title;
+        }
+
+        @Override
+        public String logKey() {
+            return logKey;
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -58,9 +58,10 @@ public class RankedSetIndexHelper {
         RANKED_SET_UPDATE("ranked set update");
 
         private final String title;
-        private String logKey;
+        private final String logKey;
         Events(String title) {
             this.title = title;
+            this.logKey = this.name();
         }
 
         Events(String title, String logKey) {
@@ -74,8 +75,9 @@ public class RankedSetIndexHelper {
         }
 
         @Override
+        @Nonnull
         public String logKey() {
-            return logKey;
+            return this.logKey;
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -62,7 +62,7 @@ public class RankedSetIndexHelper {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = logKey;
+            this.logKey = (logKey != null) ? logKey : StoreTimer.DetailEvent.super.logKey();
         }
 
         Events(String title) {
@@ -77,7 +77,7 @@ public class RankedSetIndexHelper {
         @Override
         @Nonnull
         public String logKey() {
-            return (this.logKey != null) ? this.logKey : StoreTimer.DetailEvent.super.logKey();
+            return this.logKey;
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -63,7 +63,7 @@ public class RankedSetIndexHelper {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = ((logKey != null) ? logKey : this.name()).toLowerCase(Locale.ROOT);
+            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
         }
 
         Events(String title) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -40,7 +40,6 @@ import com.apple.foundationdb.tuple.Tuple;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -63,7 +62,7 @@ public class RankedSetIndexHelper {
 
         Events(String title, String logKey) {
             this.title = title;
-            this.logKey = (logKey != null) ? logKey : this.name().toLowerCase(Locale.ROOT);
+            this.logKey = logKey;
         }
 
         Events(String title) {
@@ -78,7 +77,7 @@ public class RankedSetIndexHelper {
         @Override
         @Nonnull
         public String logKey() {
-            return this.logKey;
+            return (this.logKey != null) ? this.logKey : StoreTimer.DetailEvent.super.logKey();
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
@@ -178,7 +178,7 @@ public class FDBStoreTimerTest {
     @Test
     public void logKeyTest() {
         // If log key has not been specified, 'logKey()' should return then '.name()' of the enum.
-        assertEquals(FDBStoreTimer.Events.COMMIT.logKey(), "COMMIT");
+        assertEquals(FDBStoreTimer.Events.COMMIT.logKey(), "commit");
 
         // If log key has been specified, 'logKey()' should return the specified log key.
         assertEquals(FDBStoreTimer.Events.LOAD_RECORD_STORE_INDEX_META_DATA.logKey(), "ld_rs_idx_meta");

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
@@ -175,6 +175,15 @@ public class FDBStoreTimerTest {
         assertThrows(RecordCoreArgumentException.class, () -> StoreTimer.getDifference(anotherStoreTimer, savedTimer));
     }
 
+    @Test
+    public void logKeyTest() {
+        // If log key has not been specified, 'logKey()' should return then '.name()' of the enum.
+        assertEquals(FDBStoreTimer.Events.COMMIT.logKey(), "COMMIT");
+
+        // If log key has been specified, 'logKey()' should return the specified log key.
+        assertEquals(FDBStoreTimer.Events.LOAD_RECORD_STORE_INDEX_META_DATA.logKey(), "ld_rs_idx_meta");
+    }
+
     private void setupBaseData() {
         subspace = fdb.run(context -> {
             KeySpacePath path = TestKeySpace.getKeyspacePath("record-test", "unit");

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -175,13 +176,37 @@ public class FDBStoreTimerTest {
         assertThrows(RecordCoreArgumentException.class, () -> StoreTimer.getDifference(anotherStoreTimer, savedTimer));
     }
 
+    private enum TestEvent implements StoreTimer.Event {
+
+        EVENT_WITH_LONG_NAME("An event with a very long name", "ShorterName"),
+        EVENT_WITH_SHORT_NAME("An event with a very short name", null);
+
+        private final String title;
+        private final String logKey;
+
+        TestEvent(@Nonnull String title, String logKey) {
+            this.title = title;
+            this.logKey = (logKey != null) ? logKey : StoreTimer.Event.super.logKey();
+        }
+        
+        @Override
+        public String title() {
+            return this.title;
+        }
+
+        @Override
+        public String logKey() {
+            return this.logKey;
+        }
+    }
+
     @Test
     public void logKeyTest() {
         // If log key has not been specified, 'logKey()' should return then '.name()' of the enum.
-        assertEquals(FDBStoreTimer.Events.COMMIT.logKey(), "commit");
+        assertEquals(TestEvent.EVENT_WITH_SHORT_NAME.logKey(), "event_with_short_name");
 
         // If log key has been specified, 'logKey()' should return the specified log key.
-        assertEquals(FDBStoreTimer.Events.LOAD_RECORD_STORE_INDEX_META_DATA.logKey(), "ld_rs_idx_meta");
+        assertEquals(TestEvent.EVENT_WITH_LONG_NAME.logKey(), "ShorterName");
     }
 
     private void setupBaseData() {


### PR DESCRIPTION
- Adds 'logKey()' to StoreTime interface.
- Implements interface for all implementations.
- Overloads for implementation constructors to provide shorter metric key for
  logging.
- To exemplify usage, added short logging key to a single metric.