### PR TITLE
Resolves #806: Rank index could have option for how to handle ties

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -54,7 +54,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Rank index adds option for how to handle ties [(Issue #806)](https://github.com/FoundationDB/fdb-record-layer/issues/806)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
@@ -192,8 +192,11 @@ public class RankedSet {
         public boolean isCountDuplicates() {
             return countDuplicates;
         }
-    }
 
+        public ConfigBuilder toBuilder() {
+            return new ConfigBuilder(hashFunction, nlevels, countDuplicates);
+        }
+    }
 
     /**
      * Builder for {@link Config}.
@@ -206,6 +209,12 @@ public class RankedSet {
         private boolean countDuplicates = false;
 
         protected ConfigBuilder() {
+        }
+
+        protected ConfigBuilder(HashFunction hashFunction, int nlevels, boolean countDuplicates) {
+            this.hashFunction = hashFunction;
+            this.nlevels = nlevels;
+            this.countDuplicates = countDuplicates;
         }
 
         public HashFunction getHashFunction() {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
@@ -78,18 +78,23 @@ public class RankedSetTest extends FDBTestBase {
     }
 
     @Test
-    public void basic() throws Exception {
+    public void basic() {
         basicOperations(RankedSet.DEFAULT_HASH_FUNCTION, RankedSet.DEFAULT_HASH_FUNCTION);
     }
 
     @Test
-    public void basicCrc() throws Exception {
+    public void basicCrc() {
         basicOperations(RankedSet.CRC_HASH, RankedSet.CRC_HASH);
     }
 
     @Test
-    public void basicChange() throws Exception {
+    public void basicChange() {
         basicOperations(RankedSet.JDK_ARRAY_HASH, RankedSet.CRC_HASH);
+    }
+
+    @Test
+    public void basicRandom() {
+        basicOperations(RankedSet.RANDOM_HASH, RankedSet.RANDOM_HASH);
     }
 
     private void basicOperations(RankedSet.HashFunction firstHashFunction, RankedSet.HashFunction secondHashFunction) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -96,6 +96,13 @@ public class IndexOptions {
      */
     public static final String RANK_HASH_FUNCTION = "rankHashFunction";
 
+    /**
+     * Whether duplicate keys count separtely in the {@link IndexTypes#RANK} skip list {@link com.apple.foundationdb.async.RankedSet}.
+     *
+     * The default is {@code false}.
+     */
+    public static final String RANK_COUNT_DUPLICATES = "rankCountDuplicates";
+
     private IndexOptions() {
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
@@ -134,6 +134,14 @@ public class RankIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @Override
+    public boolean isIdempotent() {
+        // In the not counting case, updateRankedSet only does remove from ranked set for the last occurrence,
+        // since it doesn't track duplicates itself. In the counting case, we just decrement, which has the possibility
+        // of removing someone else's entry if the record being removed hasn't been indexed yet.
+        return !config.isCountDuplicates();
+    }
+
+    @Override
     public boolean canEvaluateRecordFunction(@Nonnull IndexRecordFunction<?> function) {
         return function.getName().equals(FunctionNames.RANK) &&
                 state.index.getRootExpression().equals(function.getOperand());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
@@ -80,7 +80,7 @@ public class RankIndexMaintainer extends StandardIndexMaintainer {
 
     public RankIndexMaintainer(IndexMaintainerState state) {
         super(state);
-        this.config = RankedSetIndexHelper.getConfigBuilder(state.index).build();
+        this.config = RankedSetIndexHelper.getConfig(state.index);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
@@ -67,8 +67,8 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
             public void validateChangedOptions(@Nonnull Index oldIndex, @Nonnull Set<String> changedOptions) {
                 if (!changedOptions.isEmpty()) {
                     // Allow changing from unspecified to the default (or vice versa), but not otherwise.
-                    RankedSet.ConfigBuilder oldOptions = RankedSetIndexHelper.getConfigBuilder(oldIndex);
-                    RankedSet.ConfigBuilder newOptions = RankedSetIndexHelper.getConfigBuilder(index);
+                    RankedSet.Config oldOptions = RankedSetIndexHelper.getConfig(oldIndex);
+                    RankedSet.Config newOptions = RankedSetIndexHelper.getConfig(index);
                     if (changedOptions.contains(IndexOptions.RANK_NLEVELS)) {
                         if (oldOptions.getNLevels() != newOptions.getNLevels()) {
                             throw new MetaDataException("rank levels changed",
@@ -82,6 +82,13 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
                                     LogMessageKeys.INDEX_NAME, index.getName());
                         }
                         changedOptions.remove(IndexOptions.RANK_HASH_FUNCTION);
+                    }
+                    if (changedOptions.contains(IndexOptions.RANK_COUNT_DUPLICATES)) {
+                        if (oldOptions.isCountDuplicates() != newOptions.isCountDuplicates()) {
+                            throw new MetaDataException("rank count duplicate changed",
+                                    LogMessageKeys.INDEX_NAME, index.getName());
+                        }
+                        changedOptions.remove(IndexOptions.RANK_COUNT_DUPLICATES);
                     }
                 }
                 super.validateChangedOptions(oldIndex, changedOptions);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
@@ -65,24 +65,24 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
 
             @Override
             public void validateChangedOptions(@Nonnull Index oldIndex, @Nonnull Set<String> changedOptions) {
-                // Allow changing from unspecified to the default (or vice versa), but not otherwise.
-                if (changedOptions.contains(IndexOptions.RANK_NLEVELS)) {
-                    int oldLevels = RankedSetIndexHelper.getNLevels(oldIndex);
-                    int newLevels = RankedSetIndexHelper.getNLevels(index);
-                    if (oldLevels != newLevels) {
-                        throw new MetaDataException("rank levels changed",
-                                LogMessageKeys.INDEX_NAME, index.getName());
+                if (!changedOptions.isEmpty()) {
+                    // Allow changing from unspecified to the default (or vice versa), but not otherwise.
+                    RankedSet.ConfigBuilder oldOptions = RankedSetIndexHelper.getConfigBuilder(oldIndex);
+                    RankedSet.ConfigBuilder newOptions = RankedSetIndexHelper.getConfigBuilder(index);
+                    if (changedOptions.contains(IndexOptions.RANK_NLEVELS)) {
+                        if (oldOptions.getNLevels() != newOptions.getNLevels()) {
+                            throw new MetaDataException("rank levels changed",
+                                    LogMessageKeys.INDEX_NAME, index.getName());
+                        }
+                        changedOptions.remove(IndexOptions.RANK_NLEVELS);
                     }
-                    changedOptions.remove(IndexOptions.RANK_NLEVELS);
-                }
-                if (changedOptions.contains(IndexOptions.RANK_HASH_FUNCTION)) {
-                    RankedSet.HashFunction oldFunction = RankedSetIndexHelper.getHashFunction(oldIndex);
-                    RankedSet.HashFunction newFunction = RankedSetIndexHelper.getHashFunction(index);
-                    if (!oldFunction.equals(newFunction)) {
-                        throw new MetaDataException("rank hash function changed",
-                                LogMessageKeys.INDEX_NAME, index.getName());
+                    if (changedOptions.contains(IndexOptions.RANK_HASH_FUNCTION)) {
+                        if (!oldOptions.getHashFunction().equals(newOptions.getHashFunction())) {
+                            throw new MetaDataException("rank hash function changed",
+                                    LogMessageKeys.INDEX_NAME, index.getName());
+                        }
+                        changedOptions.remove(IndexOptions.RANK_HASH_FUNCTION);
                     }
-                    changedOptions.remove(IndexOptions.RANK_HASH_FUNCTION);
                 }
                 super.validateChangedOptions(oldIndex, changedOptions);
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -309,14 +309,14 @@ public class RankedSetIndexHelper {
         }
 
         @Override
-        protected CompletableFuture<Void> addLevelZeroKey(Transaction tr, byte[] key, int level) {
-            CompletableFuture<Void> result = super.addLevelZeroKey(tr, key, level);
+        protected CompletableFuture<Void> addLevelZeroKey(Transaction tr, byte[] key, int level, boolean increment) {
+            CompletableFuture<Void> result = super.addLevelZeroKey(tr, key, level, increment);
             return context.instrument(FDBStoreTimer.DetailEvents.RANKED_SET_ADD_LEVEL_ZERO_KEY, result);
         }
 
         @Override
-        protected CompletableFuture<Void> addIncrementLevelKey(Transaction tr, byte[] key, int level) {
-            CompletableFuture<Void> result = super.addIncrementLevelKey(tr, key, level);
+        protected CompletableFuture<Void> addIncrementLevelKey(Transaction tr, byte[] key, int level, boolean orEqual) {
+            CompletableFuture<Void> result = super.addIncrementLevelKey(tr, key, level, orEqual);
             return context.instrument(FDBStoreTimer.DetailEvents.RANKED_SET_ADD_INCREMENT_LEVEL_KEY, result);
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -53,11 +53,11 @@ public class RankedSetIndexHelper {
     public static final Tuple COMPARISON_SKIPPED_SCORE = Tuple.from(Comparisons.COMPARISON_SKIPPED_BINDING);
 
     /**
-     * Parse standard options into {@link RankedSet.ConfigBuilder}.
+     * Parse standard options into {@link RankedSet.Config}.
      * @param index the index definition to get options from
-     * @return a builder for config options
+     * @return parsed config options
      */
-    public static RankedSet.ConfigBuilder getConfigBuilder(@Nonnull Index index) {
+    public static RankedSet.Config getConfig(@Nonnull Index index) {
         RankedSet.ConfigBuilder builder = RankedSet.newConfigBuilder();
         String hashFunctionOption = index.getOption(IndexOptions.RANK_HASH_FUNCTION);
         if (hashFunctionOption != null) {
@@ -71,7 +71,7 @@ public class RankedSetIndexHelper {
         if (duplicatesOption != null) {
             builder.setCountDuplicates(Boolean.parseBoolean(duplicatesOption));
         }
-        return builder;
+        return builder.build();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -88,11 +88,11 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
 
     private static final Tuple SUB_DIRECTORY_PREFIX = Tuple.from((Object)null); // Must not conflict with leaderboard subspace keys.
 
-    private final RankedSet.ConfigBuilder configBuilder;
+    private final RankedSet.Config config;
 
     public TimeWindowLeaderboardIndexMaintainer(IndexMaintainerState state) {
         super(state);
-        this.configBuilder = RankedSetIndexHelper.getConfigBuilder(state.index);
+        this.config = RankedSetIndexHelper.getConfig(state.index);
     }
 
     @Nonnull
@@ -197,9 +197,9 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
                 }
                 final Subspace extraSubspace = getSecondarySubspace();
                 final Subspace leaderboardSubspace = extraSubspace.subspace(leaderboard.getSubspaceKey());
-                final RankedSet.Config config = configBuilder.setNLevels(leaderboard.getNLevels()).build();
+                final RankedSet.Config leaderboardConfig = config.toBuilder().setNLevels(leaderboard.getNLevels()).build();
                 return RankedSetIndexHelper.rankRangeToScoreRange(state, groupPrefixSize,
-                        leaderboardSubspace, config, leaderboardRange);
+                        leaderboardSubspace, leaderboardConfig, leaderboardRange);
             });
         }
         // Add leaderboard's key to the front and take it off of the results.
@@ -362,9 +362,9 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
 
                                 // Update the corresponding rankset for this leaderboard.
                                 final Subspace rankSubspace = extraSubspace.subspace(leaderboardGroupKey);
-                                final RankedSet.Config config = configBuilder.setNLevels(leaderboard.getNLevels()).build();
+                                final RankedSet.Config leaderboardConfig = config.toBuilder().setNLevels(leaderboard.getNLevels()).build();
                                 futures.add(RankedSetIndexHelper.updateRankedSet(state, rankSubspace,
-                                        config, entryKey, indexKey.scoreKey, remove));
+                                        leaderboardConfig, entryKey, indexKey.scoreKey, remove));
                             }
                         }
                     }
@@ -484,8 +484,8 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
             final Tuple leaderboardGroupKey = leaderboard.getSubspaceKey().addAll(groupKey);
             final Subspace extraSubspace = getSecondarySubspace();
             final Subspace rankSubspace = extraSubspace.subspace(leaderboardGroupKey);
-            final RankedSet.Config config = configBuilder.setNLevels(leaderboard.getNLevels()).build();
-            final RankedSet rankedSet = new RankedSetIndexHelper.InstrumentedRankedSet(state, rankSubspace, config);
+            final RankedSet.Config leaderboardConfig = config.toBuilder().setNLevels(leaderboard.getNLevels()).build();
+            final RankedSet rankedSet = new RankedSetIndexHelper.InstrumentedRankedSet(state, rankSubspace, leaderboardConfig);
             return function.apply(leaderboard, rankedSet, groupKey, values);
         });
     }
@@ -532,8 +532,8 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
                             final Tuple leaderboardGroupKey = leaderboard.getSubspaceKey().addAll(groupKey);
                             final Subspace extraSubspace = getSecondarySubspace();
                             final Subspace rankSubspace = extraSubspace.subspace(leaderboardGroupKey);
-                            final RankedSet.Config config = configBuilder.setNLevels(leaderboard.getNLevels()).build();
-                            final RankedSet rankedSet = new RankedSetIndexHelper.InstrumentedRankedSet(state, rankSubspace, config);
+                            final RankedSet.Config leaderboardConfig = config.toBuilder().setNLevels(leaderboard.getNLevels()).build();
+                            final RankedSet rankedSet = new RankedSetIndexHelper.InstrumentedRankedSet(state, rankSubspace, leaderboardConfig);
                             // Undo any negation needed to find entry.
                             final Tuple entry = highScoreFirst ? negateScoreForHighScoreFirst(indexKey.scoreKey, 0) : indexKey.scoreKey;
                             return RankedSetIndexHelper.rankForScore(state, rankedSet, indexKey.scoreKey, true).thenApply(rank -> Pair.of(rank, entry));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -383,6 +383,11 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
     }
 
     @Override
+    public boolean isIdempotent() {
+        return !config.isCountDuplicates();
+    }
+
+    @Override
     public boolean canEvaluateRecordFunction(@Nonnull IndexRecordFunction<?> function) {
         return (function.getName().equals(FunctionNames.RANK) ||
                 function.getName().equals(FunctionNames.TIME_WINDOW_RANK) ||

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
@@ -253,6 +253,35 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    public void checkDuplicateOption() throws Exception {
+        RecordFunction<Long> rank = Query.rank("score").getFunction();
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context);
+            FDBStoredRecord<Message> rec1 = recordStore.loadRecord(Tuple.from("achilles"));
+            assertEquals((Long)1L, recordStore.evaluateRecordFunction(rank, rec1).get());
+            FDBStoredRecord<Message> rec2 = recordStore.loadRecord(Tuple.from("penelope"));
+            assertEquals((Long)2L, recordStore.evaluateRecordFunction(rank, rec2).get());
+            FDBStoredRecord<Message> rec3 = recordStore.loadRecord(Tuple.from("laodice"));
+            assertEquals((Long)3L, recordStore.evaluateRecordFunction(rank, rec3).get());
+        }
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, md -> {
+                md.removeIndex("BasicRankedRecord$score");
+                md.addIndex("BasicRankedRecord", new Index("score_count_dupes", Key.Expressions.field("score").ungrouped(),
+                        IndexTypes.RANK, Collections.singletonMap(IndexOptions.RANK_COUNT_DUPLICATES, "true")));
+            });
+            recordStore.rebuildIndex(recordStore.getRecordMetaData().getIndex("score_count_dupes")).join();
+            FDBStoredRecord<Message> rec1 = recordStore.loadRecord(Tuple.from("achilles"));
+            assertEquals((Long)1L, recordStore.evaluateRecordFunction(rank, rec1).get());
+            FDBStoredRecord<Message> rec2 = recordStore.loadRecord(Tuple.from("penelope"));
+            assertEquals((Long)2L, recordStore.evaluateRecordFunction(rank, rec2).get());
+            FDBStoredRecord<Message> rec3 = recordStore.loadRecord(Tuple.from("laodice"));
+            assertEquals((Long)4L, recordStore.evaluateRecordFunction(rank, rec3).get());
+        }
+    }
+
+
+    @Test
     public void checkUpdateWithTies() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);


### PR DESCRIPTION
Note that this doesn't actually introduce a `RankedMultiset` class, because that was hard with the current `InstrumentedRankset` class. It would be possible by creating an interface and making that a wrapper instead of a subclass. But I'm not sure it's worth it.

This moves all the `Rankset` config options, including the recently added hash function, into a separate `Config` class so that the constructors don't continue to get out of hand. At some point (but not in this PR) some of them could presumably be deprecated.