### PR TITLE
Fixes #765: Inequality comparisons are not coalesced on single field indexes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -41,7 +41,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Two inequality predicates on a single field index will now be planned as a single range scan on the index [(Issue #765)](https://github.com/FoundationDB/fdb-record-layer/issues/765)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
This makes an update to the old planner to support queries with two inequality comparisons on a single range. This extends the `AndWithThenPlanner` to also work on indexes that are actually on a single field, and then it uses that logic in `planAnd`. The alternative would be to duplicate the logic there, which seems wrong. In theory, more code could be condensed to the `AndWithThenPlanner` (which probably needs a new name).

I have some reservations that this might inadvertently change plans (other than the ones it is intended to change). Only one plan in our test suite changed, but that also required a little bit of delicate work on the old planner. As the new planner actually already handles this case correctly, an argument can be made that we do not want this change.

This fixes #765.