### PR TITLE
Resolves 731: Reload online indexer's rebuild configuration parameters

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -50,7 +50,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Fetch the config parameters of online indexer in the beginning of trasaction [(Issue #731)](https://github.com/FoundationDB/fdb-record-layer/issues/731)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -50,7 +50,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Fetch the config parameters of online indexer in the beginning of trasaction [(Issue #731)](https://github.com/FoundationDB/fdb-record-layer/issues/731)
+* **Feature** Fetch the config parameters of online indexer in the beginning of each transaction [(Issue #731)](https://github.com/FoundationDB/fdb-record-layer/issues/731)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -207,6 +207,7 @@ public enum LogMessageKeys {
     RECORD_COUNT("record_count"),
     REBUILD_RECORD_COUNTS("rebuild_record_counts"),
     SCANNED_SO_FAR("scanned_so_far"),
+    MAX_LIMIT("max_limit"),
     NEXT_CONTINUATION("next_continuation"),
 
     // Log the name of the tokenizer used

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1300,7 +1300,7 @@ public class OnlineIndexer implements AutoCloseable {
              * Set the maximum number of records to process in a single second.
              *
              * The default number of retries is {@link #DEFAULT_RECORDS_PER_SECOND} = {@value #DEFAULT_RECORDS_PER_SECOND}.
-             * @param recordsPerSecond the maximum number of records to process in a single second.
+             * @param recordsPerSecond the maximum number of records to process in a single second
              * @return this builder
              */
             @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -196,7 +196,7 @@ public class OnlineIndexer implements AutoCloseable {
         this.recordTypes = recordTypes;
         this.configLoader = configLoader;
         this.config = config;
-        this.limit = DEFAULT_LIMIT;
+        this.limit = config.maxLimit;
         this.syntheticIndex = syntheticIndex;
         this.recordsRange = computeRecordsRange();
         timeOfLastProgressLogMillis = System.currentTimeMillis();
@@ -222,7 +222,7 @@ public class OnlineIndexer implements AutoCloseable {
      * Get the current config parameters of the online indexer.
      * @return the config parameters of the online indexer
      */
-    @Nullable
+    @Nonnull
     @VisibleForTesting
     Config getConfig() {
         return config;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -188,7 +188,7 @@ public class OnlineIndexer implements AutoCloseable {
     OnlineIndexer(@Nonnull FDBDatabaseRunner runner,
                             @Nonnull FDBRecordStore.Builder recordStoreBuilder,
                             @Nonnull Index index, @Nonnull Collection<RecordType> recordTypes,
-                            @Nullable Function<Config, Config> configLoader, @Nonnull Config config,
+                            @Nonnull Function<Config, Config> configLoader, @Nonnull Config config,
                             boolean syntheticIndex) {
         this.runner = runner;
         this.recordStoreBuilder = recordStoreBuilder;
@@ -1260,17 +1260,16 @@ public class OnlineIndexer implements AutoCloseable {
 
         /**
          * To create a builder for the given config.
-         * @param config the config
          * @return a {@link Config.Builder}
          */
         @Nonnull
-        public static Builder toBuilder(@Nonnull Config config) {
-            return newBuilder()
-                    .setMaxLimit(config.maxLimit)
-                    .setIncreaseLimitAfter(config.increaseLimitAfter)
-                    .setProgressLogIntervalMillis(config.progressLogIntervalMillis)
-                    .setRecordsPerSecond(config.recordsPerSecond)
-                    .setMaxRetries(config.maxRetries);
+        public Builder toBuilder() {
+            return Config.newBuilder()
+                    .setMaxLimit(this.maxLimit)
+                    .setIncreaseLimitAfter(this.increaseLimitAfter)
+                    .setProgressLogIntervalMillis(this.progressLogIntervalMillis)
+                    .setRecordsPerSecond(this.recordsPerSecond)
+                    .setMaxRetries(this.maxRetries);
         }
 
         /**
@@ -1390,8 +1389,8 @@ public class OnlineIndexer implements AutoCloseable {
         @Nullable
         protected Collection<RecordType> recordTypes;
 
-        @Nullable
-        protected Function<Config, Config> configLoader = null;
+        @Nonnull
+        protected Function<Config, Config> configLoader = old -> old;
         protected int limit = DEFAULT_LIMIT;
         protected int maxRetries = DEFAULT_MAX_RETRIES;
         protected int recordsPerSecond = DEFAULT_RECORDS_PER_SECOND;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -101,6 +101,8 @@ import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer.DEFAULT_PROGRESS_LOG_INTERVAL;
+import static com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer.DO_NOT_RE_INCREASE_LIMIT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThan;
@@ -2663,6 +2665,8 @@ public class OnlineIndexerTest extends FDBTestBase {
                 assertEquals(indexBuilder.getLimit(), limit - indexBuilder.getConfigLoaderInvocationCount());
                 assertEquals(indexBuilder.getConfig().getMaxRetries(), 3);
                 assertEquals(indexBuilder.getConfig().getRecordsPerSecond(), 10000);
+                assertEquals(indexBuilder.getConfig().getProgressLogIntervalMillis(), DEFAULT_PROGRESS_LOG_INTERVAL);
+                assertEquals(indexBuilder.getConfig().getIncreaseLimitAfter(), DO_NOT_RE_INCREASE_LIMIT);
                 Thread.sleep(100);
             }
             assertThat("Should have done several transactions in a few seconds", pass, lessThan(100));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -2648,7 +2648,7 @@ public class OnlineIndexerTest extends FDBTestBase {
         try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
                 .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
                 .setConfigLoader(old ->
-                        OnlineIndexer.Config.newBuilder()
+                        old.toBuilder()
                                 .setMaxLimit(old.getMaxLimit() - 1)
                                 .setMaxRetries(3)
                                 .setRecordsPerSecond(10000)


### PR DESCRIPTION
The configuration paremeters of online indexer used to be passed only in
the beggining of the index build. However, these parameters may change during
long builds and never be picked up by the indexer. This change provides
a way for the indexer to load the config parameters in the beginning of
every transaction.