### PR TITLE
Fixes #905: LocatableResolver.runAsyncBorrowingReadVersion needs to be careful not to use cached read version on retry

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `FDBDatabaseRunner`s will now refetch a fresh read version on retry to avoid hitting the same conflict multiple times [(Issue #905)](https://github.com/FoundationDB/fdb-record-layer/issues/905)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunner.java
@@ -112,7 +112,15 @@ public interface FDBDatabaseRunner extends AutoCloseable {
     FDBDatabase.WeakReadSemantics getWeakReadSemantics();
 
     /**
-     * Set the read semantics used in record contexts opened by this runner.
+     * Set the read semantics used in record contexts opened by this runner. Within the retry loops
+     * {@link #run(Function)}, {@link #runAsync(Function)}, and their variants, only the first
+     * context (from the first iteration round the loop) actually sets the created record context's
+     * {@link FDBDatabase.WeakReadSemantics} to the provided value. This is because there are several
+     * reasons why a transaction may fail due to a stale read version (for example, a
+     * {@linkplain com.apple.foundationdb.record.provider.foundationdb.FDBExceptions.FDBStoreTransactionConflictException conflict}
+     * or {@linkplain com.apple.foundationdb.record.provider.foundationdb.FDBExceptions.FDBStoreTransactionIsTooOldException expired transaction}),
+     * and subsequent attempts will fail if their read version is not updated to a newer value.
+     *
      * @param weakReadSemantics allowable staleness parameters if caching read versions
      * @see FDBDatabase#openContext(Map,FDBStoreTimer,FDBDatabase.WeakReadSemantics)
      */


### PR DESCRIPTION
This modifies the behavior of `FDBDatabaseRunner`s so that they will not use the configured WeakReadSemantics on retry. This means that they should only use a cached read version at most once, so if they hit a conflict or if the transaction is too old, then on retry, they will get a chance to try again (rather than possibly using the same cached version). The issue mentions the `LocatableResolver`, which uses an `FDBDatabaseRunner` in a way that could expose this bug if the initiating transaction set the `WeakReadSemantics` to something non-trivial. This adds a test case to show that that issue that was seen through the `LocatableResolver` is also fixed.

Both of the new tests initially failed before the change to the non-testing code was made.

This fixes #905.