### PR TITLE
Resolves #745: Add support for OneOfThemWithComparison predicates.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/CascadesPlanner.java
@@ -343,6 +343,9 @@ public class CascadesPlanner implements QueryPlanner {
             if (!group.containsExactly(expression)) { // expression is gone
                 return;
             }
+            if (logger.isTraceEnabled()) {
+                logger.trace("Bindings: " +  expression.bindTo(rule.getMatcher()).count());
+            }
             expression.bindTo(rule.getMatcher()).map(bindings -> new CascadesRuleCall(context, rule, group, bindings))
                     .forEach(this::executeRuleCall);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRule.java
@@ -76,22 +76,11 @@ public abstract class PlannerRule<T extends PlannerExpression> {
         this.matcher = matcher;
     }
 
-    @Nonnull
-    public abstract ChangesMade onMatch(@Nonnull PlannerRuleCall call);
+    public abstract void onMatch(@Nonnull PlannerRuleCall call);
 
     @Nonnull
     public ExpressionMatcher<T> getMatcher() {
         return matcher;
-    }
-
-    /**
-     * An enum to describe the results of the rule's {@link #onMatch(PlannerRuleCall)} method. {@code ChangesMade} is
-     * an enum rather than a boolean so that we can extend the degree to which rules report what they did to the planner
-     * in the future without needing to update too many rules.
-     */
-    public enum ChangesMade {
-        NO_CHANGE,
-        MADE_CHANGES
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerRuleSet.java
@@ -29,14 +29,14 @@ import com.apple.foundationdb.record.query.plan.temp.rules.FindPossibleIndexForA
 import com.apple.foundationdb.record.query.plan.temp.rules.FlattenNestedAndComponentRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementDistinctRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementFilterRule;
-import com.apple.foundationdb.record.query.plan.temp.rules.FilterWithFieldWithComparisonRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.FindIndexForComponentWithComparisonRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementUnorderedUnionRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.OrToUnorderedUnionRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.FullUnorderedExpressionToScanPlanRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.LogicalToPhysicalScanRule;
-import com.apple.foundationdb.record.query.plan.temp.rules.PushConjunctFieldWithComparisonIntoExistingIndexScanRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.PushComponentWithComparisonIntoExistingScanRule;
+import com.apple.foundationdb.record.query.plan.temp.rules.PushConjunctComponentWithComparisonIntoExistingScanRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.PushDistinctFilterBelowFilterRule;
-import com.apple.foundationdb.record.query.plan.temp.rules.PushFieldWithComparisonIntoExistingIndexScanRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementTypeFilterRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.PushTypeFilterBelowFilterRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.RemoveNestedContextRule;
@@ -65,9 +65,9 @@ public class PlannerRuleSet {
     private static final List<PlannerRule<? extends PlannerExpression>> REWRITE_RULES = ImmutableList.of(
             new CombineFilterRule(),
             new SortToIndexRule(),
-            new FilterWithFieldWithComparisonRule(),
-            new PushFieldWithComparisonIntoExistingIndexScanRule(),
-            new PushConjunctFieldWithComparisonIntoExistingIndexScanRule(),
+            new FindIndexForComponentWithComparisonRule(),
+            new PushComponentWithComparisonIntoExistingScanRule(),
+            new PushConjunctComponentWithComparisonIntoExistingScanRule(),
             new RemoveRedundantTypeFilterRule(),
             new FindPossibleIndexForAndComponentRule(),
             new OrToUnorderedUnionRule(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
@@ -53,15 +53,13 @@ public class CombineFilterRule extends PlannerRule<LogicalFilterExpression> {
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         ExpressionRef<QueryComponent> first = call.get(firstMatcher);
         ExpressionRef<QueryComponent> second = call.get(secondMatcher);
         ExpressionRef<RelationalPlannerExpression> child = call.get(childMatcher);
 
         ExpressionRef<QueryComponent> combined = call.ref(new AndComponent(ImmutableList.of(first, second)));
         call.yield(call.ref(new LogicalFilterExpression(combined, child)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithConjunctNestedToNestingContextRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithConjunctNestedToNestingContextRule.java
@@ -60,9 +60,8 @@ public class FilterWithConjunctNestedToNestingContextRule extends PlannerRule<Lo
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final ExpressionRef<RelationalPlannerExpression> inner = call.get(innerMatcher);
         final NestedField nestedField = call.get(nestedFieldMatcher);
         final List<ExpressionRef<QueryComponent>> otherConjuncts = call.getBindings().getAll(otherConjunctMatcher);
@@ -72,7 +71,7 @@ public class FilterWithConjunctNestedToNestingContextRule extends PlannerRule<Lo
         final ExpressionRef<RelationalPlannerExpression> nestedInner = nestedContext.getNestedRelationalPlannerExpression(inner);
 
         if (nestedInner == null) {
-            return ChangesMade.NO_CHANGE;
+            return;
         }
 
         final ExpressionRef<RelationalPlannerExpression> nestedExpression = call.ref(
@@ -88,6 +87,5 @@ public class FilterWithConjunctNestedToNestingContextRule extends PlannerRule<Lo
             }
             call.yield(call.ref(new LogicalFilterExpression(residualFilter, nestedExpression)));
         }
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithNestedToNestingContextRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithNestedToNestingContextRule.java
@@ -53,9 +53,8 @@ public class FilterWithNestedToNestingContextRule extends PlannerRule<LogicalFil
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final ExpressionRef<RelationalPlannerExpression> inner = call.get(innerMatcher);
         final NestedField nestedField = call.get(nestedFieldMatcher);
         final ExpressionRef<QueryComponent> nestedFilter = call.get(nestedFilterMatcher);
@@ -66,8 +65,6 @@ public class FilterWithNestedToNestingContextRule extends PlannerRule<LogicalFil
         if (nestedInner != null) {
             call.yield(call.ref(new NestedContextExpression(nestedContext,
                     new LogicalFilterExpression(nestedFilter, nestedInner))));
-            return ChangesMade.MADE_CHANGES;
         }
-        return ChangesMade.NO_CHANGE;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithOneOfThemToNestingContextRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithOneOfThemToNestingContextRule.java
@@ -53,9 +53,8 @@ public class FilterWithOneOfThemToNestingContextRule extends PlannerRule<Logical
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final ExpressionRef<RelationalPlannerExpression> inner = call.get(innerMatcher);
         final OneOfThemWithComponent oneOfThem = call.get(oneOfThemMatcher);
         final ExpressionRef<QueryComponent> nestedFilter = call.get(nestedFilterMatcher);
@@ -67,8 +66,6 @@ public class FilterWithOneOfThemToNestingContextRule extends PlannerRule<Logical
         if (nestedInner != null) {
             call.yield(call.ref(new NestedContextExpression(nestedContext,
                     new LogicalFilterExpression(nestedFilter, nestedInner))));
-            return ChangesMade.MADE_CHANGES;
         }
-        return ChangesMade.NO_CHANGE;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindIndexForComponentWithComparisonRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindIndexForComponentWithComparisonRule.java
@@ -53,30 +53,21 @@ public class FindIndexForComponentWithComparisonRule extends PlannerRule<Logical
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final ComponentWithComparison singleField = call.get(filterMatcher);
         if (ScanComparisons.getComparisonType(singleField.getComparison()).equals(ScanComparisons.ComparisonType.NONE)) {
             // This comparison cannot be accomplished with a single scan.
-            return ChangesMade.NO_CHANGE;
+            return;
         }
 
-        boolean found = false;
         for (IndexEntrySource indexEntrySource : call.getContext().getIndexEntrySources()) {
             final KeyExpressionComparisons comparisons = indexEntrySource.getEmptyComparisons();
             Optional<KeyExpressionComparisons> matchedComparisons = comparisons.matchWith(singleField);
             if (matchedComparisons.isPresent()) {
                 call.yield(call.ref(new IndexEntrySourceScanExpression(indexEntrySource, IndexScanType.BY_VALUE,
                         matchedComparisons.get(), false)));
-                found = true;
             }
-        }
-        if (found) {
-            return ChangesMade.MADE_CHANGES;
-        } else {
-            // couldn't find an index
-            return ChangesMade.NO_CHANGE;
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindIndexForComponentWithComparisonRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindIndexForComponentWithComparisonRule.java
@@ -1,5 +1,5 @@
 /*
- * FilterWithFieldWithComparisonRule.java
+ * FindIndexForComponentWithComparisonRule.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.temp.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.IndexScanType;
-import com.apple.foundationdb.record.query.expressions.FieldWithComparison;
+import com.apple.foundationdb.record.query.expressions.ComponentWithComparison;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.temp.IndexEntrySource;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionComparisons;
@@ -44,34 +44,39 @@ import java.util.Optional;
  * Like the {@link com.apple.foundationdb.record.query.plan.RecordQueryPlanner}
  */
 @API(API.Status.EXPERIMENTAL)
-public class FilterWithFieldWithComparisonRule extends PlannerRule<LogicalFilterExpression> {
-    private static final ExpressionMatcher<FieldWithComparison> filterMatcher = TypeMatcher.of(FieldWithComparison.class);
+public class FindIndexForComponentWithComparisonRule extends PlannerRule<LogicalFilterExpression> {
+    private static final ExpressionMatcher<ComponentWithComparison> filterMatcher = TypeMatcher.of(ComponentWithComparison.class);
     private static final ExpressionMatcher<FullUnorderedScanExpression> scanMatcher = TypeMatcher.of(FullUnorderedScanExpression.class);
     private static final ExpressionMatcher<LogicalFilterExpression> root = TypeMatcher.of(LogicalFilterExpression.class, filterMatcher, scanMatcher);
 
-    public FilterWithFieldWithComparisonRule() {
+    public FindIndexForComponentWithComparisonRule() {
         super(root);
     }
 
     @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
-        final FieldWithComparison singleField = call.get(filterMatcher);
+        final ComponentWithComparison singleField = call.get(filterMatcher);
         if (ScanComparisons.getComparisonType(singleField.getComparison()).equals(ScanComparisons.ComparisonType.NONE)) {
             // This comparison cannot be accomplished with a single scan.
             return ChangesMade.NO_CHANGE;
         }
 
+        boolean found = false;
         for (IndexEntrySource indexEntrySource : call.getContext().getIndexEntrySources()) {
             final KeyExpressionComparisons comparisons = indexEntrySource.getEmptyComparisons();
             Optional<KeyExpressionComparisons> matchedComparisons = comparisons.matchWith(singleField);
             if (matchedComparisons.isPresent()) {
                 call.yield(call.ref(new IndexEntrySourceScanExpression(indexEntrySource, IndexScanType.BY_VALUE,
                         matchedComparisons.get(), false)));
-                return ChangesMade.MADE_CHANGES;
+                found = true;
             }
         }
-        // couldn't find an index
-        return ChangesMade.NO_CHANGE;
+        if (found) {
+            return ChangesMade.MADE_CHANGES;
+        } else {
+            // couldn't find an index
+            return ChangesMade.NO_CHANGE;
+        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindPossibleIndexForAndComponentRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindPossibleIndexForAndComponentRule.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.temp.rules;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.query.expressions.AndComponent;
+import com.apple.foundationdb.record.query.expressions.ComponentWithComparison;
 import com.apple.foundationdb.record.query.expressions.FieldWithComparison;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
@@ -43,12 +44,12 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A rule that finds all indexes that could implement one of the {@link FieldWithComparison} conjuncts of an AND filter,
- * leaving all the other filters (of any type, including other fields) as a residual filter.
+ * A rule that finds all indexes that could implement one of the {@link ComponentWithComparison} conjuncts of an AND
+ * filter, leaving all the other filters (of any type, including other fields) as a residual filter.
  */
 @API(API.Status.EXPERIMENTAL)
 public class FindPossibleIndexForAndComponentRule extends PlannerRule<LogicalFilterExpression> {
-    private static ExpressionMatcher<FieldWithComparison> fieldMatcher = TypeMatcher.of(FieldWithComparison.class);
+    private static ExpressionMatcher<ComponentWithComparison> fieldMatcher = TypeMatcher.of(FieldWithComparison.class);
     private static ReferenceMatcher<QueryComponent> residualFieldsMatcher = ReferenceMatcher.anyRef();
     private static ExpressionMatcher<AndComponent> andFilterMatcher = TypeMatcher.of(AndComponent.class,
             AnyChildWithRestMatcher.anyMatchingWithRest(fieldMatcher, residualFieldsMatcher));
@@ -63,7 +64,7 @@ public class FindPossibleIndexForAndComponentRule extends PlannerRule<LogicalFil
     @Nonnull
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
-        FieldWithComparison field = call.getBindings().get(fieldMatcher);
+        ComponentWithComparison field = call.getBindings().get(fieldMatcher);
         ChangesMade madeChanges = ChangesMade.NO_CHANGE;
         for (IndexEntrySource indexEntrySource : call.getContext().getIndexEntrySources()) {
             final KeyExpressionComparisons keyComparisons = indexEntrySource.getEmptyComparisons();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindPossibleIndexForAndComponentRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindPossibleIndexForAndComponentRule.java
@@ -61,11 +61,9 @@ public class FindPossibleIndexForAndComponentRule extends PlannerRule<LogicalFil
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         ComponentWithComparison field = call.getBindings().get(fieldMatcher);
-        ChangesMade madeChanges = ChangesMade.NO_CHANGE;
         for (IndexEntrySource indexEntrySource : call.getContext().getIndexEntrySources()) {
             final KeyExpressionComparisons keyComparisons = indexEntrySource.getEmptyComparisons();
             final Optional<KeyExpressionComparisons> matchedKeyComparisons = keyComparisons.matchWith(field);
@@ -80,10 +78,7 @@ public class FindPossibleIndexForAndComponentRule extends PlannerRule<LogicalFil
                 call.yield(call.ref(new LogicalFilterExpression(residualFilter,
                         call.ref(new IndexEntrySourceScanExpression(indexEntrySource, IndexScanType.BY_VALUE,
                                 matchedKeyComparisons.get(), false)))));
-                madeChanges = ChangesMade.MADE_CHANGES;
             }
         }
-
-        return madeChanges;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FlattenNestedAndComponentRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FlattenNestedAndComponentRule.java
@@ -68,15 +68,13 @@ public class FlattenNestedAndComponentRule extends PlannerRule<AndComponent> {
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         List<ExpressionRef<QueryComponent>> innerAndChildren = call.getBindings().getAll(andChildrenMatcher);
         List<ExpressionRef<QueryComponent>> otherOuterAndChildren = call.getBindings().getAll(otherInnerComponentsMatcher);
         List<ExpressionRef<QueryComponent>> allConjuncts = new ArrayList<>(innerAndChildren);
         allConjuncts.addAll(otherOuterAndChildren);
 
         call.yield(call.ref(new AndComponent(allConjuncts)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FullUnorderedExpressionToScanPlanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FullUnorderedExpressionToScanPlanRule.java
@@ -41,10 +41,8 @@ public class FullUnorderedExpressionToScanPlanRule extends PlannerRule<FullUnord
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         call.yield(call.ref(new RecordQueryScanPlan(ScanComparisons.EMPTY, false)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
@@ -59,17 +59,14 @@ public class ImplementDistinctRule extends PlannerRule<LogicalDistinctExpression
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         RecordQueryPlan inner = call.get(innerMatcher);
         boolean createsDuplicates = CreatesDuplicatesProperty.evaluate(inner, call.getContext());
         if (createsDuplicates) {
             call.yield(call.ref(new RecordQueryUnorderedPrimaryKeyDistinctPlan(inner)));
-            return ChangesMade.MADE_CHANGES;
         } else {
             call.yield(call.ref(inner));
-            return ChangesMade.MADE_CHANGES;
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementFilterRule.java
@@ -50,13 +50,11 @@ public class ImplementFilterRule extends PlannerRule<LogicalFilterExpression> {
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final RecordQueryPlan inner = call.get(innerMatcher);
         final ExpressionRef<QueryComponent> filter = call.get(filterMatcher);
 
         call.yield(SingleExpressionRef.of(new RecordQueryFilterPlan(call.ref(inner), filter)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
@@ -51,9 +51,8 @@ public class ImplementTypeFilterRule extends PlannerRule<LogicalTypeFilterExpres
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final LogicalTypeFilterExpression typeFilter = call.get(root);
         final RecordQueryPlan child = call.get(childMatcher);
 
@@ -67,6 +66,5 @@ public class ImplementTypeFilterRule extends PlannerRule<LogicalTypeFilterExpres
             Set<String> unsatisfiedTypeFilters = Sets.intersection(filterRecordTypes, childRecordTypes);
             call.yield(SingleExpressionRef.of(new RecordQueryTypeFilterPlan(child, unsatisfiedTypeFilters)));
         }
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
@@ -51,11 +51,9 @@ public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnorderedUni
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final List<RecordQueryPlan> planChildren = call.getBindings().getAll(childMatcher);
         call.yield(call.ref(RecordQueryUnorderedUnionPlan.from(planChildren)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/LogicalToPhysicalScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/LogicalToPhysicalScanRule.java
@@ -45,9 +45,8 @@ public class LogicalToPhysicalScanRule extends PlannerRule<IndexEntrySourceScanE
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final IndexEntrySourceScanExpression logical = call.get(root);
         final IndexEntrySource indexEntrySource = logical.getIndexEntrySource();
 
@@ -62,6 +61,5 @@ public class LogicalToPhysicalScanRule extends PlannerRule<IndexEntrySourceScanE
         } else {
             call.yield(call.ref(new RecordQueryScanPlan(logical.getComparisons().toScanComparisons(), logical.isReverse())));
         }
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
@@ -58,9 +58,8 @@ public class OrToUnorderedUnionRule extends PlannerRule<LogicalFilterExpression>
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final ExpressionRef<RelationalPlannerExpression> inner = call.get(innerMatcher);
         final List<ExpressionRef<QueryComponent>> children = call.getBindings().getAll(childMatcher);
         List<ExpressionRef<RelationalPlannerExpression>> relationalExpressionRefs = new ArrayList<>(children.size());
@@ -68,6 +67,5 @@ public class OrToUnorderedUnionRule extends PlannerRule<LogicalFilterExpression>
             relationalExpressionRefs.add(call.ref(new LogicalFilterExpression(child, inner)));
         }
         call.yield(SingleExpressionRef.of(new LogicalUnorderedUnionExpression(relationalExpressionRefs)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushComponentWithComparisonIntoExistingScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushComponentWithComparisonIntoExistingScanRule.java
@@ -1,5 +1,5 @@
 /*
- * PushFieldWithComparisonIntoExistingIndexScanRule.java
+ * PushComponentWithComparisonIntoExistingScanRule.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.temp.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.expressions.FieldWithComparison;
+import com.apple.foundationdb.record.query.expressions.ComponentWithComparison;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionComparisons;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
@@ -34,16 +34,16 @@ import javax.annotation.Nonnull;
 import java.util.Optional;
 
 /**
- * A simple rule that looks for a filter (with an equality comparison on a field) and a trivial but compatibly
- * ordered index scan with no existing comparisons and pushes the equality comparison down to the index scan.
+ * A simple rule that looks for a {@link com.apple.foundationdb.record.query.expressions.ComponentWithComparison}
+ * predicate and a compatibly ordered index scan comparison down to the index scan.
  */
 @API(API.Status.EXPERIMENTAL)
-public class PushFieldWithComparisonIntoExistingIndexScanRule extends PlannerRule<LogicalFilterExpression> {
-    private static final ExpressionMatcher<FieldWithComparison> filterMatcher = TypeMatcher.of(FieldWithComparison.class);
+public class PushComponentWithComparisonIntoExistingScanRule extends PlannerRule<LogicalFilterExpression> {
+    private static final ExpressionMatcher<ComponentWithComparison> filterMatcher = TypeMatcher.of(ComponentWithComparison.class);
     private static final ExpressionMatcher<IndexEntrySourceScanExpression> indexScanMatcher = TypeMatcher.of(IndexEntrySourceScanExpression.class);
     private static final ExpressionMatcher<LogicalFilterExpression> root = TypeMatcher.of(LogicalFilterExpression.class, filterMatcher, indexScanMatcher);
 
-    public PushFieldWithComparisonIntoExistingIndexScanRule() {
+    public PushComponentWithComparisonIntoExistingScanRule() {
         super(root);
     }
 
@@ -51,7 +51,7 @@ public class PushFieldWithComparisonIntoExistingIndexScanRule extends PlannerRul
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
         IndexEntrySourceScanExpression indexScan = call.get(indexScanMatcher);
-        FieldWithComparison filter = call.get(filterMatcher);
+        ComponentWithComparison filter = call.get(filterMatcher);
 
         final Optional<KeyExpressionComparisons> matchedComparisons = indexScan.getComparisons().matchWith(filter);
         if (matchedComparisons.isPresent()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushComponentWithComparisonIntoExistingScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushComponentWithComparisonIntoExistingScanRule.java
@@ -47,9 +47,8 @@ public class PushComponentWithComparisonIntoExistingScanRule extends PlannerRule
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         IndexEntrySourceScanExpression indexScan = call.get(indexScanMatcher);
         ComponentWithComparison filter = call.get(filterMatcher);
 
@@ -57,8 +56,6 @@ public class PushComponentWithComparisonIntoExistingScanRule extends PlannerRule
         if (matchedComparisons.isPresent()) {
             call.yield(call.ref(new IndexEntrySourceScanExpression(indexScan.getIndexEntrySource(), indexScan.getScanType(),
                             matchedComparisons.get(), indexScan.isReverse())));
-            return ChangesMade.MADE_CHANGES;
         }
-        return ChangesMade.NO_CHANGE;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushConjunctComponentWithComparisonIntoExistingScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushConjunctComponentWithComparisonIntoExistingScanRule.java
@@ -57,9 +57,8 @@ public class PushConjunctComponentWithComparisonIntoExistingScanRule extends Pla
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final IndexEntrySourceScanExpression indexScan = call.get(indexScanMatcher);
         final ComponentWithComparison field = call.get(filterMatcher);
         final List<ExpressionRef<QueryComponent>> residualFields = call.getBindings().getAll(otherFilterMatchers);
@@ -70,7 +69,7 @@ public class PushConjunctComponentWithComparisonIntoExistingScanRule extends Pla
                     indexScan.getIndexEntrySource(), indexScan.getScanType(), matchedComparisons.get(), indexScan.isReverse());
             if (residualFields.isEmpty()) {
                 call.yield(call.ref(newIndexScan));
-                return ChangesMade.MADE_CHANGES;
+                return;
             }
 
             final ExpressionRef<QueryComponent> residualFilter;
@@ -80,8 +79,6 @@ public class PushConjunctComponentWithComparisonIntoExistingScanRule extends Pla
                 residualFilter = residualFields.get(0);
             }
             call.yield(call.ref(new LogicalFilterExpression(residualFilter, call.ref(newIndexScan))));
-            return ChangesMade.MADE_CHANGES;
         }
-        return ChangesMade.NO_CHANGE;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushConjunctComponentWithComparisonIntoExistingScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushConjunctComponentWithComparisonIntoExistingScanRule.java
@@ -1,5 +1,5 @@
 /*
- * PushConjunctFieldWithComparisonIntoExistingIndexScanRule.java
+ * PushConjunctComponentWithComparisonIntoExistingScanRule.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.temp.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.expressions.AndComponent;
-import com.apple.foundationdb.record.query.expressions.FieldWithComparison;
+import com.apple.foundationdb.record.query.expressions.ComponentWithComparison;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionComparisons;
@@ -40,20 +40,20 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * A rule that selects one of the {@link FieldWithComparison} conjuncts from an AND and tries to push it into an existing
- * logical index scan.
- * @see PushFieldWithComparisonIntoExistingIndexScanRule for a very similar rule for {@code FieldWithComparison}s that are not conjuncts
+ * A rule that selects one of the {@link com.apple.foundationdb.record.query.expressions.ComponentWithComparison}
+ * conjuncts from an AND and tries to push it into an existing logical scan.
+ * @see PushComponentWithComparisonIntoExistingScanRule for a very similar rule for {@code FieldWithComparison}s that are not conjuncts
  */
 @API(API.Status.EXPERIMENTAL)
-public class PushConjunctFieldWithComparisonIntoExistingIndexScanRule extends PlannerRule<LogicalFilterExpression> {
-    private static final ExpressionMatcher<FieldWithComparison> filterMatcher = TypeMatcher.of(FieldWithComparison.class);
+public class PushConjunctComponentWithComparisonIntoExistingScanRule extends PlannerRule<LogicalFilterExpression> {
+    private static final ExpressionMatcher<ComponentWithComparison> filterMatcher = TypeMatcher.of(ComponentWithComparison.class);
     private static final ReferenceMatcher<QueryComponent> otherFilterMatchers = ReferenceMatcher.anyRef();
     private static final ExpressionMatcher<AndComponent> andMatcher = TypeMatcher.of(AndComponent.class,
             AnyChildWithRestMatcher.anyMatchingWithRest(filterMatcher, otherFilterMatchers));
     private static final ExpressionMatcher<IndexEntrySourceScanExpression> indexScanMatcher = TypeMatcher.of(IndexEntrySourceScanExpression.class);
     private static final ExpressionMatcher<LogicalFilterExpression> root = TypeMatcher.of(LogicalFilterExpression.class, andMatcher, indexScanMatcher);
 
-    public PushConjunctFieldWithComparisonIntoExistingIndexScanRule() {
+    public PushConjunctComponentWithComparisonIntoExistingScanRule() {
         super(root);
     }
 
@@ -61,7 +61,7 @@ public class PushConjunctFieldWithComparisonIntoExistingIndexScanRule extends Pl
     @Override
     public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
         final IndexEntrySourceScanExpression indexScan = call.get(indexScanMatcher);
-        final FieldWithComparison field = call.get(filterMatcher);
+        final ComponentWithComparison field = call.get(filterMatcher);
         final List<ExpressionRef<QueryComponent>> residualFields = call.getBindings().getAll(otherFilterMatchers);
 
         final Optional<KeyExpressionComparisons> matchedComparisons = indexScan.getComparisons().matchWith(field);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushDistinctFilterBelowFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushDistinctFilterBelowFilterRule.java
@@ -50,14 +50,12 @@ public class PushDistinctFilterBelowFilterRule extends PlannerRule<RecordQueryUn
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final ExpressionRef<RecordQueryPlan> inner = call.get(innerMatcher);
         final ExpressionRef<QueryComponent> filter = call.get(filterMatcher);
 
         call.yield(call.ref(new RecordQueryFilterPlan(
                 call.ref(new RecordQueryUnorderedPrimaryKeyDistinctPlan(inner)), filter)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushTypeFilterBelowFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushTypeFilterBelowFilterRule.java
@@ -53,15 +53,13 @@ public class PushTypeFilterBelowFilterRule extends PlannerRule<RecordQueryTypeFi
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final ExpressionRef<RecordQueryPlan> inner = call.get(innerMatcher);
         final ExpressionRef<QueryComponent> filter = call.get(filterMatcher);
         final Collection<String> recordTypes = call.get(root).getRecordTypes();
 
         call.yield(SingleExpressionRef.of(new RecordQueryFilterPlan(
                 SingleExpressionRef.of(new RecordQueryTypeFilterPlan(inner, recordTypes)), filter)));
-        return ChangesMade.MADE_CHANGES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveNestedContextRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveNestedContextRule.java
@@ -46,17 +46,13 @@ public class RemoveNestedContextRule extends PlannerRule<NestedContextExpression
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final NestedContextExpression context = call.get(root);
         final NestedContext nestedContext = context.getNestedContext();
         final ExpressionRef<RelationalPlannerExpression> unnestedInner = nestedContext.getUnnestedRelationalPlannerExpression(call.get(innerMatcher));
-        if (unnestedInner == null) {
-            return ChangesMade.NO_CHANGE;
-        } else {
+        if (unnestedInner != null) {
             call.yield(unnestedInner);
-            return ChangesMade.MADE_CHANGES;
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveRedundantTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveRedundantTypeFilterRule.java
@@ -49,9 +49,8 @@ public class RemoveRedundantTypeFilterRule extends PlannerRule<LogicalTypeFilter
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         LogicalTypeFilterExpression typeFilter = call.get(root);
         ExpressionRef<RelationalPlannerExpression> child = call.get(childMatcher);
 
@@ -60,16 +59,13 @@ public class RemoveRedundantTypeFilterRule extends PlannerRule<LogicalTypeFilter
         if (filterRecordTypes.containsAll(childRecordTypes)) {
             // type filter is completely redundant, so remove it entirely
             call.yield(child);
-            return ChangesMade.MADE_CHANGES;
         } else {
             // otherwise, keep a logical filter on record types which the child might produce and are included in the filter
             Set<String> unsatisfiedTypeFilters = Sets.intersection(childRecordTypes, filterRecordTypes);
             if (!unsatisfiedTypeFilters.equals(filterRecordTypes)) {
                 // there were some unnecessary filters, so remove them
                 call.yield(SingleExpressionRef.of(new LogicalTypeFilterExpression(unsatisfiedTypeFilters, child)));
-                return ChangesMade.MADE_CHANGES;
             } // otherwise, nothing changes
         }
-        return ChangesMade.NO_CHANGE;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/SortToIndexRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/SortToIndexRule.java
@@ -61,22 +61,18 @@ public class SortToIndexRule extends PlannerRule<LogicalSortExpression> {
         super(root);
     }
 
-    @Nonnull
     @Override
-    public ChangesMade onMatch(@Nonnull PlannerRuleCall call) {
+    public void onMatch(@Nonnull PlannerRuleCall call) {
         final LogicalSortExpression logicalSort = call.get(root);
         final KeyExpressionComparisons requestedSort = logicalSort.getSort();
         final boolean reverse = call.get(root).isReverse();
 
-        ChangesMade madeChanges = ChangesMade.NO_CHANGE;
         for (IndexEntrySource indexEntrySource : call.getContext().getIndexEntrySources()) {
             final KeyExpressionComparisons sortExpression = indexEntrySource.getEmptyComparisons();
             if (sortExpression.supportsSortOrder(requestedSort)) {
                 call.yield(call.ref(new IndexEntrySourceScanExpression(indexEntrySource, IndexScanType.BY_VALUE,
                         sortExpression, reverse)));
-                madeChanges = ChangesMade.MADE_CHANGES;
             }
         }
-        return madeChanges;
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCrossRecordQueryTest.java
@@ -114,7 +114,7 @@ public class FDBCrossRecordQueryTest extends FDBRecordStoreQueryTestBase {
      * Verify that multi-type record queries can scan multi-type indexes.
      * Verify that single-type record queries can scan multi-type indexes with a type filter.
      */
-    @DualPlannerTest
+    @Test
     public void testMultiRecordTypeIndexScan() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRepeatedFieldQueryTest.java
@@ -400,7 +400,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
      * Verify that repeated fields can be retrieved using indexes.
      * Verify that demanding unique values forces a distinctness plan at the end.
      */
-    @Test
+    @DualPlannerTest
     public void testComplexQuery7() throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
@@ -454,7 +454,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
      * includes the repeated field, because repeated introduces duplicates and index entries are ordered by second field
      * and so cannot be deduplicated without additional space.
      */
-    @Test
+    @DualPlannerTest
     public void testPrefixRepeated() throws Exception {
         RecordMetaDataHook hook = metaData -> {
             metaData.addIndex("MySimpleRecord", "prefix_repeated", concat(field("num_value_2"), field("repeater", FanType.FanOut)));
@@ -515,7 +515,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     /**
      * Verify that an index on a repeated field isn't used for normal scans.
      */
-    @Test
+    @DualPlannerTest
     public void testOnlyRepeatIndex() throws Exception {
         RecordMetaDataHook hook = metaData -> {
             metaData.removeIndex("MySimpleRecord$str_value_indexed");
@@ -556,7 +556,7 @@ public class FDBRepeatedFieldQueryTest extends FDBRecordStoreQueryTestBase {
      * query also includes the repeated field, because repeated introduces duplicates and index entries are ordered by
      * second field and so cannot be deduplicated without additional space.
      */
-    @Test
+    @DualPlannerTest
     public void testPrefixRepeatedNested() throws Exception {
         final RecordMetaDataHook hook = metaData -> {
             metaData.getRecordType("MyRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/PushComponentWithComparisonIntoExistingScanRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/PushComponentWithComparisonIntoExistingScanRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * PushFieldWithComparisonIntoExistingIndexScanRuleTest.java
+ * PushComponentWithComparisonIntoExistingScanRuleTest.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -46,8 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test that the rule can push a filter on a simple equality down into a compatibly ordered index.
  */
-public class PushFieldWithComparisonIntoExistingIndexScanRuleTest {
-    private static PlannerRule<LogicalFilterExpression> rule = new PushFieldWithComparisonIntoExistingIndexScanRule();
+public class PushComponentWithComparisonIntoExistingScanRuleTest {
+    private static PlannerRule<LogicalFilterExpression> rule = new PushComponentWithComparisonIntoExistingScanRule();
     private static Index singleFieldIndex = new Index("singleField", field("aField"));
     private static IndexEntrySource singleFieldIndexEntrySource = IndexEntrySource.fromIndex(singleFieldIndex);
     private static Index concatIndex = new Index("concat", concat(field("aField"), field("anotherField")));


### PR DESCRIPTION
This finishes up some relatively simple work left over from #716 by adding support for pushing `OneOfThemWithComparison` query components on (non-nested) repeated fields to appropriate index scans.

Commit ebba73d also removes the unused `MadeChanges` return type from the `onMatch()` method which was only used by the (removed) `RewritePlanner`.

Note that most of this code will be replaced with the new "view expression" abstraction soon, so it doesn't need to be reviewed too closely. However, I figured that it was easy enough to break out in a separate PR to keep the other one more focussed.