### PR TITLE
Resolves #848: Allow for setting the FDB transaction timeout on FDBRecordContexts

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -61,7 +61,8 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Additional methods, `setTransactionTimeoutMillis` and `getTransactionTimeoutMillis`, were added to the `FDBDatabaseRunner` interface that implementors will need to react to [(Issue #848)](https://github.com/FoundationDB/fdb-record-layer/issues/848)
+* **Breaking change** In resolving [Issue #848](https://github.com/FoundationDB/fdb-record-layer/issues/848), the semantics of setting a transaction ID were slightly modified so that an explicit `null` ID now also checks the MDC [(PR #849)](https://github.com/FoundationDB/fdb-record-layer/pull/849)
 
 // end next release
 -->

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -53,7 +53,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The transaction timeout option can now be set on `FDBRecordContext`s [(Issue #848)](https://github.com/FoundationDB/fdb-record-layer/issues/848)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
@@ -202,6 +202,32 @@ public interface FDBDatabaseRunner extends AutoCloseable {
     void setInitialDelayMillis(long initialDelayMillis);
 
     /**
+     * Set the transaction timeout for all transactions started by this runner. If set to {@link FDBDatabaseFactory#DEFAULT_TR_TIMEOUT_MILLIS},
+     * then this will use the value of set in the originating database's factory. If set to {@link FDBDatabaseFactory#UNLIMITED_TR_TIMEOUT_MILLIS},
+     * then no timeout will be imposed on transactions used by this runner.
+     *
+     * <p>
+     * Note that the error that the transaction hits, {@link FDBExceptions.FDBStoreTransactionTimeoutException},
+     * is not retriable, so if the runner encounters such an error, it will terminate.
+     * </p>
+     *
+     * @param transactionTimeoutMillis the transaction timeout time in milliseconds
+     * @see FDBDatabaseFactory#setTransactionTimeoutMillis(long)
+     */
+    void setTransactionTimeoutMillis(long transactionTimeoutMillis);
+
+    /**
+     * Get the transaction timeout for all transactions started by this runner. This will return the value configured
+     * for this runner through {@link #setTransactionTimeoutMillis(long)}. Note, however, that if the transaction timeout
+     * is set to {@link FDBDatabaseFactory#DEFAULT_TR_TIMEOUT_MILLIS}, then the actual timeout set for this transaction
+     * will be set to the value in the originating factory.
+     *
+     * @return the configured transacation timeout time in milliseconds
+     * @see #setTransactionTimeoutMillis(long)
+     */
+    long getTransactionTimeoutMillis();
+
+    /**
      * Open a new record context.
      * @return a new open record context
      * @see FDBDatabase#openContext(Map,FDBStoreTimer,FDBDatabase.WeakReadSemantics)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
@@ -221,7 +221,13 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
         if (closed) {
             throw new RunnerClosed();
         }
-        FDBRecordContext context = database.openContext(mdcContext, timer, weakReadSemantics, priority);
+        FDBRecordContextConfig contextConfig = FDBRecordContextConfig.newBuilder()
+                .setMdcContext(mdcContext)
+                .setTimer(timer)
+                .setWeakReadSemantics(weakReadSemantics)
+                .setPriority(priority)
+                .build();
+        FDBRecordContext context = database.openContext(contextConfig);
         addContextToClose(context);
         return context;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
@@ -71,6 +71,7 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
     private int maxAttempts;
     private long maxDelayMillis;
     private long initialDelayMillis;
+    private long transactionTimeoutMillis;
 
     private boolean closed;
     @Nonnull
@@ -93,6 +94,7 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
         this.maxAttempts = factory.getMaxAttempts();
         this.maxDelayMillis = factory.getMaxDelayMillis();
         this.initialDelayMillis = factory.getInitialDelayMillis();
+        this.transactionTimeoutMillis = factory.getTransactionTimeoutMillis();
 
         this.executor = FDBRecordContext.initExecutor(database, mdcContext);
 
@@ -216,6 +218,16 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
     }
 
     @Override
+    public void setTransactionTimeoutMillis(long transactionTimeoutMillis) {
+        this.transactionTimeoutMillis = transactionTimeoutMillis;
+    }
+
+    @Override
+    public long getTransactionTimeoutMillis() {
+        return transactionTimeoutMillis;
+    }
+
+    @Override
     @Nonnull
     public FDBRecordContext openContext() {
         if (closed) {
@@ -226,6 +238,7 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
                 .setTimer(timer)
                 .setWeakReadSemantics(weakReadSemantics)
                 .setPriority(priority)
+                .setTransactionTimeoutMillis(transactionTimeoutMillis)
                 .build();
         FDBRecordContext context = database.openContext(contextConfig);
         addContextToClose(context);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
@@ -102,6 +102,27 @@ public class FDBExceptions {
     }
 
     /**
+     * Exception thrown when a transaction times out. This refers specifically to timeouts enforced by the
+     * FoundationDB client, which can be configured by either setting the transaction timeout milliseconds
+     * on the {@link FDBDatabaseFactory}, the {@link FDBDatabaseRunner}, or the {@link FDBRecordContextConfig}.
+     *
+     * <p>
+     * Note that this exception is not retriable, and note also that it is not a child of {@link java.util.concurrent.TimeoutException}.
+     * </p>
+     *
+     * @see FDBDatabaseFactory#setTransactionTimeoutMillis(long)
+     * @see FDBDatabaseRunner#setTransactionTimeoutMillis(long)
+     * @see FDBRecordContextConfig.Builder#setTransactionTimeoutMillis(long)
+     * @see FDBRecordContext#getTimeoutMillis()
+     */
+    @SuppressWarnings("serial")
+    public static class FDBStoreTransactionTimeoutException extends FDBStoreException {
+        public FDBStoreTransactionTimeoutException(FDBException cause) {
+            super(cause);
+        }
+    }
+
+    /**
      * Transaction is too old to perform reads or be committed.
      */
     @SuppressWarnings("serial")
@@ -152,6 +173,8 @@ public class FDBExceptions {
                     return new FDBStoreTransactionIsTooOldException(fdbex).addLogInfo(logInfo);
                 case 1020:    // not_committed
                     return new FDBStoreTransactionConflictException(fdbex).addLogInfo(logInfo);
+                case 1031: // transaction_timed_out
+                    return new FDBStoreTransactionTimeoutException(fdbex).addLogInfo(logInfo);
                 case 2101:    // transaction_too_large
                     return new FDBStoreTransactionSizeException(fdbex).addLogInfo(logInfo);
                 case 2102:    // key_too_large

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
@@ -1,0 +1,308 @@
+/*
+ * FDBRecordContextConfig.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * A configuration struct that can be used to set various options on an {@link FDBRecordContext}. Instances
+ * of this configuration object can be passed to {@link FDBDatabase#openContext(FDBRecordContextConfig)}
+ * to create a new transaction with various parameters set according to the values specified here.
+ */
+public class FDBRecordContextConfig {
+    @Nullable
+    private final Map<String, String> mdcContext;
+    @Nullable
+    private final FDBStoreTimer timer;
+    @Nullable
+    private final FDBDatabase.WeakReadSemantics weakReadSemantics;
+    @Nonnull
+    private final FDBTransactionPriority priority;
+    @Nullable
+    private final String transactionId;
+
+    private FDBRecordContextConfig(@Nonnull Builder builder) {
+        this.mdcContext = builder.mdcContext;
+        this.timer = builder.timer;
+        this.weakReadSemantics = builder.weakReadSemantics;
+        this.priority = builder.priority;
+        this.transactionId = builder.transactionId;
+    }
+
+    /**
+     * Get the MDC context used to set additional keys and values when logging.
+     *
+     * @return the MDC context to use when logging
+     */
+    @Nullable
+    public Map<String, String> getMdcContext() {
+        return mdcContext;
+    }
+
+    /**
+     * Get the timer to use to instrument events. This is especially useful for tracking
+     * and timing operations that interact with the database.
+     *
+     * @return the timer to use to instrument events
+     */
+    @Nullable
+    public FDBStoreTimer getTimer() {
+        return timer;
+    }
+
+    /**
+     * Get the {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.WeakReadSemantics}
+     * configuration used when creating the transaction. This is used to determine whether this
+     * transaction should be created with a cached read version and whether this transaction should
+     * set the {@link com.apple.foundationdb.TransactionOptions#setCausalReadRisky()} option.
+     *
+     * @return the {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.WeakReadSemantics} to use when creating the transaction
+     */
+    @Nullable
+    public FDBDatabase.WeakReadSemantics getWeakReadSemantics() {
+        return weakReadSemantics;
+    }
+
+    /**
+     * Get the priority for the created transaction. For more details on that option, see
+     * {@link FDBTransactionPriority}.
+     *
+     * @return the priority for the created transaction
+     */
+    @Nonnull
+    public FDBTransactionPriority getPriority() {
+        return priority;
+    }
+
+    /**
+     * Get the ID to use for the transaction in FDB logs. See {@link FDBRecordContext}
+     * for more details.
+     *
+     * @return the ID to use for the transaction in FDB logs
+     */
+    @Nullable
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    /**
+     * Get a new builder for this class.
+     *
+     * @return a new builder for this class
+     */
+    @Nonnull
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Convert the current configuration to a builder. This will set all options in the builder to their
+     * current values in this configuration object.
+     *
+     * @return a new builder based on this configuration object
+     */
+    @Nonnull
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    /**
+     * A builder of {@link FDBRecordContextConfig}s using the standard builder pattern.
+     */
+    public static class Builder {
+        @Nullable
+        private Map<String, String> mdcContext = null;
+        @Nullable
+        private FDBStoreTimer timer = null;
+        @Nullable
+        private FDBDatabase.WeakReadSemantics weakReadSemantics = null;
+        @Nonnull
+        private FDBTransactionPriority priority = FDBTransactionPriority.DEFAULT;
+        @Nullable
+        private String transactionId = null;
+
+        private Builder() {
+        }
+
+        private Builder(@Nonnull FDBRecordContextConfig config) {
+            this.mdcContext = config.mdcContext;
+            this.timer = config.timer;
+            this.weakReadSemantics = config.weakReadSemantics;
+            this.priority = config.priority;
+            this.transactionId = config.transactionId;
+        }
+
+        /**
+         * Set the MDC context. By default, this will be set to {@code null}, which does not add any additional
+         * keys or values to the logs. Additionally, if the "uuid" key of this parameter is set and the
+         * transaction ID parameter is <em>not</em> set, then the transaction will set its logging ID based
+         * on the value of that key from the MDC context.
+         *
+         * @param mdcContext the MDC context to use when logging
+         * @return this builder
+         * @see FDBRecordContextConfig#getMdcContext()
+         * @see FDBRecordContextConfig.Builder#setTransactionId(String)
+         */
+        @Nonnull
+        public Builder setMdcContext(@Nullable Map<String, String> mdcContext) {
+            this.mdcContext = mdcContext;
+            return this;
+        }
+
+        /**
+         * Get the MDC context.
+         *
+         * @return the MDC context
+         * @see FDBRecordContextConfig#getMdcContext()
+         */
+        @Nullable
+        public Map<String, String> getMdcContext() {
+            return mdcContext;
+        }
+
+        /**
+         * Set the timer to use when instrumenting events. By default, this will be set to
+         * {@code null}, when means that events will not be instrumented.
+         *
+         * @param timer the timer to use to instrument events
+         * @return this builder
+         * @see FDBRecordContextConfig#getTimer()
+         */
+        @Nonnull
+        public Builder setTimer(@Nullable FDBStoreTimer timer) {
+            this.timer = timer;
+            return this;
+        }
+
+        /**
+         * Get the timer to use to instrument events.
+         *
+         * @return the current timer
+         * @see FDBRecordContextConfig#getTimer()
+         */
+        @Nullable
+        public FDBStoreTimer getTimer() {
+            return timer;
+        }
+
+        /**
+         * Set the {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.WeakReadSemantics} to use
+         * when creating a transaction. The default value is {@code null}, which indicates that the
+         * transaction should not use a cached read version and will not set
+         * {@link com.apple.foundationdb.TransactionOptions#setCausalReadRisky()}. This guarantees that the
+         * transaction will be linearizable, i.e., it will see all commits from all transactions that
+         * have committed before it.
+         *
+         * @param weakReadSemantics the {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.WeakReadSemantics} to use when creating the transaction
+         * @return this builder
+         * @see FDBRecordContextConfig#getWeakReadSemantics()
+         */
+        @Nonnull
+        public Builder setWeakReadSemantics(@Nullable FDBDatabase.WeakReadSemantics weakReadSemantics) {
+            this.weakReadSemantics = weakReadSemantics;
+            return this;
+        }
+
+        /**
+         * Get the {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.WeakReadSemantics} from this
+         * configuration.
+         *
+         * @return the {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.WeakReadSemantics}
+         * @see FDBRecordContextConfig#getWeakReadSemantics()
+         */
+        @Nullable
+        public FDBDatabase.WeakReadSemantics getWeakReadSemantics() {
+            return weakReadSemantics;
+        }
+
+        /**
+         * Set the {@link FDBTransactionPriority} to use when creating a transaction. By default, this
+         * will be set to {@link FDBTransactionPriority#DEFAULT}. For more details on what this value
+         * means, see {@link FDBTransactionPriority}.
+         *
+         * @param priority the priority to use when creating a transaction
+         * @return the transaction priority
+         * @see FDBTransactionPriority
+         * @see FDBRecordContextConfig#getPriority()
+         */
+        @Nonnull
+        public Builder setPriority(@Nonnull FDBTransactionPriority priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        /**
+         * Get the {@link FDBTransactionPriority}.
+         *
+         * @return the transaction priority
+         * @see FDBRecordContextConfig#getPriority()
+         */
+        @Nonnull
+        public FDBTransactionPriority getPriority() {
+            return priority;
+        }
+
+        /**
+         * Set the transaction ID to use within FDB logs. The default value of this parameter is
+         * {@code null}, which indicates that the transaction should look at the "uuid" key of the
+         * MDC context (if set) to set the transaction ID.
+         *
+         * <p>
+         * The transaction ID should typically be set to a string of entirely ASCII characters, and
+         * it should not exceed 100 bytes in length. If the string is longer than 100 bytes, then the
+         * ID may be truncated or dropped. See {@link FDBRecordContext#getTransactionId()}.
+         * </p>
+         *
+         * @param transactionId the ID to use for the transaction in FDB logs
+         * @return this builder
+         * @see FDBRecordContextConfig#getTransactionId()
+         * @see FDBRecordContext#getTransactionId()
+         */
+        @Nonnull
+        public Builder setTransactionId(@Nullable String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        /**
+         * Get the ID to use for the transaction within FDB logs.
+         *
+         * @return the ID to use for the transaction within FDB logs
+         * @see FDBRecordContextConfig#getTransactionId()
+         */
+        @Nullable
+        public String getTransactionId() {
+            return transactionId;
+        }
+
+        /**
+         * Create an {@link FDBRecordContextConfig} from this builder.
+         *
+         * @return an {@link FDBRecordContextConfig} with its values set based on this builder
+         */
+        @Nonnull
+        public FDBRecordContextConfig build() {
+            return new FDBRecordContextConfig(this);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
@@ -47,10 +47,15 @@ public class FDBTransactionContext {
     @Nullable
     protected FDBStoreTimer timer;
 
-    protected FDBTransactionContext(@Nonnull FDBDatabase database, @Nonnull Transaction transaction) {
+    protected FDBTransactionContext(@Nonnull FDBDatabase database, @Nonnull Transaction transaction, @Nullable FDBStoreTimer timer) {
         this.database = database;
         this.transaction = transaction;
         this.executor = transaction.getExecutor();
+        this.timer = timer;
+
+        if (timer != null) {
+            timer.increment(FDBStoreTimer.Counts.OPEN_CONTEXT);
+        }
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/SynchronizedSessionRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/SynchronizedSessionRunner.java
@@ -290,6 +290,16 @@ public class SynchronizedSessionRunner implements FDBDatabaseRunner {
     }
 
     @Override
+    public void setTransactionTimeoutMillis(long transactionTimeoutMillis) {
+        underlying.setTransactionTimeoutMillis(transactionTimeoutMillis);
+    }
+
+    @Override
+    public long getTransactionTimeoutMillis() {
+        return underlying.getTransactionTimeoutMillis();
+    }
+
+    @Override
     @Nonnull
     public FDBRecordContext openContext() {
         return underlying.openContext();


### PR DESCRIPTION
I, um, don't quite know how this blew up into ~700 lines added, but alas. The main goal of this change is to allow for the transaction timeout to be specified through the `FDBRecordContext`. In theory, one could always have called `ensureActive` and then set the option manually, but it seemed better to have a real way of doing this without needing to peek at internals.

This is broken into two commits:

1. The first refactors `FDBRecordContext` to take a `Config` object at creation. This is to ameliorate the fact that there was a growing number of essentially optional parameters into the object, so now those are hidden in an object. But that commit shouldn't make any functional changes *except* (because it simplified the implementation considerably), it is now the case that if you explicitly set a transaction ID to `null`, then it will still look in the MDC context for a `uuid` key. We could keep that behavior the same by, like, distinguishing between a "default" transaction ID and a "set to `null`" transaction ID, but I didn't.
1. The second adds to that config object a "timeout" parameter. The `FDBDatabaseFactory` and `FDBDatabaseRunner` classes also have timeout parameters, and transactions created by a runner will use the runner's timeout value if set, and all transactions will default to the database factory's value if unset. And, if *nothing* in these classes sets a timeout, it will use the value set at the FDB level, so this should be compatible with existing code that has used the various end-runs around the Record Layer to set these values already.

This resolves #848.