### PR TITLE
Resolves #910: Take build Docker Java version to 11

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -40,20 +40,6 @@
     </wildcardResourcePatterns>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
-      <profile name="Gradle Imported" enabled="true">
-        <outputRelativeToContentRoot value="true" />
-        <processorPath useClasspath="false">
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/23.5-jre/e9ce4989adf6092a3dab6152860e93d989e8cf88/guava-23.5-jre.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/0.8/c6f7af0e57b9d69d81b05434ef9f3c5610d498c4/auto-common-0.8.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.0.18/5f65affce1684999e2f4024983835efc3504012e/error_prone_annotations-2.0.18.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/ed28ded51a8b1c6b112568def5f4b455e6809019/j2objc-annotations-1.1.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.14/775b7e22fb10026eed3f86e8dc556dfafe35f2d5/animal-sniffer-annotations-1.14.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-qual/2.0.0/518929596ee3249127502a8573b2e008e2d51ed3/checker-qual-2.0.0.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0-rc4/44954d465f3b9065388bbd2fc08a3eb8fd07917c/auto-service-1.0-rc4.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/1.3.9/40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf/jsr305-1.3.9.jar" />
-        </processorPath>
-        <module name="fdb-record-layer-spatial_main" />
-      </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
       <module name="examples_integrationTest" target="1.8" />
@@ -74,8 +60,8 @@
       <module name="fdb-record-layer-spatial_integrationTest" target="1.8" />
       <module name="fdb-record-layer-spatial_main" target="1.8" />
       <module name="fdb-record-layer-spatial_test" target="1.8" />
-      <module name="fdb-record-layer_main" target="11" />
-      <module name="fdb-record-layer_test" target="11" />
+      <module name="fdb-record-layer_main" target="1.8" />
+      <module name="fdb-record-layer_test" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -40,6 +40,20 @@
     </wildcardResourcePatterns>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/23.5-jre/e9ce4989adf6092a3dab6152860e93d989e8cf88/guava-23.5-jre.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/0.8/c6f7af0e57b9d69d81b05434ef9f3c5610d498c4/auto-common-0.8.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.0.18/5f65affce1684999e2f4024983835efc3504012e/error_prone_annotations-2.0.18.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/ed28ded51a8b1c6b112568def5f4b455e6809019/j2objc-annotations-1.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.14/775b7e22fb10026eed3f86e8dc556dfafe35f2d5/animal-sniffer-annotations-1.14.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-qual/2.0.0/518929596ee3249127502a8573b2e008e2d51ed3/checker-qual-2.0.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0-rc4/44954d465f3b9065388bbd2fc08a3eb8fd07917c/auto-service-1.0-rc4.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/1.3.9/40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf/jsr305-1.3.9.jar" />
+        </processorPath>
+        <module name="fdb-record-layer-spatial_main" />
+      </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
       <module name="examples_integrationTest" target="1.8" />
@@ -60,8 +74,8 @@
       <module name="fdb-record-layer-spatial_integrationTest" target="1.8" />
       <module name="fdb-record-layer-spatial_main" target="1.8" />
       <module name="fdb-record-layer-spatial_test" target="1.8" />
-      <module name="fdb-record-layer_main" target="1.8" />
-      <module name="fdb-record-layer_test" target="1.8" />
+      <module name="fdb-record-layer_main" target="11" />
+      <module name="fdb-record-layer_test" target="11" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <item index="0" class="java.lang.String" itemvalue="com.google.auto.service.AutoService" />
     </list>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <item index="0" class="java.lang.String" itemvalue="com.google.auto.service.AutoService" />
     </list>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ apply from: file('gradle/coverage.gradle')
 subprojects {
     apply from: rootProject.file('gradle/testing.gradle')
 
-    sourceCompatibility = '1.8.0'
-    targetCompatibility = '1.8.0'
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
     ext {
         if (System.getenv('PROTO_VERSION') != null) {

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,11 +1,11 @@
 FROM centos:7
-LABEL version=0.0.13
+LABEL version=0.0.14
 
-RUN yum install -y java-1.8.0-openjdk-devel python git unzip wget which time
+RUN yum install -y java-11-openjdk-devel python git unzip wget which time
 RUN yum install -y https://www.foundationdb.org/downloads/6.2.7/rhel6/installers/foundationdb-clients-6.2.7-1.el6.x86_64.rpm nmap
 
 RUN mkdir -p /usr/local/bin
 COPY fdb_create_cluster_file.bash /usr/local/bin/fdb_create_cluster_file.bash
 
 ENV PATH="${PATH}:/opt/gradle/gradle-3.4.1/bin:/usr/local/bin"
-ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: fdb-record-layer-build:0.0.13
+    image: fdb-record-layer-build:0.0.14
     build:
       context: .
       dockerfile: Dockerfile.build

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,8 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 This version of the Record Layer requires a FoundationDB server version of at least version 6.2. Attempting to connect to older versions may result in the client hanging when attempting to connect to the database.
 
+Additionally, builds for the project now require JDK 11. The project is still targetting JDK 1.8 for both source and binary compatibility, so projects importing the library that have not yet upgraded to the newer JDK should still be able to import the project as before, but developers may need to update their local development environment if they have not already done so. 
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -30,7 +32,7 @@ This version of the Record Layer requires a FoundationDB server version of at le
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Requires a minimum FoundationDB client and server version of 6.2 [(Issue #702)](https://github.com/FoundationDB/fdb-record-layer/issues/702)
-* **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Builds now require JDK 11 [(Issue #910)](https://github.com/FoundationDB/fdb-record-layer/issues/910)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetection.java
@@ -23,7 +23,8 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 
 /**
- * Indicates whether <code>FDBDatabase.asyncToSync()</code> or <code>FDBRecordContext.asyncToSync()</code> should
+ * Indicates whether {@link FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture)} or
+ * {@link FDBRecordContext#asyncToSync(FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture)} should
  * attempt to detect when it is being called from an asynchronous context and, if so, how it should react to
  * this fact.  When this situation is detected, there are two scenarios that need to be dealt with:
  * <ul>
@@ -46,25 +47,27 @@ public enum BlockingInAsyncDetection {
     DISABLED(true, false),
 
     /**
-     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
-     * block, an exception will be thrown.
+     * When {@link FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture) asyncToSync()}
+     * is called in an asynchronous context and the future it is passed would block, an exception will be thrown.
      */
     IGNORE_COMPLETE_EXCEPTION_BLOCKING(true, true),
 
     /**
-     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
-     * block, an exception will be thrown; however, if the future is complete, then a warning will be logged.
+     * When {@link FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture) asyncToSync()}
+     * is called in an asynchronous context and the future it is passed would block, an exception will be thrown;
+     * however, if the future is complete, then a warning will be logged.
      */
     WARN_COMPLETE_EXCEPTION_BLOCKING(false, true),
 
     /**
-     * When <code>asyncToSync</code> is called in an asynchronous context and the future it is passed would
-     * block, a warning is logged.
+     * When {@link FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture) asyncToSync()}
+     * is called in an asynchronous context and the future it is passed would block, a warning is logged.
      */
     IGNORE_COMPLETE_WARN_BLOCKING(true, false),
 
     /**
-     * When <code>asyncToSync</code> is called in an asynchronous context, a warning is logged.
+     * When {@link FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture) asyncToSync()}
+     * is called in an asynchronous context, a warning is logged.
      */
     WARN_COMPLETE_WARN_BLOCKING(false, false)
     ;
@@ -78,9 +81,10 @@ public enum BlockingInAsyncDetection {
     }
 
     /**
-     * Indicates how to react if the future passed into <code>asyncToSync()</code> was completed. A return
-     * value of <code>true</code> indicates that this situation should be ignored, and a value of <code>false</code>
-     * indicates that a warning should be logged.
+     * Indicates how to react if the future passed into
+     * {@link FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture) asyncToSync()}
+     * was completed. A return value of <code>true</code> indicates that this situation should be ignored, and a value
+     * of <code>false</code> indicates that a warning should be logged.
      *
      * @return whether completed future should be ignored
      */
@@ -89,9 +93,10 @@ public enum BlockingInAsyncDetection {
     }
 
     /**
-     * Indicates how to react if the future passed into <code>asyncToSync()</code> has not yet been completed. A return
-     * value of <code>true</code> indicates that this situation should result in a {@link BlockingInAsyncException},
-     * and a value of <code>false</code> indicates that a warning should be logged.
+     * Indicates how to react if the future passed into
+     * {@link FDBDatabase#asyncToSync(FDBStoreTimer, FDBStoreTimer.Wait, java.util.concurrent.CompletableFuture) asyncToSync()}
+     * has not yet been completed. A return value of <code>true</code> indicates that this situation should result in a
+     * {@link BlockingInAsyncException}, and a value of <code>false</code> indicates that a warning should be logged.
      *
      * @return whether non-completed future should throw an exception
      */


### PR DESCRIPTION
This updates the JDK version we're using in our build docker, and increases the required JDK version for building the project to 11. AFAIK, there was only one thing we wanted in the build from JDK 11 that didn't require source changes, and it was related to Javadoc links. As a result, this resolves #910 (updating the Java version), and it resolves #325 (fixing some links).