### PR TITLE
Fixes #482: Test failure in RankIndexTest::repeatedRankQuery

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** A race condition was fixed in the `RankIndexMaintainer` that could result in corrupt index data if a record had multiple entries inserted into the index with the same grouping key [(Issue #482)](https://github.com/FoundationDB/fdb-record-layer/issues/482)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -361,6 +361,9 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
                                 updateOneKey(savedRecord, remove, new IndexEntry(state.index, entryKey, entryValue));
 
                                 // Update the corresponding rankset for this leaderboard.
+                                // Notice that as each leaderboard has its own subspace key and at most one score
+                                // per record is chosen per leaderboard, this is the only time this record will be
+                                // indexed in this rankSubspace. Compare/contrast: RankIndexMaintainer::updateIndexKeys
                                 final Subspace rankSubspace = extraSubspace.subspace(leaderboardGroupKey);
                                 final RankedSet.Config leaderboardConfig = config.toBuilder().setNLevels(leaderboard.getNLevels()).build();
                                 futures.add(RankedSetIndexHelper.updateRankedSet(state, rankSubspace,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunction.java
@@ -138,6 +138,11 @@ public class QueryRecordFunction<T> implements PlanHashable {
         return new QueryRecordFunctionWithComparison(function, new Comparisons.SimpleComparison(type, comparand));
     }
 
+    @Nonnull
+    public QueryComponent withParameterComparison(@Nonnull Comparisons.Type type, String parameter) {
+        return new QueryRecordFunctionWithComparison(function, new Comparisons.ParameterComparison(type, parameter));
+    }
+
     public <M extends Message> CompletableFuture<T> eval(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context, @Nullable FDBStoredRecord<M> record) {
         if (record == null) {
             return CompletableFuture.completedFuture(null);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RankIndexTest.java
@@ -48,6 +48,7 @@ import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryRecordFunction;
 import com.apple.foundationdb.record.query.plan.QueryPlanner;
@@ -62,19 +63,25 @@ import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.coveringIndexScan;
@@ -87,7 +94,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -791,6 +800,136 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
                     .asList().join();
         }
         assertEquals(Arrays.asList("achilles", "patroclus", "hector"), res);
+    }
+
+    @Test
+    void repeatedRankManyTies() throws Exception {
+        Random random = new Random(2345);
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record1 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record1");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record2 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record2");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record3 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record3");
+        for (int i = 0; i < 100; i++) {
+            record1.addScore(random.nextInt(20));
+            record2.addScore(random.nextInt(20));
+            record3.addScore(random.nextInt(20));
+        }
+        repeatedRank(Stream.of(record1, record2, record3).map(builder -> builder.build()).collect(Collectors.toList()));
+    }
+
+    @Test
+    void repeatedRankFewTies() throws Exception {
+        Random random = new Random(2345);
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record1 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record1");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record2 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record2");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record3 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record3");
+        for (int i = 0; i < 100; i++) {
+            record1.addScore(random.nextInt(100));
+            record2.addScore(random.nextInt(100));
+            record3.addScore(random.nextInt(100));
+        }
+        repeatedRank(Stream.of(record1, record2, record3).map(builder -> builder.build()).collect(Collectors.toList()));
+    }
+
+    @Test
+    void repeatedRankVeryFewTies() throws Exception {
+        Random random = new Random(2345);
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record1 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record1");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record2 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record2");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record3 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record3");
+        for (int i = 0; i < 100; i++) {
+            record1.addScore(random.nextInt(1000));
+            record2.addScore(random.nextInt(1000));
+            record3.addScore(random.nextInt(1000));
+        }
+        repeatedRank(Stream.of(record1, record2, record3).map(builder -> builder.build()).collect(Collectors.toList()));
+    }
+
+    @Test
+    void repeatedRankNoTies() throws Exception {
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record1 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record1");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record2 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record2");
+        TestRecordsRankProto.RepeatedRankedRecord.Builder record3 = TestRecordsRankProto.RepeatedRankedRecord.newBuilder()
+                .setName("record3");
+        int j = 0;
+        for (int i = 0; i < 100; i++) {
+            record1.addScore(j);
+            j++;
+            record2.addScore(j);
+            j++;
+            record3.addScore(j);
+            j++;
+        }
+        repeatedRank(Stream.of(record1, record2, record3).map(builder -> builder.build()).collect(Collectors.toList()));
+    }
+
+    public void repeatedRank(List<TestRecordsRankProto.RepeatedRankedRecord> records) throws Exception {
+        fdb = FDBDatabaseFactory.instance().getDatabase();
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context);
+            recordStore.deleteAllRecords(); // Undo loadRecords().
+            for (TestRecordsRankProto.RepeatedRankedRecord record : records) {
+                recordStore.saveRecord(record);
+            }
+            commit(context);
+        }
+
+
+        final List<Pair<Integer, String>> recordsSortedByRankWithDuplicates = records.stream()
+                .flatMap(record -> record.getScoreList().stream().map(score -> Pair.of(score, record.getName())))
+                .sorted(Comparator.comparing(Pair::getLeft))
+                .collect(Collectors.toList());
+
+        List<List<Matcher<String>>> rankWithTies = new ArrayList<>();
+        Integer lastScore = null;
+        for (Pair<Integer, String> recordsSortedByRankWithDuplicate : recordsSortedByRankWithDuplicates) {
+            int score = recordsSortedByRankWithDuplicate.getLeft();
+            final String name = recordsSortedByRankWithDuplicate.getRight();
+            if (lastScore == null || !lastScore.equals(score)) {
+                ArrayList<Matcher<String>> tie = new ArrayList<>();
+                tie.add(equalTo(name));
+                rankWithTies.add(tie);
+            } else {
+                rankWithTies.get(rankWithTies.size() - 1).add(equalTo(name));
+            }
+            lastScore = score;
+        }
+
+
+        GroupingKeyExpression expr = Key.Expressions.field("score", KeyExpression.FanType.FanOut).ungrouped();
+        RecordQuery.Builder builder = RecordQuery.newBuilder()
+                .setRecordType("RepeatedRankedRecord")
+                .setFilter(
+                        Query.rank(expr).withParameterComparison(Comparisons.Type.EQUALS, "RANK_VALUE"));
+
+        RecordQuery query = builder.setRemoveDuplicates(false).build();
+        RecordQueryPlan plan = planner.plan(query);
+
+        assertAll(IntStream.range(0, rankWithTies.size()).mapToObj(i -> () -> {
+            List<Matcher<String>> tie = rankWithTies.get(i);
+
+            try (FDBRecordContext context = openContext()) {
+                try {
+                    openRecordStore(context);
+                } catch (Exception e) {
+                    Assertions.fail(e);
+                }
+                final List<String> actualRecords = plan.execute(recordStore, EvaluationContext.forBinding("RANK_VALUE", i))
+                        .map(rec -> TestRecordsRankProto.RepeatedRankedRecord.newBuilder().mergeFrom(rec.getRecord()).getName())
+                        .asList().join();
+                assertThat("For Rank " + i, actualRecords, containsInAnyOrder(tie));
+            }
+        }));
     }
 
     @Test


### PR DESCRIPTION
This looks like it was a real concurrency bug (one that can lead to the data being corrupt). Essentially, the ranked set does not allow concurrent updates to the same subspace in the same transaction. This is a known issue, and there are real ways to fix it (like implementing some kind of locking abstraction), but it is hard to get right in a way that also does not result in blocking in async threads. The patch here fixes the text index maintainer so that it issues its updates to the same subspace serially, though it can still update unrelated subspaces in parallel.

This fixes #482.