### PR TITLE
Don't try to resolve a node without an object

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
@@ -85,7 +85,7 @@ public class KeySpaceCountTree extends TupleKeyCountTree {
 
     protected CompletableFuture<Void> resolvePathValue(@Nonnull FDBRecordContext context,
                                                        @Nonnull KeySpaceDirectory parentDirectory, @Nullable ResolvedKeySpacePath parentPath) {
-        if (resolvedPath != null) {
+        if (resolvedPath != null || !hasObject()) {
             return AsyncUtil.DONE;
         }
         try {


### PR DESCRIPTION
A regression introduced when `getObject` was made to throw instead of returning `null`.