### PR TITLE
Fixes:DefaultTextTokenizer both iterates and seeks on the BreakIterator

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/DefaultTextTokenizer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/DefaultTextTokenizer.java
@@ -99,9 +99,10 @@ public class DefaultTextTokenizer implements TextTokenizer {
             if (nextToken != null) {
                 return true;
             }
-            int nextBreak = underlying.following(lastBreak);
+            int nextBreak = underlying.next();
             while (nextToken == null && nextBreak != BreakIterator.DONE) {
                 String token = text.substring(lastBreak, nextBreak);
+                lastBreak = nextBreak;
                 // Normalize the string to a standard normalization.
                 // This is done prior to checking for alphabetic characters
                 // because some Unicode characters (like the blackboard
@@ -133,8 +134,8 @@ public class DefaultTextTokenizer implements TextTokenizer {
                     //     안녕하세요 -> 안녕하세요 (Hangul Jamo not transformed)
                     token = matcher.reset(token.toLowerCase(Locale.ROOT)).replaceAll("");
                     nextToken = token;
+                    break;
                 }
-                lastBreak = nextBreak;
                 nextBreak = underlying.next();
             }
             return nextToken != null;


### PR DESCRIPTION
Small nit but I was working on a few text based queries and this seemed germane.

<img width="1458" alt="Screen Shot 2020-04-14 at 8 23 01 PM" src="https://user-images.githubusercontent.com/1850293/79296042-2090b900-7e8f-11ea-8256-6bbe91ad45f6.png">
