### PR TITLE
Resolves #900: Gradle dependency refresh

### DIFF
--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -37,8 +37,8 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:${autoServiceVersion}"
 
     testCompile project(path: ':fdb-extensions', configuration: 'tests')
-    testCompile "org.hamcrest:hamcrest-all:1.3"
-    testCompile "com.beust:jcommander:1.71"
+    testCompile "org.hamcrest:hamcrest:2.2"
+    testCompile "com.beust:jcommander:1.78"
     testCompile "org.apache.commons:commons-math3:3.6.1"
     testCompile "org.apache.commons:commons-lang3:${commonsLang3Version}"
     testCompileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -70,7 +70,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -413,7 +413,7 @@ public class RecordCursorTest {
                 }
                 results++;
             }
-            assertThat(cursor.getNoNextReason(), isOneOf(possibleNoNextReasons));
+            assertThat(cursor.getNoNextReason(), is(oneOf(possibleNoNextReasons)));
             continuation = cursor.getContinuation();
             if (cursor.getNoNextReason().isSourceExhausted()) {
                 assertNull(continuation);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
@@ -306,13 +306,13 @@ public class TestHelpers {
         private List<LogEvent> matchedEvents = new ArrayList<>();
 
         protected MatchingAppender(@Nonnull String name, @Nonnull Pattern pattern) {
-            super(name, null, null);
+            super(name, null, null, true, null);
             this.pattern = pattern;
             this.messagePrefix = null;
         }
 
         protected MatchingAppender(@Nonnull String name, @Nonnull String messagePrefix) {
-            super(name, null, null);
+            super(name, null, null, true, null);
             this.pattern = null;
             this.messagePrefix = messagePrefix;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -110,8 +110,8 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1646,19 +1646,19 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             RecordIndexUniquenessViolation next = cursor.next();
             assertEquals(Tuple.from(3L), next.getIndexEntry().getKey());
             assertEquals(Tuple.from(1066L), next.getPrimaryKey());
-            assertThat(next.getExistingKey(), isOneOf(Tuple.from(1793L), Tuple.from(1849L)));
+            assertThat(next.getExistingKey(), is(oneOf(Tuple.from(1793L), Tuple.from(1849L))));
 
             assertTrue(cursor.hasNext());
             next = cursor.next();
             assertEquals(Tuple.from(3L), next.getIndexEntry().getKey());
             assertEquals(Tuple.from(1793L), next.getPrimaryKey());
-            assertThat(next.getExistingKey(), isOneOf(Tuple.from(1066L), Tuple.from(1849L)));
+            assertThat(next.getExistingKey(), is(oneOf(Tuple.from(1066L), Tuple.from(1849L))));
 
             assertTrue(cursor.hasNext());
             next = cursor.next();
             assertEquals(Tuple.from(3L), next.getIndexEntry().getKey());
             assertEquals(Tuple.from(1849L), next.getPrimaryKey());
-            assertThat(next.getExistingKey(), isOneOf(Tuple.from(1066L), Tuple.from(1793L)));
+            assertThat(next.getExistingKey(), is(oneOf(Tuple.from(1066L), Tuple.from(1793L))));
 
             assertFalse(cursor.hasNext());
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -63,8 +63,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -800,7 +800,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         Thread.sleep(50);
         int count2 = timer.getCount(FDBStoreTimer.Events.COMMIT);
         // Might close just after committing but before recording.
-        assertThat("At most one more commits should have occurred", count2, isOneOf(count1, count1 + 1));
+        assertThat("At most one more commits should have occurred", count2, is(oneOf(count1, count1 + 1)));
         Thread.sleep(50);
         int count3 = timer.getCount(FDBStoreTimer.Events.COMMIT);
         assertThat("No more commits should have occurred", count3, is(count2));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
@@ -61,9 +61,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -804,7 +804,7 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
                         // as we needed to do another speculative read to determine if a split record
                         // continues or not.
                         assertEquals(readLimit, rowsScanned);
-                        assertThat(recordCursor.getNoNextReason(), isOneOf(RecordCursor.NoNextReason.SCAN_LIMIT_REACHED , RecordCursor.NoNextReason.SOURCE_EXHAUSTED));
+                        assertThat(recordCursor.getNoNextReason(), is(oneOf(RecordCursor.NoNextReason.SCAN_LIMIT_REACHED , RecordCursor.NoNextReason.SOURCE_EXHAUSTED)));
                         if (!recordCursor.getNoNextReason().isSourceExhausted()) {
                             assertNotNull(recordCursor.getContinuation());
                         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
@@ -83,8 +83,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -868,7 +868,7 @@ public class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                     FDBQueriedRecord<Message> rec = cursor.next();
                     TestRecordsEnumProto.MyShapeRecord.Builder shapeRec = TestRecordsEnumProto.MyShapeRecord.newBuilder();
                     shapeRec.mergeFrom(rec.getRecord());
-                    assertThat(shapeRec.getColor(), isOneOf(TestRecordsEnumProto.MyShapeRecord.Color.RED, TestRecordsEnumProto.MyShapeRecord.Color.BLUE));
+                    assertThat(shapeRec.getColor(), is(oneOf(TestRecordsEnumProto.MyShapeRecord.Color.RED, TestRecordsEnumProto.MyShapeRecord.Color.BLUE)));
                     i++;
                 }
             }

--- a/fdb-record-layer-icu/gradle.properties
+++ b/fdb-record-layer-icu/gradle.properties
@@ -18,4 +18,4 @@
 # limitations under the License.
 #
 
-icuVersion=63.1
+icuVersion=66.1

--- a/fdb-record-layer-spatial/gradle.properties
+++ b/fdb-record-layer-spatial/gradle.properties
@@ -19,4 +19,4 @@
 #
 
 geophileVersion=2.3.0
-jtsVersion=1.16.0
+jtsVersion=1.16.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,14 +30,14 @@ group=org.foundationdb
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation
 
 fdbVersion=6.2.10
-jsr305Version=3.0.1
-slf4jVersion=1.7.14
-commonsLang3Version=3.9
-log4jVersion=2.4.1
-guavaVersion=27.0.1-jre
-autoServiceVersion=1.0-rc4
-junitVersion=5.5.2
-jacocoVersion=0.8.2
+jsr305Version=3.0.2
+slf4jVersion=1.7.30
+commonsLang3Version=3.10
+log4jVersion=2.13.1
+guavaVersion=28.1-jre
+autoServiceVersion=1.0-rc6
+junitVersion=5.6.2
+jacocoVersion=0.8.5
 
 protobuf2Version=2.6.1
 protobuf3Version=3.6.1


### PR DESCRIPTION
This updates most of our dependencies to their most recent versions, just to stay current. We'll probably also want to increase the FDB server version to 6.2.19, but I haven't done that yet because it will conflict with #911 in kind of a weird way.

This resolves #900.