### PR TITLE
Fixes #941: Record store check for empty stores with system data could exclude the INDEX_BUILD_SPACE

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Opening a store with `ERROR_IF_NO_INFO_AND_HAS_RECORDS_OR_INDEXES` now allows opening a record store if the data is in the `INDEX_BUILD_SPACE` [(Issue #941)](https://github.com/FoundationDB/fdb-record-layer/issues/941)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1866,14 +1866,15 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         } else if (existenceCheck == StoreExistenceCheck.ERROR_IF_NO_INFO_AND_HAS_RECORDS_OR_INDEXES) {
             final FDBRecordStoreKeyspace keyspace = determineRecordStoreKeyspace(firstKey, subspaceProvider, context);
             // White list of acceptable key ranges for the first key. This may need to be updated as more keyspaces are added.
-            // Includes: INDEX_STATE_SPACE and INDEX_RANGE_SPACE as that contains only meta-data about the state of the index but no "user data"
+            // Includes: INDEX_STATE_SPACE, INDEX_RANGE_SPACE, and INDEX_BUILD_SPACE as those contain only meta-data about the state of the
+            // index or index build but no "user data"
             // Excludes: anything with records or data about records, i.e., RECORD (as it contains records), INDEX and INDEX_SECONDARY space (as
             // they contains data from indexes), RECORD_COUNT (as that is/was effectively an index), INDEX_UNIQUENESS_VIOLATIONS_SPACE (as it
             // contains data that should be consistent with the index), and RECORD_VERSION_SPACE (as it contains data that is effectively tied
             // to the records). In a record store where the only corruption is the lack of a store header, then if the store has no records,
             // INDEX_UNIQUENESS_VIOLATIONS_SPACE and RECORD_VERSION_SPACE should be empty as well, but this isn't validated. In theory, if the
             // RECORD_COUNT keyspace was zero, that would be consistent, so it would be "safe" to only warn then as well.
-            if (FDBRecordStoreKeyspace.INDEX_STATE_SPACE.equals(keyspace) || FDBRecordStoreKeyspace.INDEX_RANGE_SPACE.equals(keyspace)) {
+            if (FDBRecordStoreKeyspace.INDEX_STATE_SPACE.equals(keyspace) || FDBRecordStoreKeyspace.INDEX_RANGE_SPACE.equals(keyspace) || FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.equals(keyspace)) {
                 LOGGER.warn(KeyValueLogMessage.of("Record store has no info or records but is not empty",
                         subspaceProvider.logKey(), subspaceProvider.toString(context),
                         LogMessageKeys.KEY, firstKey));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -3253,6 +3253,23 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
             commit(context);
         }
 
+        // Delete everything except a value in the index build space
+        try (FDBRecordContext context = openContext()) {
+            FDBRecordStore store = storeBuilder.setContext(context).open();
+            final Subspace subspace = OnlineIndexer.indexBuildScannedRecordsSubspace(store, metaData.getIndex("MySimpleRecord$str_value_indexed"));
+            context.ensureActive().set(subspace.getKey(), FDBRecordStore.encodeRecordCount(1215)); // set a key in the INDEX_BUILD_SPACE
+            context.ensureActive().clear(store.getSubspace().getKey(), subspace.getKey());
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            storeBuilder.setContext(context);
+            assertThrows(RecordStoreNoInfoAndNotEmptyException.class, storeBuilder::createOrOpen);
+        }
+        try (FDBRecordContext context = openContext()) {
+            storeBuilder.setContext(context).createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NO_INFO_AND_HAS_RECORDS_OR_INDEXES);
+            commit(context);
+        }
+
         // Insert a record, then delete the store header
         try (FDBRecordContext context = openContext()) {
             // open as the previous open with the relaxed existence check should have fixed the store header


### PR DESCRIPTION
This allows a record store to be opened in `ERROR_IF_NO_INFO_AND_HAS_RECORDS_OR_INDEXES` if the only data it finds is in the `INDEX_BUILD_SPACE`, which is used to hold data for the online indexer. The idea here is that those should be allowed because they contain data that is used by the index build and doesn't contain user data, which is the main place where corruption can happen if a store is opened without a store header.

Note that this is against the 2.8.118 patch branch. This fixes #941.