### PR TITLE
Fixes #901: False positive of uniqueness violations prevents building indexes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -33,7 +33,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Requires a minimum FoundationDB client and server version of 6.2 [(Issue #702)](https://github.com/FoundationDB/fdb-record-layer/issues/702)
 * **Breaking change** Builds now require JDK 11 [(Issue #910)](https://github.com/FoundationDB/fdb-record-layer/issues/910)
-* **Breaking change** `FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolations` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in replace of `updateOneKey` [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
+* **Breaking change** `FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolation` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in replace of `updateOneKey` [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** False positive of uniqueness violations prevents building indexes [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
@@ -33,7 +33,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Requires a minimum FoundationDB client and server version of 6.2 [(Issue #702)](https://github.com/FoundationDB/fdb-record-layer/issues/702)
 * **Breaking change** Builds now require JDK 11 [(Issue #910)](https://github.com/FoundationDB/fdb-record-layer/issues/910)
-* **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** `StandardIndexMaintainer` is now providing `updateOneKeyAsync` instead of `updateOneKey` [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,6 +12,8 @@ This version of the Record Layer requires a FoundationDB server version of at le
 
 Additionally, builds for the project now require JDK 11. The project is still targetting JDK 1.8 for both source and binary compatibility, so projects importing the library that have not yet upgraded to the newer JDK should still be able to import the project as before, but developers may need to update their local development environment if they have not already done so. 
 
+`FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolation` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in replace of `updateOneKey` .
+
 <!--
 // begin next release
 ### NEXT_RELEASE

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -33,7 +33,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Requires a minimum FoundationDB client and server version of 6.2 [(Issue #702)](https://github.com/FoundationDB/fdb-record-layer/issues/702)
 * **Breaking change** Builds now require JDK 11 [(Issue #910)](https://github.com/FoundationDB/fdb-record-layer/issues/910)
-* **Breaking change** `StandardIndexMaintainer` is now providing `updateOneKeyAsync` instead of `updateOneKey` [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
+* **Breaking change** `FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolations` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in replace of `updateOneKey` [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -12,7 +12,7 @@ This version of the Record Layer requires a FoundationDB server version of at le
 
 Additionally, builds for the project now require JDK 11. The project is still targetting JDK 1.8 for both source and binary compatibility, so projects importing the library that have not yet upgraded to the newer JDK should still be able to import the project as before, but developers may need to update their local development environment if they have not already done so. 
 
-`FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolation` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in replace of `updateOneKey` .
+`FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolation` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in place of `updateOneKey` .
 
 <!--
 // begin next release

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1211,8 +1211,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             if (remainPrimaryKey == null || !remainPrimaryKey.equals(uniquenessViolation.getPrimaryKey())) {
                 return deleteRecordAsync(uniquenessViolation.getPrimaryKey()).thenApply(ignore -> null);
             } else {
-                // The uniqueness violation entry of the remained primary key will de removed as part of
-                // removeUniquenessViolationsAsync when deleting the second last record that contains the value key.
+                // The uniqueness violation entry of the remained primary key will be removed as part of
+                // removeUniquenessViolationsAsync when deleting the second to last record that contains the value key.
                 return AsyncUtil.DONE;
             }
         }, getPipelineSize(PipelineOperation.RESOLVE_UNIQUENESS));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1233,8 +1233,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             if (primaryKey == null || !primaryKey.equals(uniquenessViolation.getPrimaryKey())) {
                 return deleteRecordAsync(uniquenessViolation.getPrimaryKey()).thenApply(ignore -> null);
             } else {
-                getIndexMaintainer(index).updateUniquenessViolations(valueKey, primaryKey, null, true);
-                return AsyncUtil.DONE;
+                return getIndexMaintainer(index).removeUniquenessViolationsAsync(valueKey, primaryKey);
             }
         }, getPipelineSize(PipelineOperation.RESOLVE_UNIQUENESS));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -114,10 +114,27 @@ public abstract class IndexMaintainer {
      * @param valueKey the indexed key that is (apparently) not unique
      * @param primaryKey the primary key of one record that is causing a violation
      * @param existingKey the primary key of another record that is causing a violation (or <code>null</code> if none specified)
-     * @param remove <code>true</code> if removing the violation and <code>false</code> if adding it
+     * @param remove <code>true</code> if removing the violation and <code>false</code> if adding it. When
+     * <code>true</code>, it is favored use {@link #removeUniquenessViolationsAsync(Tuple, Tuple)} instead.
      */
     @Nonnull
     public abstract void updateUniquenessViolations(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey, @Nullable Tuple existingKey, boolean remove);
+
+    /**
+     * Remove a uniqueness violation within the database. This is used to keep track of
+     * uniqueness violations that occur when an index is in write-only mode, both during
+     * the built itself and by other writes. This means that the writes will succeed, but
+     * it will cause a later attempt to make the index readable to fail.
+     *
+     * This will remove the last uniqueness violation entry when removing the second last one under the same
+     * <code>valueKey</code>, in contrast to {@link #updateUniquenessViolations(Tuple, Tuple, Tuple, boolean)} which
+     * may not.
+     * @param valueKey the indexed key that is (apparently) not unique
+     * @param primaryKey the primary key of one record that is causing a violation
+     * @return a future that is complete when the uniqueness violation is removed
+     */
+    @Nonnull
+    public abstract CompletableFuture<Void> removeUniquenessViolationsAsync(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey);
 
     /**
      * Scans through the list of uniqueness violations within the database.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -106,35 +106,6 @@ public abstract class IndexMaintainer {
     public abstract <M extends Message> CompletableFuture<Void> update(@Nullable FDBIndexableRecord<M> oldRecord,
                                                                        @Nullable FDBIndexableRecord<M> newRecord);
 
-    /**
-     * Remove or add a uniqueness violation within the database. This is used to keep track of
-     * uniqueness violations that occur when an index is in write-only mode, both during
-     * the built itself and by other writes. This means that the writes will succeed, but
-     * it will cause a later attempt to make the index readable to fail.
-     * @param valueKey the indexed key that is (apparently) not unique
-     * @param primaryKey the primary key of one record that is causing a violation
-     * @param existingKey the primary key of another record that is causing a violation (or <code>null</code> if none specified)
-     * @param remove <code>true</code> if removing the violation and <code>false</code> if adding it. When
-     * <code>true</code>, it is favored use {@link #removeUniquenessViolationsAsync(Tuple, Tuple)} instead.
-     */
-    @Nonnull
-    public abstract void updateUniquenessViolations(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey, @Nullable Tuple existingKey, boolean remove);
-
-    /**
-     * Remove a uniqueness violation within the database. This is used to keep track of
-     * uniqueness violations that occur when an index is in write-only mode, both during
-     * the built itself and by other writes. This means that the writes will succeed, but
-     * it will cause a later attempt to make the index readable to fail.
-     *
-     * This will remove the last uniqueness violation entry when removing the second last one under the same
-     * <code>valueKey</code>, in contrast to {@link #updateUniquenessViolations(Tuple, Tuple, Tuple, boolean)} which
-     * may not.
-     * @param valueKey the indexed key that is (apparently) not unique
-     * @param primaryKey the primary key of one record that is causing a violation
-     * @return a future that is complete when the uniqueness violation is removed
-     */
-    @Nonnull
-    public abstract CompletableFuture<Void> removeUniquenessViolationsAsync(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey);
 
     /**
      * Scans through the list of uniqueness violations within the database.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainer.java
@@ -73,18 +73,6 @@ public class NoOpIndexMaintainer extends IndexMaintainer {
 
     @Nonnull
     @Override
-    public void updateUniquenessViolations(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey, @Nullable Tuple existingKey, boolean remove) {
-        // doesn't do anything
-    }
-
-    @Nonnull
-    @Override
-    public CompletableFuture<Void> removeUniquenessViolationsAsync(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey) {
-        return AsyncUtil.DONE;
-    }
-
-    @Nonnull
-    @Override
     public RecordCursor<IndexEntry> scanUniquenessViolations(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
         return RecordCursor.empty();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainer.java
@@ -79,6 +79,12 @@ public class NoOpIndexMaintainer extends IndexMaintainer {
 
     @Nonnull
     @Override
+    public CompletableFuture<Void> removeUniquenessViolationsAsync(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey) {
+        return AsyncUtil.DONE;
+    }
+
+    @Nonnull
+    @Override
     public RecordCursor<IndexEntry> scanUniquenessViolations(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
         return RecordCursor.empty();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainer.java
@@ -20,9 +20,10 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
-import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.async.RankedSet;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.FunctionNames;
@@ -115,8 +116,12 @@ public class RankIndexMaintainer extends StandardIndexMaintainer {
         final Subspace extraSubspace = getSecondarySubspace();
         final List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (IndexEntry indexEntry : indexEntries) {
-            // First maintain an ordinary B-tree index by score.
+            // Maintain an ordinary B-tree index by score.
             CompletableFuture<Void> updateOrdinaryIndex = updateOneKeyAsync(savedRecord, remove, indexEntry);
+            if (!MoreAsyncUtil.isCompletedNormally(updateOrdinaryIndex)) {
+                futures.add(updateOrdinaryIndex);
+            }
+
             final Subspace rankSubspace;
             final Tuple scoreKey;
             if (groupPrefixSize > 0) {
@@ -127,9 +132,8 @@ public class RankIndexMaintainer extends StandardIndexMaintainer {
                 rankSubspace = extraSubspace;
                 scoreKey = indexEntry.getKey();
             }
-            futures.add(updateOrdinaryIndex.thenCompose(vignore ->
-                    RankedSetIndexHelper.updateRankedSet(state, rankSubspace, config, indexEntry.getKey(), scoreKey,
-                            remove)));
+            futures.add(RankedSetIndexHelper.updateRankedSet(state, rankSubspace, config, indexEntry.getKey(),
+                    scoreKey, remove));
         }
         return AsyncUtil.whenAll(futures);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainer.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.MutationType;
+import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCoreException;
@@ -40,6 +41,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Implementation of {@link IndexMaintainer} for the "version" index type. Here, the keys of the index are
@@ -69,9 +71,9 @@ public class VersionIndexMaintainer extends StandardIndexMaintainer {
 
     // Called by updateIndexKeys in StandardIndexMaintainer.
     @Override
-    protected <M extends Message> void updateOneKey(@Nonnull final FDBIndexableRecord<M> savedRecord,
-                                                    final boolean remove,
-                                                    @Nonnull final IndexEntry indexEntry) {
+    protected <M extends Message> CompletableFuture<Void> updateOneKeyAsync(@Nonnull final FDBIndexableRecord<M> savedRecord,
+                                                                      final boolean remove,
+                                                                      @Nonnull final IndexEntry indexEntry) {
         if (state.index.isUnique()) {
             throw new MetaDataException(String.format("%s index %s does not support unique indexes", state.index.getType(), state.index.getName()));
         }
@@ -107,5 +109,6 @@ public class VersionIndexMaintainer extends StandardIndexMaintainer {
                 state.store.getTimer().recordSinceNanoTime(FDBStoreTimer.Events.SAVE_INDEX_ENTRY, startTime);
             }
         }
+        return AsyncUtil.DONE;
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TerribleIndexMaintainer.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TerribleIndexMaintainer.java
@@ -99,6 +99,12 @@ public class TerribleIndexMaintainer extends IndexMaintainer {
 
     @Nonnull
     @Override
+    public CompletableFuture<Void> removeUniquenessViolationsAsync(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey) {
+        return AsyncUtil.DONE;
+    }
+
+    @Nonnull
+    @Override
     public RecordCursor<IndexEntry> scanUniquenessViolations(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
         throw new UnsupportedOperationException("Terrible index cannot scan uniqueness violations");
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TerribleIndexMaintainer.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TerribleIndexMaintainer.java
@@ -93,16 +93,6 @@ public class TerribleIndexMaintainer extends IndexMaintainer {
         }
     }
 
-    @Override
-    public void updateUniquenessViolations(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey, @Nullable Tuple indexKey, boolean remove) {
-    }
-
-    @Nonnull
-    @Override
-    public CompletableFuture<Void> removeUniquenessViolationsAsync(@Nonnull Tuple valueKey, @Nonnull Tuple primaryKey) {
-        return AsyncUtil.DONE;
-    }
-
     @Nonnull
     @Override
     public RecordCursor<IndexEntry> scanUniquenessViolations(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {


### PR DESCRIPTION
See background from https://github.com/FoundationDB/fdb-record-layer/issues/901

The main problem fixed by this PR is that: `FDBRecordStore.resolveUniquenessViolation` used to be relied on to delete the last uniqueness violation entry when delete the second last one. But this is not the only way the uniqueness violation is resolved. It doesn't cover the case that the violation is resolved when record is deleted organically. To resolve this problem, now it will delete the last entry as part of deleting records (See `removeUniquenessViolationsAsync`).

This change also tries to consolidate uniqueness logic at `StandardIndexMaintainer` level:
- `FDBRecordStore .addUniquenessCheck`  -> `StandardIndexMaintainer.checkUniqueness`
- `IndexMaintainer.updateUniquenessViolations` -> `StandardIndexMaintainer .addUniquenessViolations` and `StandardIndexMaintainer.removeUniquenessViolationsAsync`
