### PR TITLE
Resolves #823: Need a way to tell whether a QueryPlan has a RecordQueryLoadByKeysPlan

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
@@ -123,6 +123,12 @@ public interface QueryPlan<T> extends PlanHashable, RelationalPlannerExpression 
     Set<String> getUsedIndexes();
 
     /**
+     * Indicates whether this plan (or one of its components) loads records by their primary key.
+     * @return <code>true</code> if this plan (or one of its components) loads records by their primary key
+     */
+    boolean hasLoadBykeys();
+
+    /**
      * Adds one to an appropriate {@link StoreTimer} counter for each plan and subplan of this plan, allowing tracking
      * of which plans are being chosen (e.g. index scan vs. full scan).
      * @param timer the counters to increment

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -124,6 +124,11 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
         return getChild().getUsedIndexes();
     }
 
+    @Override
+    public boolean hasLoadBykeys() {
+        return false;
+    }
+
     @Nonnull
     @Override
     public String toString() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
@@ -111,27 +111,6 @@ public class RecordQueryFilterPlan implements RecordQueryPlanWithChild {
         return getInner().isReverse();
     }
 
-    @Override
-    public boolean hasRecordScan() {
-        return getInner().hasRecordScan();
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getInner().hasFullRecordScan();
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getInner().hasIndexScan(indexName);
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        return getInner().getUsedIndexes();
-    }
-
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
@@ -43,7 +43,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * A query plan that executes a child plan once for each of the elements of some {@code IN} list.
@@ -103,27 +102,6 @@ public abstract class RecordQueryInJoinPlan implements RecordQueryPlanWithChild 
 
     public boolean isSorted() {
         return sortValuesNeeded;
-    }
-
-    @Override
-    public boolean hasRecordScan() {
-        return getInner().hasRecordScan();
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getInner().hasFullRecordScan();
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getInner().hasIndexScan(indexName);
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        return getInner().getUsedIndexes();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -117,6 +117,11 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
         return Collections.singleton(indexName);
     }
 
+    @Override
+    public boolean hasLoadBykeys() {
+        return false;
+    }
+
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -43,11 +43,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -141,21 +139,6 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
         return reverse;
     }
 
-    @Override
-    public boolean hasRecordScan() {
-        return getChildStream().anyMatch(RecordQueryPlan::hasRecordScan);
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getChildStream().anyMatch(RecordQueryPlan::hasFullRecordScan);
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getChildStream().anyMatch(childPlan -> childPlan.hasIndexScan(indexName));
-    }
-
     @Nonnull
     private Stream<RecordQueryPlan> getChildStream() {
         return children.stream().map(ExpressionRef::get);
@@ -170,16 +153,6 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
     @Nonnull
     public KeyExpression getComparisonKey() {
         return comparisonKey;
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        HashSet<String> usedIndexes = new HashSet<>();
-        for (ExpressionRef<RecordQueryPlan> childRef : children) {
-            usedIndexes.addAll(childRef.get().getUsedIndexes());
-        }
-        return usedIndexes;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -117,6 +117,11 @@ public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren 
         return new HashSet<>();
     }
 
+    @Override
+    public boolean hasLoadBykeys() {
+        return false;
+    }
+
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -119,7 +119,7 @@ public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren 
 
     @Override
     public boolean hasLoadBykeys() {
-        return false;
+        return true;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.annotation.API;
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A query plan with a single child plan.
@@ -42,5 +43,31 @@ public interface RecordQueryPlanWithChild extends RecordQueryPlanWithChildren {
     @Override
     default int getRelationalChildCount() {
         return 1;
+    }
+
+    @Override
+    default boolean hasRecordScan() {
+        return getChild().hasRecordScan();
+    }
+
+    @Override
+    default boolean hasFullRecordScan() {
+        return getChild().hasFullRecordScan();
+    }
+
+    @Override
+    default boolean hasIndexScan(@Nonnull String indexName) {
+        return getChild().hasIndexScan(indexName);
+    }
+
+    @Nonnull
+    @Override
+    default Set<String> getUsedIndexes() {
+        return getChild().getUsedIndexes();
+    }
+
+    @Override
+    default boolean hasLoadBykeys() {
+        return getChild().hasLoadBykeys();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChildren.java
@@ -23,9 +23,42 @@ package com.apple.foundationdb.record.query.plan.plans;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.expressions.RelationalExpressionWithChildren;
 
+import javax.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * A query plan with child plans.
  */
 @API(API.Status.EXPERIMENTAL)
 public interface RecordQueryPlanWithChildren extends RecordQueryPlan, RelationalExpressionWithChildren {
+    @Override
+    default boolean hasRecordScan() {
+        return getChildren().stream().anyMatch(RecordQueryPlan::hasRecordScan);
+    }
+
+    @Override
+    default boolean hasFullRecordScan() {
+        return getChildren().stream().anyMatch(RecordQueryPlan::hasFullRecordScan);
+    }
+
+    @Override
+    default boolean hasIndexScan(@Nonnull String indexName) {
+        return getChildren().stream().anyMatch(p -> p.hasIndexScan(indexName));
+    }
+
+    @Nonnull
+    @Override
+    default Set<String> getUsedIndexes() {
+        final Set<String> result = new HashSet<>();
+        for (RecordQueryPlan child : getChildren()) {
+            result.addAll(child.getUsedIndexes());
+        }
+        return result;
+    }
+
+    @Override
+    default boolean hasLoadBykeys() {
+        return getChildren().stream().anyMatch(RecordQueryPlan::hasLoadBykeys);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -103,6 +103,11 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
         return new HashSet<>();
     }
 
+    @Override
+    public boolean hasLoadBykeys() {
+        return false;
+    }
+
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -49,7 +49,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -116,30 +115,9 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
     }
 
     @Override
-    public boolean hasRecordScan() {
-        return getChild().hasRecordScan();
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getChild().hasFullRecordScan();
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getChild().hasIndexScan(indexName);
-    }
-
-    @Override
     @Nonnull
     public RecordQueryPlan getChild() {
         return plan.get();
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        return getChild().getUsedIndexes();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
@@ -113,6 +113,11 @@ public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex {
     }
 
     @Override
+    public boolean hasLoadBykeys() {
+        return false;
+    }
+
+    @Override
     public void logPlanStructure(StoreTimer timer) {
         timer.increment(FDBStoreTimer.Counts.PLAN_INDEX);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
@@ -95,27 +95,6 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
         return getInner().isReverse();
     }
 
-    @Override
-    public boolean hasRecordScan() {
-        return getInner().hasRecordScan();
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getInner().hasFullRecordScan();
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getInner().hasIndexScan(indexName);
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        return getInner().getUsedIndexes();
-    }
-
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -39,11 +39,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -102,21 +100,6 @@ abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChildren {
         return reverse;
     }
 
-    @Override
-    public boolean hasRecordScan() {
-        return getChildStream().anyMatch(RecordQueryPlan::hasRecordScan);
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getChildStream().anyMatch(RecordQueryPlan::hasFullRecordScan);
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getChildStream().anyMatch(child -> child.hasIndexScan(indexName));
-    }
-
     @Nonnull
     private Stream<RecordQueryPlan> getChildStream() {
         return children.stream().map(ExpressionRef::get);
@@ -126,16 +109,6 @@ abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChildren {
     @Nonnull
     public List<RecordQueryPlan> getChildren() {
         return getChildStream().collect(Collectors.toList());
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        HashSet<String> usedIndexes = new HashSet<>();
-        for (ExpressionRef<RecordQueryPlan> child : children) {
-            usedIndexes.addAll(child.get().getUsedIndexes());
-        }
-        return usedIndexes;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
@@ -106,27 +106,6 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
         return comparisonKey;
     }
 
-    @Override
-    public boolean hasRecordScan() {
-        return getInner().hasRecordScan();
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getInner().hasFullRecordScan();
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getInner().hasIndexScan(indexName);
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        return getInner().getUsedIndexes();
-    }
-
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -100,27 +100,6 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
         return getInner();
     }
 
-    @Override
-    public boolean hasRecordScan() {
-        return getInner().hasRecordScan();
-    }
-
-    @Override
-    public boolean hasFullRecordScan() {
-        return getInner().hasFullRecordScan();
-    }
-
-    @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
-        return getInner().hasIndexScan(indexName);
-    }
-
-    @Nonnull
-    @Override
-    public Set<String> getUsedIndexes() {
-        return getInner().getUsedIndexes();
-    }
-
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
@@ -163,6 +163,11 @@ public abstract class GeophileSpatialObjectQueryPlan implements RecordQueryPlanW
     }
 
     @Override
+    public boolean hasLoadBykeys() {
+        return false;
+    }
+
+    @Override
     public void logPlanStructure(StoreTimer timer) {
         timer.increment(FDBStoreTimer.Counts.PLAN_INDEX);
     }


### PR DESCRIPTION
I considered making this have a default of `false` for everyone. But that seemed like it might be dangerous in general. So, as a compromise, I made plans _with children_ default this and other similar methods by passing on the each child. I could be convinced not to even do that, or of some more ambitious scheme for general predicate checking over children.