### PR TITLE
Resolves #839: Add aggregate counters for the number of reads and writes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -46,7 +46,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Aggregate metrics added for the number of reads, writes, and deletes [(Issue #839)](https://github.com/FoundationDB/fdb-record-layer/issues/839)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -243,7 +243,7 @@ public class StoreTimer {
     }
 
     /**
-     * An aggregate event is an event whos value is computed over the value of another set of events.
+     * An aggregate event is an event whose value is computed over the value of another set of events.
      */
     public interface Aggregate extends Event {
         /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
@@ -259,21 +259,33 @@ public class FDBStoreTimerTest {
         // I don't want this test to fail if new aggregates are added, but do want to verify that the
         // getAggregates() at least does return some of the expected aggregates.
         assertTrue(storeTimer.getAggregates().contains(FDBStoreTimer.EventAggregates.COMMITS));
+        assertTrue(storeTimer.getAggregates().contains(FDBStoreTimer.CountAggregates.READS));
         assertTrue(storeTimer.getAggregates().contains(FDBStoreTimer.CountAggregates.BYTES_READ));
+        assertTrue(storeTimer.getAggregates().contains(FDBStoreTimer.CountAggregates.WRITES));
         assertTrue(storeTimer.getAggregates().contains(FDBStoreTimer.CountAggregates.BYTES_WRITTEN));
 
+        storeTimer.increment(FDBStoreTimer.Counts.SAVE_RECORD_KEY, 2);
         storeTimer.increment(FDBStoreTimer.Counts.SAVE_RECORD_KEY_BYTES, 20);
         storeTimer.increment(FDBStoreTimer.Counts.SAVE_RECORD_VALUE_BYTES, 20);
         storeTimer.increment(FDBStoreTimer.Counts.SAVE_RECORD_KEY_BYTES, 11);
         storeTimer.increment(FDBStoreTimer.Counts.SAVE_RECORD_VALUE_BYTES, 97);
+        storeTimer.increment(FDBStoreTimer.Counts.SAVE_INDEX_KEY, 4);
         storeTimer.increment(FDBStoreTimer.Counts.SAVE_INDEX_KEY_BYTES, 44);
         storeTimer.increment(FDBStoreTimer.Counts.SAVE_INDEX_VALUE_BYTES, 287);
 
+        assertNotNull(storeTimer.getCounter(FDBStoreTimer.CountAggregates.WRITES));
+        assertEquals(6, storeTimer.getCount(FDBStoreTimer.CountAggregates.WRITES),
+                "Incorrect aggregate count for WRITES");
         assertNotNull(storeTimer.getCounter(FDBStoreTimer.CountAggregates.BYTES_WRITTEN));
         assertEquals(479, storeTimer.getCount(FDBStoreTimer.CountAggregates.BYTES_WRITTEN),
                 "Incorrect aggregate count for BYTES_WRITTEN");
+        assertEquals(0, storeTimer.getTimeNanos(FDBStoreTimer.CountAggregates.WRITES),
+                "Incorrect aggregate time for WRITES");
         assertEquals(0, storeTimer.getTimeNanos(FDBStoreTimer.CountAggregates.BYTES_WRITTEN),
                 "Incorrect aggregate time for BYTES_WRITTEN");
+        assertNull(storeTimer.getCounter(FDBStoreTimer.CountAggregates.READS));
+        assertEquals(0, storeTimer.getCount(FDBStoreTimer.CountAggregates.READS),
+                "READS should be zero");
         assertNull(storeTimer.getCounter(FDBStoreTimer.CountAggregates.BYTES_READ));
         assertEquals(0, storeTimer.getCount(FDBStoreTimer.CountAggregates.BYTES_READ),
                 "BYTES_READ should be zero");


### PR DESCRIPTION
In addition to the current metrics we have on the number of bytes read, written, and deleted, this also adds aggregates for the number of keys read, written, and deleted (etc.). This can be useful as there are some pathologies that result from lots of small reads, so having something that tracks the number of distinct reads can be useful.