### PR TITLE
Fixes #782: Lookups by primary key can leak into other records in certain circumstances

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -43,7 +43,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Two inequality predicates on a single field index will now be planned as a single range scan on the index [(Issue #765)](https://github.com/FoundationDB/fdb-record-layer/issues/765)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Primary keys where one key contained a string or byte array that was a prefix of another could lead to deserialization errors when loading [(Issue #782)](https://github.com/FoundationDB/fdb-record-layer/issues/782)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
This fixes a bug that was an interaction between how we store data and how we scan data. In particular, if there were two records with string or byte array fields as part of their primary key, then if the value of one record's primary key was a prefix of another's, and the first character (or byte) of the other record after the common prefix was a zero, then we would read data from the second record if we were asked to read just the first.

Some background: the tuple layer encodes strings (and byte arrays) by (1) appending a type code byte to the beginning (`\x01` for byte arrays and `\x02` for strings), (2) then writing out the contents of byte array or string (UTF-8 encoded) with any zero bytes (or null characters) replaced with the byte sequence `\x00\xff`, and then (3) the zero byte as a terminating character. (No tuple type codes begin with `\xff`, so a terminating null and an escaped zero byte can always be distinguished.) So, for example, the string "foo" would be encoded as `\x02foo\x00`, and the string "foo\0bar" would be encoded as `\x02foo\x00\xffbar\x00`.

Before this patch, when we were asked for a record with primary key "foo", we would scan over all keys in the primary index that began with `\x02foo\x00`, i.e., from `\x02foo\x00` to `\x02foo\x01`. However, note that `\x02foo\x00\xffbar\x00` is in this range, so the key (for a different record with primary key "foo\0bar") is also included in the scan. With this patch, we now scan only for records that are "strictly" prefixed by the key,so for "foo", that is `\x02foo\x00\x00` to `\x02foo\x00\xff`. Now, `\x02foo\x00\xffbar\x00` is *outside* the range. This is safe as all data are written by taking the record's primary key and then adding a tuple-encoded integer after it with one exception: in older format versions, if records are required to all fit in one FDB key, then they did not get the integer suffix. However, that goes through a different read path (that just does a single-key get on the desired key), so it is not touched by this change.

Note that this is against master. In theory, if this bug is considered serious enough, we could rebase this onto a patch branch.

This fixes #782.