### PR TITLE
Resolves #828: RankedSet poorly split for non-random keys 

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -45,7 +45,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** StoreTimer.getDifference() should not return unchanged metrics [(Issue #832)](https://github.com/FoundationDB/fdb-record-layer/issues/832)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Allow setting hash function used by `RankedSet` [(Issue #828)](https://github.com/FoundationDB/fdb-record-layer/issues/828)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -89,6 +89,13 @@ public class IndexOptions {
      */
     public static final String RANK_NLEVELS = "rankNLevels";
 
+    /**
+     * The hash function to use in the {@link IndexTypes#RANK} skip list {@link com.apple.foundationdb.async.RankedSet}.
+     *
+     * The default is {@link com.apple.foundationdb.async.RankedSet#DEFAULT_HASH_FUNCTION}.
+     */
+    public static final String RANK_HASH_FUNCTION = "rankHashFunction";
+
     private IndexOptions() {
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetHashFunctions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetHashFunctions.java
@@ -1,0 +1,81 @@
+/*
+ * RankedSetHashFunctions.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.indexes;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.RankedSet;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Known hash functions available as index options.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class RankedSetHashFunctions {
+    public static final String JDK = "JDK";
+    public static final String CRC = "CRC";
+    public static final String MURMUR3 = "MURMUR3";
+
+    private static final RankedSet.HashFunction MURMUR3_HASH_FUNCTION = new GuavaHashFunction(Hashing.murmur3_32());
+
+    private static final Map<String, RankedSet.HashFunction> extent = buildExtent();
+
+    private static Map<String, RankedSet.HashFunction> buildExtent() {
+        Map<String, RankedSet.HashFunction> result = new HashMap<>();
+        result.put(JDK, RankedSet.JDK_ARRAY_HASH);
+        result.put(CRC, RankedSet.CRC_HASH);
+        result.put(MURMUR3, MURMUR3_HASH_FUNCTION);
+        return result;
+    }
+
+    public static RankedSet.HashFunction getHashFunction(@Nonnull String name) {
+        RankedSet.HashFunction result = extent.get(name);
+        if (result != null) {
+            return result;
+        }
+        throw new RecordCoreArgumentException("hash function not found: " + name);
+    }
+
+    private RankedSetHashFunctions() {
+    }
+
+    /**
+     * Use {@code com.google.common.hash.HashFunction}s as {@code RankedSet.HashFunction}s.
+     */
+    private static class GuavaHashFunction implements RankedSet.HashFunction {
+        @Nonnull
+        private final HashFunction guava;
+
+        public GuavaHashFunction(HashFunction guava) {
+            this.guava = guava;
+        }
+
+        @Override
+        public int hash(byte[] key) {
+            return guava.hashBytes(key).asInt();
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -40,8 +40,6 @@ import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,44 +52,6 @@ import java.util.concurrent.CompletableFuture;
 public class RankedSetIndexHelper {
     public static final Tuple COMPARISON_SKIPPED_SCORE = Tuple.from(Comparisons.COMPARISON_SKIPPED_BINDING);
 
-    public static final RankedSet.HashFunction MURMUR3_HASH_FUNCTION = new GuavaHashFunction(Hashing.murmur3_32());
-
-    /**
-     * Use {@code com.google.common.hash.HashFunction}s as {@code RankedSet.HashFunction}s.
-     */
-    public static class GuavaHashFunction implements RankedSet.HashFunction {
-        @Nonnull
-        private final HashFunction guava;
-
-        public GuavaHashFunction(HashFunction guava) {
-            this.guava = guava;
-        }
-
-        @Override
-        public int hash(byte[] key) {
-            return guava.hashBytes(key).asInt();
-        }
-    }
-
-    /**
-     * Known hash functions available as index options.
-     */
-    public enum HashFunctionNames {
-        JDK(RankedSet.JDK_ARRAY_HASH),
-        CRC(RankedSet.CRC_HASH),
-        MURMUR3(MURMUR3_HASH_FUNCTION);
-
-        private final RankedSet.HashFunction hashFunction;
-
-        HashFunctionNames(RankedSet.HashFunction hashFunction) {
-            this.hashFunction = hashFunction;
-        }
-
-        public RankedSet.HashFunction getHashFunction() {
-            return hashFunction;
-        }
-    }
-
     public static int getNLevels(@Nonnull Index index) {
         String nlevelsOption = index.getOption(IndexOptions.RANK_NLEVELS);
         return nlevelsOption == null ? RankedSet.DEFAULT_LEVELS : Integer.parseInt(nlevelsOption);
@@ -99,7 +59,7 @@ public class RankedSetIndexHelper {
 
     public static RankedSet.HashFunction getHashFunction(@Nonnull Index index) {
         String hashFunctionOption = index.getOption(IndexOptions.RANK_HASH_FUNCTION);
-        return hashFunctionOption == null ? RankedSet.DEFAULT_HASH_FUNCTION : HashFunctionNames.valueOf(hashFunctionOption).getHashFunction();
+        return hashFunctionOption == null ? RankedSet.DEFAULT_HASH_FUNCTION : RankedSetHashFunctions.getHashFunction(hashFunctionOption);
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
+import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
@@ -50,6 +51,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.RankedSetIndexHelper;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
@@ -362,7 +364,8 @@ public class LeaderboardIndexTest extends FDBTestBase {
 
         @Override
         public void addIndex(RecordMetaDataBuilder metaDataBuilder) {
-            metaDataBuilder.addIndex("NestedLeaderboardRecord", new Index("LeaderboardIndex", keyExpression, IndexTypes.TIME_WINDOW_LEADERBOARD));
+            metaDataBuilder.addIndex("NestedLeaderboardRecord", new Index("LeaderboardIndex", keyExpression, IndexTypes.TIME_WINDOW_LEADERBOARD,
+                    Collections.singletonMap(IndexOptions.RANK_HASH_FUNCTION, RankedSetIndexHelper.HashFunctionNames.MURMUR3.name())));
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -51,7 +51,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
-import com.apple.foundationdb.record.provider.foundationdb.indexes.RankedSetIndexHelper;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.RankedSetHashFunctions;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
@@ -365,7 +365,7 @@ public class LeaderboardIndexTest extends FDBTestBase {
         @Override
         public void addIndex(RecordMetaDataBuilder metaDataBuilder) {
             metaDataBuilder.addIndex("NestedLeaderboardRecord", new Index("LeaderboardIndex", keyExpression, IndexTypes.TIME_WINDOW_LEADERBOARD,
-                    Collections.singletonMap(IndexOptions.RANK_HASH_FUNCTION, RankedSetIndexHelper.HashFunctionNames.MURMUR3.name())));
+                    Collections.singletonMap(IndexOptions.RANK_HASH_FUNCTION, RankedSetHashFunctions.MURMUR3)));
         }
     }
 


### PR DESCRIPTION
Introduces an index option for `RANK` and `TIME_WINDOW_LEADERBOARD` indexes that controls what hash function is used.
Note that while it is technically safe to change the hash function for existing data, this is not recommended, as it changes the distribution.