### PR TITLE
Resolves #751: Asynchronous spatial join

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Make spatial joins asynchronous [(Issue #751)](https://github.com/FoundationDB/fdb-record-layer/issues/751)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexImpl.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexImpl.java
@@ -23,9 +23,9 @@ package com.apple.foundationdb.record.spatial.geophile;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.tuple.Tuple;
-import com.geophile.z.Cursor;
 import com.geophile.z.Index;
-import com.geophile.z.Record;
+import com.geophile.z.async.CursorAsync;
+import com.geophile.z.async.IndexAsync;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,7 +34,7 @@ import java.util.function.BiFunction;
 /**
  * Adapt {@link GeophileIndexMaintainer} to Geophile {@link Index}.
  */
-class GeophileIndexImpl extends Index<GeophileRecordImpl> {
+class GeophileIndexImpl extends IndexAsync<GeophileRecordImpl> {
     @Nonnull
     private final IndexMaintainer indexMaintainer;
     @Nullable
@@ -50,28 +50,13 @@ class GeophileIndexImpl extends Index<GeophileRecordImpl> {
     }
 
     @Override
-    public void add(GeophileRecordImpl record) {
-        throw new UnsupportedOperationException("add not supported");
-    }
-
-    @Override
-    public boolean remove(long z, Record.Filter<GeophileRecordImpl> filter) {
-        throw new UnsupportedOperationException("remove not supported");
-    }
-
-    @Override
-    public Cursor<GeophileRecordImpl> cursor() {
+    public CursorAsync<GeophileRecordImpl> cursorAsync() {
         return new GeophileCursorImpl(this, indexMaintainer, prefix, recordFunction);
     }
 
     @Override
     public GeophileRecordImpl newRecord() {
         return new GeophileRecordImpl(null, null);
-    }
-
-    @Override
-    public boolean blindUpdates() {
-        return false;
     }
 
     @Override

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
@@ -31,8 +31,8 @@ import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.spatial.common.DoubleValueOrParameter;
 import com.apple.foundationdb.tuple.Tuple;
-import com.geophile.z.SpatialJoin;
 import com.geophile.z.SpatialObject;
+import com.geophile.z.async.SpatialJoinAsync;
 import com.geophile.z.index.RecordWithSpatialObject;
 import com.geophile.z.spatialobject.d2.Point;
 import com.google.common.collect.ImmutableList;
@@ -87,7 +87,7 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
 
     @Nullable
     @Override
-    protected SpatialJoin.Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(@Nonnull EvaluationContext context) {
+    protected SpatialJoinAsync.Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(@Nonnull EvaluationContext context) {
         if (covering) {
             Double distanceValue = distance.getValue(context);
             Double centerLatitudeValue = centerLatitude.getValue(context);

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialIndexJoinPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialIndexJoinPlan.java
@@ -29,8 +29,8 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBIndexedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.IndexOrphanBehavior;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
-import com.geophile.z.SpatialIndex;
-import com.geophile.z.SpatialJoin;
+import com.geophile.z.async.SpatialIndexAsync;
+import com.geophile.z.async.SpatialJoinAsync;
 import com.google.protobuf.Message;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -63,10 +63,10 @@ public class GeophileSpatialIndexJoinPlan {
 
     @Nonnull
     public <M extends Message> RecordCursor<Pair<FDBIndexedRecord<M>, FDBIndexedRecord<M>>> execute(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context) {
-        final SpatialJoin spatialJoin = SpatialJoin.newSpatialJoin(SpatialJoin.Duplicates.INCLUDE);
-        final GeophileSpatialJoin geophileSpatialJoin = new GeophileSpatialJoin(spatialJoin, store.getUntypedRecordStore(), context);
-        final SpatialIndex<GeophileRecordImpl> leftSpatialIndex = geophileSpatialJoin.getSpatialIndex(leftIndexName, leftPrefixComparisons);
-        final SpatialIndex<GeophileRecordImpl> rightSpatialIndex = geophileSpatialJoin.getSpatialIndex(rightIndexName, rightPrefixComparisons);
+        final SpatialJoinAsync<GeophileRecordImpl, GeophileRecordImpl> spatialJoin = SpatialJoinAsync.newSpatialJoin(SpatialJoinAsync.Duplicates.INCLUDE);
+        final GeophileSpatialJoin<GeophileRecordImpl, GeophileRecordImpl> geophileSpatialJoin = new GeophileSpatialJoin<>(spatialJoin, store.getUntypedRecordStore(), context);
+        final SpatialIndexAsync<GeophileRecordImpl> leftSpatialIndex = geophileSpatialJoin.getSpatialIndex(leftIndexName, leftPrefixComparisons);
+        final SpatialIndexAsync<GeophileRecordImpl> rightSpatialIndex = geophileSpatialJoin.getSpatialIndex(rightIndexName, rightPrefixComparisons);
         return fetchIndexRecords(store, geophileSpatialJoin.recordCursor(leftSpatialIndex, rightSpatialIndex));
     }
 

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialJoin.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialJoin.java
@@ -20,60 +20,67 @@
 
 package com.apple.foundationdb.record.spatial.geophile;
 
+import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.cursors.IllegalContinuationAccessChecker;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.tuple.Tuple;
-import com.geophile.z.Index;
 import com.geophile.z.Space;
-import com.geophile.z.SpatialIndex;
 import com.geophile.z.SpatialJoin;
 import com.geophile.z.SpatialObject;
+import com.geophile.z.async.IndexAsync;
+import com.geophile.z.async.IteratorAsync;
+import com.geophile.z.async.SpatialIndexAsync;
+import com.geophile.z.async.SpatialJoinAsync;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.Iterator;
+import javax.annotation.Nullable;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 
 /**
  * Generate {@link RecordCursor} from {@link GeophileIndexMaintainer} using Geophile {@link SpatialJoin}.
  */
-class GeophileSpatialJoin {
+class GeophileSpatialJoin<L, R> {
     @Nonnull
-    private final SpatialJoin spatialJoin;
+    private final SpatialJoinAsync<L, R> spatialJoin;
     @Nonnull
     private final FDBRecordStore store;
     @Nonnull
     private final EvaluationContext context;
 
-    GeophileSpatialJoin(@Nonnull SpatialJoin spatialJoin, @Nonnull FDBRecordStore store, @Nonnull EvaluationContext context) {
+    GeophileSpatialJoin(@Nonnull SpatialJoinAsync<L, R> spatialJoin, @Nonnull FDBRecordStore store, @Nonnull EvaluationContext context) {
         this.spatialJoin = spatialJoin;
         this.store = store;
         this.context = context;
     }
 
     @Nonnull
-    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName) {
+    public SpatialIndexAsync<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName) {
         return getSpatialIndex(indexName, ScanComparisons.EMPTY);
     }
 
     @Nonnull
-    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName,
-                                                            @Nonnull ScanComparisons prefixComparisons) {
+    public SpatialIndexAsync<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName,
+                                                                 @Nonnull ScanComparisons prefixComparisons) {
         return getSpatialIndex(indexName, prefixComparisons, GeophileRecordImpl::new);
     }
 
     @Nonnull
-    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName,
-                                                            @Nonnull ScanComparisons prefixComparisons,
-                                                            @Nonnull BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
+    public SpatialIndexAsync<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName,
+                                                                 @Nonnull ScanComparisons prefixComparisons,
+                                                                 @Nonnull BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
         if (!prefixComparisons.isEquality()) {
             throw new RecordCoreArgumentException("prefix comparisons must only have equality");
         }
@@ -81,52 +88,129 @@ class GeophileSpatialJoin {
         final IndexMaintainer indexMaintainer = store.getIndexMaintainer(store.getRecordMetaData().getIndex(indexName));
         final TupleRange prefixRange = prefixComparisons.toTupleRange(store, context);
         final Tuple prefix = prefixRange.getLow();  // Since this is an equality, will match getHigh(), too.
-        final Index<GeophileRecordImpl> index = new GeophileIndexImpl(indexMaintainer, prefix, recordFunction);
+        final IndexAsync<GeophileRecordImpl> index = new GeophileIndexImpl(indexMaintainer, prefix, recordFunction);
         final Space space = ((GeophileIndexMaintainer)indexMaintainer).getSpace();
-        try {
-            return SpatialIndex.newSpatialIndex(space, index);
-        } catch (IOException ex) {
-            throw new RecordCoreException("Unexpected IO exception", ex);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RecordCoreException(ex);
-        }
+        return SpatialIndexAsync.newSpatialIndexAsync(space, index);
     }
 
     @Nonnull
     public RecordCursor<IndexEntry> recordCursor(@Nonnull SpatialObject spatialObject,
-                                                 @Nonnull SpatialIndex<GeophileRecordImpl> spatialIndex) {
+                                                 @Nonnull SpatialIndexAsync<GeophileRecordImpl> spatialIndex) {
         // TODO: This is a synchronous implementation using Iterators. A proper RecordCursor implementation needs
         //  Geophile async extensions. Also need to pass down executeProperties.
-        final Iterator<GeophileRecordImpl> iterator;
-        try {
-            iterator = spatialJoin.iterator(spatialObject, spatialIndex);
-        } catch (IOException ex) {
-            throw new RecordCoreException("Unexpected IO exception", ex);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RecordCoreException(ex);
-        }
-        final RecordCursor<GeophileRecordImpl> recordCursor = RecordCursor.fromIterator(store.getExecutor(), iterator);
+        final IteratorAsync<GeophileRecordImpl> iterator = spatialJoin.iterator(spatialObject, spatialIndex);
+        final RecordCursor<GeophileRecordImpl> recordCursor = cursorFromIteratorAsync(iterator);
         return recordCursor.map(GeophileRecordImpl::getIndexEntry);
     }
 
     @Nonnull
-    public RecordCursor<Pair<IndexEntry, IndexEntry>> recordCursor(@Nonnull SpatialIndex<GeophileRecordImpl> left,
-                                                                   @Nonnull SpatialIndex<GeophileRecordImpl> right) {
+    public RecordCursor<Pair<IndexEntry, IndexEntry>> recordCursor(@Nonnull SpatialIndexAsync<GeophileRecordImpl> left,
+                                                                   @Nonnull SpatialIndexAsync<GeophileRecordImpl> right) {
         // TODO: This is a synchronous implementation using Iterators. A proper RecordCursor implementation needs
         //  Geophile async extensions. Also need to pass down executeProperties.
-        final Iterator<com.geophile.z.Pair<GeophileRecordImpl, GeophileRecordImpl>> iterator;
-        try {
-            iterator = spatialJoin.iterator(left, right);
-        } catch (IOException ex) {
-            throw new RecordCoreException("Unexpected IO exception", ex);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new RecordCoreException(ex);
-        }
-        final RecordCursor<com.geophile.z.Pair<GeophileRecordImpl, GeophileRecordImpl>> recordCursor = RecordCursor.fromIterator(store.getExecutor(), iterator);
+        final IteratorAsync<com.geophile.z.Pair<GeophileRecordImpl, GeophileRecordImpl>> iterator = spatialJoin.iterator(left, right);
+        final RecordCursor<com.geophile.z.Pair<GeophileRecordImpl, GeophileRecordImpl>> recordCursor = cursorFromIteratorAsync(iterator);
         return recordCursor.map(p -> Pair.of(p.left().getIndexEntry(), p.right().getIndexEntry()));
+    }
+
+    protected <T> RecordCursor<T> cursorFromIteratorAsync(@Nonnull IteratorAsync<T> iteratorAsync) {
+        return new IteratorAsyncCursor<>(store.getExecutor(), iteratorAsync);
+    }
+
+    static class IteratorAsyncCursor<T> implements RecordCursor<T> {
+        @Nonnull
+        private final Executor executor;
+        @Nonnull
+        private final IteratorAsync<T> iteratorAsync;
+        protected int valuesSeen;
+
+        @Nullable
+        protected CompletableFuture<Boolean> hasNextFuture;
+        @Nullable
+        protected RecordCursorResult<T> nextResult;
+
+        // for detecting incorrect cursor usage
+        protected boolean mayGetContinuation = false;
+
+        protected IteratorAsyncCursor(@Nonnull Executor executor, @Nonnull IteratorAsync<T> iteratorAsync) {
+            this.executor = executor;
+            this.iteratorAsync = iteratorAsync;
+            this.valuesSeen = 0;
+        }
+
+        @Nonnull
+        @Override
+        public CompletableFuture<RecordCursorResult<T>> onNext() {
+            return iteratorAsync.nextAsync().thenApply(next -> {
+                mayGetContinuation = next == null;
+                if (next != null) {
+                    // TODO: Need real continuations here.
+                    valuesSeen++;
+                    nextResult = RecordCursorResult.withNextValue(next, ByteArrayContinuation.fromInt(valuesSeen));
+                } else {
+                    nextResult = RecordCursorResult.exhausted();
+                }
+                return nextResult;
+
+            });
+        }
+
+        @Override
+        public void close() {
+            if (hasNextFuture != null) {
+                hasNextFuture.cancel(false);
+            }
+        }
+
+        @Nonnull
+        @Override
+        public Executor getExecutor() {
+            return executor;
+        }
+
+        @Override
+        public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+            visitor.visitEnter(this);
+            return visitor.visitLeave(this);
+        }
+
+        @Nonnull
+        @Override
+        @Deprecated
+        public CompletableFuture<Boolean> onHasNext() {
+            if (hasNextFuture == null) {
+                mayGetContinuation = false;
+                hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
+            }
+            return hasNextFuture;
+        }
+
+        @Nullable
+        @Override
+        @Deprecated
+        public T next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            mayGetContinuation = true;
+            hasNextFuture = null;
+            return nextResult.get();
+        }
+
+        @Nullable
+        @Override
+        @Deprecated
+        public byte[] getContinuation() {
+            IllegalContinuationAccessChecker.check(mayGetContinuation);
+            return nextResult.getContinuation().toBytes();
+        }
+
+        @Nonnull
+        @Override
+        @Deprecated
+        public NoNextReason getNoNextReason() {
+            return nextResult.getNoNextReason();
+        }
     }
 
 }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
@@ -36,9 +36,9 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithNoChild
 import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.tuple.Tuple;
-import com.geophile.z.SpatialIndex;
-import com.geophile.z.SpatialJoin;
 import com.geophile.z.SpatialObject;
+import com.geophile.z.async.SpatialIndexAsync;
+import com.geophile.z.async.SpatialJoinAsync;
 import com.geophile.z.index.RecordWithSpatialObject;
 import com.google.protobuf.Message;
 
@@ -86,7 +86,7 @@ public abstract class GeophileSpatialObjectQueryPlan implements RecordQueryPlanW
      */
     @Nullable
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract") // null is a reasonable default
-    protected SpatialJoin.Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(@Nonnull EvaluationContext context) {
+    protected SpatialJoinAsync.Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(@Nonnull EvaluationContext context) {
         return null;
     }
 
@@ -130,9 +130,9 @@ public abstract class GeophileSpatialObjectQueryPlan implements RecordQueryPlanW
         if (spatialObject == null) {
             return RecordCursor.empty();
         }
-        final SpatialJoin spatialJoin = SpatialJoin.newSpatialJoin(SpatialJoin.Duplicates.INCLUDE, getFilter(context));
-        final GeophileSpatialJoin geophileSpatialJoin = new GeophileSpatialJoin(spatialJoin, store.getUntypedRecordStore(), context);
-        final SpatialIndex<GeophileRecordImpl> spatialIndex = geophileSpatialJoin.getSpatialIndex(indexName, prefixComparisons, getRecordFunction());
+        final SpatialJoinAsync<RecordWithSpatialObject, GeophileRecordImpl> spatialJoin = SpatialJoinAsync.newSpatialJoin(SpatialJoinAsync.Duplicates.INCLUDE, getFilter(context));
+        final GeophileSpatialJoin<RecordWithSpatialObject, GeophileRecordImpl> geophileSpatialJoin = new GeophileSpatialJoin<>(spatialJoin, store.getUntypedRecordStore(), context);
+        final SpatialIndexAsync<GeophileRecordImpl> spatialIndex = geophileSpatialJoin.getSpatialIndex(indexName, prefixComparisons, getRecordFunction());
         return geophileSpatialJoin.recordCursor(spatialObject, spatialIndex);
     }
 

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/CompletableFutures.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/CompletableFutures.java
@@ -1,0 +1,97 @@
+/*
+ * WhileTrue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+/**
+ * Helper class for asynchronous iteration.
+ */
+public class CompletableFutures
+{
+    public static final CompletableFuture<Void> NULL = CompletableFuture.completedFuture(null);
+    public static final CompletableFuture<Boolean> FALSE = CompletableFuture.completedFuture(Boolean.FALSE);
+    public static final CompletableFuture<Boolean> TRUE = CompletableFuture.completedFuture(Boolean.TRUE);
+
+    private CompletableFutures() {
+    }
+
+    /**
+     * Call given body in a loop.
+     * @param body the code to run in the loop
+     * @return a future that completes after the body has returned {@code false}
+     */
+    public static CompletableFuture<Void> whileTrue(Supplier<? extends CompletableFuture<Boolean>> body) {
+        return new WhileTrue(body).run();
+    }
+
+    static class WhileTrue implements BiFunction<Boolean, Throwable, Void> {
+        final Supplier<? extends CompletableFuture<Boolean>> body;
+        final CompletableFuture<Void> done;
+
+        WhileTrue(Supplier<? extends CompletableFuture<Boolean>> body) {
+            this.body = body;
+            this.done = new CompletableFuture<>();
+        }
+
+        @Override
+        public Void apply(Boolean more, Throwable error) {
+            if (error != null) {
+                done.completeExceptionally(error);
+            } else {
+                while (true) {
+                    if (!more) {
+                        done.complete(null);
+                        break;
+                    }
+                    CompletableFuture<Boolean> result;
+                    try {
+                        result = body.get();
+                    } catch (Exception e) {
+                        done.completeExceptionally(e);
+                        break;
+                    }
+                    if (result.isDone()) {
+                        if (result.isCompletedExceptionally()) {
+                            result.handle(this);
+                            break;
+                        } else {
+                            more = result.join();
+                        }
+                    } else {
+                        result.handleAsync(this);
+                        break;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public CompletableFuture<Void> run() {
+            apply(true, null);
+            return done;
+        }
+    }
+
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/CursorAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/CursorAsync.java
@@ -1,0 +1,131 @@
+/*
+ * CursorAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Record;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Asynchronous version of {@link com.geophile.z.Cursor}.
+ * @param <RECORD> type for spatial records
+ */
+@SuppressWarnings({"checkstyle:ClassTypeParameterName", "PMD.GenericsNaming"})
+public abstract class CursorAsync<RECORD extends Record>
+{
+    // Object state
+
+    private final boolean stableRecords;
+    private RECORD current;
+    private State state = State.NEVER_USED;
+
+    // CursorAsync interface
+
+    /**
+     * <ul>
+     * <li><b>If the Cursor has just been created:</b>
+     *     The result of calling this method is undefined.
+     *
+     * <li><b>If the Cursor has just been positioned using {@link #goTo(Record)}:</b>
+     *     This method moves the Cursor to the
+     *     {@link com.geophile.z.Record} with the key passed to goTo, or to the smallest
+     *     {@link com.geophile.z.Record} whose key is greater than that key. If the key
+     *     is greater than that largest key in the index, then the Cursor is closed and null is returned.
+     *
+     * <li><b>If the Cursor has just been accessed using next():</b>
+     *     This method moves the Cursor to the {@link com.geophile.z.Record}
+     *     with the next larger key, or to null if the Cursor was already positioned at the last
+     *     {@link com.geophile.z.Record} of the index.
+     * </ul>
+     * @return A future completing to the {@link com.geophile.z.Record} at the new Cursor position, or null if the Cursor
+     * was moved past the last record.
+     */
+    public abstract CompletableFuture<RECORD> next();
+
+    /**
+     * Position the Cursor at the {@link com.geophile.z.Record} with the given key. If there is
+     * no such record, then the Cursor position is "between" records, and a call to {@link #next()}
+     * will position the Cursor at one of the bounding records.
+     * @param key The key to search for.
+     */
+    public abstract void goTo(RECORD key);
+
+    /**
+     * Mark the Cursor as no longer usable. Subsequent calls to {@link #goTo(Record)} or {@link #next()}
+     * will have undefined results.
+     */
+    public void close()
+    {
+        state = State.DONE;
+        current = null;
+    }
+
+    // For use by subclasses
+
+    protected final RECORD current()
+    {
+        return current;
+    }
+
+    protected final void current(RECORD record)
+    {
+        assert state != State.DONE;
+        if (stableRecords) {
+            current = record;
+        } else {
+            record.copyTo(current);
+        }
+    }
+
+    protected State state()
+    {
+        return state;
+    }
+
+    protected void state(State newState)
+    {
+        assert newState != State.DONE;
+        state = newState;
+    }
+
+    protected CursorAsync(IndexAsync<RECORD> indexAsync)
+    {
+        stableRecords = indexAsync.stableRecords();
+        current = stableRecords ? null : indexAsync.newRecord();
+    }
+
+    // Inner classes
+
+    protected enum State
+    {
+        // The cursor has been created, but has never been used to retrieve a record. If the key used to create
+        // the cursor is present, then next() will retrieve the associated record. This state
+        // is also used when a cursor is repositioned using goTo().
+        NEVER_USED,
+
+        // The cursor has been created and used to retrieve at least one record. next() moves the
+        // cursor before retrieving a record.
+        IN_USE,
+
+        // The cursor has returned all records. A subsequent call to next() will return null.
+        DONE
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/DuplicateEliminatingIteratorAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/DuplicateEliminatingIteratorAsync.java
@@ -1,0 +1,59 @@
+/*
+ * DuplicateEliminatingIteratorAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Asynchronous version of {@code com.geophile.z.spatialjoin.DuplicateEliminatingIterator}.
+ * @param <T> element type
+ */
+class DuplicateEliminatingIteratorAsync<T> implements IteratorAsync<T> {
+    // Object state
+
+    private final IteratorAsync<T> input;
+    private final Set<T> seen = new HashSet<>();
+    private T next;
+
+    @Override
+    public CompletableFuture<T> nextAsync() {
+        return CompletableFutures.whileTrue(() -> {
+            return input.nextAsync().thenApply(next -> {
+                if (next == null) {
+                    return false;
+                }
+                if (seen.add(next)) {
+                    this.next = next;
+                    return false;
+                }
+                return true;
+            });
+        }).thenApply(vignore -> next);
+    }
+
+    // DuplicateEliminatingIterator interface
+
+    public DuplicateEliminatingIteratorAsync(IteratorAsync<T> input) {
+        this.input = input;
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/IndexAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/IndexAsync.java
@@ -1,0 +1,119 @@
+/*
+ * IndexAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Cursor;
+import com.geophile.z.Index;
+import com.geophile.z.Record;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Asynchronous version of {@link com.geophile.z.Index}.
+ * @param <RECORD> type for spatial records
+ */
+@SuppressWarnings({"checkstyle:ClassTypeParameterName", "checkstyle:MethodTypeParameterName", "PMD.GenericsNaming"})
+public abstract class IndexAsync<RECORD extends Record>
+{
+    /**
+     * Returns a {@link CursorAsync} that can visit this Index's records.
+     * @return A {@link CursorAsync} that can visit this Index's records.
+     */
+    public abstract CursorAsync<RECORD> cursorAsync();
+
+    /**
+     * Returns a {@link com.geophile.z.Record} that can be added to this Index.
+     * @return A {@link com.geophile.z.Record} that can be added to this Index.
+     */
+    public abstract RECORD newRecord();
+
+    /**
+     * Returns a {@link com.geophile.z.Record} that can be used as a key to search this Index.
+     * @return A {@link com.geophile.z.Record} that can be used as a key to search this Index.
+     */
+    public RECORD newKeyRecord()
+    {
+        return newRecord();
+    }
+
+    /**
+     * Indicates whether records retrieved from this index are stable. A stable record doesn't change
+     * as the cursor that produces it advances. A record that is not stable has state tied to the cursor,
+     * and may change as the cursor moves.
+     * @return true iff records retrieved from this index are stable.
+     */
+    public abstract boolean stableRecords();
+
+    /**
+     * Create an asynchronous index from a synchronous one.
+     * @param index a synchronous index
+     * @param <RECORD> the type of the indexed records
+     * @return an asynchronous wrapper for the given index
+     */
+    public static <RECORD extends Record> IndexAsync<RECORD> fromSync(final Index<RECORD> index) {
+        return new IndexAsync<RECORD>() {
+            @Override
+            public CursorAsync<RECORD> cursorAsync() {
+                final Cursor<RECORD> cursor;
+                try {
+                    cursor = index.cursor();
+                } catch (IOException | InterruptedException ex) {
+                    throw new RuntimeException(ex);
+                }
+                return new CursorAsync<RECORD>(this) {
+                    @Override
+                    public CompletableFuture<RECORD> next() {
+                        final RECORD record;
+                        try {
+                            record = cursor.next();
+                        } catch (IOException | InterruptedException ex) {
+                            throw new RuntimeException(ex);
+                        }
+                        if (record != null) {
+                            current(record);
+                        }
+                        return CompletableFuture.completedFuture(record);
+                    }
+
+                    @Override
+                    public void goTo(RECORD key) {
+                        try {
+                            cursor.goTo(key);
+                        } catch (IOException | InterruptedException ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    }
+                };
+            }
+
+            @Override
+            public RECORD newRecord() {
+                return index.newRecord();
+            }
+
+            @Override
+            public boolean stableRecords() {
+                return index.stableRecords();
+            }
+        };
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/IteratorAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/IteratorAsync.java
@@ -1,0 +1,31 @@
+/*
+ * DuplicateEliminatingIteratorAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Asynchronous version of {@code java.util.Iterator}.
+ * @param <T> element type
+ */
+public interface IteratorAsync<T> {
+    CompletableFuture<T> nextAsync();
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialIndexAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialIndexAsync.java
@@ -1,0 +1,101 @@
+/*
+ * SpatialIndexAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Record;
+import com.geophile.z.Space;
+import com.geophile.z.SpatialObject;
+import com.geophile.z.space.SpaceImpl;
+
+/**
+ * Asynchronous version of {@link com.geophile.z.SpatialIndex}.
+ * @param <RECORD> type for spatial records
+ */
+@SuppressWarnings({"checkstyle:ClassTypeParameterName", "PMD.GenericsNaming", "checkstyle:MethodTypeParameterName"})
+public class SpatialIndexAsync<RECORD extends Record>
+{
+    // Class state
+
+    protected static final int USE_SPATIAL_OBJECT_MAX_Z = -1;
+
+    // Object state
+
+    protected final SpaceImpl space;
+    protected final IndexAsync<RECORD> index;
+    protected final Options options;
+
+    /**
+     * Returns the {@link com.geophile.z.Space} associated with this SpatialIndex.
+     * @return The {@link com.geophile.z.Space} associated with this SpatialIndex.
+     */
+    public final Space space()
+    {
+        return space;
+    }
+
+    /**
+     * Creates a SpatialIndexAsync. The index
+     * should never be manipulated directly at any time. It is intended to be maintained and searched only
+     * through the interface of this class.
+     * @param space The {@link Space} containing the {@link SpatialObject}s to be indexed.
+     * @param index The {@link IndexAsync} that will store the indexed {@link SpatialObject}s.
+     * @param <RECORD> type for spatial records
+     * @return A new SpatialIndexAsync
+     */
+    public static <RECORD extends Record> SpatialIndexAsync<RECORD> newSpatialIndexAsync(Space space,
+                                                                                         IndexAsync<RECORD> index) {
+        return newSpatialIndexAsync(space, index, Options.DEFAULT);
+    }
+
+    /**
+     * Creates a SpatialIndexAsync. The index
+     * should never be manipulated directly at any time. It is intended to be maintained and searched only
+     * through the interface of this class.
+     * @param space The {@link Space} containing the {@link SpatialObject}s to be indexed.
+     * @param index The {@link IndexAsync} that will store the indexed {@link SpatialObject}s.
+     * @param options index {@link Options} for new index.
+     * @param <RECORD> type for spatial records
+     * @return A new SpatialIndexAsync.
+     */
+    public static <RECORD extends Record> SpatialIndexAsync<RECORD> newSpatialIndexAsync(Space space,
+                                                                                         IndexAsync<RECORD> index,
+                                                                                         Options options) {
+        return new SpatialIndexImplAsync<>((SpaceImpl) space, index, options);
+    }
+
+    // For use by subclasses
+
+    protected SpatialIndexAsync(SpaceImpl space, IndexAsync<RECORD> index, Options options)
+    {
+        this.space = space;
+        this.index = index;
+        this.options = options;
+    }
+
+    // Inner classes
+
+    /**
+     * Options for {@link #newSpatialIndexAsync(Space, IndexAsync, Options)}.
+     */
+    public enum Options {
+        DEFAULT, SINGLE_CELL
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialIndexImplAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialIndexImplAsync.java
@@ -1,0 +1,62 @@
+/*
+ * SpatialIndexImplAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Record;
+import com.geophile.z.space.SpaceImpl;
+
+/**
+ * Asynchronous version of {@link com.geophile.z.space.SpatialIndexImpl}.
+ * @param <RECORD> type for spatial records
+ */
+@SuppressWarnings({"checkstyle:ClassTypeParameterName", "PMD.GenericsNaming"})
+public class SpatialIndexImplAsync<RECORD extends Record> extends SpatialIndexAsync<RECORD>
+{
+    // Object state
+
+    private final boolean singleCell;
+
+    // Object interface
+
+    @Override
+    public String toString()
+    {
+        return index.toString();
+    }
+
+    // SpatialIndexAsync interface
+
+    public boolean singleCell()
+    {
+        return singleCell;
+    }
+
+    public IndexAsync<RECORD> index()
+    {
+        return index;
+    }
+
+    public SpatialIndexImplAsync(SpaceImpl space, IndexAsync<RECORD> index, Options options)
+    {
+        super(space, index, options);
+        singleCell = options == Options.SINGLE_CELL;
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinAsync.java
@@ -1,0 +1,202 @@
+/*
+ * SpatialJoinAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Pair;
+import com.geophile.z.Record;
+import com.geophile.z.SpatialObject;
+
+/**
+ * Asynchronous version of {@code com.geophile.z.SpatialJoin}.
+ * @param <LEFT> the type on the left
+ * @param <RIGHT> the type on the right
+ */
+@SuppressWarnings({"checkstyle:MethodTypeParameterName", "PMD.GenericsNaming"})
+public abstract class SpatialJoinAsync<LEFT, RIGHT>
+{
+    /**
+     * Creates and configures a new SpatialJoin object.
+     *
+     * @param duplicates    Indicates whether the spatial join will suppress duplicates.
+     * @param filter        Used to eliminate false positives from the spatial join output.
+     * @param leftObserver  Used to monitor operations on the left input to the spatial join.
+     * @param rightObserver Used to monitor operations on the right input to the spatial join.
+     * @param <LEFT>        Type of object passed to the left filter argument.
+     * @param <RIGHT>       TYpe of object passed to the right filter argument.
+     * @return A configured SpatialJoin object. All spatial joins computed using it will use the configuration
+     * specified by the above arguments.
+     */
+    public static <LEFT, RIGHT> SpatialJoinAsync<LEFT, RIGHT> newSpatialJoin(Duplicates duplicates,
+                                                                             Filter<LEFT, RIGHT> filter,
+                                                                             InputObserver leftObserver,
+                                                                             InputObserver rightObserver)
+    {
+        return new SpatialJoinImplAsync<>(duplicates, filter, leftObserver, rightObserver);
+    }
+
+    /**
+     * Creates and configures a new SpatialJoin object.
+     *
+     * @param duplicates Indicates whether the spatial join will suppress duplicates.
+     * @param filter     Used to eliminate false positives from the spatial join output.
+     * @param <LEFT>     Type of object passed to the left filter argument.
+     * @param <RIGHT>    TYpe of object passed to the right filter argument.
+     * @return A configured SpatialJoin object. All spatial joins computed using it will use the configuration
+     * specified by the above arguments.
+     */
+    public static <LEFT, RIGHT> SpatialJoinAsync<LEFT, RIGHT> newSpatialJoin(Duplicates duplicates,
+                                                                             Filter<LEFT, RIGHT> filter)
+    {
+        return new SpatialJoinImplAsync<>(duplicates, filter, null, null);
+    }
+
+    /**
+     * Creates and configures a new SpatialJoin object.
+     *
+     * @param duplicates Indicates whether the spatial join will suppress duplicates.
+     * @param <LEFT>     Type of object for left side of join
+     * @param <RIGHT>    Type of object for right side of join
+     * @return A configured SpatialJoin object. All spatial joins computed using it will use the configuration
+     * specified by the above arguments. False positives will be included in spatial join output.
+     */
+    public static <LEFT, RIGHT> SpatialJoinAsync<LEFT, RIGHT> newSpatialJoin(Duplicates duplicates)
+    {
+        return new SpatialJoinImplAsync<>(duplicates, null, null, null);
+    }
+
+    /**
+     * Returns an {@link java.util.Iterator} that will provide access to spatial join results.
+     * The objects accessed through the {@link java.util.Iterator} are {@link com.geophile.z.Pair}s,
+     * such that the left object comes from the leftSpatialIndex, and the right object comes from the rightSpatialIndex.
+     * The results are not filtered, and so may contain false positives.
+     *
+     * @param <LEFT_RECORD>     Type of {@link com.geophile.z.Record} in leftSpatialIndex.
+     * @param <RIGHT_RECORD>    Type of {@link com.geophile.z.Record} in rightSpatialIndex.
+     * @param leftSpatialIndex  One spatial join input.
+     * @param rightSpatialIndex The other spatial join input.
+     * @return An {@link java.util.Iterator} providing access to spatial join results.
+     */
+    public abstract <LEFT_RECORD extends Record, RIGHT_RECORD extends Record> IteratorAsync<Pair<LEFT_RECORD, RIGHT_RECORD>> iterator(SpatialIndexAsync<LEFT_RECORD> leftSpatialIndex,
+                                                                                                                                      SpatialIndexAsync<RIGHT_RECORD> rightSpatialIndex);
+
+    /**
+     * Returns an {@link java.util.Iterator} that will provide access to spatial join results.
+     * The objects accessed through the {@link java.util.Iterator} are {@link com.geophile.z.SpatialObject}s
+     * from the data argument that overlap the given query object.
+     * The results are filtered using the given filter, and should not contain false positives.
+     *
+     * @param <RECORD> Type of {@link com.geophile.z.Record} in data.
+     * @param query    Used to locate data elements of interest.
+     * @param data     The set of {@link com.geophile.z.SpatialObject}s to be searched.
+     * @return An {@link java.util.Iterator} providing access to spatial join results.
+     */
+    public abstract <RECORD extends Record> IteratorAsync<RECORD> iterator(SpatialObject query,
+                                                                           SpatialIndexAsync<RECORD> data);
+
+    /**
+     * Specifies duplicate-handling behavior for spatial joins.
+     */
+    public enum Duplicates
+    {
+        /**
+         * Return duplicate {@link com.geophile.z.Pair}s found by the spatial join algorithm. This option is somewhat
+         * faster and has a lower memory requirement, but may be less convenient for the application.
+         */
+        INCLUDE,
+
+        /**
+         * Suppress duplicate {@link com.geophile.z.Pair}s found by the spatial join algorithm. This option
+         * is somewhat slower, and has a higher memory requirement, proportional to the number of
+         * {@link com.geophile.z.Pair}s retrieved, but should be more convenient for the application.
+         */
+        EXCLUDE
+    }
+
+    /**
+     * Used to monitor operations on a spatial join input.
+     */
+    public static class InputObserver
+    {
+        /**
+         * Called when the input enters the given z-value.
+         * @param z Z-value being entered.
+         */
+        public void enter(long z)
+        {}
+
+        /**
+         * Called when the input exits the given z-value.
+         * @param z Z-value being exited.
+         */
+        public void exit(long z)
+        {}
+
+        /**
+         * Called when a random access to z has occurred on the given cursor. This method must not
+         * cause the cursor state to be modified in any way.
+         * @param cursor Cursor used to implement the random access.
+         * @param z The z-value located by the random access.
+         * @param <RECORD> type for spatial records
+         */
+        public <RECORD extends Record> void randomAccess(CursorAsync<RECORD> cursor, long z)
+        {}
+
+        /**
+         * Called when a sequential access has occurred on the given cursor.
+         * This method must not cause the cursor state to be modified in any way.
+         * @param cursor Cursor used to implement the sequential access.
+         * @param zRandomAccess The z-value located by the random access that preceded the current
+         *                      sequential access.
+         * @param record The record located by this sequential access.
+         * @param <RECORD> type for spatial records
+         */
+        public <RECORD extends Record> void sequentialAccess(CursorAsync<RECORD> cursor, long zRandomAccess, RECORD record)
+        {}
+
+        /**
+         * Called when an ancestor search is done (using SpatialJoinInput.findAncestorToResume).
+         * @param cursor Cursor used for the ancestor search.
+         * @param zStart The starting point of the ancestor search.
+         * @param zAncestor The ancestor found, or SpaceImpl.Z_NULL if none found.
+         * @param <RECORD> type for spatial records
+         */
+        public <RECORD extends Record> void ancestorSearch(CursorAsync<RECORD> cursor, long zStart, long zAncestor)
+        {}
+    }
+
+    /**
+     * Used to remove false positives from spatial join output.
+     *
+     * @param <LEFT>  Type of object passed to the left filter argument.
+     * @param <RIGHT> TYpe of object passed to the right filter argument.
+     */
+    public interface Filter<LEFT, RIGHT>
+    {
+        /**
+         * Indicates whether the left and right objects overlap.
+         *
+         * @param left  Object from the left side of the spatial join.
+         * @param right Object from the right side of the spatial join.
+         * @return true if the objects overlap, false otherwise.
+         */
+        boolean overlap(LEFT left, RIGHT right);
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinImplAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinImplAsync.java
@@ -1,0 +1,100 @@
+/*
+ * SpatialJoinInputAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.geophile.z.Pair;
+import com.geophile.z.Record;
+import com.geophile.z.SpatialJoinException;
+import com.geophile.z.SpatialObject;
+
+/**
+ * Asynchronous version of {@code com.geophile.z.spatialjoin.SpatialJoinImpl}.
+ * @param <LEFT> the type on the left
+ * @param <RIGHT> the type on the right
+ */
+@SuppressWarnings({"checkstyle:MethodTypeParameterName", "PMD.GenericsNaming"})
+public class SpatialJoinImplAsync<LEFT, RIGHT> extends SpatialJoinAsync<LEFT, RIGHT>
+{
+    private static final String SINGLE_CELL_OPTIMIZATION_PROPERTY = "singlecellopt";
+
+    private final Duplicates duplicates;
+    private final Filter<LEFT, RIGHT> filter;
+    private final InputObserver leftObserver;
+    private final InputObserver rightObserver;
+
+    public SpatialJoinImplAsync(Duplicates duplicates,
+                                Filter<LEFT, RIGHT> filter,
+                                InputObserver leftObserver,
+                                InputObserver rightObserver)
+    {
+        if (duplicates == null) {
+            throw new IllegalArgumentException();
+        }
+        this.duplicates = duplicates;
+        this.filter = filter == null ? (r, s) -> true : filter;
+        this.leftObserver = leftObserver;
+        this.rightObserver = rightObserver;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    @SpotBugsSuppressWarnings("BC_UNCONFIRMED_CAST")
+    public <LEFT_RECORD extends Record, RIGHT_RECORD extends Record> IteratorAsync<Pair<LEFT_RECORD, RIGHT_RECORD>> iterator(SpatialIndexAsync<LEFT_RECORD> leftSpatialIndex,
+                                                                                                                             SpatialIndexAsync<RIGHT_RECORD> rightSpatialIndex)
+    {
+        if (!leftSpatialIndex.space().equals(rightSpatialIndex.space())) {
+            throw new SpatialJoinException("Attempt to join spatial indexes with incompatible spaces");
+        }
+        IteratorAsync<Pair<LEFT_RECORD, RIGHT_RECORD>> iterator =
+                SpatialJoinIteratorAsync.pairIteratorAsync((SpatialIndexImplAsync<LEFT_RECORD>) leftSpatialIndex,
+                                                           (SpatialIndexImplAsync<RIGHT_RECORD>) rightSpatialIndex,
+                                                           (Filter<LEFT_RECORD, RIGHT_RECORD>)filter,
+                                                           leftObserver,
+                                                           rightObserver);
+        if (duplicates == SpatialJoinAsync.Duplicates.EXCLUDE) {
+            iterator = new DuplicateEliminatingIteratorAsync<Pair<LEFT_RECORD, RIGHT_RECORD>>(iterator);
+        }
+        return iterator;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    @SpotBugsSuppressWarnings("BC_UNCONFIRMED_CAST")
+    public <RECORD extends Record> IteratorAsync<RECORD> iterator(final SpatialObject query,
+                                                                  SpatialIndexAsync<RECORD> data)
+    {
+        IteratorAsync<RECORD> iterator = SpatialJoinIteratorAsync.spatialObjectIteratorAsync(query,
+                                                                                             (SpatialIndexImplAsync) data,
+                                                                                             (Filter<SpatialObject, RECORD>)filter,
+                                                                                             leftObserver,
+                                                                                             rightObserver);
+        if (duplicates == SpatialJoinAsync.Duplicates.EXCLUDE) {
+            iterator = new DuplicateEliminatingIteratorAsync<>(iterator);
+        }
+        return iterator;
+    }
+
+    public static boolean singleCellOptimization()
+    {
+        return Boolean.valueOf(System.getProperty(SINGLE_CELL_OPTIMIZATION_PROPERTY, "true"));
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinInputAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinInputAsync.java
@@ -1,0 +1,365 @@
+/*
+ * SpatialJoinInputAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Record;
+import com.geophile.z.space.SpaceImpl;
+import com.geophile.z.spatialjoin.SpatialJoinImpl;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.geophile.z.space.SpaceImpl.formatZ;
+
+/**
+ * Asynchronous version of {@code SpatialJoinInput}.
+ * @param <RECORD> type for spatial records
+ */
+@SuppressWarnings({"checkstyle:ClassTypeParameterName", "PMD.GenericsNaming", "checkstyle:MethodTypeParameterName"})
+class SpatialJoinInputAsync<RECORD extends Record, OTHER_RECORD extends Record>
+{
+    // Class state
+
+    // A 64-bit z-value is definitely less than Long.MAX_VALUE. The maxium z-value length is 57, which is recorded
+    // in a 6-bit length field. So the length field will always have some zeros in the last 6 bits,
+    // while Long.MAX_VALUE doesn't.
+    public static final long EOF = Long.MAX_VALUE;
+    private static final Logger LOG = Logger.getLogger(SpatialJoinInputAsync.class.getName());
+    private static final AtomicInteger idGenerator = new AtomicInteger(0);
+    private static final SpatialJoinAsync.InputObserver DEFAULT_OBSERVER = new SpatialJoinAsync.InputObserver();
+
+    // Object state
+
+    private final int id = idGenerator.getAndIncrement();
+    private final SpatialIndexImplAsync<RECORD> spatialIndex;
+    private final boolean stableRecords;
+    private final boolean singleCell;
+    private SpatialJoinInputAsync<OTHER_RECORD, RECORD> that;
+    private final SpatialJoinOutputAsync<RECORD, OTHER_RECORD> spatialJoinOutput;
+    // nest contains z-values that have been entered but not exited. current is the next z-value to enter,
+    // and cursor contains later z-values.
+    private final Deque<RECORD> nest = new ArrayDeque<>();
+    private final CursorAsync<RECORD> cursor;
+    private RECORD current;
+    private final RECORD randomAccessKey;
+    // For use in finding ancestors
+    @SuppressWarnings("checkstyle:MemberName")
+    private final long[] zCandidates = new long[SpaceImpl.MAX_Z_BITS];
+    private long lastZRandomAccess; // For observing access pattern
+    private boolean eof = false;
+    private final boolean singleCellOptimization;
+    private final SpatialJoinAsync.InputObserver observer;
+
+    // Object interface
+
+    @Override
+    public final String toString() {
+        return name();
+    }
+
+    // SpatialJoinInputAsync interface
+
+    public long nextEntry() {
+        return eof ? EOF : SpaceImpl.zLo(current.z());
+    }
+
+    public long nextExit() {
+        return nest.isEmpty() ? EOF : SpaceImpl.zHi(nest.peek().z());
+    }
+
+    // This happens inside the constructor of the synchronous version, but needs to be async operations here.
+    public CompletableFuture<Void> start() {
+        IndexAsync<RECORD> index = spatialIndex.index();
+        RECORD zMinKey = index.newKeyRecord();
+        zMinKey.z(SpaceImpl.Z_MIN);
+        cursorGoTo(cursor, zMinKey);
+        return cursorNext(cursor).thenAccept(record -> {
+            copyToCurrent(record);
+            log("initialize");
+        });
+    }
+        
+    public CompletableFuture<Void> enterZ() {
+        assert !eof;
+        observer.enter(current.z());
+        CompletableFuture<Void> enter;
+        if (currentOverlapsOtherNest() ||
+                !that.eof && overlap(current.z(), that.current.z())) {
+            // Enter current
+            if (!nest.isEmpty()) {
+                long topZ = nest.peek().z();
+                assert SpaceImpl.contains(topZ, current.z());
+            }
+            push(current);
+            enter = cursorNext(cursor).thenAccept(this::copyToCurrent);
+        } else {
+            enter = advanceCursor();
+        }
+        return enter.thenAccept(vignore -> log("enter"));
+    }
+
+    public void exitZ()
+    {
+        assert !nest.isEmpty();
+        RECORD top = nest.pop();
+        observer.exit(top.z());
+        that.generateSpatialJoinOutput(top);
+        log("exit");
+    }
+
+    public final void otherInput(SpatialJoinInputAsync<OTHER_RECORD, RECORD> that)
+    {
+        this.that = that;
+    }
+
+    public static <RECORD extends Record, OTHER_RECORD extends Record> SpatialJoinInputAsync<RECORD, OTHER_RECORD> newSpatialJoinInputAsync(SpatialIndexImplAsync<RECORD> spatialIndex,
+                                                                                                                                            SpatialJoinOutputAsync<RECORD, OTHER_RECORD> spatialJoinOutput,
+                                                                                                                                            SpatialJoinAsync.InputObserver observer)
+    {
+        return new SpatialJoinInputAsync<>(spatialIndex, spatialJoinOutput, observer);
+    }
+
+    // For use by this class
+
+    private CompletableFuture<Void> advanceCursor()
+    {
+        // Use that.current to skip ahead
+        if (that.eof) {
+            // If that.current is EOF, then we can skip to the end on this side too.
+            this.eof = true;
+        } else {
+            assert !eof; // Should have been checked in caller, but just to be sure.
+            long thisCurrentZ = this.current.z();
+            long thatCurrentZ = that.current.z();
+            assert thatCurrentZ >= thisCurrentZ; // otherwise, we would have entered that.current
+            if (thatCurrentZ > thisCurrentZ) {
+                if (singleCellOptimization && singleCell) {
+                    randomAccessKey.z(thatCurrentZ);
+                    cursorGoTo(cursor, randomAccessKey);
+                    return cursorNext(cursor).thenAccept(this::copyToCurrent);
+                } else {
+                    // Why this works: There are two cases to consider.
+                    // 1) thatCurrentZ contains thisCurrentZ: thisCurrentZ might be the correct place to
+                    //    resume. But it is also possible that there is a larger, containing ancestor z-value,
+                    //    a, such that a.lo() < thatCurrentZ. This call finds that ancestor.
+                    // 2) thatCurrentZ does not contain thisCurrentZ, which means that thatCurrentZ.hi() <=
+                    //    thisCurrentZ.lo(). We need to find an ancestor of thisCurrentZ, a. If a.lo() >
+                    //    thatCurrentZ.hi(), then the random access would have discovered it, so this case can't happen.
+                    //    We must therefore look for a container of thisCurrentZ that ALSO contains thatCurrentZ.
+                    //    So again, we can start the search for an ancestor at thatCurrentZ.
+                    return advanceToNextOrAncestor(thatCurrentZ, thisCurrentZ);
+                }
+            }
+        }
+        return CompletableFutures.NULL;
+    }
+
+    // Advance to an ancestor of zStart, or if there is none, to the z-value after zStart.
+    private CompletableFuture<Void> advanceToNextOrAncestor(long zStart, long zLowerBound)
+    {
+        // Generate all the ancestors that need to be considered.
+        int nCandidates = 0;
+        {
+            long zCandidate = zStart;
+            while (zCandidate > zLowerBound) {
+                zCandidates[nCandidates++] = zCandidate;
+                zCandidate = SpaceImpl.parent(zCandidate);
+            }
+        }
+        // In the caller, thatCurrentZ > thisCurrentZ, so zStart > zLowerBound, and zCandidate is initialized to
+        // zStart. So zCandidate > zLowerBound has to be true at least once, and nCandidates > 0.
+        assert nCandidates > 0;
+        // Find the largest ancestor among the candidates that exists.
+        AtomicInteger c = new AtomicInteger(nCandidates);
+        AtomicBoolean foundAncestor = new AtomicBoolean(false);
+        return CompletableFutures.whileTrue(() -> {
+            int ci = c.decrementAndGet();
+            if (ci < 0) {
+                return CompletableFutures.FALSE;
+            }
+            long zCandidate = zCandidates[ci];
+            randomAccessKey.z(zCandidate);
+            cursorGoTo(cursor, randomAccessKey);
+            return cursorNext(cursor).thenApply(record -> {
+                if (ci == 0) {
+                    // No ancestors were found. Go to the record following zStart.
+                    assert zCandidate == zStart;
+                    copyToCurrent(record);
+                    return false;
+                } else if (record != null && record.z() == zCandidate) {
+                    copyToCurrent(record);
+                    foundAncestor.set(true);
+                    return false;
+                } else {
+                    return true;
+                }
+            });
+        }).thenAccept(vignore -> {
+            if (eof) {
+                cursor.close();
+            } else {
+                assert current.z() >= zLowerBound;
+            }
+            observer.ancestorSearch(cursor,
+                    zStart,
+                    foundAncestor.get() ? current.z() : SpaceImpl.Z_NULL);
+        });
+    }
+
+    private boolean currentOverlapsOtherNest()
+    {
+        boolean overlap = false;
+        Record thatNestTop = that.nestTop();
+        if (thatNestTop != null) {
+            long thisCurrentZ = current.z();
+            overlap =
+                SpaceImpl.contains(thisCurrentZ, thatNestTop.z()) ||
+                SpaceImpl.contains(that.nestBottom().z(), thisCurrentZ);
+        }
+        return overlap;
+    }
+
+    private Record nestTop()
+    {
+        return nest.peek();
+    }
+
+    private Record nestBottom()
+    {
+        return nest.peekLast();
+    }
+
+    private void generateSpatialJoinOutput(OTHER_RECORD thatRecord)
+    {
+        for (RECORD thisRecord : nest) {
+            spatialJoinOutput.add(thisRecord, thatRecord);
+        }
+    }
+
+    private boolean overlap(long z1, long z2)
+    {
+        return SpaceImpl.contains(z1, z2) || SpaceImpl.contains(z2, z1);
+    }
+
+    private String name()
+    {
+        return String.format("sjinput(%s)", id);
+    }
+
+    private SpatialJoinInputAsync(SpatialIndexImplAsync<RECORD> spatialIndex,
+                                  SpatialJoinOutputAsync<RECORD, OTHER_RECORD> spatialJoinOutput,
+                                  SpatialJoinAsync.InputObserver observer)
+    {
+        IndexAsync<RECORD> index = spatialIndex.index();
+        this.stableRecords = index.stableRecords();
+        this.spatialIndex = spatialIndex;
+        this.observer = observer == null ? DEFAULT_OBSERVER : observer;
+        // Initialize cursor
+        this.cursor = index.cursorAsync();
+        this.current = stableRecords ? null : index.newRecord();
+        this.randomAccessKey = index.newKeyRecord();
+        this.spatialJoinOutput = spatialJoinOutput;
+        this.singleCell = spatialIndex.singleCell();
+        this.singleCellOptimization = SpatialJoinImpl.singleCellOptimization();
+    }
+
+    private void copyToCurrent(RECORD record)
+    {
+        if (record == null) {
+            eof = true;
+        } else {
+            if (stableRecords) {
+                current = record;
+            } else {
+                record.copyTo(current);
+            }
+            eof = false;
+        }
+    }
+
+    private void push(RECORD record)
+    {
+        if (stableRecords) {
+            nest.push(record);
+        } else {
+            RECORD copy = spatialIndex.index().newRecord();
+            record.copyTo(copy);
+            nest.push(copy);
+        }
+    }
+
+    private void cursorGoTo(CursorAsync<RECORD> cursor, RECORD key)
+    {
+        cursor.goTo(key);
+        lastZRandomAccess = key.z();
+        observer.randomAccess(cursor, lastZRandomAccess);
+    }
+
+    private CompletableFuture<RECORD> cursorNext(CursorAsync<RECORD> cursor)
+    {
+        return cursor.next().thenApply(record -> {
+            observer.sequentialAccess(cursor, lastZRandomAccess, record);
+            return record;
+        });
+    }
+
+    private void log(String label)
+    {
+        if (LOG.isLoggable(Level.FINE)) {
+            StringBuilder buffer = new StringBuilder();
+            Iterator<RECORD> nestScan = nest.descendingIterator();
+            long[] zs = new long[64];
+            int[] counts = new int[64];
+            int n = 0;
+            while (nestScan.hasNext()) {
+                Record record = nestScan.next();
+                long z = record.z();
+                if (n > 0 && zs[n - 1] == z) {
+                    counts[n - 1]++;
+                } else {
+                    zs[n] = z;
+                    counts[n] = 1;
+                    n++;
+                }
+            }
+            for (int i = 0; i < n; i++) {
+                long z = zs[i];
+                buffer.append(' ');
+                buffer.append(formatZ(z));
+                if (counts[i] > 1) {
+                    buffer.append('[');
+                    buffer.append(counts[i]);
+                    buffer.append(']');
+                }
+            }
+            String nextZ = eof ? "eof" : formatZ(current.z());
+            LOG.log(Level.FINE,
+                    "{0} {1}: nest:{2}, current: {3}",
+                    new Object[]{this, label, buffer.toString(), nextZ});
+        }
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinIteratorAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinIteratorAsync.java
@@ -1,0 +1,287 @@
+/*
+ * SpatialJoinIteratorAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Pair;
+import com.geophile.z.Record;
+import com.geophile.z.SpatialIndex;
+import com.geophile.z.SpatialObject;
+import com.geophile.z.index.RecordWithSpatialObject;
+import com.geophile.z.index.sortedarray.SortedArray;
+import com.geophile.z.space.SpaceImpl;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// T is either Pair or SpatialObject
+
+/**
+ * Asynchronous version of {@code com.geophile.z.spatialjoin.SpatialJoinIterator}.
+ * @param <T> element type
+ */
+@SuppressWarnings({"checkstyle:MethodTypeParameterName", "PMD.GenericsNaming", "checkstyle:ClassTypeParameterName"})
+class SpatialJoinIteratorAsync<LEFT_RECORD extends Record, RIGHT_RECORD extends Record, T> implements IteratorAsync<T>
+{
+    // Class state
+
+    private static final Logger LOG = Logger.getLogger(SpatialJoinIteratorAsync.class.getName());
+    private static final AtomicInteger idGenerator = new AtomicInteger(0);
+
+    // Object state
+
+    private final String name = String.format("sj(%s)", idGenerator.getAndIncrement());
+    private final SpatialJoinInputAsync<LEFT_RECORD, RIGHT_RECORD> left;
+    private final SpatialJoinInputAsync<RIGHT_RECORD, LEFT_RECORD> right;
+    private final Queue<T> pending = new ArrayDeque<>();
+    private boolean leftStarted;
+    private boolean rightStarted;
+
+    // Object interface
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+
+    // IteratorAsync interface
+
+    @Override
+    public CompletableFuture<T> nextAsync() {
+        return ensurePending().thenApply(vignore -> {
+            if (pending.isEmpty()) {
+                return null;
+            }
+            T next = pending.poll();
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.FINE, "{0} -> {1}", new Object[]{this, next});
+            }
+            return next;
+        });
+    }
+
+    // SpatialJoinIterator interface
+
+    public static <LEFT_RECORD extends Record, RIGHT_RECORD extends Record> SpatialJoinIteratorAsync<LEFT_RECORD, RIGHT_RECORD, Pair<LEFT_RECORD, RIGHT_RECORD>>
+            pairIteratorAsync(SpatialIndexImplAsync<LEFT_RECORD> leftSpatialIndex,
+                              SpatialIndexImplAsync<RIGHT_RECORD> rightSpatialIndex,
+                              SpatialJoinAsync.Filter<LEFT_RECORD, RIGHT_RECORD> filter,
+                              SpatialJoinAsync.InputObserver leftInputObserver,
+                              SpatialJoinAsync.InputObserver rightInputObserver)
+    {
+        return new SpatialJoinIteratorAsync<>(leftSpatialIndex,
+                                         rightSpatialIndex,
+                                         new PairOutputGenerator<>(),
+                                         filter,
+                                         leftInputObserver,
+                                         rightInputObserver);
+    }
+
+    public static <RECORD extends Record> SpatialJoinIteratorAsync<RecordWithSpatialObject, RECORD, RECORD>
+            spatialObjectIteratorAsync(SpatialObject leftSpatialObject,
+                                       SpatialIndexImplAsync<RECORD> rightSpatialIndex,
+                                       SpatialJoinAsync.Filter<SpatialObject, RECORD> filter,
+                                       SpatialJoinAsync.InputObserver leftInputObserver,
+                                       SpatialJoinAsync.InputObserver rightInputObserver)
+    {
+
+        return new SpatialJoinIteratorAsync<>(leftSpatialObject,
+                                              rightSpatialIndex,
+                                              new RecordOutputGenerator<>(),
+                                              filter,
+                                              leftInputObserver,
+                                              rightInputObserver);
+    }
+
+    // For use by this class
+
+    private SpatialJoinIteratorAsync(SpatialIndexImplAsync<LEFT_RECORD> leftSpatialIndex,
+                                     SpatialIndexImplAsync<RIGHT_RECORD> rightSpatialIndex,
+                                     final OutputGenerator<LEFT_RECORD, RIGHT_RECORD, T> outputGenerator,
+                                     final SpatialJoinAsync.Filter<LEFT_RECORD, RIGHT_RECORD> filter,
+                                     SpatialJoinAsync.InputObserver leftInputObserver,
+                                     SpatialJoinAsync.InputObserver rightInputObserver)
+    {
+        SpatialJoinOutputAsync<LEFT_RECORD, RIGHT_RECORD> pendingLeftRight =
+                (left, right) -> {
+                    if (filter.overlap(left, right)) {
+                        pending.add(outputGenerator.generateOutput(left, right));
+                    }
+                };
+        left = SpatialJoinInputAsync.newSpatialJoinInputAsync(leftSpatialIndex, pendingLeftRight, leftInputObserver);
+        SpatialJoinOutputAsync<RIGHT_RECORD, LEFT_RECORD> pendingRightLeft =
+                (right, left) -> {
+                    if (filter.overlap(left, right)) {
+                        pending.add(outputGenerator.generateOutput(left, right));
+                    }
+                };
+        right = SpatialJoinInputAsync.newSpatialJoinInputAsync(rightSpatialIndex, pendingRightLeft, rightInputObserver);
+        left.otherInput(right);
+        right.otherInput(left);
+        if (LOG.isLoggable(Level.INFO)) {
+            LOG.log(Level.INFO,
+                    "SpatialJoinIterator {0}: {1} x {2}",
+                    new Object[]{this, left, right});
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private SpatialJoinIteratorAsync(final SpatialObject querySpatialObject,
+                                     SpatialIndexImplAsync<RIGHT_RECORD> dataSpatialIndex,
+                                     final OutputGenerator<LEFT_RECORD, RIGHT_RECORD, RIGHT_RECORD> outputGenerator,
+                                     final SpatialJoinAsync.Filter<SpatialObject, RIGHT_RECORD> filter,
+                                     SpatialJoinAsync.InputObserver leftInputObserver,
+                                     SpatialJoinAsync.InputObserver rightInputObserver)
+    {
+        final SortedArray<RecordWithSpatialObject> queryIndex = new SortedArray.OfBaseRecord();
+        try {
+            final SpatialIndex<RecordWithSpatialObject> querySpatialIndex = SpatialIndex.newSpatialIndex(dataSpatialIndex.space(),
+                    queryIndex,
+                    querySpatialObject.maxZ() == 1
+                    ? SpatialIndex.Options.SINGLE_CELL
+                    : SpatialIndex.Options.DEFAULT);
+            querySpatialIndex.add(querySpatialObject,
+                    () -> {
+                        RecordWithSpatialObject queryRecord = queryIndex.newRecord();
+                        queryRecord.spatialObject(querySpatialObject);
+                        return queryRecord;
+                    });
+        } catch (IOException | InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+        final IndexAsync<LEFT_RECORD> queryIndexAsync = (IndexAsync<LEFT_RECORD>)IndexAsync.fromSync(queryIndex);
+        final SpatialIndexImplAsync<LEFT_RECORD> querySpatialIndexAsync = new SpatialIndexImplAsync<>((SpaceImpl) dataSpatialIndex.space(),
+                queryIndexAsync,
+                querySpatialObject.maxZ() == 1 ? SpatialIndexAsync.Options.SINGLE_CELL : SpatialIndexAsync.Options.DEFAULT);
+        SpatialJoinOutputAsync<LEFT_RECORD, RIGHT_RECORD> pendingLeftRight =
+                (left, right) -> {
+                    if (filter.overlap(querySpatialObject, right)) {
+                        pending.add((T)outputGenerator.generateOutput(left, right));
+                    }
+                };
+        left = SpatialJoinInputAsync.newSpatialJoinInputAsync(querySpatialIndexAsync,
+                                                    pendingLeftRight,
+                                                    leftInputObserver);
+        SpatialJoinOutputAsync<RIGHT_RECORD, LEFT_RECORD> pendingRightLeft =
+                (right, left) -> {
+                    if (filter.overlap(querySpatialObject, right)) {
+                        pending.add((T)outputGenerator.generateOutput(left, right));
+                    }
+                };
+        right = SpatialJoinInputAsync.newSpatialJoinInputAsync(dataSpatialIndex,
+                                                     pendingRightLeft,
+                                                     rightInputObserver);
+        left.otherInput(right);
+        right.otherInput(left);
+        if (LOG.isLoggable(Level.INFO)) {
+            LOG.log(Level.INFO,
+                    "SpatialJoinIterator {0}: {1} x {2}",
+                    new Object[]{this, left, right});
+        }
+    }
+
+    private CompletableFuture<Void> ensurePending()
+    {
+        if (pending.isEmpty()) {
+            return findPairs();
+        } else {
+            return CompletableFutures.NULL;
+        }
+    }
+
+    // The synchronous version also calls this from the constructors. That's hard when it's async, so just don't bother.
+    private CompletableFuture<Void> findPairs()
+    {
+        assert pending.isEmpty();
+        return CompletableFutures.whileTrue(() -> {
+            if (!leftStarted) {
+                return left.start().thenApply(vignore -> {
+                    leftStarted = true;
+                    return true;
+                });
+            }
+            if (!rightStarted) {
+                return right.start().thenApply(vignore -> {
+                    rightStarted = true;
+                    return true;
+                });
+            }
+            long zLeftEnter = left.nextEntry();
+            long zLeftExit = left.nextExit();
+            long zRightEnter = right.nextEntry();
+            long zRightExit = right.nextExit();
+            long zMin = min(zLeftEnter, zLeftExit, zRightEnter, zRightExit);
+            if (zMin < SpatialJoinInputAsync.EOF) {
+                // Prefer entry to exit to avoid missing join output
+                if (zMin == zLeftEnter) {
+                    return left.enterZ().thenApply(vigore -> pending.isEmpty());
+                } else if (zMin == zRightEnter) {
+                    return right.enterZ().thenApply(vigore -> pending.isEmpty());
+                } else if (zMin == zLeftExit) {
+                    left.exitZ();
+                } else {
+                    right.exitZ();
+                }
+                return CompletableFuture.completedFuture(pending.isEmpty());
+            } else {
+                return CompletableFutures.FALSE;
+            }
+        });
+    }
+
+    private long min(long a, long b, long c, long d)
+    {
+        return Math.min(Math.min(a, b), Math.min(c, d));
+    }
+
+    // Inner classes
+
+    private interface OutputGenerator<LEFT_RECORD extends Record, RIGHT_RECORD extends Record, T>
+    {
+        T generateOutput(LEFT_RECORD left, RIGHT_RECORD right);
+    }
+
+    private static class PairOutputGenerator<LEFT_RECORD extends Record, RIGHT_RECORD extends Record> implements OutputGenerator<LEFT_RECORD, RIGHT_RECORD, Pair<LEFT_RECORD, RIGHT_RECORD>>
+    {
+        @Override
+        public Pair<LEFT_RECORD, RIGHT_RECORD> generateOutput(LEFT_RECORD left, RIGHT_RECORD right)
+        {
+            assert left != null;
+            assert right != null;
+            return new Pair<>(left, right);
+        }
+    }
+
+    private static class RecordOutputGenerator<RECORD extends Record> implements OutputGenerator<RecordWithSpatialObject, RECORD, RECORD>
+    {
+        @Override
+        public RECORD generateOutput(RecordWithSpatialObject left, RECORD right)
+        {
+            assert right != null;
+            return right;
+        }
+    }
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinOutputAsync.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/SpatialJoinOutputAsync.java
@@ -1,0 +1,29 @@
+/*
+ * SpatialJoinInputAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.geophile.z.async;
+
+import com.geophile.z.Record;
+
+@SuppressWarnings({"PMD.GenericsNaming"})
+interface SpatialJoinOutputAsync<LEFT_RECORD extends Record, RIGHT_RECORD extends Record>
+{
+    void add(LEFT_RECORD r, RIGHT_RECORD s);
+}

--- a/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/package-info.java
+++ b/fdb-record-layer-spatial/src/main/java/com/geophile/z/async/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Asynchronous versions of standard Geophile classes.
+ * There should not be any dependencies on record layer / FDB stuff in here, so that they can one day be merged upstream.
+ */
+package com.geophile.z.async;


### PR DESCRIPTION
Introduces copies of the spatial join implementation classes that use `CompletableFuture`s for advancing a cursor. These are in a separate `com.geophile.z.async` package that could conceivably be merged upstream someday. That package includes its own async analogue of `Iterator`, rather than introducing a dependency on FDB.

This does not yet address the need for continuation support. To do this, it will be necessary to serialize the state of nesting. As a result, it would benefit from a resolution to #769.