### PR TITLE
Resolves #934: Retry OnlineIndexer when it hits RecordStoreStaleMetaDataVersionException

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -52,7 +52,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Retry `OnlineIndexer` when it hits `RecordStoreStaleMetaDataVersionException` [(Issue #934)](https://github.com/FoundationDB/fdb-record-layer/issues/934)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -413,8 +413,10 @@ public class OnlineIndexer implements AutoCloseable {
                 } else {
                     int currTries = tries.getAndIncrement();
                     FDBException fdbE = getFDBException(e);
-                    if (currTries < config.maxRetries && fdbE != null && lessenWorkCodes.contains(fdbE.getCode())) {
-                        if (handleLessenWork != null) {
+                    if (currTries < config.maxRetries && (
+                            (fdbE != null && lessenWorkCodes.contains(fdbE.getCode())) ||
+                            (e instanceof RecordStoreStaleMetaDataVersionException))) {
+                        if (handleLessenWork != null && fdbE != null) {
                             handleLessenWork.accept(fdbE, onlineIndexerLogMessageKeyValues);
                         }
                         long delay = (long)(Math.random() * toWait.get());


### PR DESCRIPTION
This needs to be patched to 2.8.118.0. I manually created a branch called `fdb-record-layer-2.8.118.0` from tag `2.8.118.0`, and then used it as base. Is it the correct way to do it?