### PR TITLE
Resolves #748: Support forcefully releasing synchronized session locks and stopping ongoing online index builds

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -50,7 +50,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Support forcefully releasing synchronized session locks and stopping ongoing online index builds [(Issue #748)](https://github.com/FoundationDB/fdb-record-layer/issues/748)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSession.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSession.java
@@ -188,6 +188,24 @@ public class SynchronizedSession {
         });
     }
 
+    /**
+     * End any session by releasing the lock no matter this session holds the lock or not.
+     * @param tr transaction to use
+     */
+    public void forceReleaseLock(@Nonnull Transaction tr) {
+        forceReleaseLock(tr, lockSubspace);
+    }
+
+    /**
+     * End any active session on the given lock by releasing the lock. A later transaction from that session should be
+     * able to check the lock and fail with {@link SynchronizedSessionLockedException}.
+     * @param tr transaction to use
+     * @param lockSubspace the lock whose active session needs to be ended
+     */
+    public static void forceReleaseLock(@Nonnull Transaction tr, @Nonnull Subspace lockSubspace) {
+        tr.clear(lockSubspace.range());
+    }
+
     private CompletableFuture<UUID> getLockSessionId(@Nonnull Transaction tr) {
         return tr.get(lockSessionIdSubspaceKey)
                 .thenApply(value -> value == null ? null : Tuple.fromBytes(value).getUUID(0));

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSession.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSession.java
@@ -189,20 +189,30 @@ public class SynchronizedSession {
     }
 
     /**
-     * End any session by releasing the lock no matter this session holds the lock or not.
+     * End any active session on the lock subspace by releasing the lock no matter whether this session holds the lock
+     * or not.
+     * <p>
+     * It only takes place when the given transaction is committed. It will only be enforced when the other processes
+     * holding the lock go to check the lease in later transactions, where they will fail with
+     * {@link SynchronizedSessionLockedException}.
+     * </p>
      * @param tr transaction to use
      */
-    public void forceReleaseLock(@Nonnull Transaction tr) {
-        forceReleaseLock(tr, lockSubspace);
+    public void endAnySession(@Nonnull Transaction tr) {
+        endAnySession(tr, lockSubspace);
     }
 
     /**
-     * End any active session on the given lock by releasing the lock. A later transaction from that session should be
-     * able to check the lock and fail with {@link SynchronizedSessionLockedException}.
+     * End any active session on the given lock subspace by releasing the lock.
+     * <p>
+     * It only takes place when the given transaction is committed. It will only be enforced when the other processes
+     * holding the lock go to check the lease in later transactions, where they will fail with
+     * {@link SynchronizedSessionLockedException}.
+     * </p>
      * @param tr transaction to use
      * @param lockSubspace the lock whose active session needs to be ended
      */
-    public static void forceReleaseLock(@Nonnull Transaction tr, @Nonnull Subspace lockSubspace) {
+    public static void endAnySession(@Nonnull Transaction tr, @Nonnull Subspace lockSubspace) {
         tr.clear(lockSubspace.range());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -315,6 +315,8 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_CHECK_VERSION("wait for check version"),
         /** Wait for {@link OnlineIndexer} to complete building an index. */
         WAIT_ONLINE_BUILD_INDEX("wait for online build index"),
+        /** Wait for {@link OnlineIndexer} to stop ongoing online index builds. */
+        WAIT_STOP_ONLINE_INDEX_BUILD("wait for stopping ongoing online index builds"),
         /** Wait for {@link OnlineIndexer} to build endpoints. */
         WAIT_BUILD_ENDPOINTS("wait for building endpoints"),
         /** Wait for a record scan without an index. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/SynchronizedSessionRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/SynchronizedSessionRunner.java
@@ -20,8 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.synchronizedsession;
 
-
-import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
@@ -168,16 +166,14 @@ public class SynchronizedSessionRunner implements FDBDatabaseRunner {
     }
 
     /**
-     * Releases the lock to end any synchronized session on it, no matter the current session holds the lock or not.
-     * <p>
-     * A {@link SynchronizedSessionRunner} or {@link SynchronizedSession} is not necessary for this purpose, as one can
-     * simply use the static version {@link SynchronizedSession#forceReleaseLock(Transaction, Subspace)}.
-     * </p>
+     * Releases the lock to end any synchronized session on the same lock subspace, no matter whether the current
+     * session holds the lock or not.
      * @return a future that will return {@code null} when the session is ended
+     * @see SynchronizedSession#endAnySession(Transaction, Subspace)
      */
     public CompletableFuture<Void> endAnySessionAsync() {
         return underlying.runAsync(context -> {
-            session.forceReleaseLock(context.ensureActive());
+            session.endAnySession(context.ensureActive());
             return AsyncUtil.DONE;
         });
     }


### PR DESCRIPTION
~~This PR is depending on https://github.com/FoundationDB/fdb-record-layer/issues/727. I'll add tests after the depended PR is merged.~~
