### PR TITLE
Fixes #761: fdb-record-layer-icu-pb3 jar is not published

### DIFF
--- a/build.py
+++ b/build.py
@@ -154,8 +154,13 @@ def build(release=False, proto2=False, proto3=False, publish=False):
             return False
 
         if publish:
+            # These are enumerated rather than just using the full project bintrayUpload command to avoid uploading
+            # the fdb-extensions subproject twice. (Note that as overwrite is not supported, doing so would result
+            # in the build failing.)
             success = run_gradle(3, ':fdb-record-layer-core-pb3:bintrayUpload',
                                     ':fdb-record-layer-core-pb3-shaded:bintrayUpload',
+                                    ':fdb-record-layer-icu-pb3:bintrayUpload',
+                                    ':fdb-record-layer-spatial-pb3:bintrayUpload',
                                     '-PcoreNotStrict',
                                     '-PreleaseBuild={0}'.format('true' if release else 'false'),
                                     '-PpublishBuild=true')

--- a/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
+++ b/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
@@ -19,6 +19,7 @@
  */
 
 apply from: rootProject.file('gradle/proto.gradle')
+apply from: rootProject.file('gradle/publishing.gradle')
 if (!hasProperty('coreNotStrict')) {
     apply from: rootProject.file('gradle/strict.gradle')
 }
@@ -78,4 +79,14 @@ task unzipGeonames(dependsOn: downloadGeonames, type: Copy) {
 
 if (!skipSlow) {
     test.dependsOn unzipGeonames
+}
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            pom {
+                description = 'Spatial index support for fdb-record-layer'
+            }
+        }
+    }
 }


### PR DESCRIPTION
This adds publishing for the -pb3 jars for the ICU and spatial index subprojects. The spatial index stuff actually wasn't being published at all, so this fixes that as well.

This fixes #761.