### PR TITLE
Address #884: Geospatial subproject build relies on external files which are no longer available

### DIFF
--- a/build.py
+++ b/build.py
@@ -160,7 +160,7 @@ def build(release=False, proto2=False, proto3=False, publish=False):
             success = run_gradle(3, ':fdb-record-layer-core-pb3:bintrayUpload',
                                     ':fdb-record-layer-core-pb3-shaded:bintrayUpload',
                                     ':fdb-record-layer-icu-pb3:bintrayUpload',
-                                    ':fdb-record-layer-spatial-pb3:bintrayUpload',
+                                    # ':fdb-record-layer-spatial-pb3:bintrayUpload',  # Disabled due to Issue #884
                                     '-PcoreNotStrict',
                                     '-PreleaseBuild={0}'.format('true' if release else 'false'),
                                     '-PpublishBuild=true')

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -62,6 +62,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* Releases for the `fdb-record-layer-spatial` library have been temporarily disabled [(Issue #884)](https://github.com/FoundationDB/fdb-record-layer/issues/884)
 
 // end next release
 -->

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,7 @@ include 'fdb-extensions'
 include 'fdb-record-layer-core'
 include 'fdb-record-layer-core-shaded'
 include 'fdb-record-layer-icu'
-include 'fdb-record-layer-spatial'
+// include 'fdb-record-layer-spatial' // Disabled due to Issue #884
 include 'examples'
 
 // It's confusing to have dozens of files called build.gradle scattered around the project
@@ -56,5 +56,5 @@ if (protoMajorVersion != "2") {
     project(':fdb-record-layer-core').name = "fdb-record-layer-core-pb${protoMajorVersion}"
     project(':fdb-record-layer-core-shaded').name = "fdb-record-layer-core-pb${protoMajorVersion}-shaded"
     project(':fdb-record-layer-icu').name = "fdb-record-layer-icu-pb${protoMajorVersion}"
-    project(':fdb-record-layer-spatial').name = "fdb-record-layer-spatial-pb${protoMajorVersion}"
+    // project(':fdb-record-layer-spatial').name = "fdb-record-layer-spatial-pb${protoMajorVersion}" // Disabled due to Issue #884
 }


### PR DESCRIPTION
This disables the build of the `fdb-record-layer-spatial` project until an actual fix to #884 can be achieved. This unblocks the builds of the other projects, though, which is good.