### PR TITLE
Resolves #752: Add a separate store timer events for batch priority GRV latency

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -452,7 +452,10 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
                     }
                     return newReadVersion;
                 });
-        localReadVersionFuture = instrument(FDBStoreTimer.Events.GET_READ_VERSION, localReadVersionFuture, startTimeNanos);
+        // Instrument batch priority transactions and non-batch priority transactions separately as additional latency
+        // is expected from back pressure on batch priority transactions.
+        FDBStoreTimer.Event grvEvent = FDBTransactionPriority.BATCH.equals(priority) ? FDBStoreTimer.Events.BATCH_GET_READ_VERSION : FDBStoreTimer.Events.GET_READ_VERSION;
+        localReadVersionFuture = instrument(grvEvent, localReadVersionFuture, startTimeNanos);
         readVersionFuture = localReadVersionFuture;
         return localReadVersionFuture;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -43,12 +43,33 @@ public class FDBStoreTimer extends StoreTimer {
         PERFORM_NO_OP("perform no-op"),
         /**
          * The amount of time taken to get a read version when explicitly called.
-         * This includes any injected latency added before issuing the request.
+         * This metric is recorded only if the transaction is not conducted at batch priority.
+         * This includes any injected latency by the client before issuing the request.
          * @see #INJECTED_GET_READ_VERSION_LATENCY
+         * @see FDBTransactionPriority
          */
         GET_READ_VERSION("get read version"),
         /**
-         * The amount of time injected prior to getting a read version.
+         * The amount of time taken to get a read version for batch priority transactions.
+         * This is a separate metric from {@link #GET_READ_VERSION} (which is recorded on non-batch
+         * priority transactions) because the performance of batch priority read reversion requests are
+         * is requested to be significantly different than the performance of non-batch priority
+         * requests. This is because the read version request is the primary mechanism by which the
+         * FoundationDB cluster can introduce back pressure, and the cluster will favor higher priority
+         * transactions over lower priority transactions.
+         *
+         * <p>
+         * Like {@link #GET_READ_VERSION}, this includes any latency injected by the client
+         * before issuing the request.
+         * </p>
+         *
+         * @see #GET_READ_VERSION
+         * @see #INJECTED_GET_READ_VERSION_LATENCY
+         * @see FDBTransactionPriority
+         */
+        BATCH_GET_READ_VERSION("batch priority get read version"),
+        /**
+         * The amount of time injected by the client prior to getting a read version.
          * @see FDBDatabase#injectLatency(FDBLatencySource)
          */
         INJECTED_GET_READ_VERSION_LATENCY("injected get read version latency"),

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -314,6 +314,16 @@ public class FDBRecordContextTest extends FDBTestBase {
         }
     }
 
+    @Test
+    public void getReadVersionAtBatch() {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer, null, FDBTransactionPriority.BATCH)) {
+            context.getReadVersion();
+            assertEquals(1, timer.getCount(FDBStoreTimer.Events.BATCH_GET_READ_VERSION));
+            assertEquals(0, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION));
+        }
+    }
+
     @ParameterizedTest(name = "setTrIdThroughMdc [traced = {0}]")
     @BooleanSource
     public void setTrIdThroughMdc(boolean traced) {


### PR DESCRIPTION
This creates a separate store timer metric for batch priority GRV requests. This switches batch GRV requests to use a totally separate metric in stead of (rather than in addition to) the GRV metric that is timed for regular GRV requests.

This was done by adding a new store timer event, and now batch priority read version requests are instrumented only using the new event. The alternative would be to have introduced _two_ new events, "batch" and "default" priority grv events (and perhaps also a "system immediate" priority grv event) and then all requests get instrumented with the current event and then also with the event specific for their priority. I went with the former rather than the latter as (1) I could see it being confusing to have two metrics for each read version request and (2) given the performance differences, I *think* there is an argument that batch read version and non-batch read version requests are different enough that just instrumenting them separately is fine. But I'm open to the other way, too.

This resolves #752.