### PR TITLE
Fixes #947: TupleKeyCountTree.addPrefixChild only ever adds one child

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,7 +42,7 @@ The `FDBDatabase::getReadVersion()` method has been replaced with the `FDBRecord
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** TupleKeyCountTree.addPrefixChild only ever adds one child [(Issue #947)](https://github.com/FoundationDB/fdb-record-layer/issues/947)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
@@ -157,13 +157,13 @@ public class TupleKeyCountTree {
     }
 
     @Nonnull
-    protected TupleKeyCountTree newPrefixChild(@Nonnull byte[] bytes, @Nonnull Object prefix) {
-        return newChild(bytes, prefix);
+    protected TupleKeyCountTree newPrefixChild(@Nonnull byte[] prefixBytes, @Nonnull Object prefix) {
+        return newChild(prefixBytes, prefix);
     }
 
     @Nonnull
-    protected TupleKeyCountTree newChild(@Nonnull byte[] bytes, @Nonnull Object object) {
-        return new TupleKeyCountTree(this, bytes, object);
+    protected TupleKeyCountTree newChild(@Nonnull byte[] childBytes, @Nonnull Object object) {
+        return new TupleKeyCountTree(this, childBytes, object);
     }
 
     public int getCount() {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
@@ -152,12 +152,12 @@ public class TupleKeyCountTree {
     @Nonnull
     public TupleKeyCountTree addPrefixChild(@Nonnull Object prefix) {
         count++;
-        return children.computeIfAbsent(bytes, b -> newPrefixChild(prefix));
+        final byte[] prefixBytes = Tuple.from(prefix).pack();
+        return children.computeIfAbsent(bytes, b -> newPrefixChild(prefixBytes, prefix));
     }
 
     @Nonnull
-    protected TupleKeyCountTree newPrefixChild(@Nonnull Object prefix) {
-        final byte[] bytes = Tuple.from(prefix).pack();
+    protected TupleKeyCountTree newPrefixChild(@Nonnull byte[] bytes, @Nonnull Object prefix) {
         return newChild(bytes, prefix);
     }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
@@ -153,7 +153,7 @@ public class TupleKeyCountTree {
     public TupleKeyCountTree addPrefixChild(@Nonnull Object prefix) {
         count++;
         final byte[] prefixBytes = Tuple.from(prefix).pack();
-        return children.computeIfAbsent(bytes, b -> newPrefixChild(prefixBytes, prefix));
+        return children.computeIfAbsent(prefixBytes, b -> newPrefixChild(prefixBytes, prefix));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
@@ -385,14 +385,14 @@ public class KeySpaceCountTree extends TupleKeyCountTree {
 
     @Override
     @Nonnull
-    protected TupleKeyCountTree newChild(@Nonnull byte[] bytes, @Nonnull Object object) {
-        return new KeySpaceCountTree(this, bytes, object);
+    protected TupleKeyCountTree newChild(@Nonnull byte[] childBytes, @Nonnull Object object) {
+        return new KeySpaceCountTree(this, childBytes, object);
     }
 
     @Override
     @Nonnull
-    protected TupleKeyCountTree newPrefixChild(@Nonnull byte[] bytes, @Nonnull Object prefix) {
-        TupleKeyCountTree result = super.newPrefixChild(bytes, prefix);
+    protected TupleKeyCountTree newPrefixChild(@Nonnull byte[] prefixBytes, @Nonnull Object prefix) {
+        TupleKeyCountTree result = super.newPrefixChild(prefixBytes, prefix);
         ((KeySpaceCountTree)result).resolved = new ResolvedPrefixRoot(resolved, prefix);
         return result;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
@@ -391,8 +391,8 @@ public class KeySpaceCountTree extends TupleKeyCountTree {
 
     @Override
     @Nonnull
-    protected TupleKeyCountTree newPrefixChild(@Nonnull Object prefix) {
-        TupleKeyCountTree result = super.newPrefixChild(prefix);
+    protected TupleKeyCountTree newPrefixChild(@Nonnull byte[] bytes, @Nonnull Object prefix) {
+        TupleKeyCountTree result = super.newPrefixChild(bytes, prefix);
         ((KeySpaceCountTree)result).resolved = new ResolvedPrefixRoot(resolved, prefix);
         return result;
     }


### PR DESCRIPTION
Use the prefix's bytes as the unique child key.