### PR TITLE
Fixes:897 InClause evaluation is N^2

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** In Clauses no longer do N^2 comparisons [(Issue #913)](https://github.com/FoundationDB/fdb-record-layer/pull/913)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/expressions/QueryExpressionTest.java
@@ -362,7 +362,7 @@ public class QueryExpressionTest {
                         break;
                     }
                     final List<?> listComparand = (List<?>) val2;
-                    if (listComparand == null || listComparand.stream().anyMatch(o -> o == null)) {
+                    if (listComparand == null) {
                         try {
                             assertThrows(name, NullPointerException.class,
                                     () -> new Comparisons.ListComparison(Comparisons.Type.IN, listComparand));


### PR DESCRIPTION
Remove the n^2 evaluation for in clauses.

There are several queries I have been attempting to tune that have 100's of in clause participants coupled with 1K rows returned.