### PR TITLE
Resolves #702: Increase required FDB version to 6.2

### DIFF
--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,8 +1,8 @@
 FROM centos:7
-LABEL version=0.0.11
+LABEL version=0.0.13
 
 RUN yum install -y java-1.8.0-openjdk-devel python git unzip wget which time
-RUN yum install -y https://www.foundationdb.org/downloads/6.1.8/rhel6/installers/foundationdb-clients-6.1.8-1.el6.x86_64.rpm nmap
+RUN yum install -y https://www.foundationdb.org/downloads/6.2.7/rhel6/installers/foundationdb-clients-6.2.7-1.el6.x86_64.rpm nmap
 
 RUN mkdir -p /usr/local/bin
 COPY fdb_create_cluster_file.bash /usr/local/bin/fdb_create_cluster_file.bash

--- a/build/Dockerfile.fdbserver
+++ b/build/Dockerfile.fdbserver
@@ -1,7 +1,7 @@
 FROM centos:7
-LABEL version=6.1.8
+LABEL version=6.2.7
 
-RUN yum install -y which initscripts rsync net-tools passwd https://www.foundationdb.org/downloads/6.1.8/rhel6/installers/foundationdb-clients-6.1.8-1.el6.x86_64.rpm https://www.foundationdb.org/downloads/6.1.8/rhel6/installers/foundationdb-server-6.1.8-1.el6.x86_64.rpm
+RUN yum install -y which initscripts rsync net-tools passwd https://www.foundationdb.org/downloads/6.2.7/rhel6/installers/foundationdb-clients-6.2.7-1.el6.x86_64.rpm https://www.foundationdb.org/downloads/6.2.7/rhel6/installers/foundationdb-server-6.2.7-1.el6.x86_64.rpm
 
 USER root
 

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: fdb-record-layer-build:0.0.11
+    image: fdb-record-layer-build:0.0.13
     build:
       context: .
       dockerfile: Dockerfile.build
@@ -17,7 +17,7 @@ services:
       - FDBHOSTNAME=fdbserver
 
   fdbserver:
-    image: foundationdb-server:6.1.8
+    image: foundationdb-server:6.2.7
     environment:
       - FDBSTARTOPT=2
       - HOST_IP=0.0.0.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,6 +6,10 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ## 2.9
 
+### Breaking Changes
+
+This version of the Record Layer requires a FoundationDB server version of at least version 6.2. Attempting to connect to older versions may result in the client hanging when attempting to connect to the database.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -25,7 +29,7 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Requires a minimum FoundationDB client and server version of 6.2 [(Issue #702)](https://github.com/FoundationDB/fdb-record-layer/issues/702)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/FDBTestBase.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/FDBTestBase.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
 public abstract class FDBTestBase {
     @BeforeAll
     public static void setupFDB() {
-        FDB fdb = FDB.selectAPIVersion(610);
+        FDB fdb = FDB.selectAPIVersion(620);
         fdb.setUnclosedWarning(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -55,7 +55,7 @@ public class FDBDatabaseFactory {
      * {@link com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver} retrieval requests.
      */
     public static final int DEFAULT_DIRECTORY_CACHE_SIZE = 5000;
-    private static final int API_VERSION = 610;
+    private static final int API_VERSION = 620;
 
     @Nonnull
     private static final FDBDatabaseFactory INSTANCE = new FDBDatabaseFactory();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/TracedTransaction.java
@@ -174,6 +174,11 @@ public class TracedTransaction implements Transaction {
     }
 
     @Override
+    public CompletableFuture<Long> getApproximateSize() {
+        return transaction.getApproximateSize();
+    }
+
+    @Override
     public CompletableFuture<Transaction> onError(Throwable e) {
         return transaction.onError(e);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ group=org.foundationdb
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation
 
-fdbVersion=6.1.8
+fdbVersion=6.2.10
 jsr305Version=3.0.1
 slf4jVersion=1.7.14
 commonsLang3Version=3.9


### PR DESCRIPTION
This increases the required FDB client and server version to 6.2, and it updates our build infrastructure to use that newer version. The main feature that this will enable is it will allow us to use the new `getApproximateSize` feature in 6.2, but the work to use this in, say, index builds has not been done.