### PR TITLE
Fixes #725: OneOfThemWith{Component,} does not distinguish empty vs null

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `Field.oneOfThem(boolean emptyIsUnknown)` for when the repeated field can otherwise distinguish null or null behavior is not desired [(Issue #725)](https://github.com/FoundationDB/fdb-record-layer/issues/725)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BaseRepeatedField.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BaseRepeatedField.java
@@ -29,15 +29,18 @@ import java.util.List;
 
 abstract class BaseRepeatedField extends BaseField {
 
-    public BaseRepeatedField(@Nonnull String fieldName) {
+    private final boolean emptyIsUnknown;
+
+    public BaseRepeatedField(@Nonnull String fieldName, boolean emptyIsUnknown) {
         super(fieldName);
+        this.emptyIsUnknown = emptyIsUnknown;
     }
 
     @Nullable
     @SuppressWarnings("unchecked")
     protected List<Object> getValues(@Nonnull MessageOrBuilder message) {
         final Descriptors.FieldDescriptor field = findFieldDescriptor(message);
-        if (message.getRepeatedFieldCount(field) == 0) {
+        if (emptyIsUnknown && message.getRepeatedFieldCount(field) == 0) {
             return null;
         } else {
             return (List<Object>) message.getField(field);
@@ -51,5 +54,30 @@ abstract class BaseRepeatedField extends BaseField {
             throw new Query.InvalidExpressionException("Expected repeated field, but it was scalar " + getFieldName());
         }
         return field;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BaseRepeatedField)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BaseRepeatedField baseRepeatedField = (BaseRepeatedField) o;
+        return emptyIsUnknown == baseRepeatedField.emptyIsUnknown;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + (emptyIsUnknown ? 0 : 1);
+    }
+
+    @Override
+    public int planHash() {
+        return super.planHash() + (emptyIsUnknown ? 0 : 1);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BaseRepeatedField.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BaseRepeatedField.java
@@ -29,18 +29,18 @@ import java.util.List;
 
 abstract class BaseRepeatedField extends BaseField {
 
-    private final boolean emptyIsUnknown;
+    private final Field.OneOfThemEmptyMode emptyMode;
 
-    public BaseRepeatedField(@Nonnull String fieldName, boolean emptyIsUnknown) {
+    public BaseRepeatedField(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode) {
         super(fieldName);
-        this.emptyIsUnknown = emptyIsUnknown;
+        this.emptyMode = emptyMode;
     }
 
     @Nullable
     @SuppressWarnings("unchecked")
     protected List<Object> getValues(@Nonnull MessageOrBuilder message) {
         final Descriptors.FieldDescriptor field = findFieldDescriptor(message);
-        if (emptyIsUnknown && message.getRepeatedFieldCount(field) == 0) {
+        if (emptyMode == Field.OneOfThemEmptyMode.EMPTY_UNKNOWN && message.getRepeatedFieldCount(field) == 0) {
             return null;
         } else {
             return (List<Object>) message.getField(field);
@@ -68,16 +68,16 @@ abstract class BaseRepeatedField extends BaseField {
             return false;
         }
         BaseRepeatedField baseRepeatedField = (BaseRepeatedField) o;
-        return emptyIsUnknown == baseRepeatedField.emptyIsUnknown;
+        return emptyMode == baseRepeatedField.emptyMode;
     }
 
     @Override
     public int hashCode() {
-        return super.hashCode() + (emptyIsUnknown ? 0 : 1);
+        return super.hashCode() + emptyMode.hashCode();
     }
 
     @Override
     public int planHash() {
-        return super.planHash() + (emptyIsUnknown ? 0 : 1);
+        return super.planHash() + emptyMode.ordinal();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/EmptyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/EmptyComparison.java
@@ -45,7 +45,7 @@ public class EmptyComparison extends BaseRepeatedField implements ComponentWithN
     private final boolean isEmpty;
 
     public EmptyComparison(@Nonnull String fieldName, boolean isEmpty) {
-        super(fieldName);
+        super(fieldName, false);
         this.isEmpty = isEmpty;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/EmptyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/EmptyComparison.java
@@ -45,7 +45,7 @@ public class EmptyComparison extends BaseRepeatedField implements ComponentWithN
     private final boolean isEmpty;
 
     public EmptyComparison(@Nonnull String fieldName, boolean isEmpty) {
-        super(fieldName, false);
+        super(fieldName, Field.OneOfThemEmptyMode.EMPTY_NO_MATCHES);
         this.isEmpty = isEmpty;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
@@ -67,7 +67,7 @@ public class Field {
     /**
      * If the associated field is a repeated one, this allows you to match against one of those values, the record will
      * be returned if any one of the values returns true. The record may be returned more than once.
-     * @param emptyIsUnknown {@code true} if an empty repeated field should cause an UNKNOWN result instead of failing to match any (and so returning FALSE).
+     * @param emptyIsUnknown {@code true} if an empty repeated field should cause an UNKNOWN result instead of failing to match any (and so returning FALSE)
      * @return an OneOfThem that can have further assertions called on it about the value of the given field.
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
@@ -68,7 +68,7 @@ public class Field {
      * If the associated field is a repeated one, this allows you to match against one of those values, the record will
      * be returned if any one of the values returns true. The record may be returned more than once.
      * @param emptyIsUnknown {@code true} if an empty repeated field should cause an UNKNOWN result instead of failing to match any (and so returning FALSE)
-     * @return an OneOfThem that can have further assertions called on it about the value of the given field.
+     * @return an OneOfThem that can have further assertions called on it about the value of the given field
      */
     @Nonnull
     public OneOfThem oneOfThem(boolean emptyIsUnknown) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
@@ -44,6 +44,17 @@ public class Field {
     }
 
     /**
+     * How an empty / unset repeated field should be handled.
+     */
+    enum OneOfThemEmptyMode {
+        /** An empty repeated field causes {@code oneOfThem} predicates to return UNKNOWN, like a scalar NULL value. */
+        EMPTY_UNKNOWN,
+        /** An empty repeated field is treated like any other list, just with no elements, so none can match. */
+        EMPTY_NO_MATCHES
+        // TODO: A mode that depends on the nullability (versus field default value) of the record type's field in the descriptor / meta-data.
+    }
+
+    /**
      * If the associated field is a submessage, this allows you to match against the fields within that submessage.
      * The child is evaluated and validated in the context of this field, not the record containing this field.
      * @param child a component asserting about the content of the submessage in this field
@@ -68,12 +79,12 @@ public class Field {
     /**
      * If the associated field is a repeated one, this allows you to match against one of the repeated values.
      * The record will be returned if any one of the values returns {@code true}. The same record may be returned more than once.
-     * @param emptyIsUnknown {@code true} if an empty repeated field should cause an UNKNOWN result instead of failing to match any (and so returning FALSE)
+     * @param emptyMode whether an empty repeated field should cause an UNKNOWN result instead of failing to match any (and so returning FALSE)
      * @return an OneOfThem that can have further assertions called on it about the value of the given field
      */
     @Nonnull
-    public OneOfThem oneOfThem(boolean emptyIsUnknown) {
-        return new OneOfThem(fieldName, emptyIsUnknown);
+    public OneOfThem oneOfThem(OneOfThemEmptyMode emptyMode) {
+        return new OneOfThem(fieldName, emptyMode);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
@@ -65,6 +65,17 @@ public class Field {
     }
 
     /**
+     * If the associated field is a repeated one, this allows you to match against one of those values, the record will
+     * be returned if any one of the values returns true. The record may be returned more than once.
+     * @param emptyIsUnknown {@code true} if an empty repeated field should cause an UNKNOWN result instead of failing to match any (and so returning FALSE).
+     * @return an OneOfThem that can have further assertions called on it about the value of the given field.
+     */
+    @Nonnull
+    public OneOfThem oneOfThem(boolean emptyIsUnknown) {
+        return new OneOfThem(fieldName, emptyIsUnknown);
+    }
+
+    /**
      * Checks if the field has a value equal to the given comparand.
      * Evaluates to null if the field does not have a value.
      * @param comparand the object to compare with the value in the field

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Field.java
@@ -55,9 +55,10 @@ public class Field {
     }
 
     /**
-     * If the associated field is a repeated one, this allows you to match against one of those values, the record will
-     * be returned if any one of the values returns true. The record may be returned more than once.
-     * @return an OneOfThem that can have further assertions called on it about the value of the given field.
+     * If the associated field is a repeated one, this allows you to match against one of the repeated values.
+     * The record will be returned if any one of the values returns {@code true}. The same record may be returned more than once.
+     * If the repeated field is empty, the match result will be UNKNOWN.
+     * @return an OneOfThem that can have further assertions called on it about the value of the given field
      */
     @Nonnull
     public OneOfThem oneOfThem() {
@@ -65,8 +66,8 @@ public class Field {
     }
 
     /**
-     * If the associated field is a repeated one, this allows you to match against one of those values, the record will
-     * be returned if any one of the values returns true. The record may be returned more than once.
+     * If the associated field is a repeated one, this allows you to match against one of the repeated values.
+     * The record will be returned if any one of the values returns {@code true}. The same record may be returned more than once.
      * @param emptyIsUnknown {@code true} if an empty repeated field should cause an UNKNOWN result instead of failing to match any (and so returning FALSE)
      * @return an OneOfThem that can have further assertions called on it about the value of the given field
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThem.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThem.java
@@ -36,15 +36,15 @@ import java.util.List;
 public class OneOfThem {
     @Nonnull
     private final String fieldName;
-    private final boolean emptyIsUnknown;
+    private final Field.OneOfThemEmptyMode emptyMode;
 
     public OneOfThem(@Nonnull String fieldName) {
-        this(fieldName, true);
+        this(fieldName, Field.OneOfThemEmptyMode.EMPTY_UNKNOWN);
     }
 
-    public OneOfThem(@Nonnull String fieldName, boolean emptyIsUnknown) {
+    public OneOfThem(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode) {
         this.fieldName = fieldName;
-        this.emptyIsUnknown = emptyIsUnknown;
+        this.emptyMode = emptyMode;
     }
 
     /**
@@ -55,7 +55,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent matches(@Nonnull QueryComponent child) {
-        return new OneOfThemWithComponent(fieldName, emptyIsUnknown, child);
+        return new OneOfThemWithComponent(fieldName, emptyMode, child);
     }
 
     /**
@@ -66,7 +66,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent equalsValue(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, comparand));
     }
 
@@ -78,7 +78,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent notEquals(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.SimpleComparison(Comparisons.Type.NOT_EQUALS, comparand));
     }
 
@@ -90,7 +90,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent greaterThan(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN, comparand));
     }
 
@@ -102,7 +102,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent greaterThanOrEquals(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN_OR_EQUALS, comparand));
     }
 
@@ -114,7 +114,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent lessThan(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.SimpleComparison(Comparisons.Type.LESS_THAN, comparand));
     }
 
@@ -126,7 +126,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent lessThanOrEquals(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.SimpleComparison(Comparisons.Type.LESS_THAN_OR_EQUALS, comparand));
     }
 
@@ -137,7 +137,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent startsWith(@Nonnull String comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.SimpleComparison(Comparisons.Type.STARTS_WITH, comparand));
     }
 
@@ -148,7 +148,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent in(@Nonnull List<?> comparand) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.ListComparison(Comparisons.Type.IN, comparand));
     }
 
@@ -159,7 +159,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent in(@Nonnull String param) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+        return new OneOfThemWithComparison(fieldName, emptyMode,
                 new Comparisons.ParameterComparison(Comparisons.Type.IN, param));
     }
 
@@ -175,7 +175,7 @@ public class OneOfThem {
      */
     @Nonnull
     public Text text() {
-        return new OneOfThemText(fieldName, emptyIsUnknown);
+        return new OneOfThemText(fieldName, emptyMode);
     }
 
     /**
@@ -190,7 +190,7 @@ public class OneOfThem {
      */
     @Nonnull
     public Text text(@Nullable String tokenizerName) {
-        return new OneOfThemText(fieldName, emptyIsUnknown, tokenizerName);
+        return new OneOfThemText(fieldName, emptyMode, tokenizerName);
     }
 
     /**
@@ -210,6 +210,6 @@ public class OneOfThem {
      */
     @Nonnull
     public Text text(@Nullable String tokenizerName, @Nullable String defaultTokenizerName) {
-        return new OneOfThemText(fieldName,  emptyIsUnknown, tokenizerName, defaultTokenizerName);
+        return new OneOfThemText(fieldName,  emptyMode, tokenizerName, defaultTokenizerName);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThem.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThem.java
@@ -36,9 +36,15 @@ import java.util.List;
 public class OneOfThem {
     @Nonnull
     private final String fieldName;
+    private final boolean emptyIsUnknown;
 
     public OneOfThem(@Nonnull String fieldName) {
+        this(fieldName, true);
+    }
+
+    public OneOfThem(@Nonnull String fieldName, boolean emptyIsUnknown) {
         this.fieldName = fieldName;
+        this.emptyIsUnknown = emptyIsUnknown;
     }
 
     /**
@@ -49,7 +55,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent matches(@Nonnull QueryComponent child) {
-        return new OneOfThemWithComponent(fieldName, child);
+        return new OneOfThemWithComponent(fieldName, emptyIsUnknown, child);
     }
 
     /**
@@ -60,7 +66,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent equalsValue(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName,
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
                 new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, comparand));
     }
 
@@ -72,7 +78,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent notEquals(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName,
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
                 new Comparisons.SimpleComparison(Comparisons.Type.NOT_EQUALS, comparand));
     }
 
@@ -84,7 +90,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent greaterThan(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName,
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
                 new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN, comparand));
     }
 
@@ -96,7 +102,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent greaterThanOrEquals(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName,
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
                 new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN_OR_EQUALS, comparand));
     }
 
@@ -108,7 +114,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent lessThan(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName,
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
                 new Comparisons.SimpleComparison(Comparisons.Type.LESS_THAN, comparand));
     }
 
@@ -120,7 +126,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent lessThanOrEquals(@Nonnull Object comparand) {
-        return new OneOfThemWithComparison(fieldName,
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
                 new Comparisons.SimpleComparison(Comparisons.Type.LESS_THAN_OR_EQUALS, comparand));
     }
 
@@ -131,7 +137,7 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent startsWith(@Nonnull String comparand) {
-        return new OneOfThemWithComparison(fieldName,
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
                 new Comparisons.SimpleComparison(Comparisons.Type.STARTS_WITH, comparand));
     }
 
@@ -142,7 +148,8 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent in(@Nonnull List<?> comparand) {
-        return new OneOfThemWithComparison(fieldName, new Comparisons.ListComparison(Comparisons.Type.IN, comparand));
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+                new Comparisons.ListComparison(Comparisons.Type.IN, comparand));
     }
 
     /**
@@ -152,7 +159,8 @@ public class OneOfThem {
      */
     @Nonnull
     public QueryComponent in(@Nonnull String param) {
-        return new OneOfThemWithComparison(fieldName, new Comparisons.ParameterComparison(Comparisons.Type.IN, param));
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown,
+                new Comparisons.ParameterComparison(Comparisons.Type.IN, param));
     }
 
     /**
@@ -167,7 +175,7 @@ public class OneOfThem {
      */
     @Nonnull
     public Text text() {
-        return new OneOfThemText(fieldName);
+        return new OneOfThemText(fieldName, emptyIsUnknown);
     }
 
     /**
@@ -182,7 +190,7 @@ public class OneOfThem {
      */
     @Nonnull
     public Text text(@Nullable String tokenizerName) {
-        return new OneOfThemText(fieldName, tokenizerName);
+        return new OneOfThemText(fieldName, emptyIsUnknown, tokenizerName);
     }
 
     /**
@@ -202,6 +210,6 @@ public class OneOfThem {
      */
     @Nonnull
     public Text text(@Nullable String tokenizerName, @Nullable String defaultTokenizerName) {
-        return new OneOfThemText(fieldName, tokenizerName, defaultTokenizerName);
+        return new OneOfThemText(fieldName,  emptyIsUnknown, tokenizerName, defaultTokenizerName);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemText.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemText.java
@@ -27,23 +27,25 @@ import javax.annotation.Nullable;
 class OneOfThemText extends Text {
     @Nonnull
     private final String fieldName;
+    private final boolean emptyIsUnknown;
 
-    OneOfThemText(@Nonnull String fieldName) {
-        this(fieldName, null);
+    OneOfThemText(@Nonnull String fieldName, boolean emptyIsUnknown) {
+        this(fieldName, emptyIsUnknown, null);
     }
 
-    OneOfThemText(@Nonnull String fieldName, @Nullable String tokenizerName) {
-        this(fieldName, tokenizerName, null);
+    OneOfThemText(@Nonnull String fieldName, boolean emptyIsUnknown, @Nullable String tokenizerName) {
+        this(fieldName, emptyIsUnknown, tokenizerName, null);
     }
 
-    OneOfThemText(@Nonnull String fieldName, @Nullable String tokenizerName, @Nullable String defaultTokenizerName) {
+    OneOfThemText(@Nonnull String fieldName, boolean emptyIsUnknown, @Nullable String tokenizerName, @Nullable String defaultTokenizerName) {
         super(tokenizerName, defaultTokenizerName);
         this.fieldName = fieldName;
+        this.emptyIsUnknown = emptyIsUnknown;
     }
 
     @Nonnull
     @Override
     ComponentWithComparison getComponent(@Nonnull Comparisons.Comparison comparison) {
-        return new OneOfThemWithComparison(fieldName, comparison);
+        return new OneOfThemWithComparison(fieldName, emptyIsUnknown, comparison);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemText.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemText.java
@@ -27,25 +27,25 @@ import javax.annotation.Nullable;
 class OneOfThemText extends Text {
     @Nonnull
     private final String fieldName;
-    private final boolean emptyIsUnknown;
+    private final Field.OneOfThemEmptyMode emptyMode;
 
-    OneOfThemText(@Nonnull String fieldName, boolean emptyIsUnknown) {
-        this(fieldName, emptyIsUnknown, null);
+    OneOfThemText(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode) {
+        this(fieldName, emptyMode, null);
     }
 
-    OneOfThemText(@Nonnull String fieldName, boolean emptyIsUnknown, @Nullable String tokenizerName) {
-        this(fieldName, emptyIsUnknown, tokenizerName, null);
+    OneOfThemText(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode, @Nullable String tokenizerName) {
+        this(fieldName, emptyMode, tokenizerName, null);
     }
 
-    OneOfThemText(@Nonnull String fieldName, boolean emptyIsUnknown, @Nullable String tokenizerName, @Nullable String defaultTokenizerName) {
+    OneOfThemText(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode, @Nullable String tokenizerName, @Nullable String defaultTokenizerName) {
         super(tokenizerName, defaultTokenizerName);
         this.fieldName = fieldName;
-        this.emptyIsUnknown = emptyIsUnknown;
+        this.emptyMode = emptyMode;
     }
 
     @Nonnull
     @Override
     ComponentWithComparison getComponent(@Nonnull Comparisons.Comparison comparison) {
-        return new OneOfThemWithComparison(fieldName, emptyIsUnknown, comparison);
+        return new OneOfThemWithComparison(fieldName, emptyMode, comparison);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComparison.java
@@ -46,7 +46,11 @@ public class OneOfThemWithComparison extends BaseRepeatedField implements Compon
     private final Comparisons.Comparison comparison;
 
     public OneOfThemWithComparison(@Nonnull String fieldName, @Nonnull Comparisons.Comparison comparison) {
-        super(fieldName);
+        this(fieldName, true, comparison);
+    }
+
+    public OneOfThemWithComparison(@Nonnull String fieldName, boolean emptyIsUnknown, @Nonnull Comparisons.Comparison comparison) {
+        super(fieldName, emptyIsUnknown);
         this.comparison = comparison;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComparison.java
@@ -46,11 +46,11 @@ public class OneOfThemWithComparison extends BaseRepeatedField implements Compon
     private final Comparisons.Comparison comparison;
 
     public OneOfThemWithComparison(@Nonnull String fieldName, @Nonnull Comparisons.Comparison comparison) {
-        this(fieldName, true, comparison);
+        this(fieldName, Field.OneOfThemEmptyMode.EMPTY_UNKNOWN, comparison);
     }
 
-    public OneOfThemWithComparison(@Nonnull String fieldName, boolean emptyIsUnknown, @Nonnull Comparisons.Comparison comparison) {
-        super(fieldName, emptyIsUnknown);
+    public OneOfThemWithComparison(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode, @Nonnull Comparisons.Comparison comparison) {
+        super(fieldName, emptyMode);
         this.comparison = comparison;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
@@ -47,11 +47,19 @@ public class OneOfThemWithComponent extends BaseRepeatedField implements Compone
     private final ExpressionRef<QueryComponent> child;
 
     public OneOfThemWithComponent(@Nonnull String fieldName, @Nonnull QueryComponent child) {
-        this(fieldName, SingleExpressionRef.of(child));
+        this(fieldName, true, child);
     }
 
     public OneOfThemWithComponent(@Nonnull String fieldName, @Nonnull ExpressionRef<QueryComponent> child) {
-        super(fieldName);
+        this(fieldName, true, child);
+    }
+
+    public OneOfThemWithComponent(@Nonnull String fieldName, boolean emptyIsUnknown, @Nonnull QueryComponent child) {
+        this(fieldName, emptyIsUnknown, SingleExpressionRef.of(child));
+    }
+
+    public OneOfThemWithComponent(@Nonnull String fieldName, boolean emptyIsUnknown, @Nonnull ExpressionRef<QueryComponent> child) {
+        super(fieldName, emptyIsUnknown);
         this.child = child;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
@@ -47,19 +47,19 @@ public class OneOfThemWithComponent extends BaseRepeatedField implements Compone
     private final ExpressionRef<QueryComponent> child;
 
     public OneOfThemWithComponent(@Nonnull String fieldName, @Nonnull QueryComponent child) {
-        this(fieldName, true, child);
+        this(fieldName, Field.OneOfThemEmptyMode.EMPTY_UNKNOWN, child);
     }
 
     public OneOfThemWithComponent(@Nonnull String fieldName, @Nonnull ExpressionRef<QueryComponent> child) {
-        this(fieldName, true, child);
+        this(fieldName, Field.OneOfThemEmptyMode.EMPTY_UNKNOWN, child);
     }
 
-    public OneOfThemWithComponent(@Nonnull String fieldName, boolean emptyIsUnknown, @Nonnull QueryComponent child) {
-        this(fieldName, emptyIsUnknown, SingleExpressionRef.of(child));
+    public OneOfThemWithComponent(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode, @Nonnull QueryComponent child) {
+        this(fieldName, emptyMode, SingleExpressionRef.of(child));
     }
 
-    public OneOfThemWithComponent(@Nonnull String fieldName, boolean emptyIsUnknown, @Nonnull ExpressionRef<QueryComponent> child) {
-        super(fieldName, emptyIsUnknown);
+    public OneOfThemWithComponent(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode, @Nonnull ExpressionRef<QueryComponent> child) {
+        super(fieldName, emptyMode);
         this.child = child;
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
@@ -34,7 +34,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.NestedContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
-import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
@@ -42,6 +41,7 @@ import com.google.protobuf.Message;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -142,26 +142,26 @@ public class QueryExpressionTest {
         }
     };
 
-    @ParameterizedTest(name = "testOneOfThemEqualsValue [emptyIsUnknown = {0}]")
-    @BooleanSource
-    public void testOneOfThemEqualsValue(boolean emptyIsUnknown) throws Exception {
+    @ParameterizedTest(name = "testOneOfThemEqualsValue [emptyMode = {0}]")
+    @EnumSource(Field.OneOfThemEmptyMode.class)
+    public void testOneOfThemEqualsValue(Field.OneOfThemEmptyMode emptyMode) throws Exception {
         final TestScalarFieldAccess oneRepeatedValue = TestScalarFieldAccess.newBuilder()
                 .addRepeatMe("fishes")
                 .build();
-        final QueryComponent component = field("repeat_me").oneOfThem(emptyIsUnknown).equalsValue("fishes");
+        final QueryComponent component = field("repeat_me").oneOfThem(emptyMode).equalsValue("fishes");
         component.validate(TestScalarFieldAccess.getDescriptor());
         final Boolean eval = evaluate(component, oneRepeatedValue);
         assertEquals(Boolean.TRUE, eval);
     }
 
-    @ParameterizedTest(name = "testOneOfThemEqualsNoValues [emptyIsUnknown = {0}]")
-    @BooleanSource
-    public void testOneOfThemEqualsNoValues(boolean emptyIsUnknown) throws Exception {
+    @ParameterizedTest(name = "testOneOfThemEqualsNoValues [emptyMode = {0}]")
+    @EnumSource(Field.OneOfThemEmptyMode.class)
+    public void testOneOfThemEqualsNoValues(Field.OneOfThemEmptyMode emptyMode) throws Exception {
         final TestScalarFieldAccess noRepeatedValues = TestScalarFieldAccess.newBuilder().build();
-        final QueryComponent component = field("repeat_me").oneOfThem(emptyIsUnknown).equalsValue("fishes");
+        final QueryComponent component = field("repeat_me").oneOfThem(emptyMode).equalsValue("fishes");
         component.validate(TestScalarFieldAccess.getDescriptor());
         final Boolean eval = evaluate(component, noRepeatedValues);
-        assertEquals(emptyIsUnknown ? null : Boolean.FALSE, eval);
+        assertEquals(emptyMode == Field.OneOfThemEmptyMode.EMPTY_UNKNOWN ? null : Boolean.FALSE, eval);
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
@@ -142,6 +142,18 @@ public class QueryExpressionTest {
         }
     };
 
+    @ParameterizedTest(name = "testOneOfThemEqualsValue [emptyIsUnknown = {0}]")
+    @BooleanSource
+    public void testOneOfThemEqualsValue(boolean emptyIsUnknown) throws Exception {
+        final TestScalarFieldAccess oneRepeatedValue = TestScalarFieldAccess.newBuilder()
+                .addRepeatMe("fishes")
+                .build();
+        final QueryComponent component = field("repeat_me").oneOfThem(emptyIsUnknown).equalsValue("fishes");
+        component.validate(TestScalarFieldAccess.getDescriptor());
+        final Boolean eval = evaluate(component, oneRepeatedValue);
+        assertEquals(Boolean.TRUE, eval);
+    }
+
     @ParameterizedTest(name = "testOneOfThemEqualsNoValues [emptyIsUnknown = {0}]")
     @BooleanSource
     public void testOneOfThemEqualsNoValues(boolean emptyIsUnknown) throws Exception {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
@@ -34,12 +34,14 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.NestedContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerExpression;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -140,13 +142,14 @@ public class QueryExpressionTest {
         }
     };
 
-    @Test
-    public void testOneOfThemEqualsNoValues() throws Exception {
+    @ParameterizedTest(name = "testOneOfThemEqualsNoValues [emptyIsUnknown = {0}]")
+    @BooleanSource
+    public void testOneOfThemEqualsNoValues(boolean emptyIsUnknown) throws Exception {
         final TestScalarFieldAccess noRepeatedValues = TestScalarFieldAccess.newBuilder().build();
-        final QueryComponent component = field("repeat_me").oneOfThem().equalsValue("fishes");
+        final QueryComponent component = field("repeat_me").oneOfThem(emptyIsUnknown).equalsValue("fishes");
         component.validate(TestScalarFieldAccess.getDescriptor());
         final Boolean eval = evaluate(component, noRepeatedValues);
-        assertNull(eval);
+        assertEquals(emptyIsUnknown ? null : Boolean.FALSE, eval);
     }
 
     @Test


### PR DESCRIPTION
This introduces a new boolean parameter to `oneOfThem` and everything else in that path.

Note that no changes are made to the planner, which does not care about the difference, since it only turns query component into index operations in cases as part of a filter expression without anything like `IS UNKNOWN` or `NOT`.