### PR TITLE
Resolves #767: Add methods for adding conflict ranges for records

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -53,7 +53,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Feature** Support building indexes online in a safer and simpler way [(Issue #727)](https://github.com/FoundationDB/fdb-record-layer/issues/727)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Read and write conflict ranges can now be added on individual records [(Issue #767)](https://github.com/FoundationDB/fdb-record-layer/issues/767)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Building indexes with `OnlineIndexer` has now been changed to be safer and simpler. One can set `indexStatePrecondition` to `ERROR_IF_DISABLED_CONTINUE_IF_WRITE_ONLY` and set `useSynchronizedSession` to `false` to make the indexer follow the same behavior as before if necessary. [(Issue #727)](https://github.com/FoundationDB/fdb-record-layer/issues/727)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1053,6 +1053,23 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 primaryKey, metaData.isSplitLongRecords(), omitUnsplitRecordSuffix);
     }
 
+    @Nonnull
+    private Range getRangeForRecord(@Nonnull Tuple primaryKey) {
+        return TupleRange.allOf(primaryKey).toRange(recordsSubspace());
+    }
+
+    @Override
+    public void addRecordReadConflict(@Nonnull Tuple primaryKey) {
+        final Range recordRange = getRangeForRecord(primaryKey);
+        ensureContextActive().addReadConflictRange(recordRange.begin, recordRange.end);
+    }
+
+    @Override
+    public void addRecordWriteConflict(@Nonnull Tuple primaryKey) {
+        final Range recordRange = getRangeForRecord(primaryKey);
+        ensureContextActive().addWriteConflictRange(recordRange.begin, recordRange.end);
+    }
+
     /**
      * Asynchronously read a record from the database.
      * @param primaryKey the key for the record to be loaded

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -594,7 +594,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
      * One use case is that this can be used to promote a read from {@link IsolationLevel#SNAPSHOT} to
      * {@link IsolationLevel#SERIALIZABLE}. For example, if one performs a query at {@link IsolationLevel#SNAPSHOT} and
      * then uses a subset of the records to determine a few other writes, then one can add conflicts to <em>only</em>
-     * the records actually used. For example, if one
+     * the records actually used.
      * </p>
      *
      * <p>

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -140,6 +140,16 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
         return untypedStore.recordExistsAsync(primaryKey, isolationLevel);
     }
 
+    @Override
+    public void addRecordReadConflict(@Nonnull Tuple primaryKey) {
+        untypedStore.addRecordReadConflict(primaryKey);
+    }
+
+    @Override
+    public void addRecordWriteConflict(@Nonnull Tuple primaryKey) {
+        untypedStore.addRecordWriteConflict(primaryKey);
+    }
+
     @Nonnull
     @Override
     public RecordCursor<FDBStoredRecord<M>> scanRecords(@Nullable Tuple low, @Nullable Tuple high, @Nonnull EndpointType lowEndpoint, @Nonnull EndpointType highEndpoint, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {


### PR DESCRIPTION
This adds additional methods to the FDBRecordStoreBase interface for add read and write conflicts on records by their primary key. This can be used by advanced users who need additional control over their conflicts for certain operations.

This resolves #767.