### PR TITLE
Resolves #792: Could use better detailed metrics in RankedSet.add.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -242,6 +242,12 @@ public class FDBStoreTimer extends StoreTimer {
         RANKED_SET_NEXT_LOOKUP_KEY("ranked set next lookup key"),
         /** The amount of time spent checking for a key in a {@link com.apple.foundationdb.async.RankedSet} skip list. */
         RANKED_SET_CONTAINS("ranked set contains"),
+        /** The amount of time spent adding to the finest level of a {@link com.apple.foundationdb.async.RankedSet} skip list. */
+        RANKED_SET_ADD_LEVEL_ZERO_KEY("ranked set add level 0 key"),
+        /** The amount of time spent incrementing an existing level key of a {@link com.apple.foundationdb.async.RankedSet} skip list. */
+        RANKED_SET_ADD_INCREMENT_LEVEL_KEY("ranked set add increment level key"),
+        /** The amount of time spent incrementing an splitting a level of a {@link com.apple.foundationdb.async.RankedSet} skip list by inserting another key. */
+        RANKED_SET_ADD_INSERT_LEVEL_KEY("ranked set add insert level key"),
         /** The amount of time spent reading the lock state of a {@link com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver}. */
         RESOLVER_STATE_READ("read resolver state"),
         /** The amount of time spent scanning the directory subspace after a hard miss in {@link FDBReverseDirectoryCache}. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
+import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.ReadTransactionContext;
@@ -289,6 +290,23 @@ public class RankedSetIndexHelper {
             }
         }
 
+        @Override
+        protected CompletableFuture<Void> addLevelZeroKey(Transaction tr, byte[] key, int level) {
+            CompletableFuture<Void> result = super.addLevelZeroKey(tr, key, level);
+            return context.instrument(FDBStoreTimer.DetailEvents.RANKED_SET_ADD_LEVEL_ZERO_KEY, result);
+        }
+
+        @Override
+        protected CompletableFuture<Void> addIncrementLevelKey(Transaction tr, byte[] key, int level) {
+            CompletableFuture<Void> result = super.addIncrementLevelKey(tr, key, level);
+            return context.instrument(FDBStoreTimer.DetailEvents.RANKED_SET_ADD_INCREMENT_LEVEL_KEY, result);
+        }
+
+        @Override
+        protected CompletableFuture<Void> addInsertLevelKey(Transaction tr, byte[] key, int level) {
+            CompletableFuture<Void> result = super.addInsertLevelKey(tr, key, level);
+            return context.instrument(FDBStoreTimer.DetailEvents.RANKED_SET_ADD_INSERT_LEVEL_KEY, result);
+        }
     }
 
 }


### PR DESCRIPTION
Break out the various cases of per-level mutations in `add`, so that they can be individually instrumented.