### PR TITLE
Fixes #756: Serialization of LiteralKeyExpression can be incorrect.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -40,7 +40,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking bug fix** Protobuf serialization of `LiteralKeyExpression` is now correct for `Long`s and `byte[]`s. [(Issue #756)](https://github.com/FoundationDB/fdb-record-layer/issues/756)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
@@ -129,7 +129,7 @@ public class LiteralKeyExpression<T> extends BaseKeyExpression implements AtomKe
         }
         if (proto.hasBytesValue()) {
             ++found;
-            value = proto.getBytesValue();
+            value = proto.getBytesValue().toByteArray();
         }
         if (found == 0) {
             ++found;
@@ -149,7 +149,7 @@ public class LiteralKeyExpression<T> extends BaseKeyExpression implements AtomKe
         } else if (value instanceof Float) {
             builder.setFloatValue((Float) value);
         } else if (value instanceof Number) {
-            builder.setFloatValue(((Number) value).longValue());
+            builder.setLongValue(((Number) value).longValue());
         } else if (value instanceof Boolean) {
             builder.setBoolValue((Boolean) value);
         } else if (value instanceof String) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpressionTest.java
@@ -1,0 +1,120 @@
+/*
+ * LiteralKeyExpressionTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.record.RecordMetaDataProto;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.common.text.TextSamples;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Unit tests for the {@link LiteralKeyExpression}.
+ */
+public class LiteralKeyExpressionTest {
+    private static final byte[] byteArray = {0x00, 0x0f, 0x16};
+
+    private static Stream<Object> correctValues() {
+        return Stream.of(
+                1.0f,
+                2.0d,
+                100L,
+                Long.MIN_VALUE,
+                Long.MAX_VALUE,
+                true,
+                false,
+                "a string",
+                "(╯°□°)╯︵ ┻━┻",
+                "┳━┳ ヽ(ಠل͜ಠ)ﾉ",
+                TextSamples.EMOJIS,
+                TextSamples.YIDDISH,
+                "\n",
+                byteArray);
+    }
+
+    private static Stream<Integer> incorrectIntegerValues() {
+        return Stream.of(5, -10, Integer.MAX_VALUE, Integer.MIN_VALUE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("correctValues")
+    public void serializationTest(@Nonnull Object value) throws InvalidProtocolBufferException {
+        final LiteralKeyExpression<?> keyExpression = Key.Expressions.value(value);
+        final LiteralKeyExpression<?> parsedViaProto = LiteralKeyExpression.fromProto(keyExpression.toProto());
+        final LiteralKeyExpression<?> parsedViaBytes = LiteralKeyExpression.fromProto(
+                RecordMetaDataProto.Value.parseFrom(keyExpression.toProto().toByteArray()));
+        assertEquals(keyExpression, parsedViaProto);
+        assertEquals(keyExpression, parsedViaBytes);
+        if (value instanceof byte[]) {
+            assertArrayEquals(((byte[]) value), ((byte[]) parsedViaProto.getValue()));
+            assertArrayEquals(((byte[]) value), ((byte[]) parsedViaBytes.getValue()));
+        } else {
+            assertEquals(value, parsedViaProto.getValue());
+            assertEquals(value, parsedViaBytes.getValue());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("incorrectIntegerValues")
+    public void incorrectIntegerSerializationTest(@Nonnull Integer value) throws InvalidProtocolBufferException {
+        final LiteralKeyExpression<?> keyExpression = Key.Expressions.value(value);
+        final LiteralKeyExpression<?> parsedViaProto = LiteralKeyExpression.fromProto(keyExpression.toProto());
+        final LiteralKeyExpression<?> parsedViaBytes = LiteralKeyExpression.fromProto(
+                RecordMetaDataProto.Value.parseFrom(keyExpression.toProto().toByteArray()));
+        assertEquals(value, keyExpression.getValue());
+        assertEquals(keyExpression, parsedViaProto); // Comparison uses proto objects so both sides have Longs.
+
+        // Integer values are cast to Long before serializing so they are deserialized as Longs.
+        assertNotEquals(value, parsedViaProto.getValue());
+        assertNotEquals(value, parsedViaBytes.getValue());
+        // Values (as integers) are correct.
+        assertEquals(value.intValue(), ((Long) parsedViaProto.getValue()).intValue());
+        assertEquals(value.intValue(), ((Long) parsedViaBytes.getValue()).intValue());
+    }
+
+    @Test
+    @SuppressWarnings("AvoidEscapedUnicodeCharacters")
+    public void incorrectUnicodeSurrogatePairSerializationTest() throws InvalidProtocolBufferException {
+        final String malformedSurrogateValue = "malformed surrogate pair: \uD83C";
+        final LiteralKeyExpression<String> keyExpression = Key.Expressions.value(malformedSurrogateValue);
+        assertEquals(malformedSurrogateValue, keyExpression.getValue());
+
+        final LiteralKeyExpression<?> parsedViaProto = LiteralKeyExpression.fromProto(keyExpression.toProto());
+        final LiteralKeyExpression<?> parsedViaBytes = LiteralKeyExpression.fromProto(
+                RecordMetaDataProto.Value.parseFrom(keyExpression.toProto().toByteArray()));
+
+        assertEquals(keyExpression, parsedViaProto); // Comparison uses proto objects, so both sides have Longs.
+        // Comparison with proto objects works since we never leave Java.
+        assertEquals(malformedSurrogateValue, parsedViaProto.getValue());
+        // Comparison with Protobuf byte serialization doesn't because it uses UTF-8 instead of UTF-16.
+        assertNotEquals(malformedSurrogateValue, parsedViaBytes.getValue());
+
+    }
+}


### PR DESCRIPTION
Previously, serializing certain `LiteralKeyExpression`s (of type`Long` or `byte[]`) would produce a Protobuf that, when deserialized, would not contain a value of a different type (`Float` or `ByteString`, respectively). This fixes #756 and adds some tests that should give us more confidence that the serialization is correct.