### PR TITLE
Resolves #864: KeySpacePath resolution should re-use the initiating transaction's read version

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -47,7 +47,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** The `LocatableResolver::resolve` methods have overloads that allow ancillary transactions started for key space path resolution to avoid starting another read version request [(Issue #864)](https://github.com/FoundationDB/fdb-record-layer/issues/864)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -1074,6 +1074,8 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      * <li>Same {@linkplain FDBStoreTimer timer}</li>
      * <li>Same {@linkplain #getMdcContext() MDC context}</li>
      * <li>Same {@linkplain FDBDatabase.WeakReadSemantics weak read semantics}</li>
+     * <li>Same {@linkplain FDBTransactionPriority priority}</li>
+     * <li>Same {@linkplain #getTimeoutMillis() transaction timeout}</li>
      * </ul>
      * @return a new database runner based on this context
      */
@@ -1083,6 +1085,8 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         runner.setTimer(timer);
         runner.setMdcContext(getMdcContext());
         runner.setWeakReadSemantics(weakReadSemantics);
+        runner.setPriority(priority);
+        runner.setTransactionTimeoutMillis(timeoutMillis);
         return runner;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
@@ -376,7 +376,7 @@ public class FDBReverseDirectoryCache {
      * used for tests in order to avoid spurious conflicts.
      */
     @VisibleForTesting
-    public void waitUntilReady() {
+    public void waitUntilReadyForTesting() {
         reverseDirectoryCacheEntry.join();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
@@ -371,6 +371,15 @@ public class FDBReverseDirectoryCache {
         }
     }
 
+    /**
+     * Wait for any asynchronous work started at object creation time to complete. This should only be
+     * used for tests in order to avoid spurious conflicts.
+     */
+    @VisibleForTesting
+    public void waitUntilReady() {
+        reverseDirectoryCacheEntry.join();
+    }
+
     private CompletableFuture<Subspace> getReverseCacheSubspace(LocatableResolver scope) {
         return reverseDirectoryCacheEntry.thenCombine(scope.getBaseSubspaceAsync(), (entry, subspace) ->
                 subspace.subspace(Tuple.from(entry)));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
@@ -287,7 +287,7 @@ public class DirectoryLayerDirectory extends KeySpaceDirectory {
     @Nonnull
     private CompletableFuture<ResolverResult> lookupInScope(@Nonnull final FDBRecordContext context, @Nonnull final String key) {
         return scopeGenerator.apply(context).thenCompose(resolver ->
-            resolver.resolveWithMetadata(context.getTimer(), key, createHooks));
+            resolver.resolveWithMetadata(context, key, createHooks));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -154,6 +154,23 @@ public abstract class LocatableResolver {
      * Map the String <code>name</code> to a Long within the scope of the path that this object was constructed with.
      * Will return the value that's persisted in FDB or create it if it does not exist.
      *
+     * <p>
+     * For an instrumented version of this method, see {@link #resolve(FDBStoreTimer, String)}.
+     * </p>
+     *
+     * @param name the value to resolve
+     * @return a future for the resolved Long value
+     * @see #resolve(FDBStoreTimer, String)
+     */
+    @Nonnull
+    public CompletableFuture<Long> resolve(@Nonnull String name) {
+        return resolve((FDBStoreTimer)null, name, ResolverCreateHooks.getDefault());
+    }
+
+    /**
+     * Map the String <code>name</code> to a Long within the scope of the path that this object was constructed with.
+     * Will return the value that's persisted in FDB or create it if it does not exist.
+     *
      * @param timer the {@link FDBStoreTimer} used for collecting metrics
      * @param name the value to resolve
      * @return a future for the resolved Long value
@@ -182,6 +199,25 @@ public abstract class LocatableResolver {
     @Nonnull
     public CompletableFuture<Long> resolve(@Nonnull FDBRecordContext context, @Nonnull String name) {
         return resolve(context, name, ResolverCreateHooks.getDefault());
+    }
+
+    /**
+     * Map the String <code>name</code> to a Long within the scope of the path that this object was constructed with.
+     * Will return the value that's persisted in FDB or create it if it does not exist.
+     *
+     * <p>
+     * For an instrumented version of this method, see {@link #resolve(FDBStoreTimer, String, ResolverCreateHooks)}
+     * </p>
+     *
+     * @param name the value to resolve
+     * @param hooks {@link ResolverCreateHooks} to run on create
+     * @return a future for the resolved Long value
+     * @see #resolve(FDBStoreTimer, String, ResolverCreateHooks)
+     */
+    @Nonnull
+    public CompletableFuture<Long> resolve(@Nonnull String name,
+                                           @Nonnull ResolverCreateHooks hooks) {
+        return resolve((FDBStoreTimer)null, name, hooks);
     }
 
     /**
@@ -224,6 +260,28 @@ public abstract class LocatableResolver {
                                            @Nonnull ResolverCreateHooks hooks) {
         return resolveWithMetadata(context, name, hooks)
                 .thenApply(ResolverResult::getValue);
+    }
+
+    /**
+     * Map the String <code>name</code> to a {@link ResolverResult} within the scope of the path that this object was
+     * constructed with. If we are creating the entry for <code>name</code>, The {@link ResolverCreateHooks} provided
+     * as <code>hooks</code> will be run. Any metadata that was already present or created can be seen by calling
+     * {@link ResolverResult#getMetadata()} on the returned result.
+     * Will return the value that's persisted in FDB or create it if it does not exist.
+     * 
+     * <p>
+     * For an instrumented version of this method, see {@link #resolveWithMetadata(FDBStoreTimer, String, ResolverCreateHooks)}.
+     * </p>
+     *
+     * @param name the value to resolve
+     * @param hooks {@link ResolverCreateHooks} to run on create
+     * @return a future for the {@link ResolverResult} containing the resolved value and metadata
+     * @see #resolveWithMetadata(FDBStoreTimer, String, ResolverCreateHooks)
+     */
+    @Nonnull
+    public CompletableFuture<ResolverResult> resolveWithMetadata(@Nonnull String name,
+                                                                 @Nonnull ResolverCreateHooks hooks) {
+        return resolveWithMetadata((FDBStoreTimer)null, name, hooks);
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
@@ -99,12 +99,12 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
         Map<String, Long> allocations = new HashMap<>();
         for (int i = 0; i < 50; i++) {
             String key = "key-" + i;
-            Long value = writer.resolve(null, key).join();
+            Long value = writer.resolve((FDBStoreTimer)null, key).join();
             allocations.put(key, value);
         }
 
         for (Map.Entry<String, Long> entry : allocations.entrySet()) {
-            Long value = reader.resolve(null, entry.getKey()).join();
+            Long value = reader.resolve((FDBStoreTimer)null, entry.getKey()).join();
             String reverseLookup = reader.reverseLookup(null, entry.getValue()).join();
             assertEquals(value, entry.getValue());
             assertEquals(reverseLookup, entry.getKey());
@@ -141,7 +141,7 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
                     });
         });
 
-        Long value = otherResolver.resolve(null, key).join();
+        Long value = otherResolver.resolve((FDBStoreTimer)null, key).join();
         loop.join();
         assertThat("The loop eventually reads the value we allocated", value, is(valueFromLoop.get()));
     }
@@ -155,7 +155,7 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
                 key -> database.runAsync(context ->
                         directoryLayer.createOrOpen(context.ensureActive(), Collections.singletonList(key))
                                 .thenApply(subspace -> Tuple.fromBytes(subspace.pack()).getLong(0))),
-                key -> globalScope.resolve(null, key),
+                key -> globalScope.resolve((FDBStoreTimer)null, key),
                 ExtendedDirectoryLayer.global(database), ScopedDirectoryLayer.global(database));
     }
 
@@ -201,8 +201,8 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
                                                LocatableResolver resolver2) {
         testParallelAllocation(checkDirectoryLayer,
                 database,
-                key -> resolver1.resolve(null, key),
-                key -> resolver2.resolve(null, key),
+                key -> resolver1.resolve((FDBStoreTimer)null, key),
+                key -> resolver2.resolve((FDBStoreTimer)null, key),
                 resolver1,
                 resolver2);
     }
@@ -267,8 +267,8 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
         for (int i = 0; i < 100; i++) {
             String oldDirLayerKey = i + "-old-dl-key";
             String newDirLayerKey = i + "-new-dl-key";
-            operations.add(directoryLayer.resolve(null, oldDirLayerKey).thenApply(value -> mappingsFromOld.put(oldDirLayerKey, value)));
-            operations.add(globalScope.resolve(null, newDirLayerKey).thenApply(value -> mappingsFromNew.put(newDirLayerKey, value)));
+            operations.add(directoryLayer.resolve((FDBStoreTimer)null, oldDirLayerKey).thenApply(value -> mappingsFromOld.put(oldDirLayerKey, value)));
+            operations.add(globalScope.resolve((FDBStoreTimer)null, newDirLayerKey).thenApply(value -> mappingsFromNew.put(newDirLayerKey, value)));
         }
         CompletableFuture.allOf(operations.toArray(new CompletableFuture<?>[0])).join();
 
@@ -292,11 +292,11 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     public void testScopedDirectoryLayerResolvesWithoutMetadata() {
         MetadataHook hook = name -> Tuple.from("metadata-for-" + name).pack();
         ResolverCreateHooks createHooks = new ResolverCreateHooks(ResolverCreateHooks.DEFAULT_CHECK, hook);
-        ResolverResult result = globalScope.resolveWithMetadata(null, "some-key", createHooks).join();
+        ResolverResult result = globalScope.resolveWithMetadata((FDBStoreTimer)null, "some-key", createHooks).join();
         assertArrayEquals(Tuple.from("metadata-for-some-key").pack(), result.getMetadata(), "metadata was added");
 
         ResolverResult resultFromScoped = ScopedDirectoryLayer.global(database)
-                .resolveWithMetadata(null, "some-key", /* no hooks */ ResolverCreateHooks.getDefault())
+                .resolveWithMetadata((FDBStoreTimer)null, "some-key", /* no hooks */ ResolverCreateHooks.getDefault())
                 .join();
         assertEquals(resultFromScoped.getValue(), result.getValue());
         assertThat(resultFromScoped.getMetadata(), is(nullValue()));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -237,7 +237,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         fdb.clearCaches();
 
         // In the scoped directory layer test, this can conflict with initializing the reverse directory layer
-        fdb.getReverseDirectoryCache().waitUntilReady();
+        fdb.getReverseDirectoryCache().waitUntilReadyForTesting();
 
         final String key = "hello " + UUID.randomUUID();
 
@@ -291,7 +291,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         fdb.clearCaches();
 
         // In the scoped directory layer test, this can conflict with initializing the reverse directory layer
-        fdb.getReverseDirectoryCache().waitUntilReady();
+        fdb.getReverseDirectoryCache().waitUntilReadyForTesting();
 
         final String key = "hello " + UUID.randomUUID();
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -83,8 +83,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -128,10 +130,10 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         }
         LocatableResolver resolver = scopedDirectoryGenerator.apply(database, path1);
 
-        Long value = resolver.resolve(null, "foo").join();
+        Long value = resolver.resolve((FDBStoreTimer)null, "foo").join();
 
         for (int i = 0; i < 5; i++) {
-            Long fetched = resolver.resolve(null, "foo").join();
+            Long fetched = resolver.resolve((FDBStoreTimer)null, "foo").join();
             assertThat("we should always get the original value", fetched, is(value));
         }
         CacheStats stats = database.getDirectoryCacheStats();
@@ -230,6 +232,152 @@ public abstract class LocatableResolverTest extends FDBTestBase {
     }
 
     @Test
+    public void testDirectoryCacheWithUncommittedContext() {
+        FDBDatabase fdb = FDBDatabaseFactory.instance().getDatabase();
+        fdb.clearCaches();
+
+        // In the scoped directory layer test, this can conflict with initializing the reverse directory layer
+        fdb.getReverseDirectoryCache().waitUntilReady();
+
+        final String key = "hello " + UUID.randomUUID();
+
+        FDBStoreTimer timer = new FDBStoreTimer();
+        long resolved;
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            context.getReadVersion(); // Ensure initial get read version is instrumented
+            resolved = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+            assertAll(
+                    () -> assertThat("directory resolution should not have been from cache", timer.getCount(FDBStoreTimer.Events.DIRECTORY_READ), equalTo(1)),
+                    () -> assertThat("should only have opened at most 2 child transaction", timer.getCount(FDBStoreTimer.Counts.OPEN_CONTEXT), lessThanOrEqualTo(3)),
+                    () -> assertThat("should only have gotten one read version", timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION), equalTo(1)),
+                    () -> assertThat("should have only committed the inner transaction", timer.getCount(FDBStoreTimer.Events.COMMIT), lessThanOrEqualTo(1))
+            );
+            // do not commit transaction (though child transaction updating the resolved key should have been committed)
+        }
+
+        // Should read cached value
+        timer.reset();
+        long resolved2;
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            context.getReadVersion(); // Ensure initial get read version is instrumented
+            resolved2 = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+            assertAll(
+                    () -> assertThat( "resolved value from cache does not match initial resolution", resolved2, equalTo(resolved)),
+                    () -> assertEquals(0, timer.getCount(FDBStoreTimer.Events.DIRECTORY_READ), "should not have read from the directory layer"),
+                    () -> assertEquals(1, timer.getCount(FDBStoreTimer.Counts.OPEN_CONTEXT), "should not have opened any additional contexts"),
+                    () -> assertEquals(1, timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION), "should not need any additional read versions"),
+                    () -> assertEquals(0, timer.getCount(FDBStoreTimer.Events.COMMIT))
+            );
+        }
+
+        // Clear the caches and see that the value in the database matches
+        database.clearCaches();
+        timer.reset();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            long resolved3 = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+            assertAll(
+                    () -> assertThat( "resolved value from database does not match initial resolution", resolved3, equalTo(resolved)),
+                    () -> assertThat("directory resolution should not have been from cache", timer.getCount(FDBStoreTimer.Events.DIRECTORY_READ), equalTo(1)),
+                    () -> assertThat("should only have opened at most 2 child transaction", timer.getCount(FDBStoreTimer.Counts.OPEN_CONTEXT), lessThanOrEqualTo(3)),
+                    () -> assertThat("should only have gotten one read version", timer.getCount(FDBStoreTimer.Events.GET_READ_VERSION), equalTo(1)),
+                    () -> assertThat("should only have committed the inner transaction", timer.getCount(FDBStoreTimer.Events.COMMIT), lessThanOrEqualTo(1))
+            );
+        }
+    }
+
+    @Test
+    public void testCachesWinnerOfConflict() {
+        FDBDatabase fdb = FDBDatabaseFactory.instance().getDatabase();
+        fdb.clearCaches();
+
+        // In the scoped directory layer test, this can conflict with initializing the reverse directory layer
+        fdb.getReverseDirectoryCache().waitUntilReady();
+
+        final String key = "hello " + UUID.randomUUID();
+
+        long resolved;
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context1 = fdb.openContext(null, timer); FDBRecordContext context2 = fdb.openContext(null, timer)) {
+            // Ensure both started
+            context1.getReadVersion();
+            context2.getReadVersion();
+
+            // Both contexts try to create the key
+            CompletableFuture<Long> resolvedFuture1 = globalScope.resolve(context1, key);
+            CompletableFuture<Long> resolvedFuture2 = globalScope.resolve(context2, key);
+
+            long resolved1 = context1.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, resolvedFuture1);
+            long resolved2 = context2.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, resolvedFuture2);
+
+            assertAll(
+                    () -> assertThat("two concurrent resolutions of the same key should match", resolved1, equalTo(resolved2)),
+                    () -> assertThat("at least one transaction should read from database", timer.getCount(FDBStoreTimer.Events.DIRECTORY_READ), greaterThanOrEqualTo(1)),
+                    () -> assertThat("should not open more transactions than the two parents and five children", timer.getCount(FDBStoreTimer.Counts.OPEN_CONTEXT), lessThanOrEqualTo(7)),
+                    () -> assertThat("should not have committed more than the five children", timer.getCount(FDBStoreTimer.Events.COMMIT), lessThanOrEqualTo(5))
+            );
+            resolved = resolved1;
+        }
+
+        timer.reset();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            context.getReadVersion();
+            long resolvedAgain = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+            assertAll(
+                    () -> assertThat("resolved value in cache should match initial resolution", resolvedAgain, equalTo(resolved)),
+                    () -> assertThat("should have resolved from cache", timer.getCount(FDBStoreTimer.Events.DIRECTORY_READ), equalTo(0))
+            );
+        }
+    }
+
+    /**
+     * This is mainly to test a counter factual where the same transaction is used to actually resolve the value as
+     * is used by the caller. In that case, one could accidentally pollute the cache with uncommitted data. To protect
+     * against that, this test is designed to fail if someone changes the resolution logic so that uncommitted data
+     * (even possibly uncommitted data re-read from the same transaction that wrote it) might be put in the cache.
+     */
+    @Test
+    public void testDoesNotCacheValueReadFromReadYourWritesCache() {
+        FDBDatabase fdb = FDBDatabaseFactory.instance().getDatabase();
+        fdb.clearCaches();
+
+        final String key = "hello " + UUID.randomUUID();
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        long resolved;
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            // First time: nothing in cache or DB. Entry is created.
+            resolved = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+            assertEquals(1, timer.getCount(FDBStoreTimer.Events.DIRECTORY_READ), "should have read from the database");
+
+            // Second time: if same context used to create and read, then this would read from transaction's read your writes cache, not the database
+            long resolvedAgain = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+            assertEquals(resolved, resolvedAgain, "resolving the same key should not change the value even in the same transaction");
+
+            // do not commit main transaction
+        }
+
+        // Read from cache. If present, this should not have changed its value
+        timer.reset();
+        boolean cached;
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            long resolvedFromCache = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+            cached = timer.getCount(FDBStoreTimer.Events.DIRECTORY_READ) == 0;
+            if (cached) {
+                assertEquals(resolved, resolvedFromCache, "resolved value should have changed when reading from cache");
+            }
+        }
+
+        // Clear caches, and re-read from the database.
+        if (cached) {
+            fdb.clearCaches();
+            timer.reset();
+            try (FDBRecordContext context = fdb.openContext(null, timer)) {
+                long resolvedFromDb = context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE, globalScope.resolve(context, key));
+                assertEquals(resolved, resolvedFromDb, "resolved value from database should have matched initial resolution");
+            }
+        }
+    }
+
+    @Test
     public void testResolveUseCacheCommits() {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setDirectoryCacheSize(10);
@@ -269,7 +417,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         try (FDBRecordContext context = database.openContext()) {
             for (int i = 0; i < 10; i++) {
                 String key = "string-" + i;
-                Long value = globalScope.resolve(context.getTimer(), key).join();
+                Long value = globalScope.resolve(context, key).join();
                 mappings.put(key, value);
             }
         }
@@ -294,8 +442,8 @@ public abstract class LocatableResolverTest extends FDBTestBase {
     public void testResolveWithNoMetadata() {
         Long value;
         ResolverResult noHookResult;
-        value = globalScope.resolve(null, "resolve-string").join();
-        noHookResult = globalScope.resolveWithMetadata(null, "resolve-string", ResolverCreateHooks.getDefault()).join();
+        value = globalScope.resolve((FDBStoreTimer)null, "resolve-string").join();
+        noHookResult = globalScope.resolveWithMetadata((FDBStoreTimer)null, "resolve-string", ResolverCreateHooks.getDefault()).join();
         assertThat("the value is the same", noHookResult.getValue(), is(value));
         assertThat("entry was created without metadata", noHookResult.getMetadata(), is(nullValue()));
     }
@@ -736,15 +884,15 @@ public abstract class LocatableResolverTest extends FDBTestBase {
 
         ResolverCreateHooks validHooks = new ResolverCreateHooks(validCheck, DEFAULT_HOOK);
         ResolverCreateHooks invalidHooks = new ResolverCreateHooks(invalidCheck, DEFAULT_HOOK);
-        Long value = path1Resolver.resolve(null, "some-key", validHooks).join();
+        Long value = path1Resolver.resolve((FDBStoreTimer)null, "some-key", validHooks).join();
         try (FDBRecordContext context = database.openContext()) {
             assertThat("it succeeds and writes the value", path1Resolver.mustResolve(context, "some-key").join(), is(value));
         }
 
-        assertThat("when reading the same key it doesn't perform the check", path1Resolver.resolve(null, "some-key", invalidHooks).join(), is(value));
+        assertThat("when reading the same key it doesn't perform the check", path1Resolver.resolve((FDBStoreTimer)null, "some-key", invalidHooks).join(), is(value));
 
         try {
-            path1Resolver.resolve(null, "another-key", invalidHooks).join();
+            path1Resolver.resolve((FDBStoreTimer)null, "another-key", invalidHooks).join();
             fail("should throw CompletionException");
         } catch (CompletionException ex) {
             assertThat("it has the correct cause", ex.getCause(), is(instanceOf(LocatableResolverLockedException.class)));
@@ -758,7 +906,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         MetadataHook hook = ignore -> metadata;
         final ResolverResult result;
         final ResolverCreateHooks hooks = new ResolverCreateHooks(DEFAULT_CHECK, hook);
-        result = globalScope.resolveWithMetadata(null, "a-key", hooks).join();
+        result = globalScope.resolveWithMetadata((FDBStoreTimer)null, "a-key", hooks).join();
         assertArrayEquals(metadata, result.getMetadata());
 
         // check that the result with metadata is persisted to the database
@@ -769,7 +917,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
             assertArrayEquals(expected.getMetadata(), resultFromDB.getMetadata());
         }
 
-        assertEquals(expected, globalScope.resolveWithMetadata(null, "a-key", hooks).join());
+        assertEquals(expected, globalScope.resolveWithMetadata((FDBStoreTimer)null, "a-key", hooks).join());
 
         byte[] newMetadata = Tuple.from("some-different-metadata").pack();
         MetadataHook newHook = ignore -> newMetadata;
@@ -777,7 +925,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
 
         // make sure we don't just read the cached value
         database.clearCaches();
-        assertArrayEquals(metadata, globalScope.resolveWithMetadata(null, "a-key", newHooks).join().getMetadata(),
+        assertArrayEquals(metadata, globalScope.resolveWithMetadata((FDBStoreTimer)null, "a-key", newHooks).join().getMetadata(),
                 "hook is only run on create, does not update metadata");
     }
 
@@ -798,7 +946,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         globalScope.updateMetadataAndVersion("some-key", newMetadata).join();
         ResolverResult expected = new ResolverResult(initialResult.getValue(), newMetadata);
         eventually("we see the new metadata", () ->
-                        globalScope.resolveWithMetadata(null, "some-key", hooks).join(),
+                        globalScope.resolveWithMetadata((FDBStoreTimer)null, "some-key", hooks).join(),
                 is(expected), 120, 10);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
@@ -149,7 +148,7 @@ public class ResolverMappingDigestTest extends FDBTestBase {
             boolean metadataForThisKey = allowMetadata && random.nextBoolean();
             byte[] metadata = metadataForThisKey ? Tuple.from("some metadata for key: " + key).pack() : null;
             MetadataHook hook = ignore -> metadata;
-            result = primary.resolveWithMetadata((FDBStoreTimer)null, key, new ResolverCreateHooks(DEFAULT_CHECK, hook)).join();
+            result = primary.resolveWithMetadata(key, new ResolverCreateHooks(DEFAULT_CHECK, hook)).join();
 
             mappings.put(key, result);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingDigestTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
@@ -148,7 +149,7 @@ public class ResolverMappingDigestTest extends FDBTestBase {
             boolean metadataForThisKey = allowMetadata && random.nextBoolean();
             byte[] metadata = metadataForThisKey ? Tuple.from("some metadata for key: " + key).pack() : null;
             MetadataHook hook = ignore -> metadata;
-            result = primary.resolveWithMetadata(null, key, new ResolverCreateHooks(DEFAULT_CHECK, hook)).join();
+            result = primary.resolveWithMetadata((FDBStoreTimer)null, key, new ResolverCreateHooks(DEFAULT_CHECK, hook)).join();
 
             mappings.put(key, result);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 
 import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.subspace.Subspace;
@@ -110,7 +109,7 @@ public class ScopedDirectoryLayerTest extends LocatableResolverTest {
         }
 
         LocatableResolver resolver = scopedDirectoryGenerator.apply(database, path);
-        Long value = resolver.resolve((FDBStoreTimer)null, "foo").join();
+        Long value = resolver.resolve("foo").join();
 
         DirectoryLayer directoryLayer = new DirectoryLayer(
                 new Subspace(Bytes.concat(path.toTuple().pack(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())),
@@ -132,14 +131,14 @@ public class ScopedDirectoryLayerTest extends LocatableResolverTest {
         String key1 = "key1";
         assertThat(noMetadata.getMetadataHook().apply(key1), is(nullValue()));
         // works as long as the metadatahook returns null
-        globalScope.resolveWithMetadata((FDBStoreTimer)null, key1, noMetadata).join();
+        globalScope.resolveWithMetadata(key1, noMetadata).join();
 
         String key2 = "key2";
         MetadataHook hook = name -> Tuple.from(name).pack();
         ResolverCreateHooks withMetadata = new ResolverCreateHooks(ResolverCreateHooks.DEFAULT_CHECK, hook);
         assertThat(withMetadata.getMetadataHook().apply(key2), is(not(nullValue())));
         assertThrows(CompletionException.class,
-                () -> globalScope.resolveWithMetadata((FDBStoreTimer)null, key2, withMetadata).join());
+                () -> globalScope.resolveWithMetadata(key2, withMetadata).join());
     }
 
     private void validate(FDBRecordContext context, LocatableResolver resolver, DirectoryLayer directoryLayer, String key, Long value) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayerTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 
 import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
 import com.apple.foundationdb.subspace.Subspace;
@@ -109,7 +110,7 @@ public class ScopedDirectoryLayerTest extends LocatableResolverTest {
         }
 
         LocatableResolver resolver = scopedDirectoryGenerator.apply(database, path);
-        Long value = resolver.resolve(null, "foo").join();
+        Long value = resolver.resolve((FDBStoreTimer)null, "foo").join();
 
         DirectoryLayer directoryLayer = new DirectoryLayer(
                 new Subspace(Bytes.concat(path.toTuple().pack(), DirectoryLayer.DEFAULT_NODE_SUBSPACE.getKey())),
@@ -131,14 +132,14 @@ public class ScopedDirectoryLayerTest extends LocatableResolverTest {
         String key1 = "key1";
         assertThat(noMetadata.getMetadataHook().apply(key1), is(nullValue()));
         // works as long as the metadatahook returns null
-        globalScope.resolveWithMetadata(null, key1, noMetadata).join();
+        globalScope.resolveWithMetadata((FDBStoreTimer)null, key1, noMetadata).join();
 
         String key2 = "key2";
         MetadataHook hook = name -> Tuple.from(name).pack();
         ResolverCreateHooks withMetadata = new ResolverCreateHooks(ResolverCreateHooks.DEFAULT_CHECK, hook);
         assertThat(withMetadata.getMetadataHook().apply(key2), is(not(nullValue())));
         assertThrows(CompletionException.class,
-                () -> globalScope.resolveWithMetadata(null, key2, withMetadata).join());
+                () -> globalScope.resolveWithMetadata((FDBStoreTimer)null, key2, withMetadata).join());
     }
 
     private void validate(FDBRecordContext context, LocatableResolver resolver, DirectoryLayer directoryLayer, String key, Long value) {


### PR DESCRIPTION
This adds overloads to `LocatableResolver::resolve` that allow a transaction to be passed, and then the resolver uses that transaction's read version when performing reads from the directory layer. In the "usual case" (which should be when a new entry does not need to be created), this transaction won't be committed anyway, so the only loss in efficiency over using the transaction itself is some extra memory (and no extra network requests).

It would probably still be a good idea to do #853 (if we can figure out what we want to do about caching), but this is easier and gets us 99% of the benefit. That being said, there is more cognitive load needed to understand this API, which is perhaps a smell.

This resolves #864.