### PR TITLE
Resolves #877: Add utility method for casting wrapped type of FDBRecord

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/ProtoUtils.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/ProtoUtils.java
@@ -1,0 +1,51 @@
+/*
+ * ProtoUtils.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.common;
+
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public class ProtoUtils {
+    @Nonnull
+    public static <M extends Message, N extends M> N cast(@Nonnull M oldMessage, @Nonnull Class<N> newMessageClass, @Nonnull Supplier<? extends Message.Builder> builderSupplier) {
+        if (newMessageClass.isInstance(oldMessage)) {
+            return newMessageClass.cast(oldMessage);
+        } else {
+            Message redoneMessage = builderSupplier.get().mergeFrom(oldMessage).build();
+            return newMessageClass.cast(redoneMessage);
+        }
+    }
+
+    @Nullable
+    public static <M extends Message, N extends M> N castOrNull(@Nullable M oldMessage, @Nonnull Class<N> newMessageClass, @Nonnull Supplier<? extends Message.Builder> builderSupplier) {
+        if (oldMessage == null) {
+            return null;
+        } else {
+            return cast(oldMessage, newMessageClass, builderSupplier);
+        }
+    }
+
+    private ProtoUtils() {
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TypeCheckingRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TypeCheckingRecordSerializer.java
@@ -1,0 +1,70 @@
+/*
+ * TypeCheckingRecordSerializer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.common;
+
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public class TypeCheckingRecordSerializer<M extends Message> implements RecordSerializer<M> {
+    @Nonnull
+    private final RecordSerializer<? super M> underlying;
+    @Nonnull
+    private final Class<M> messageClass;
+    @Nonnull
+    private final Supplier<? extends Message.Builder> builderSupplier;
+
+    private TypeCheckingRecordSerializer(@Nonnull RecordSerializer<? super  M> underlying, @Nonnull Class<M> messageClass, @Nonnull Supplier<? extends Message.Builder> builderSupplier) {
+        this.underlying = underlying;
+        this.messageClass = messageClass;
+        this.builderSupplier = builderSupplier;
+    }
+
+    @Nonnull
+    @Override
+    public byte[] serialize(@Nonnull RecordMetaData metaData, @Nonnull RecordType recordType, @Nonnull M record, @Nullable StoreTimer timer) {
+        return underlying.serialize(metaData, recordType, record, timer);
+    }
+
+    @Nonnull
+    @Override
+    public M deserialize(@Nonnull RecordMetaData metaData, @Nonnull Tuple primaryKey, @Nonnull byte[] serialized, @Nullable StoreTimer timer) {
+        Message msg = underlying.deserialize(metaData, primaryKey, serialized, timer);
+        return ProtoUtils.cast(msg, messageClass, builderSupplier);
+    }
+
+    @Nonnull
+    @Override
+    public RecordSerializer<Message> widen() {
+        return underlying.widen();
+    }
+
+    public static <M extends Message> TypeCheckingRecordSerializer<M> of(@Nonnull RecordSerializer<? super M> serializer, @Nonnull Class<M> messageClass, @Nonnull Supplier<? extends Message.Builder> builderSupplier) {
+        return new TypeCheckingRecordSerializer<>(serializer, messageClass, builderSupplier);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexableRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexableRecord.java
@@ -23,6 +23,9 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.google.protobuf.Message;
 
+import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
 /**
  * A record that can be passed to an index maintainer.
  *
@@ -30,4 +33,7 @@ import com.google.protobuf.Message;
  */
 @API(API.Status.STABLE)
 public interface FDBIndexableRecord<M extends Message> extends FDBRecord<M>, FDBStoredSizes {
+    @Nonnull
+    @Override
+    <N extends M> FDBIndexableRecord<N> cast(@Nonnull Class<N> messageClass, Supplier<? extends Message.Builder> builderSupplier);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRecord.java
@@ -32,6 +32,7 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * A record that has been loaded via an index.
@@ -138,6 +139,12 @@ public class FDBIndexedRecord<M extends Message> implements FDBRecord<M>, FDBSto
     @Override
     public FDBRecordVersion getVersion() {
         return getStoredRecord().getVersion();
+    }
+
+    @Nonnull
+    @Override
+    public <N extends M> FDBIndexedRecord<N> cast(@Nonnull Class<N> messageClass, Supplier<? extends Message.Builder> builderSupplier) {
+        return new FDBIndexedRecord<>(indexEntry, storedRecord == null ? null : storedRecord.cast(messageClass, builderSupplier));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecord.java
@@ -27,6 +27,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 /**
  * A record associated with the corresponding meta-data.
@@ -69,4 +70,7 @@ public interface FDBRecord<M extends Message> {
      */
     @Nullable
     FDBRecordVersion getVersion();
+
+    @Nonnull
+    <N extends M> FDBRecord<N> cast(@Nonnull Class<N> messageClass, Supplier<? extends Message.Builder> builderSupplier);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -50,6 +50,7 @@ import com.apple.foundationdb.record.metadata.StoreRecordFunction;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
+import com.apple.foundationdb.record.provider.common.TypeCheckingRecordSerializer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.storestate.FDBRecordStoreStateCache;
 import com.apple.foundationdb.record.query.RecordQuery;
@@ -68,6 +69,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 /**
  * Base interface for typed and untyped record stores.
@@ -127,6 +129,17 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
      */
     default <N extends Message> FDBTypedRecordStore<N> getTypedRecordStore(@Nonnull RecordSerializer<N> serializer) {
         return new FDBTypedRecordStore<>(getUntypedRecordStore(), serializer);
+    }
+
+    /**
+     * Get a typed record store for the given type.
+     *
+     * @param messageClass
+     * @param <N>
+     * @return
+     */
+    default <N extends M> FDBTypedRecordStore<N> getTypedRecordStore(@Nonnull Class<N> messageClass, @Nonnull Supplier<? extends Message.Builder> builderSupplier) {
+        return new FDBTypedRecordStore<>(getUntypedRecordStore(), TypeCheckingRecordSerializer.of(getSerializer(), messageClass, builderSupplier));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
@@ -22,11 +22,13 @@ package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.provider.common.ProtoUtils;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 /**
  * A record stored in the database.
@@ -102,6 +104,12 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     @Override
     public FDBRecordVersion getVersion() {
         return recordVersion;
+    }
+
+    @Nonnull
+    @Override
+    public <N extends M> FDBStoredRecord<N> cast(@Nonnull Class<N> messageClass, Supplier<? extends Message.Builder> builderSupplier) {
+        return new FDBStoredRecord<>(primaryKey, recordType, ProtoUtils.cast(record, messageClass, builderSupplier), this, recordVersion);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
@@ -23,11 +23,13 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.provider.common.ProtoUtils;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 /**
  * A builder for {@link FDBStoredRecord}.
@@ -95,6 +97,18 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
     @Override
     public FDBRecordVersion getVersion() {
         return recordVersion;
+    }
+
+    @Nonnull
+    @Override
+    public <N extends M> FDBStoredRecordBuilder<N> cast(@Nonnull Class<N> messageClass, Supplier<? extends Message.Builder> builderSupplier) {
+        FDBStoredRecordBuilder<N> storedRecordBuilder = new FDBStoredRecordBuilder<>();
+        storedRecordBuilder.setPrimaryKey(primaryKey);
+        storedRecordBuilder.setRecordType(recordType);
+        storedRecordBuilder.setRecord(ProtoUtils.castOrNull(record, messageClass, builderSupplier));
+        storedRecordBuilder.setVersion(recordVersion);
+        storedRecordBuilder.setSize(this);
+        return storedRecordBuilder;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSyntheticRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSyntheticRecord.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * A record synthesized from stored records.
@@ -214,4 +215,9 @@ public class FDBSyntheticRecord implements FDBIndexableRecord<Message> {
         return str.toString();
     }
 
+    @Nonnull
+    @Override
+    public <N extends Message> FDBIndexableRecord<N> cast(@Nonnull Class<N> messageClass, Supplier<? extends Message.Builder> builderSupplier) {
+        throw new UnsupportedOperationException("cannot cast a synthetic record");
+    }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/UnstoredRecord.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/UnstoredRecord.java
@@ -28,6 +28,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 /**
  * An {@link FDBRecord} that doesn't actually link to any record store.
@@ -68,6 +69,12 @@ public class UnstoredRecord<M extends Message> implements FDBRecord<M> {
     @Nullable
     @Override
     public FDBRecordVersion getVersion() {
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public <N extends M> FDBRecord<N> cast(@Nonnull Class<N> messageClass, Supplier<? extends Message.Builder> builderSupplier) {
         return null;
     }
 }


### PR DESCRIPTION
This resolves #877, though it's currently just a draft to potentially get eyes on the approach.

This adds a utility class with some static methods. Then the various implementations add ways of recreating themselves with the message type changed. Note that each one (unless I messed up) overrides the return type to be themselves.

Some missing information:

1. Documentation on the methods.
1. A real solution for synthetic records.
1. Tests
1. Release notes

But I wanted this some place people could see.