### PR TITLE
Resolves #925: Add assertions into record layer

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -54,7 +54,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Feature Add assertions into record layer [(Issue #925)](https://github.com/FoundationDB/fdb-record-layer/issues/925)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -54,7 +54,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature Add assertions into record layer [(Issue #925)](https://github.com/FoundationDB/fdb-record-layer/issues/925)
+* **Feature** Add key/value size enforcement assertions to FDBRecordContext [(Issue #925)](https://github.com/FoundationDB/fdb-record-layer/issues/925)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -748,10 +748,13 @@ public class FDBDatabase {
      * @return newly created transaction
      */
     private Transaction createTransaction(Executor executor, @Nullable StoreTimer storeTimer, @Nullable Map<String, String> mdcContext, boolean transactionIsTraced) {
+        final boolean enableAssertions = factory.areAssertionsEnabled();
         Transaction transaction = database.createTransaction(executor);
 
         if (storeTimer != null) {
-            transaction = new InstrumentedTransaction(storeTimer, transaction);
+            transaction = new InstrumentedTransaction(storeTimer, transaction, enableAssertions);
+        } else if (enableAssertions) {
+            transaction = new InstrumentedTransaction(new FDBStoreTimer(), transaction, enableAssertions);
         }
 
         if (transactionIsTraced) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.RecordCoreRetriableTransactionException;
 import com.apple.foundationdb.record.ResolverStateProto;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
-import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverResult;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ScopedValue;
@@ -410,7 +409,7 @@ public class FDBDatabase {
         openFDB();
         final boolean transactionIsTraced = transactionIsTracedSupplier.get();
         final Executor executor = newContextExecutor(contextConfig.getMdcContext());
-        final Transaction transaction = createTransaction(executor, contextConfig.getTimer(), contextConfig.getMdcContext(), transactionIsTraced);
+        final Transaction transaction = createTransaction(contextConfig, executor, transactionIsTraced);
 
         FDBRecordContext context = new FDBRecordContext(this, transaction, contextConfig, transactionIsTraced);
         final WeakReadSemantics weakReadSemantics = context.getWeakReadSemantics();
@@ -733,32 +732,35 @@ public class FDBDatabase {
     @Deprecated
     @API(API.Status.DEPRECATED)
     public Transaction createTransaction(Executor executor, @Nullable Map<String, String> mdcContext, boolean transactionIsTraced) {
-        return createTransaction(executor, null, mdcContext, transactionIsTraced);
+        return createTransaction(
+                FDBRecordContextConfig.newBuilder()
+                        .setMdcContext(mdcContext)
+                        .build(),
+                executor,
+                transactionIsTraced);
     }
 
     /**
      * Creates a new transaction against the database.
      *
      * @param executor the executor to be used for asynchronous operations
-     * @param storeTimer if not {@code null}, will be used too track low level operations (e.g. reads/writes/deletes)
-     * @param mdcContext if not [@code null} and tracing is enabled, information in the context will be included
-     *      in tracing log messages
      * @param transactionIsTraced if true, the transaction will produce tracing messages (for example, logging when
      *      the transaction is cleaned up without having been closed)
      * @return newly created transaction
      */
-    private Transaction createTransaction(Executor executor, @Nullable StoreTimer storeTimer, @Nullable Map<String, String> mdcContext, boolean transactionIsTraced) {
-        final boolean enableAssertions = factory.areAssertionsEnabled();
+    private Transaction createTransaction(@Nonnull FDBRecordContextConfig config,
+                                          @Nonnull Executor executor,
+                                          boolean transactionIsTraced) {
         Transaction transaction = database.createTransaction(executor);
 
-        if (storeTimer != null) {
-            transaction = new InstrumentedTransaction(storeTimer, transaction, enableAssertions);
-        } else if (enableAssertions) {
-            transaction = new InstrumentedTransaction(new FDBStoreTimer(), transaction, enableAssertions);
+        if (config.getTimer() != null) {
+            transaction = new InstrumentedTransaction(config.getTimer(), transaction, config.areAssertionsEnabled());
+        } else if (config.areAssertionsEnabled()) {
+            transaction = new InstrumentedTransaction(null, transaction, true);
         }
 
         if (transactionIsTraced) {
-            transaction = new TracedTransaction(transaction, mdcContext);
+            transaction = new TracedTransaction(transaction, config.getMdcContext());
         }
 
         return transaction;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -122,13 +122,6 @@ public class FDBDatabaseFactory {
      */
     @Nonnull
     private Supplier<Boolean> transactionIsTracedSupplier = LOGGER::isTraceEnabled;
-    /**
-     * A supplier that, when it returns true, enables assertions/sanity checks on certain operations. This supplier is
-     * polled upon the creation of a new {@code FDBRecordContext} and all subsequent operations on that context will
-     * (or will not) enforce assertions based upon the return value.
-     */
-    @Nonnull
-    private Supplier<Boolean> enableAssertionsSupplier = DEFAULT_ENABLE_ASSERTIONS_SUPPLIER;
     @Nonnull
     private Supplier<BlockingInAsyncDetection> blockingInAsyncDetectionSupplier = () -> BlockingInAsyncDetection.DISABLED;
     @Nonnull
@@ -486,25 +479,6 @@ public class FDBDatabaseFactory {
 
     public Supplier<Boolean> getTransactionIsTracedSupplier() {
         return transactionIsTracedSupplier;
-    }
-
-    /**
-     * Sets a supplier that is polled upon the creation of new {@link FDBRecordContext}'s to either enable or disable
-     * sanity check assertions of operations performed on that context.
-     *
-     * @param enableAssertionsSupplier a supplier that returns {@code true} if assertions should be enabled
-     */
-    public void setEnableAssertionsSupplier(Supplier<Boolean> enableAssertionsSupplier) {
-        this.enableAssertionsSupplier = enableAssertionsSupplier;
-    }
-
-    /**
-     * Polls the supplier installed by {@link #setEnableAssertionsSupplier(Supplier)} to determine if a transaction
-     * should have sanity check assertions enabled.
-     * @return {@code true} if sanity check assertions should be enabled
-     */
-    protected boolean areAssertionsEnabled() {
-        return enableAssertionsSupplier.get();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -50,7 +50,6 @@ public class FDBDatabaseFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabaseFactory.class);
 
     protected static final Function<FDBLatencySource, Long> DEFAULT_LATENCY_INJECTOR = api -> 0L;
-    protected static final Supplier<Boolean> DEFAULT_ENABLE_ASSERTIONS_SUPPLIER = () -> false;
 
     /**
      * The default number of entries that is to be cached, per database, from

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -50,6 +50,7 @@ public class FDBDatabaseFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabaseFactory.class);
 
     protected static final Function<FDBLatencySource, Long> DEFAULT_LATENCY_INJECTOR = api -> 0L;
+    protected static final Supplier<Boolean> DEFAULT_ENABLE_ASSERTIONS_SUPPLIER = () -> false;
 
     /**
      * The default number of entries that is to be cached, per database, from
@@ -121,6 +122,13 @@ public class FDBDatabaseFactory {
      */
     @Nonnull
     private Supplier<Boolean> transactionIsTracedSupplier = LOGGER::isTraceEnabled;
+    /**
+     * A supplier that, when it returns true, enables assertions/sanity checks on certain operations. This supplier is
+     * polled upon the creation of a new {@code FDBRecordContext} and all subsequent operations on that context will
+     * (or will not) enforce assertions based upon the return value.
+     */
+    @Nonnull
+    private Supplier<Boolean> enableAssertionsSupplier = DEFAULT_ENABLE_ASSERTIONS_SUPPLIER;
     @Nonnull
     private Supplier<BlockingInAsyncDetection> blockingInAsyncDetectionSupplier = () -> BlockingInAsyncDetection.DISABLED;
     @Nonnull
@@ -478,6 +486,25 @@ public class FDBDatabaseFactory {
 
     public Supplier<Boolean> getTransactionIsTracedSupplier() {
         return transactionIsTracedSupplier;
+    }
+
+    /**
+     * Sets a supplier that is polled upon the creation of new {@link FDBRecordContext}'s to either enable or disable
+     * sanity check assertions of operations performed on that context.
+     *
+     * @param enableAssertionsSupplier a supplier that returns {@code true} if assertions should be enabled
+     */
+    public void setEnableAssertionsSupplier(Supplier<Boolean> enableAssertionsSupplier) {
+        this.enableAssertionsSupplier = enableAssertionsSupplier;
+    }
+
+    /**
+     * Polls the supplier installed by {@link #setEnableAssertionsSupplier(Supplier)} to determine if a transaction
+     * should have sanity check assertions enabled.
+     * @return {@code true} if sanity check assertions should be enabled
+     */
+    protected boolean areAssertionsEnabled() {
+        return enableAssertionsSupplier.get();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
@@ -43,6 +43,7 @@ public class FDBRecordContextConfig {
     @Nullable
     private final String transactionId;
     private final long transactionTimeoutMillis;
+    private final boolean enableAssertions;
 
     private FDBRecordContextConfig(@Nonnull Builder builder) {
         this.mdcContext = builder.mdcContext;
@@ -51,6 +52,7 @@ public class FDBRecordContextConfig {
         this.priority = builder.priority;
         this.transactionId = builder.transactionId;
         this.transactionTimeoutMillis = builder.transactionTimeoutMillis;
+        this.enableAssertions = builder.enableAssertions;
     }
 
     /**
@@ -120,6 +122,14 @@ public class FDBRecordContextConfig {
     }
 
     /**
+     * Returns whether or not internal correctness assertions are enabled.
+     * @return whether or not internal correctness assertions are enabled
+     */
+    public boolean areAssertionsEnabled() {
+        return enableAssertions;
+    }
+
+    /**
      * Get a new builder for this class.
      *
      * @return a new builder for this class
@@ -155,6 +165,7 @@ public class FDBRecordContextConfig {
         @Nullable
         private String transactionId = null;
         private long transactionTimeoutMillis = FDBDatabaseFactory.DEFAULT_TR_TIMEOUT_MILLIS;
+        private boolean enableAssertions = false;
 
         private Builder() {
         }
@@ -166,6 +177,7 @@ public class FDBRecordContextConfig {
             this.priority = config.priority;
             this.transactionId = config.transactionId;
             this.transactionTimeoutMillis = config.transactionTimeoutMillis;
+            this.enableAssertions = config.enableAssertions;
         }
 
         /**
@@ -334,6 +346,27 @@ public class FDBRecordContextConfig {
 
         private long getTransactionTimeoutMillis() {
             return transactionTimeoutMillis;
+        }
+
+
+        /**
+         * Enables or disables internal correctness assertions for the context, such as validating maximum key and
+         * value lengths for all database requests.
+         *
+         * @param enableAssertions whether or not assertions are enabled
+         * @return this builder
+         */
+        public Builder setEnableAssertions(boolean enableAssertions) {
+            this.enableAssertions = enableAssertions;
+            return this;
+        }
+
+        /**
+         * Return whether or not correctness assertions will enabled for the context.
+         * @return {@code true} if correctness assertions are to be enabled for the context
+         */
+        public boolean areAssertionsEnabled() {
+            return enableAssertions;
         }
 
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
@@ -29,7 +29,9 @@ import com.apple.foundationdb.TransactionOptions;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncIterator;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -45,14 +47,21 @@ import java.util.function.Function;
  * @param <T> the type of transaction to be instrumented
  */
 abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements ReadTransaction {
+
+    protected static final int MAX_KEY_LENGTH = 10_000;
+    protected static final int MAX_VALUE_LENGTH = 100_000;
+
     @Nonnull
     protected StoreTimer timer;
     @Nonnull
     protected T underlying;
 
-    public InstrumentedReadTransaction(@Nonnull StoreTimer timer, @Nonnull T underlying) {
+    protected final boolean enableAssertions;
+
+    public InstrumentedReadTransaction(@Nonnull StoreTimer timer, @Nonnull T underlying, boolean enableAssertions) {
         this.timer = timer;
         this.underlying = underlying;
+        this.enableAssertions = enableAssertions;
     }
 
     @Override
@@ -72,97 +81,97 @@ abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements
 
     @Override
     public boolean addReadConflictRangeIfNotSnapshot(byte[] keyBegin, byte[] keyEnd) {
-        return underlying.addReadConflictRangeIfNotSnapshot(keyBegin, keyEnd);
+        return underlying.addReadConflictRangeIfNotSnapshot(checkKey(keyBegin), checkKey(keyEnd));
     }
 
     @Override
     public boolean addReadConflictKeyIfNotSnapshot(byte[] key) {
-        return underlying.addReadConflictKeyIfNotSnapshot(key);
+        return underlying.addReadConflictKeyIfNotSnapshot(checkKey(key));
     }
 
     @Override
     public CompletableFuture<byte[]> get(byte[] key) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return underlying.get(key).thenApply(this::recordRead);
+        return underlying.get(checkKey(key)).thenApply(this::recordRead);
     }
 
     @Override
     public CompletableFuture<byte[]> getKey(KeySelector keySelector) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return underlying.getKey(keySelector).thenApply(this::recordRead);
+        return underlying.getKey(checkKey(keySelector)).thenApply(this::recordRead);
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end) {
         /* Should this could as one read? */
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end)));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end, int limit) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end, limit));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end), limit));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end, int limit, boolean reverse) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end, limit, reverse));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end), limit, reverse));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end, int limit, boolean reverse, StreamingMode streamingMode) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end, limit, reverse, streamingMode));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end), limit, reverse, streamingMode));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(byte[] begin, byte[] end) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end)));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(byte[] begin, byte[] end, int limit) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end, limit));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end), limit));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(byte[] begin, byte[] end, int limit, boolean reverse) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end, limit, reverse));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end), limit, reverse));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(byte[] begin, byte[] end, int limit, boolean reverse, StreamingMode streamingMode) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(begin, end, limit, reverse, streamingMode));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(begin), checkKey(end), limit, reverse, streamingMode));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(Range range) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(range));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(range)));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(Range range, int limit) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(range, limit));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(range), limit));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(Range range, int limit, boolean reverse) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(range, limit, reverse));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(range), limit, reverse));
     }
 
     @Override
     public AsyncIterable<KeyValue> getRange(Range range, int limit, boolean reverse, StreamingMode streamingMode) {
         timer.increment(FDBStoreTimer.Counts.READS);
-        return new ByteCountingAsyncIterable(underlying.getRange(range, limit, reverse, streamingMode));
+        return new ByteCountingAsyncIterable(underlying.getRange(checkKey(range), limit, reverse, streamingMode));
     }
 
     @Override
@@ -197,6 +206,39 @@ abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements
     protected KeyValue recordRead(@Nonnull KeyValue keyValue) {
         timer.increment(FDBStoreTimer.Counts.BYTES_READ, keyValue.getKey().length + keyValue.getValue().length);
         return keyValue;
+    }
+
+    @Nonnull
+    protected KeySelector checkKey(@Nonnull KeySelector keySelector) {
+        checkKey(keySelector.getKey());
+        return keySelector;
+    }
+
+    @Nonnull
+    protected Range checkKey(@Nonnull Range range) {
+        checkKey(range.begin);
+        checkKey(range.end);
+        return range;
+    }
+
+    @Nonnull
+    protected byte[] checkKey(@Nonnull byte[] key) {
+        if (enableAssertions && key.length > MAX_KEY_LENGTH) {
+            throw new FDBExceptions.FDBStoreKeySizeException("Key length exceeds limit",
+                    LogMessageKeys.KEY_SIZE, key.length,
+                    LogMessageKeys.KEY, ByteArrayUtil2.loggable(key));
+        }
+        return key;
+    }
+
+    @Nonnull
+    protected byte[] checkValue(@Nonnull byte[] value) {
+        if (enableAssertions && value.length > MAX_VALUE_LENGTH) {
+            throw new FDBExceptions.FDBStoreValueSizeException("Value length exceeds limit",
+                    LogMessageKeys.VALUE_SIZE, value.length,
+                    LogMessageKeys.VALUE, ByteArrayUtil2.loggable(value));
+        }
+        return value;
     }
 
     private class ByteCountingAsyncIterable implements AsyncIterable<KeyValue> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedTransaction.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.MutationType;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 
@@ -38,56 +39,60 @@ import java.util.function.Function;
  * Wrapper around {@link Transaction} that instruments certain calls to expose their behavior with
  * {@link FDBStoreTimer} metrics.
  */
+@API(API.Status.INTERNAL)
 public class InstrumentedTransaction extends InstrumentedReadTransaction<Transaction> implements Transaction {
 
     @Nullable
     protected ReadTransaction snapshot; // lazily cached snapshot wrapper
 
-    public InstrumentedTransaction(@Nonnull StoreTimer timer, @Nonnull Transaction underlying) {
-        super(timer, underlying);
+    public InstrumentedTransaction(@Nonnull StoreTimer timer, @Nonnull Transaction underlying, boolean enableAssertions) {
+        super(timer, underlying, enableAssertions);
     }
 
     @Override
     public void addReadConflictRange(byte[] keyBegin, byte[] keyEnd) {
-        underlying.addReadConflictRange(keyBegin, keyEnd);
+        underlying.addReadConflictRange(checkKey(keyBegin), checkKey(keyEnd));
     }
 
     @Override
     public void addReadConflictKey(byte[] key) {
-        underlying.addReadConflictKey(key);
+        underlying.addReadConflictKey(checkKey(key));
     }
 
     @Override
     public void addWriteConflictRange(byte[] keyBegin, byte[] keyEnd) {
-        underlying.addWriteConflictRange(keyBegin, keyEnd);
+        underlying.addWriteConflictRange(checkKey(keyBegin), checkKey(keyEnd));
     }
 
     @Override
     public void addWriteConflictKey(byte[] key) {
-        underlying.addWriteConflictKey(key);
+        underlying.addWriteConflictKey(checkKey(key));
     }
 
     @Override
     public void set(byte[] key, byte[] value) {
-        underlying.set(key, value);
+        underlying.set(checkKey(key), checkValue(value));
         timer.increment(FDBStoreTimer.Counts.WRITES);
         timer.increment(FDBStoreTimer.Counts.BYTES_WRITTEN, key.length + value.length);
     }
 
     @Override
     public void clear(byte[] key) {
-        underlying.clear(key);
+        underlying.clear(checkKey(key));
         timer.increment(FDBStoreTimer.Counts.DELETES);
     }
 
     @Override
     public void clear(byte[] keyBegin, byte[] keyEnd) {
-        underlying.clear(keyBegin, keyEnd);
+        underlying.clear(checkKey(keyBegin), checkKey(keyEnd));
         timer.increment(FDBStoreTimer.Counts.DELETES);
     }
 
     @Override
     public void clear(Range range) {
+        checkKey(range.begin);
+        checkKey(range.end);
+
         underlying.clear(range);
         timer.increment(FDBStoreTimer.Counts.DELETES);
     }
@@ -95,13 +100,13 @@ public class InstrumentedTransaction extends InstrumentedReadTransaction<Transac
     @Override
     @Deprecated
     public void clearRangeStartsWith(byte[] prefix) {
-        underlying.clearRangeStartsWith(prefix);
+        underlying.clearRangeStartsWith(checkKey(prefix));
         timer.increment(FDBStoreTimer.Counts.DELETES);
     }
 
     @Override
     public void mutate(MutationType opType, byte[] key, byte[] param) {
-        underlying.mutate(opType, key, param);
+        underlying.mutate(opType, checkKey(key), param);
         /* Do we want to track each mutation type separately as well? */
         timer.increment(FDBStoreTimer.Counts.MUTATIONS);
     }
@@ -135,7 +140,7 @@ public class InstrumentedTransaction extends InstrumentedReadTransaction<Transac
 
     @Override
     public CompletableFuture<Void> watch(byte[] bytes) throws FDBException {
-        return underlying.watch(bytes);
+        return underlying.watch(checkKey(bytes));
     }
 
     @Override
@@ -166,7 +171,7 @@ public class InstrumentedTransaction extends InstrumentedReadTransaction<Transac
     @Override
     public ReadTransaction snapshot() {
         if (snapshot == null) {
-            snapshot = new Snapshot(timer, underlying.snapshot());
+            snapshot = new Snapshot(timer, underlying.snapshot(), enableAssertions);
         }
         return snapshot;
     }
@@ -181,19 +186,9 @@ public class InstrumentedTransaction extends InstrumentedReadTransaction<Transac
         underlying.setReadVersion(l);
     }
 
-    @Override
-    public boolean addReadConflictRangeIfNotSnapshot(byte[] keyBegin, byte[] keyEnd) {
-        return underlying.addReadConflictRangeIfNotSnapshot(keyBegin, keyEnd);
-    }
-
-    @Override
-    public boolean addReadConflictKeyIfNotSnapshot(byte[] key) {
-        return underlying.addReadConflictKeyIfNotSnapshot(key);
-    }
-
     private static class Snapshot extends InstrumentedReadTransaction<ReadTransaction> implements ReadTransaction {
-        public Snapshot(@Nonnull StoreTimer timer, @Nonnull ReadTransaction underlying) {
-            super(timer, underlying);
+        public Snapshot(@Nonnull StoreTimer timer, @Nonnull ReadTransaction underlying, boolean enableAssertions) {
+            super(timer, underlying, enableAssertions);
         }
 
         @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -505,8 +505,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     private void testSizeAssertion(Consumer<FDBRecordContext> consumer, Class<? extends Exception> exception) {
-        FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
-        FDBDatabase database = factory.getDatabase();
+        FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
 
         // By default key size validation happens in the FDB driver at commit time
         try (FDBRecordContext context = database.openContext()) {
@@ -514,17 +513,10 @@ public class FDBDatabaseTest extends FDBTestBase {
             assertThrows(exception, () -> context.commit());
         }
 
-        try {
-            factory.clear();
-
-            // enabling assertions causes checks to happen in record layer code
-            factory.setEnableAssertionsSupplier(() -> true);
-            try (FDBRecordContext context = database.openContext()) {
-                assertThrows(exception, () -> consumer.accept(context));
-            }
-        } finally {
-            factory.setEnableAssertionsSupplier(() -> false);
-            factory.clear();
+        // enabling assertions causes checks to happen in record layer code
+        try (FDBRecordContext context = database.openContext(
+                FDBRecordContextConfig.newBuilder().setEnableAssertions(true).build())) {
+            assertThrows(exception, () -> consumer.accept(context));
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -489,4 +489,42 @@ public class FDBDatabaseTest extends FDBTestBase {
             LOGGER.info(logMessage.toString());
         }
     }
+
+    @Test
+    public void testAssertionsOnKeySize() {
+        testSizeAssertion(context ->
+                        context.ensureActive().set(Tuple.from(1, new byte[InstrumentedTransaction.MAX_KEY_LENGTH]).pack(), Tuple.from(1).pack()),
+                FDBExceptions.FDBStoreKeySizeException.class);
+    }
+
+    @Test
+    public void testAssertionsOnValueSize() {
+        testSizeAssertion(context ->
+                        context.ensureActive().set(Tuple.from(1).pack(), Tuple.from(2, new byte[InstrumentedTransaction.MAX_VALUE_LENGTH]).pack()),
+                FDBExceptions.FDBStoreValueSizeException.class);
+    }
+
+    private void testSizeAssertion(Consumer<FDBRecordContext> consumer, Class<? extends Exception> exception) {
+        FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
+        FDBDatabase database = factory.getDatabase();
+
+        // By default key size validation happens in the FDB driver at commit time
+        try (FDBRecordContext context = database.openContext()) {
+            consumer.accept(context);
+            assertThrows(exception, () -> context.commit());
+        }
+
+        try {
+            factory.clear();
+
+            // enabling assertions causes checks to happen in record layer code
+            factory.setEnableAssertionsSupplier(() -> true);
+            try (FDBRecordContext context = database.openContext()) {
+                assertThrows(exception, () -> consumer.accept(context));
+            }
+        } finally {
+            factory.setEnableAssertionsSupplier(() -> false);
+            factory.clear();
+        }
+    }
 }


### PR DESCRIPTION
This change allows `FDBDatabaseFactory` to be configured with a supplier which
can decide whether or not assertions are to be enabled within the record layer
API.  This supplier is polled each time an `FDBRecordContext` is created and,
thus, all operations from the context will have assertions checked (or not)
as it is used.  The initial set of assertions are around validating key and
value byte sizes.