### PR TITLE
Resolve #835: Expose bytes/records scanned through ExecuteState

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -52,7 +52,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Expose bytes/records scanned through `ExecuteState` [(Issue #835)](https://github.com/FoundationDB/fdb-record-layer/issues/835)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -55,7 +55,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Feature** Expose bytes/records scanned through `ExecuteState` [(Issue #835)](https://github.com/FoundationDB/fdb-record-layer/issues/835)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** `ByteScanLimiter` and `RecordScanLimiter` are now interfaces. Instances with various concrete behavior are constructed through factory classes. [(PR #836)](https://github.com/FoundationDB/fdb-record-layer/pull/836)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
@@ -708,4 +708,3 @@ The capability and reliability of text queries on more sophisticated indexes has
 ### 2.1.10.0
 
 * **Feature** A new record type key expression allows for structuring data in a record store more akin to how tables are stored in a traditional relational database [(Issue #27)](https://github.com/FoundationDB/fdb-record-layer/issues/27)
-

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteScanLimiterFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteScanLimiterFactory.java
@@ -1,0 +1,201 @@
+/*
+ * ByteScanLimiterFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A factory that produces implementations of {@link ByteScanLimiter}s.
+ */
+@API(API.Status.INTERNAL)
+public class ByteScanLimiterFactory
+{
+    private static final Untracked UNTRACKED = new Untracked();
+
+    private ByteScanLimiterFactory() {
+        // Cannot instantiate the factory
+    }
+
+    /**
+     * Creates a limiter that enforces a maximum number of bytes that can be processed in a single scan.
+     *
+     * @param limit the maximum number of bytes that can be processed in a single scan
+     * @return an enforcing limiter
+     */
+    public static ByteScanLimiter enforce(long limit) {
+        return new Enforcing(limit);
+    }
+
+    /**
+     * Creates a limiter that tracks the number of bytes that has been scanned, but does not impose a limit.
+     * @return a tracking limiter
+     */
+    public static ByteScanLimiter tracking() {
+        return new Tracking();
+    }
+
+    /**
+     * Creates a limiter that neither enforces nor tracks the number of bytes scanned.
+     *
+     * @return an untracked limiter
+     */
+    public static ByteScanLimiter untracked() {
+        return UNTRACKED;
+    }
+
+    /**
+     * An implementation of {@link ByteScanLimiter} that tracks and enforces byte scan resource consumption.
+     */
+    private static class Enforcing implements ByteScanLimiter {
+
+        private final long originalLimit;
+        private final AtomicLong bytesRemaining;
+
+        private Enforcing(long limit) {
+            originalLimit = limit;
+            bytesRemaining = new AtomicLong(limit);
+        }
+
+        @Override
+        @Nonnull
+        public ByteScanLimiter reset() {
+            return new Enforcing(originalLimit);
+        }
+
+        @Override
+        public boolean isEnforcing() {
+            return true;
+        }
+
+        @Override
+        public boolean hasBytesRemaining() {
+            return bytesRemaining.get() > 0;
+        }
+
+        @Override
+        public void registerScannedBytes(long bytes) {
+            bytesRemaining.addAndGet(-bytes);
+        }
+
+        @Override
+        public long getLimit() {
+            return originalLimit;
+        }
+
+        @Override
+        public long getBytesScanned() {
+            return originalLimit - bytesRemaining.get();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("ByteScanLimiter(%d limit, %d left)", originalLimit, bytesRemaining.get());
+        }
+    }
+
+    /**
+     * An implementation of {@link ByteScanLimiter} that tracks but does not enforce any limit.
+     */
+    private static class Tracking implements ByteScanLimiter {
+
+        private final AtomicLong bytesScanned = new AtomicLong();
+
+        @Override
+        @Nonnull
+        public ByteScanLimiter reset() {
+            return new Tracking();
+        }
+
+        @Override
+        public boolean isEnforcing() {
+            return false;
+        }
+
+        @Override
+        public boolean hasBytesRemaining() {
+            return true;
+        }
+
+        @Override
+        public void registerScannedBytes(long bytes) {
+            bytesScanned.addAndGet(bytes);
+        }
+
+        @Override
+        public long getLimit() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public long getBytesScanned() {
+            return bytesScanned.get();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("ByteScanLimiter(UNLIMITED, %d scanned)", bytesScanned.get());
+        }
+    }
+
+    /**
+     * An implementation of {@link ByteScanLimiter} that tracks but does not enforce any limit.
+     */
+    private static class Untracked implements ByteScanLimiter {
+        @Override
+        @Nonnull
+        public ByteScanLimiter reset() {
+            return this;
+        }
+
+        @Override
+        public boolean isEnforcing() {
+            return false;
+        }
+
+        @Override
+        public boolean hasBytesRemaining() {
+            return true;
+        }
+
+        @Override
+        public void registerScannedBytes(long bytes) {
+            // IGNORED
+        }
+
+        @Override
+        public long getLimit() {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public long getBytesScanned() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            return "ByteScanLimiter(NO_LIMIT)";
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
@@ -141,7 +141,7 @@ public class ExecuteProperties {
      */
     public int getScannedRecordsLimit() {
         final RecordScanLimiter recordScanLimiter = getState().getRecordScanLimiter();
-        return recordScanLimiter == null ? Integer.MAX_VALUE : recordScanLimiter.getLimit();
+        return recordScanLimiter.isUnlimited() ? Integer.MAX_VALUE : recordScanLimiter.getLimit();
     }
 
     /**
@@ -152,7 +152,7 @@ public class ExecuteProperties {
      */
     public long getScannedBytesLimit() {
         final ByteScanLimiter byteScanLimiter = getState().getByteScanLimiter();
-        return byteScanLimiter == null ? Long.MAX_VALUE : byteScanLimiter.getLimit();
+        return byteScanLimiter.isUnlimited() ? Long.MAX_VALUE : byteScanLimiter.getLimit();
     }
 
     @Nonnull
@@ -263,9 +263,11 @@ public class ExecuteProperties {
         if (other.timeLimit != UNLIMITED_TIME) {
             builder.setTimeLimit(other.timeLimit);
         }
-        if (other.state.getRecordScanLimiter() != null) {
+
+        if (!other.state.getRecordScanLimiter().isUnlimited() || !other.state.getByteScanLimiter().isUnlimited()) {
             builder.setState(other.state);
         }
+
         return builder.build();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteState.java
@@ -39,7 +39,7 @@ public class ExecuteState {
     /**
      * An execute state with no scan limits.
      */
-    public static final ExecuteState NO_LIMITS = new ExecuteState(RecordScanLimiter.Untracked.INSTANCE, ByteScanLimiter.Untracked.INSTANCE);
+    public static final ExecuteState NO_LIMITS = new ExecuteState(RecordScanLimiterFactory.untracked(), ByteScanLimiterFactory.untracked());
 
     /**
      * An empty execute state with no scan limits.
@@ -62,8 +62,8 @@ public class ExecuteState {
      *     number of bytes may be scanned
      */
     public ExecuteState(@Nullable RecordScanLimiter recordScanLimiter, @Nullable ByteScanLimiter byteScanLimiter) {
-        this.recordScanLimiter = recordScanLimiter == null ? new RecordScanLimiter(RecordScanLimiter.UNLIMITED) : recordScanLimiter;
-        this.byteScanLimiter = byteScanLimiter == null ? new ByteScanLimiter(ByteScanLimiter.UNLIMITED) : byteScanLimiter;
+        this.recordScanLimiter = recordScanLimiter == null ? RecordScanLimiterFactory.tracking() : recordScanLimiter;
+        this.byteScanLimiter = byteScanLimiter == null ? ByteScanLimiterFactory.tracking() : byteScanLimiter;
     }
 
     /**
@@ -77,11 +77,8 @@ public class ExecuteState {
         this(recordScanLimiter, null);
     }
 
-    /**
-     * Creates an execute state that enforces no limits.
-     */
     public ExecuteState() {
-        this(null, null);
+        this(RecordScanLimiterFactory.tracking(), ByteScanLimiterFactory.tracking());
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiter.java
@@ -23,57 +23,33 @@ package com.apple.foundationdb.record;
 import com.apple.foundationdb.annotation.API;
 
 import javax.annotation.Nonnull;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Track number of records scanned up to some limit, after which record scans should not be allowed.
  *
  * @see ExecuteState#getRecordScanLimiter
  */
-@API(API.Status.MAINTAINED)
-public class RecordScanLimiter {
-    /**
-     * Value that indicates that the scan limiter should effectively be used purely for tracking the number of
-     * records scanned without actually enforcing a limit.
-     */
-    public static final int UNLIMITED = Integer.MAX_VALUE;
-
-    private final int originalLimit;
-    private final AtomicInteger allowedRecordScansRemaining;
-
-    public RecordScanLimiter(int limit) {
-        originalLimit = limit;
-        allowedRecordScansRemaining = new AtomicInteger(limit);
-    }
-
+@API(API.Status.INTERNAL)
+public interface RecordScanLimiter {
     /**
      * Create a new {@code RecordScanLimiter} with this limiter's original limit, ignoring any calls to {@link #tryRecordScan()}.
      * @return a new limiter with the same original scan limit as this limiter
      */
     @Nonnull
-    public RecordScanLimiter reset() {
-        return new RecordScanLimiter(originalLimit);
-    }
+    RecordScanLimiter reset();
 
     /**
      * Return whether or not this limiter has an actual limit.
      *
      * @return {@code true} if the limiter is enforcing a limit.
      */
-    public boolean isUnlimited() {
-        return this.originalLimit == UNLIMITED;
-    }
+    boolean isEnforcing();
 
     /**
      * Atomically decrement the counter and return false if falls below 0.
      * @return <code>true</code> if the remaining count is at least 0, and <code>false</code> if it is less than 0
      */
-    public boolean tryRecordScan() {
-        int remaining = allowedRecordScansRemaining.getAndDecrement();
-
-        // Realistically we should never able to scan MAX_INT records in a single transaction, but you never know...
-        return remaining > 0 || originalLimit == UNLIMITED;
-    }
+    boolean tryRecordScan();
 
     /**
      * Get the record scan limit. In particular, this will return the target
@@ -81,49 +57,13 @@ public class RecordScanLimiter {
      *
      * @return the record scan limit being enforced
      */
-    public int getLimit() {
-        return originalLimit;
-    }
+    int getLimit();
 
     /**
      * Returns the number of records that have been scanned thus far.
      *
      * @return the number of records that have been scanned
      */
-    public int getRecordsScanned() {
-        return originalLimit - allowedRecordScansRemaining.get();
-    }
-
-    @Override
-    public String toString() {
-        return String.format("RecordScanLimiter(%d limit, %d left)", originalLimit, allowedRecordScansRemaining.get());
-    }
-
-    /**
-     * A non-tracking, non-enforcing limiter.
-     */
-    protected static class Untracked extends RecordScanLimiter {
-        public static final Untracked INSTANCE = new Untracked();
-
-        private Untracked() {
-            super(UNLIMITED);
-        }
-
-        @Nonnull
-        @Override
-        public RecordScanLimiter reset() {
-            return this;
-        }
-
-        @Override
-        public boolean tryRecordScan() {
-            return true;
-        }
-
-        @Override
-        public int getRecordsScanned() {
-            return 0;
-        }
-    }
+    int getRecordsScanned();
 }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiterFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiterFactory.java
@@ -1,0 +1,181 @@
+/*
+ * RecordScanLimiterFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A factory that produces implementations of {@link RecordScanLimiter}s.
+ */
+@API(API.Status.INTERNAL)
+public class RecordScanLimiterFactory {
+
+    private static final RecordScanLimiter UNTRACKED = new Untracked();
+
+    /**
+     * Creates a limiter that enforces a maximum number of records that can be processed in a single scan.
+     *
+     * @param limit the maximum number of records that can be processed in a single scan
+     * @return an enforcing limiter
+     */
+    public static RecordScanLimiter enforce(int limit) {
+        return new Enforcing(limit);
+    }
+
+    /**
+     * Creates a limiter that tracks the number of records that has been scanned, but does not impose a limit.
+     * @return a tracking limiter
+     */
+    public static RecordScanLimiter tracking() {
+        return new Tracking();
+    }
+
+    /**
+     * Creates a limiter that neither enforces nor tracks the number of records scanned.
+     *
+     * @return an untracked limiter
+     */
+    public static RecordScanLimiter untracked() {
+        return UNTRACKED;
+    }
+
+    /**
+     * Implementation of a {@link RecordScanLimiter} that tracks records scanned and enforces a limit.
+     */
+    private static class Enforcing implements RecordScanLimiter {
+        private final int originalLimit;
+        private final AtomicInteger allowedRecordScansRemaining;
+
+        public Enforcing(int limit) {
+            originalLimit = limit;
+            allowedRecordScansRemaining = new AtomicInteger(limit);
+        }
+
+        @Override
+        @Nonnull
+        public RecordScanLimiter reset() {
+            return new Enforcing(originalLimit);
+        }
+
+        @Override
+        public boolean isEnforcing() {
+            return true;
+        }
+
+        @Override
+        public boolean tryRecordScan() {
+            return allowedRecordScansRemaining.getAndDecrement() > 0;
+        }
+
+        @Override
+        public int getLimit() {
+            return originalLimit;
+        }
+
+        @Override
+        public int getRecordsScanned() {
+            return originalLimit - allowedRecordScansRemaining.get();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("RecordScanLimiter(%d limit, %d left)", originalLimit, allowedRecordScansRemaining.get());
+        }
+    }
+
+    /**
+     * Implementation of a {@link RecordScanLimiter} that tracks records scanned but does not enforce a limit.
+     */
+    private static class Tracking implements RecordScanLimiter {
+        private final AtomicInteger recordsScanned = new AtomicInteger();
+
+        @Override
+        @Nonnull
+        public RecordScanLimiter reset() {
+            return new Tracking();
+        }
+
+        @Override
+        public boolean isEnforcing() {
+            return false;
+        }
+
+        @Override
+        public boolean tryRecordScan() {
+            recordsScanned.incrementAndGet();
+            return true;
+        }
+
+        @Override
+        public int getLimit() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public int getRecordsScanned() {
+            return recordsScanned.get();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("RecordScanLimiter(UNLIMITED, %d scanned)", recordsScanned.get());
+        }
+    }
+
+    /**
+     * Implementation of a {@link RecordScanLimiter} that does not track or enforce any limits.
+     */
+    private static class Untracked implements RecordScanLimiter {
+        @Override
+        @Nonnull
+        public RecordScanLimiter reset() {
+            return this;
+        }
+
+        @Override
+        public boolean isEnforcing() {
+            return false;
+        }
+
+        @Override
+        public boolean tryRecordScan() {
+            return true;
+        }
+
+        @Override
+        public int getLimit() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public int getRecordsScanned() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            return "RecordScanLimiter(NO_LIMIT)";
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
@@ -532,13 +532,8 @@ public class TextIndexMaintainer extends StandardIndexMaintainer {
         ExecuteProperties adjustedExecuteProperties = withAdjustedLimit.getExecuteProperties();
 
         // Callback for updating the byte scan limit
-        final Consumer<KeyValue> callback;
         final ByteScanLimiter byteScanLimiter = adjustedExecuteProperties.getState().getByteScanLimiter();
-        if (byteScanLimiter == null) {
-            callback = null;
-        } else {
-            callback = keyValue -> byteScanLimiter.registerScannedBytes(keyValue.getKey().length + keyValue.getValue().length);
-        }
+        final Consumer<KeyValue> callback = keyValue -> byteScanLimiter.registerScannedBytes(keyValue.getKey().length + keyValue.getValue().length);
 
         BunchedMapMultiIterator<Tuple, List<Integer>, Tuple> iterator = BUNCHED_MAP.scanMulti(
                 state.context.readTransaction(adjustedExecuteProperties.getIsolationLevel().isSnapshot()),

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/ExecutePropertiesTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/ExecutePropertiesTest.java
@@ -81,11 +81,18 @@ public class ExecutePropertiesTest {
     public void testGetNoLimits() {
         assertEquals(ExecuteProperties.UNLIMITED_TIME, ExecuteProperties.SERIAL_EXECUTE.getTimeLimit());
         assertEquals(Integer.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getScannedRecordsLimit());
-        assertTrue(ExecuteProperties.SERIAL_EXECUTE.getState().getRecordScanLimiter().isUnlimited());
+        assertFalse(ExecuteProperties.SERIAL_EXECUTE.getState().getRecordScanLimiter().isEnforcing());
         assertEquals(Long.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getScannedBytesLimit());
-        assertTrue(ExecuteProperties.SERIAL_EXECUTE.getState().getByteScanLimiter().isUnlimited());
+        assertFalse(ExecuteProperties.SERIAL_EXECUTE.getState().getByteScanLimiter().isEnforcing());
         assertEquals(Transaction.ROW_LIMIT_UNLIMITED, ExecuteProperties.SERIAL_EXECUTE.getReturnedRowLimit());
         assertEquals(Integer.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getReturnedRowLimitOrMax());
+
+        // Ensure that these these constant ExecuteProperties do not do any scan tracking (this would be
+        // confusing to do as they may be shared across many requests).
+        assertTrue(ExecuteProperties.SERIAL_EXECUTE.getState().getRecordScanLimiter().tryRecordScan());
+        assertEquals(0, ExecuteProperties.SERIAL_EXECUTE.getState().getRecordScanLimiter().getRecordsScanned());
+        ExecuteProperties.SERIAL_EXECUTE.getState().getByteScanLimiter().registerScannedBytes(100L);
+        assertEquals(0, ExecuteProperties.SERIAL_EXECUTE.getState().getByteScanLimiter().getBytesScanned());
     }
 
     /**
@@ -96,12 +103,49 @@ public class ExecutePropertiesTest {
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
                 .setTimeLimit(100L)
                 .setScannedBytesLimit(1000L)
-                .setScannedRecordsLimit(1000)
+                .setScannedRecordsLimit(2)
                 .setReturnedRowLimit(200)
                 .build();
         assertEquals(100L, executeProperties.getTimeLimit());
         assertEquals(1000L, executeProperties.getScannedBytesLimit());
-        assertEquals(1000, executeProperties.getScannedRecordsLimit());
+        assertEquals(2, executeProperties.getScannedRecordsLimit());
         assertEquals(200, executeProperties.getReturnedRowLimit());
+
+        final RecordScanLimiter recordScanLimiter = executeProperties.getState().getRecordScanLimiter();
+        assertTrue(recordScanLimiter.isEnforcing());
+        assertTrue(recordScanLimiter.tryRecordScan());
+        assertTrue(recordScanLimiter.tryRecordScan());
+        assertEquals(2, recordScanLimiter.getRecordsScanned());
+        assertFalse(recordScanLimiter.tryRecordScan());
+
+        final ByteScanLimiter byteScanLimiter = executeProperties.getState().getByteScanLimiter();
+        assertTrue(byteScanLimiter.isEnforcing());
+        byteScanLimiter.registerScannedBytes(500L);
+        assertTrue(byteScanLimiter.hasBytesRemaining());
+        byteScanLimiter.registerScannedBytes(499L);
+        assertTrue(byteScanLimiter.hasBytesRemaining());
+        assertEquals(999, byteScanLimiter.getBytesScanned());
+        byteScanLimiter.registerScannedBytes(37L);
+        assertFalse(byteScanLimiter.hasBytesRemaining());
+    }
+
+    @Test
+    public void testTrackingNotEnforcing() {
+        ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                .setReturnedRowLimit(200)
+                .build();
+
+        final RecordScanLimiter recordScanLimiter = executeProperties.getState().getRecordScanLimiter();
+        assertFalse(recordScanLimiter.isEnforcing());
+        assertTrue(recordScanLimiter.tryRecordScan());
+        assertTrue(recordScanLimiter.tryRecordScan());
+        assertEquals(2, recordScanLimiter.getRecordsScanned());
+
+        final ByteScanLimiter byteScanLimiter = executeProperties.getState().getByteScanLimiter();
+        assertFalse(byteScanLimiter.isEnforcing());
+        byteScanLimiter.registerScannedBytes(200_000L);
+        byteScanLimiter.registerScannedBytes(200_000L);
+        assertTrue(byteScanLimiter.hasBytesRemaining());
+        assertEquals(400_000L, byteScanLimiter.getBytesScanned());
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/ExecutePropertiesTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/ExecutePropertiesTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -82,9 +81,9 @@ public class ExecutePropertiesTest {
     public void testGetNoLimits() {
         assertEquals(ExecuteProperties.UNLIMITED_TIME, ExecuteProperties.SERIAL_EXECUTE.getTimeLimit());
         assertEquals(Integer.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getScannedRecordsLimit());
-        assertNull(ExecuteProperties.SERIAL_EXECUTE.getState().getRecordScanLimiter());
+        assertTrue(ExecuteProperties.SERIAL_EXECUTE.getState().getRecordScanLimiter().isUnlimited());
         assertEquals(Long.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getScannedBytesLimit());
-        assertNull(ExecuteProperties.SERIAL_EXECUTE.getState().getByteScanLimiter());
+        assertTrue(ExecuteProperties.SERIAL_EXECUTE.getState().getByteScanLimiter().isUnlimited());
         assertEquals(Transaction.ROW_LIMIT_UNLIMITED, ExecuteProperties.SERIAL_EXECUTE.getReturnedRowLimit());
         assertEquals(Integer.MAX_VALUE, ExecuteProperties.SERIAL_EXECUTE.getReturnedRowLimitOrMax());
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/CursorLimitManagerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/CursorLimitManagerTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.cursors;
 
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordScanLimiter;
+import com.apple.foundationdb.record.RecordScanLimiterFactory;
 import com.apple.foundationdb.record.ScanLimitReachedException;
 import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TimeScanLimiter;
@@ -65,7 +66,7 @@ public class CursorLimitManagerTest {
 
     public void testRecordScanLimiterBase(boolean failOnLimitReached) {
         final int numberOfScans = 12;
-        final RecordScanLimiter recordScanLimiter = new RecordScanLimiter(numberOfScans);
+        final RecordScanLimiter recordScanLimiter = RecordScanLimiterFactory.enforce(numberOfScans);
         final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, failOnLimitReached, null, null);
 
         for (int i = 0; i < numberOfScans; i++) {
@@ -124,7 +125,7 @@ public class CursorLimitManagerTest {
     public void testTimeoutBeforeScanLimit() {
         final int untilTimeout = 7;
         final int numberOfScans = 12;
-        final RecordScanLimiter recordScanLimiter = new RecordScanLimiter(numberOfScans);
+        final RecordScanLimiter recordScanLimiter = RecordScanLimiterFactory.enforce(numberOfScans);
         final FakeTimeLimiter fakeTimeLimiter = new FakeTimeLimiter();
         final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, null, fakeTimeLimiter);
 
@@ -143,7 +144,7 @@ public class CursorLimitManagerTest {
     @Test
     public void testSimultaneousRecordScanLimitAndTimeout() {
         final int numberOfScans = 12;
-        final RecordScanLimiter recordScanLimiter = new RecordScanLimiter(numberOfScans);
+        final RecordScanLimiter recordScanLimiter = RecordScanLimiterFactory.enforce(numberOfScans);
         final FakeTimeLimiter fakeTimeLimiter = new FakeTimeLimiter();
         final CursorLimitManager manager = new CursorLimitManager(recordScanLimiter, false, null, fakeTimeLimiter);
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordScanLimiter;
+import com.apple.foundationdb.record.RecordScanLimiterFactory;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.cursors.CursorLimitManager;
@@ -300,7 +301,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void simpleScanLimit() {
         fdb.run(context -> {
-            RecordScanLimiter limiter = new RecordScanLimiter(2);
+            RecordScanLimiter limiter = RecordScanLimiterFactory.enforce(2);
             KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setRange(TupleRange.ALL)
@@ -318,7 +319,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void limitNotReached() {
         fdb.run(context -> {
-            RecordScanLimiter limiter = new RecordScanLimiter(4);
+            RecordScanLimiter limiter = RecordScanLimiterFactory.enforce(4);
             KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_EXCLUSIVE)
@@ -341,7 +342,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void sharedLimiter() {
         fdb.run(context -> {
-            RecordScanLimiter limiter = new RecordScanLimiter(4);
+            RecordScanLimiter limiter = RecordScanLimiterFactory.enforce(4);
             KeyValueCursor.Builder builder =  KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_EXCLUSIVE)
@@ -368,7 +369,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void limiterWithLookahead() {
         fdb.run(context -> {
-            RecordScanLimiter limiter = new RecordScanLimiter(1);
+            RecordScanLimiter limiter = RecordScanLimiterFactory.enforce(1);
             KeyValueCursor kvCursor =  KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_EXCLUSIVE)


### PR DESCRIPTION
This includes some efforts to still allow for the use of the
`NO_LIMITS` constant in fashion that should have little overhead
on execution performance.