### PR TITLE
Resolves #841: Add a custom index queryability filter for planning.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,6 +22,8 @@ Additionally, each record store now allows users to set custom fields in the sto
 
 Importantly, it is rather expensive to write this data (as all concurrent operations to the record store will fail with a conflict), and as the data in these fields are read with every transaction, it is not advised that the user write to these fields too often or store too much data in them. However, if there is a relatively small amount of data with a very low write-rate, it might be appropriate to use this feature. This feature also requires that the user set the format version for a record store to [`HEADER_USER_FIELDS_FORMAT_VERSION`](https://javadoc.io/page/org.foundationdb/fdb-record-layer-core/latest/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.html#HEADER_USER_FIELDS_FORMAT_VERSION). The default format version was not updated to that version.
 
+A client can now specify a custom `IndexQueryabilityFilter` that determines which indexes should be considered by the query planner.
+
 ### Breaking Changes
 
 A new format version, [`CACHEABLE_STATE_FORMAT_VERSION`](https://javadoc.io/page/org.foundationdb/fdb-record-layer-core/latest/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.html#CACHEABLE_STATE_FORMAT_VERSION), was introduced in this version of the Record Layer. Users who wish to experience zero downtime when upgrading from earlier versions should initialize all record stores to the previous maximum format version, [`SAVE_VERSION_WITH_RECORD_FORMAT_VERSION`](https://javadoc.io/page/org.foundationdb/fdb-record-layer-core/latest/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.html#SAVE_VERSION_WITH_RECORD_FORMAT_VERSION), until all clients have been upgraded to version 2.8. If the update is done without this measure, then older clients running 2.7 or older will not be able to read from any record stores written using version 2.8. The new format version is also required to use the new `MetaDataVersionStampStoreStateCache` class to cache a record store's initialization state.
@@ -50,7 +52,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Add an index queryability function to `RecordQuery` [(Issue #841)](https://github.com/FoundationDB/fdb-record-layer/issues/841)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/IndexQueryabilityFilter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/IndexQueryabilityFilter.java
@@ -1,0 +1,51 @@
+/*
+ * IndexQueryabilityFilter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A filter used to determine whether an index should be considered when planning queries.
+ */
+@API(API.Status.EXPERIMENTAL)
+@FunctionalInterface
+public interface IndexQueryabilityFilter {
+    /**
+     * The default index queryability filter which uses all indexes except those with the
+     * {@link IndexOptions#ALLOWED_FOR_QUERY_OPTION} set to {@code false}.
+     */
+    IndexQueryabilityFilter DEFAULT =
+            index -> index.getBooleanOption(IndexOptions.ALLOWED_FOR_QUERY_OPTION, true);
+
+    /**
+     * Return whether the given index should be considered by the query planner. Note that the planner is not required
+     * to use an index for which {@code isQueryable()} is {@code true}.
+     * @param index an index
+     * @return whether the given index should be considered by the planner
+     */
+    boolean isQueryable(@Nonnull Index index);
+
+}
+

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/RecordQuery.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/RecordQuery.java
@@ -54,6 +54,8 @@ public class RecordQuery {
     private final Collection<String> recordTypes;
     @Nullable
     private final Collection<String> allowedIndexes;
+    @Nonnull
+    private final IndexQueryabilityFilter queryabilityFilter;
     @Nullable
     private final QueryComponent filter;
     @Nullable
@@ -65,6 +67,7 @@ public class RecordQuery {
 
     private RecordQuery(@Nonnull Collection<String> recordTypes,
                         @Nullable Collection<String> allowedIndexes,
+                        @Nonnull IndexQueryabilityFilter queryabilityFilter,
                         @Nullable QueryComponent filter,
                         @Nullable KeyExpression sort,
                         boolean sortReverse,
@@ -72,6 +75,7 @@ public class RecordQuery {
                         @Nullable List<KeyExpression> requiredResults) {
         this.recordTypes = recordTypes;
         this.allowedIndexes = allowedIndexes;
+        this.queryabilityFilter = queryabilityFilter;
         this.filter = filter;
         this.sort = sort;
         this.sortReverse = sortReverse;
@@ -91,6 +95,12 @@ public class RecordQuery {
     @Nullable
     public Collection<String> getAllowedIndexes() {
         return allowedIndexes;
+    }
+
+    @API(API.Status.EXPERIMENTAL)
+    @Nonnull
+    public IndexQueryabilityFilter getIndexQueryabilityFilter() {
+        return queryabilityFilter;
     }
 
     @Nullable
@@ -174,6 +184,8 @@ public class RecordQuery {
         private Collection<String> recordTypes = ALL_TYPES;
         @Nullable
         private Collection<String> allowedIndexes = null;
+        @Nonnull
+        private IndexQueryabilityFilter queryabilityFilter = IndexQueryabilityFilter.DEFAULT;
         @Nullable
         private QueryComponent filter = null;
         @Nullable
@@ -189,6 +201,7 @@ public class RecordQuery {
         protected Builder(RecordQuery query) {
             this.recordTypes = query.recordTypes;
             this.allowedIndexes = query.allowedIndexes;
+            this.queryabilityFilter = query.queryabilityFilter;
             this.filter = query.filter;
             this.sort = query.sort;
             this.sortReverse = query.sortReverse;
@@ -197,7 +210,8 @@ public class RecordQuery {
         }
 
         public RecordQuery build() {
-            return new RecordQuery(recordTypes, allowedIndexes, filter, sort, sortReverse, removeDuplicates, requiredResults);
+            return new RecordQuery(recordTypes, allowedIndexes, queryabilityFilter,
+                    filter, sort, sortReverse, removeDuplicates, requiredResults);
         }
 
         @Nonnull
@@ -219,6 +233,12 @@ public class RecordQuery {
             return allowedIndexes;
         }
 
+        /**
+         * Define the indexes that the planner can consider when planning the query.
+         * If set, the allowed indexes override the index queryability filter.
+         * @param allowedIndexes a collection of index names
+         * @return this builder
+         */
         public Builder setAllowedIndexes(@Nullable Collection<String> allowedIndexes) {
             this.allowedIndexes = allowedIndexes;
             return this;
@@ -226,6 +246,18 @@ public class RecordQuery {
 
         public Builder setAllowedIndex(@Nullable String allowedIndex) {
             return setAllowedIndexes(Collections.singleton(allowedIndex));
+        }
+
+        /**
+         * Set a function that defines whether each index should be used by the query planner.
+         * Note that if allowed indexes are used then the queryability filter is ignored.
+         * The default index queryability filter is {@link IndexQueryabilityFilter#DEFAULT}.
+         * @param queryabilityFilter a queryability filter to use
+         * @return this builder
+         */
+        public Builder setIndexQueryabilityFilter(@Nonnull IndexQueryabilityFilter queryabilityFilter) {
+            this.queryabilityFilter = queryabilityFilter;
+            return this;
         }
 
         @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
@@ -515,7 +514,7 @@ public class RecordQueryPlanner implements QueryPlanner {
 
         indexes.removeIf(query.hasAllowedIndexes() ?
                 index -> !query.getAllowedIndexes().contains(index.getName()) :
-                index -> !index.getBooleanOption(IndexOptions.ALLOWED_FOR_QUERY_OPTION, true));
+                index -> !query.getIndexQueryabilityFilter().isQueryable(index));
 
         return new PlanContext(query, indexes, commonPrimaryKey);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/MetaDataPlanContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/MetaDataPlanContext.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.RecordQuery;
@@ -98,8 +97,9 @@ public class MetaDataPlanContext implements PlanContext {
         } finally {
             recordStoreState.endRead();
         }
-        indexList.removeIf(index -> query.hasAllowedIndexes() && !query.getAllowedIndexes().contains(index.getName()) ||
-                    !query.hasAllowedIndexes() && !index.getBooleanOption(IndexOptions.ALLOWED_FOR_QUERY_OPTION, true));
+        indexList.removeIf(query.hasAllowedIndexes() ?
+                index -> !query.getAllowedIndexes().contains(index.getName()) :
+                index -> !query.getIndexQueryabilityFilter().isQueryable(index));
 
         ImmutableSet.Builder<IndexEntrySource> builder = ImmutableSet.builder();
         if (commonPrimaryKey != null) {


### PR DESCRIPTION
Add a new field to `RecordQuery` that allows a user to specify a custom filtering function that determines whether an index should be considered by the planner. This replaces the previous hard-coded check for the value of `IndexOptions.ALLOWED_FOR_QUERY_OPTION`, which remains the default.

This change does not break backwards compatibility.

See #841 for more discussion of why we need this filter.