### PR TITLE
Resolves #789: Remove descriptor from debug logs on failed deserialization

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -53,7 +53,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Upon a failed record deserialization, the file descriptor is only logged if the logger is at `TRACE` instead of `DEBUG` [(Issue #789)](https://github.com/FoundationDB/fdb-record-layer/issues/789)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -994,10 +994,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             final LoggableException ex2 = new RecordCoreException("Failed to deserialize record", ex);
             ex2.addLogInfo(
                     subspaceProvider.logKey(), subspaceProvider.toString(context),
-                    LogMessageKeys.PRIMARY_KEY, primaryKey);
+                    LogMessageKeys.PRIMARY_KEY, primaryKey,
+                    LogMessageKeys.META_DATA_VERSION, metaData.getVersion());
             if (LOGGER.isDebugEnabled()) {
-                ex2.addLogInfo("serialized", ByteArrayUtil2.loggable(serialized),
-                        "descriptor", metaData.getUnionDescriptor().getFile().toProto());
+                ex2.addLogInfo("serialized", ByteArrayUtil2.loggable(serialized));
+            }
+            if (LOGGER.isTraceEnabled()) {
+                ex2.addLogInfo("descriptor", metaData.getUnionDescriptor().getFile().toProto());
             }
             throw ex2;
         }


### PR DESCRIPTION
This moves logging the descriptor upon failed record deserialization from `DEBUG` to `TRACE`. This is to help clean up our `DEBUG` level logs.

This resolves #789.