### PR TITLE
Resolves #735: The InExtractor is making duplicates that can easily be avoided

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -45,7 +45,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** The InExtractor was making duplicates that can easily be avoided [(Issue #735)](https://github.com/FoundationDB/fdb-record-layer/issues/735)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BaseRepeatedField.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BaseRepeatedField.java
@@ -28,12 +28,17 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 abstract class BaseRepeatedField extends BaseField {
-
+    @Nonnull
     private final Field.OneOfThemEmptyMode emptyMode;
 
     public BaseRepeatedField(@Nonnull String fieldName, Field.OneOfThemEmptyMode emptyMode) {
         super(fieldName);
         this.emptyMode = emptyMode;
+    }
+
+    @Nonnull
+    public Field.OneOfThemEmptyMode getEmptyMode() {
+        return emptyMode;
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NestedField.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NestedField.java
@@ -78,6 +78,9 @@ public class NestedField extends BaseNestedField {
 
     @Override
     public QueryComponent withOtherChild(QueryComponent newChild) {
+        if (newChild == getChild()) {
+            return this;
+        }
         return new NestedField(getFieldName(), newChild);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NotComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NotComponent.java
@@ -105,6 +105,9 @@ public class NotComponent implements ComponentWithSingleChild {
 
     @Override
     public QueryComponent withOtherChild(QueryComponent newChild) {
+        if (newChild == getChild()) {
+            return this;
+        }
         return new NotComponent(newChild);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OneOfThemWithComponent.java
@@ -123,7 +123,10 @@ public class OneOfThemWithComponent extends BaseRepeatedField implements Compone
 
     @Override
     public QueryComponent withOtherChild(QueryComponent newChild) {
-        return new OneOfThemWithComponent(getFieldName(), newChild);
+        if (newChild == getChild()) {
+            return this;
+        }
+        return new OneOfThemWithComponent(getFieldName(), getEmptyMode(), newChild);
     }
 
     @Override


### PR DESCRIPTION
Noticed while fixing missing preservation of empty mode when do need a new one-of-them.

I could be convinced that this should be done somewhere else, but it does not seem like all much extra complexity.