### PR TITLE
Fixes #844: AsyncLoadingCache should cancel work on deadline exceeded

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -40,7 +40,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** A new overload of `AsyncLoadingCache::orElseGet` allows the cache to cancel work if it cannot be loaded in the deadline [(Issue #844)](https://github.com/FoundationDB/fdb-record-layer/issues/844)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -814,15 +814,14 @@ public class MoreAsyncUtil {
      * no deadline is imposed on the future.
      *
      * @param deadlineTimeMillis the maximum time to wait for the asynchronous operation to complete, specified in milliseconds
-     * @param supplier the {@link Supplier} of the asynchronous result
+     * @param valueFuture the asynchronous task to impose a deadline on
      * @param <T> the return type for the get operation
      * @return a future that will either complete with the result of the asynchronous get operation or
      * complete exceptionally if the deadline is exceeded
      */
     @API(API.Status.EXPERIMENTAL)
     public static <T> CompletableFuture<T> getWithDeadline(long deadlineTimeMillis,
-                                                           @Nonnull Supplier<CompletableFuture<T>> supplier) {
-        final CompletableFuture<T> valueFuture = supplier.get();
+                                                           @Nonnull CompletableFuture<T> valueFuture) {
         if (deadlineTimeMillis == Long.MAX_VALUE) {
             return valueFuture;
         }
@@ -937,7 +936,7 @@ public class MoreAsyncUtil {
     private MoreAsyncUtil() {}
 
     /**
-     * Exception that will be thrown when the <code>supplier</code> in {@link #getWithDeadline(long, Supplier)} fails to
+     * Exception that will be thrown when the <code>supplier</code> in {@link #getWithDeadline(long, CompletableFuture)} fails to
      * complete within the specified deadline time.
      */
     @SuppressWarnings("serial")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AsyncLoadingTask.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AsyncLoadingTask.java
@@ -1,0 +1,96 @@
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A task that can be supplied to an {@link AsyncLoadingCache}. This allows for an asynchronous task to be
+ * started and then cancelled later in the future.
+ *
+ * <p>
+ * Note that this API is experimental. It seems likely that as there is a broader, underlying problem on how
+ * to manage futures in a way that actually cancels the underlying work, it is possible that this API changes
+ * or is pushed down in the future.
+ * </p>
+ *
+ * @param <T> the type
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface AsyncLoadingTask<T> extends AutoCloseable {
+    /**
+     * Asynchronously load a value. Implementors can assume that this method will only be called
+     * once.
+     */
+    CompletableFuture<T> load();
+
+    /**
+     * Close any outstanding work associated with this task if possible. Note that unlike the close method
+     * in {@link AutoCloseable}s, this is not allowed to throw a checked exception.
+     */
+    @Override
+    void close();
+
+    /**
+     * Create an {@link AsyncLoadingTask} from a {@link Supplier} of a {@link CompletableFuture}. When
+     * {@link #load()} is called, the {@link Supplier} will be called to provide the given future. When
+     * {@link #close()} is called, the future, if created, will be cancelled. Note, however, that cancelling
+     * a future is not necessarily guaranteed to cancel any of the underlying work.
+     *
+     * @param futureSupplier a supplier of a {@link CompletableFuture}
+     * @param <T> the type returned by this future
+     * @return a task that wrapping the given supplier
+     */
+    static <T> AsyncLoadingTask<T> fromFutureSupplier(@Nonnull Supplier<CompletableFuture<T>> futureSupplier) {
+        return new AsyncLoadingTask<T>() {
+            @Nullable
+            private CompletableFuture<T> future;
+
+            @Override
+            public CompletableFuture<T> load() {
+                if (future == null) {
+                    future = futureSupplier.get();
+                }
+                return future;
+            }
+
+            @Override
+            public void close() {
+                if (future != null) {
+                    future.cancel(true);
+                }
+            }
+        };
+    }
+
+    /**
+     * Create an {@link AsyncLoadingTask} based on an {@link FDBDatabaseRunner} and a retriable operation. On
+     * {@link #load()}, this will run the operation (perhaps more than once if retries are required). On
+     * {@link #close()}, this will close the runner, which should cancel any ongoing transactions and stop
+     * future tasks from running.
+     *
+     * @param runner the runner to use to run the retriable task
+     * @param retriable the retriable operation to run
+     * @param <T> the type returned by the retriable task
+     * @return a task that wraps running the task with an {@link FDBDatabaseRunner}
+     */
+    static <T> AsyncLoadingTask<T> fromDatabaseRunner(@Nonnull FDBDatabaseRunner runner, @Nonnull Function<? super FDBRecordContext, CompletableFuture<? extends T>> retriable) {
+        return new AsyncLoadingTask<T>() {
+            @Override
+            public CompletableFuture<T> load() {
+                return runner.runAsync(retriable);
+            }
+
+            @Override
+            public void close() {
+                runner.close();
+            }
+        };
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.AsyncLoadingCache;
+import com.apple.foundationdb.record.AsyncLoadingTask;
 import com.apple.foundationdb.record.LoggableTimeoutException;
 import com.apple.foundationdb.record.RecordCoreRetriableTransactionException;
 import com.apple.foundationdb.record.ResolverStateProto;
@@ -558,7 +559,7 @@ public class FDBDatabase {
     @Nonnull
     @API(API.Status.INTERNAL)
     public CompletableFuture<ResolverStateProto.State> getStateForResolver(@Nonnull LocatableResolver resolver,
-                                                                           @Nonnull Supplier<CompletableFuture<ResolverStateProto.State>> loader) {
+                                                                           @Nonnull AsyncLoadingTask<ResolverStateProto.State> loader) {
         return resolverStateCache.orElseGet(resolver, loader);
     }
 


### PR DESCRIPTION
Now, if the right overload is used, the `AsyncLoadingCache` can be configured to cancel work if it encounters an error while attempting to load the value. The `LocatableResolver` code has been modified to use this new code path.

This fixes #844.