### PR TITLE
Resolves #950: introduce the concept of a quantifier to the data flow…

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,6 +8,8 @@
     </option>
     <option name="LINE_SEPARATOR" value="&#10;" />
     <JavaCodeStyleSettings>
+      <option name="GENERATE_FINAL_LOCALS" value="true" />
+      <option name="GENERATE_FINAL_PARAMETERS" value="true" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="500" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="500" />
       <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -34,8 +34,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
-import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.google.common.collect.ImmutableList;
@@ -55,7 +53,7 @@ import java.util.Set;
 public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
 
     @Nonnull
-    private final ExpressionRef<RecordQueryPlanWithIndex> indexPlan;
+    private final RecordQueryPlanWithIndex indexPlan;
     @Nonnull
     private final String recordTypeName;
     @Nonnull
@@ -68,7 +66,7 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
 
     public RecordQueryCoveringIndexPlan(@Nonnull RecordQueryPlanWithIndex indexPlan,
                                         @Nonnull final String recordTypeName, @Nonnull IndexKeyValueToPartialRecord toRecord) {
-        this.indexPlan = GroupExpressionRef.of(indexPlan);
+        this.indexPlan = indexPlan;
         this.recordTypeName = recordTypeName;
         this.toRecord = toRecord;
     }
@@ -86,19 +84,18 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
         final Descriptors.Descriptor recordDescriptor = recordType.getDescriptor();
         boolean hasPrimaryKey = getScanType() != IndexScanType.BY_GROUP;
         return indexPlan
-                .get()
                 .executeEntries(store, context, continuation, executeProperties)
                 .map(indexEntry -> store.coveredIndexQueriedRecord(index, indexEntry, recordType, (M) toRecord.toRecord(recordDescriptor, indexEntry), hasPrimaryKey));
     }
 
     @Nonnull
     public String getIndexName() {
-        return indexPlan.get().getIndexName();
+        return indexPlan.getIndexName();
     }
 
     @Nonnull
     public IndexScanType getScanType() {
-        return indexPlan.get().getScanType();
+        return indexPlan.getScanType();
     }
 
     @Override
@@ -182,7 +179,7 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
 
     @Override
     public RecordQueryPlan getChild() {
-        return indexPlan.get();
+        return indexPlan;
     }
 
     @Override
@@ -194,6 +191,6 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithChild {
     @Override
     @API(API.Status.EXPERIMENTAL)
     public List<? extends Quantifier> getQuantifiers() {
-        return ImmutableList.of(Quantifier.physical(indexPlan));
+        return ImmutableList.of();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -93,13 +91,6 @@ public class RecordQueryFilterPlan extends RecordQueryFilterPlanBase {
 
     @Nonnull
     @Override
-    @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
-    }
-
-    @Nonnull
-    @Override
     public String toString() {
         return getInner() + " | " + getFilter();
     }
@@ -137,5 +128,4 @@ public class RecordQueryFilterPlan extends RecordQueryFilterPlanBase {
     public QueryComponent getFilter() {
         return filter;
     }
-
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlanBase.java
@@ -30,15 +30,15 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -104,8 +104,8 @@ abstract class RecordQueryFilterPlanBase implements RecordQueryPlanWithChild {
 
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(inner);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(Quantifier.physical(inner));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
@@ -31,16 +31,16 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -53,14 +53,12 @@ public abstract class RecordQueryInJoinPlan implements RecordQueryPlanWithChild 
     protected static final Comparator<Object> VALUE_COMPARATOR = (o1, o2) -> ((Comparable)o1).compareTo((Comparable)o2);
 
     protected final ExpressionRef<RecordQueryPlan> plan;
-    protected final List<ExpressionRef<? extends RelationalExpression>> children;
     protected final String bindingName;
     protected final boolean sortValuesNeeded;
     protected final boolean sortReverse;
 
     public RecordQueryInJoinPlan(RecordQueryPlan plan, String bindingName, boolean sortValuesNeeded, boolean sortReverse) {
         this.plan = GroupExpressionRef.of(plan);
-        this.children = Collections.singletonList(this.plan);
         this.bindingName = bindingName;
         this.sortValuesNeeded = sortValuesNeeded;
         this.sortReverse = sortReverse;
@@ -107,8 +105,8 @@ public abstract class RecordQueryInJoinPlan implements RecordQueryPlanWithChild 
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return children.iterator();
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(Quantifier.physical(plan));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -33,7 +33,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
@@ -42,7 +41,6 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -123,13 +121,6 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
     @Override
     public boolean hasLoadBykeys() {
         return false;
-    }
-
-    @Nonnull
-    @Override
-    @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -34,6 +34,8 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.cursors.IntersectionCursor;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.apple.foundationdb.record.query.plan.temp.Quantifiers;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -43,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -68,8 +69,7 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
     private final List<ExpressionRef<RecordQueryPlan>> children;
     @Nonnull
     private final KeyExpression comparisonKey;
-    @Nonnull
-    private final List<ExpressionRef<? extends RelationalExpression>> expressionChildren;
+
     private boolean reverse;
 
     /**
@@ -112,10 +112,6 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
         this.children = children;
         this.comparisonKey = comparisonKey;
         this.reverse = reverse;
-
-        final ImmutableList.Builder<ExpressionRef<? extends RelationalExpression>> expressionChildrenBuilder = ImmutableList.builder();
-        expressionChildrenBuilder.addAll(children);
-        expressionChildren = expressionChildrenBuilder.build();
     }
 
     @Nonnull
@@ -158,15 +154,14 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren 
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return expressionChildren.iterator();
+    public List<? extends Quantifier> getQuantifiers() {
+        return Quantifiers.fromPlans(children);
     }
 
     @Nonnull
     @Override
     public String toString() {
-        return String.join(" " + INTERSECT + " ",
-                getChildStream().map(RecordQueryPlan::toString).collect(Collectors.toList()));
+        return getChildStream().map(RecordQueryPlan::toString).collect(Collectors.joining(" " + INTERSECT + " "));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -31,16 +31,13 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -120,13 +117,6 @@ public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren 
     @Override
     public boolean hasLoadBykeys() {
         return true;
-    }
-
-    @Nonnull
-    @Override
-    @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithNoChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithNoChildren.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.plans;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -34,6 +35,12 @@ public interface RecordQueryPlanWithNoChildren extends RecordQueryPlan {
     @Override
     @Nonnull
     default List<RecordQueryPlan> getChildren() {
+        return Collections.emptyList();
+    }
+
+    @Nonnull
+    @Override
+    default List<? extends Quantifier> getQuantifiers() {
         return Collections.emptyList();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
@@ -40,9 +39,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -110,13 +107,6 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     @Override
     public boolean hasLoadBykeys() {
         return false;
-    }
-
-    @Nonnull
-    @Override
-    @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -38,15 +38,15 @@ import com.apple.foundationdb.record.provider.foundationdb.indexes.RankedSetInde
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.tuple.Tuple;
-import com.google.common.collect.Iterators;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -123,8 +123,8 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(this.plan);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(Quantifier.physical(plan));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
@@ -30,15 +30,12 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.TextScan;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -47,7 +44,7 @@ import java.util.Set;
  * in that the comparison on a query might actually be split into multiple queries.
  */
 @API(API.Status.MAINTAINED)
-public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex {
+public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex, RecordQueryPlanWithNoChildren {
 
     @Nonnull
     private final String indexName;
@@ -127,12 +124,6 @@ public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex {
         return 1;
     }
 
-    @Nonnull
-    @Override
-    public List<RecordQueryPlan> getChildren() {
-        return Collections.emptyList();
-    }
-
     @Override
     @API(API.Status.EXPERIMENTAL)
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression) {
@@ -164,13 +155,6 @@ public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex {
     @Override
     public int planHash() {
         return indexName.hashCode() + textScan.planHash() + (reverse ? 1 : 0);
-    }
-
-    @Nonnull
-    @Override
-    @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
@@ -30,14 +30,15 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
-import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
-import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -102,8 +102,8 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(this.inner);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(Quantifier.physical(this.inner));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -59,8 +58,6 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
 
     @Nonnull
     private final KeyExpression comparisonKey;
-    @Nonnull
-    private final List<ExpressionRef<? extends RelationalExpression>> expressionChildren;
     private final boolean showComparisonKey;
 
     /**
@@ -106,7 +103,6 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
                                  boolean ignoredTemporaryFlag) {
         super(children, reverse);
         this.comparisonKey = comparisonKey;
-        this.expressionChildren = ImmutableList.copyOf(super.getPlannerExpressionChildren());
         this.showComparisonKey = showComparisonKey;
     }
 
@@ -121,13 +117,6 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
     @Nonnull
     public KeyExpression getComparisonKey() {
         return comparisonKey;
-    }
-
-    @Nonnull
-    @Override
-    @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return expressionChildren.iterator();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -30,7 +30,8 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.apple.foundationdb.record.query.plan.temp.Quantifiers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
@@ -39,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -114,8 +114,8 @@ abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChildren {
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return children.iterator();
+    public List<? extends Quantifier> getQuantifiers() {
+        return Quantifiers.fromPlans(children);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
@@ -32,9 +32,10 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +44,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -109,8 +110,8 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(inner);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(Quantifier.physical(inner));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -30,10 +30,11 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -103,8 +104,8 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
     @Nonnull
     @Override
     @API(API.Status.EXPERIMENTAL)
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(this.inner);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(Quantifier.physical(inner));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Bindable.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Bindable.java
@@ -34,10 +34,10 @@ import java.util.stream.Stream;
 @API(API.Status.EXPERIMENTAL)
 public interface Bindable {
     /**
-     * Attempt to match the binding to this bindable object.
-     * @param binding the binding to match against
+     * Attempt to match the matcher to this bindable object.
+     * @param matcher the matcher to match against
      * @return a map of bindings if the match succeeded, or an empty <code>Optional</code> if it failed
      */
     @Nonnull
-    Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> binding);
+    Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> matcher);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ExpressionRef.java
@@ -48,6 +48,7 @@ public interface ExpressionRef<T extends RelationalExpression> extends Bindable 
     @Nonnull
     T get();
 
+    @Nullable
     <U> U acceptPropertyVisitor(@Nonnull PlannerProperty<U> property);
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PlannerProperty.java
@@ -37,12 +37,12 @@ import java.util.List;
  *
  * <p>
  * To avoid littering {@link RelationalExpression} classes with methods for various properties, properties are implemented
- * using a variant of the hierarchical visitor pattern over a dag of {@link RelationalExpression}s, {@link Quantifier},
+ * using a variant of the hierarchical visitor pattern over a DAG of {@link RelationalExpression}s, {@link Quantifier}s,
  * and {@link ExpressionRef}s.
  * A property can be evaluated against an expression tree by having the visitor traverse a DAG of heterogeneous objects
  * where expressions are said to own quantifiers which range over expression references which then contain expressions
- * again. Shared sub graphs are visited multiple times. If desired, the caller must ensure that a sub graph is not
- * revisited if visited before.
+ * again. Shared sub graphs are visited multiple times. If desired, the caller must ensure that a sub-graph is not
+ * visited more than once.
  *
  * Note that the methods {@link #evaluateAtExpression}, {@link #evaluateAtQuantifier}, and {@link #evaluateAtRef} are handed the
  * results of the visitor evaluated at their owned quantifiers, references, and members respectively. Since most properties
@@ -53,7 +53,7 @@ import java.util.List;
 @API(API.Status.EXPERIMENTAL)
 public interface PlannerProperty<T> {
     /**
-     * Return whether the property should visit the sub graph rooted at the given expression.
+     * Return whether the property should visit the sub-graph rooted at the given expression.
      * Called on nodes in the expression graph in visit pre-order of the depth-first traversal of the graph.
      * That is, as each node is visited for the first time, {@code shouldVisit()} is called on that node.
      * If {@code shouldVisit()} returns {@code false}, then {@link #evaluateAtExpression(RelationalExpression, List)} will
@@ -64,19 +64,18 @@ public interface PlannerProperty<T> {
     boolean shouldVisit(@Nonnull RelationalExpression expression);
 
     /**
-     * Return whether the property should visit the given expression reference and by transitive property the expressions
-     * the {@link ExpressionRef} references.
+     * Return whether the property should visit the given reference and, transitively, the members of the reference.
      * Called on expression references in the graph in visit pre-order of the depth-first traversal of the graph.
      * That is, as a reference is visited, {@code shouldVisit()} is called on that reference.
      * If {@code shouldVisit()} returns {@code false}, then {@link #evaluateAtRef(ExpressionRef, List)} will
-     * not be called on the given expression reference.
+     * not be called on the given reference.
      * @param ref the expression reference to visit
      * @return {@code true} if the members of {@code ref} should be visited and {@code false} if they should not be visited
      */
     boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref);
 
     /**
-     * Return whether the property should visit the given quantifier and the expression reference that the quantifier
+     * Return whether the property should visit the given quantifier and the references that the quantifier
      * ranges over.
      * Called on quantifiers in the graph in visit pre-order of the depth-first traversal of the graph.
      * That is, as a quantifier is visited, {@code shouldVisit()} is called on that quantifier.
@@ -113,7 +112,7 @@ public interface PlannerProperty<T> {
     T evaluateAtRef(@Nonnull ExpressionRef<? extends RelationalExpression> ref, @Nonnull List<T> memberResults);
 
     /**
-     * Evaluate the property at the given quantifier, using the result of evaluating the property at the expression
+     * Evaluate the property at the given quantifier, using the result of evaluating the property at the
      * reference the quantifier ranges over.
      * Called on quantifiers in the graph in visit post-order of the depth-first traversal of the graph.
      * That is, as each quantifier is visited (after the expression reference it ranges over has been visited, if applicable),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
@@ -31,26 +31,35 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
+ * Models the concept of quantification.
+ * 
+ * <p>
  * A quantifier describes the data flow between the output of one {@link RelationalExpression} {@code R} and the
- * consumption of that data by another {@code RelationalExpression} {@code S}. {@code S} is said to own the quantifier, while the
- * quantifier is said to range over {@code R}. Quantifiers come in very few but very distinct flavors. All flavors are
- * implemented by static inner final classes in order to emulate a sealed trait.
+ * consumption of that data by another {@code RelationalExpression} {@code S}. {@code S} is said to own the quantifier,
+ * while the quantifier is said to range over {@code R}. Quantifiers come in very few but very distinct flavors.
+ * All flavors are implemented by static inner final classes in order to emulate a sealed trait.
+ * </p>
  *
- * Quantifiers separate what it means to be producing versus consuming records. The expression a quantifier ranges over
+ * <p>
+ * Quantifiers separate what it means to be producing versus consuming items. The expression a quantifier ranges over
  * produces records, the quantifier flows information (in a manner determined by the flavor) that is consumed by the expression
  * containing or owning the quantifier. That expression can consume the data in a way independent of how the data was
  * produced in the first place.
+ * </p>
  *
+ * <p>
  * A quantifier works closely with the expression that owns it. Depending on the semantics of the owning expression
  * it becomes possible to model correlations. For example, in a logical join expression the quantifier can provide a binding
- * of the record being currently consumed by the join's outer to other (inner) parts of the data flow that are also rooted
+ * of the item being currently consumed by the join's outer to other (inner) parts of the data flow that are also rooted
  * at the owning (join) expression.
+ * </p>
  */
 public abstract class Quantifier implements Bindable {
     /**
-     * A quantifier that conceptually flows one record at a time from the expression it ranges over to
+     * A quantifier that conceptually flows one item at a time from the expression it ranges over to
      * the owning expression.
      */
+    @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and hashCode() should be overwritten which is not necessary
     public static final class ForEach extends Quantifier {
         private final ExpressionRef<? extends RelationalExpression> rangesOver;
 
@@ -83,11 +92,11 @@ public abstract class Quantifier implements Bindable {
     }
 
     /**
-     * A quantifier that conceptually flows exactly one record containing a boolean to the owning
+     * A quantifier that conceptually flows exactly one item containing a boolean to the owning
      * expression indicating whether the sub-graph that the quantifier ranges over produced a non-empty or an empty
      * result. When the semantics of this quantifiers are realized in an execution strategy that strategy should
-     * facilitate a boolean "short-circuit" mechanism as the result will be {@code record(true)} as soon as the sub-graph produces
-     * the first record.
+     * facilitate a boolean "short-circuit" mechanism as the result will be {@code true} as soon as the sub-graph produces
+     * the first item.
      */
     @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and hashCode() should be overwritten which is not necessary
     public static final class Existential extends Quantifier {
@@ -178,7 +187,6 @@ public abstract class Quantifier implements Bindable {
     /**
      * Return a short hand string for the quantifier. As a quantifier's semantics is usually quite subtle and should
      * not distract from expressions. For example, when a data flow is visualized the returned string should be <em>short</em>.
-``
      * @return a short string representing the quantifier.
      */
     @Nonnull
@@ -211,11 +219,11 @@ public abstract class Quantifier implements Bindable {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ForEach)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final ForEach forEach = (ForEach)o;
-        return Objects.equals(getRangesOver(), forEach.getRangesOver());
+        final Quantifier that = (Quantifier)o;
+        return Objects.equals(getRangesOver(), that.getRangesOver());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
@@ -31,24 +31,24 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
- * A quantifier is a conduit facilitating the data flow between the output of one {@link RelationalExpression} R and the
- * consumption of that data by another {@link RelationalExpression} S. S is said to own the quantifier, while the
- * quantifier is said to range over R. Quantifiers come in very few but very distinct flavors. All flavors are
- * implemented by static inner final classes as to emulate a sealed trait.
+ * A quantifier describes the data flow between the output of one {@link RelationalExpression} {@code R} and the
+ * consumption of that data by another {@code RelationalExpression} {@code S}. {@code S} is said to own the quantifier, while the
+ * quantifier is said to range over {@code R}. Quantifiers come in very few but very distinct flavors. All flavors are
+ * implemented by static inner final classes in order to emulate a sealed trait.
  *
  * Quantifiers separate what it means to be producing versus consuming records. The expression a quantifier ranges over
- * produces records, the quantifier flows information (according to the flavor) which is then consumed by the expression
+ * produces records, the quantifier flows information (in a manner determined by the flavor) that is consumed by the expression
  * containing or owning the quantifier. That expression can consume the data in a way independent of how the data was
  * produced in the first place.
  *
  * A quantifier works closely with the expression that owns it. Depending on the semantics of the owning expression
- * it becomes possible to model correlations,  e.g. for a logical join expression the quantifier can provide a binding
+ * it becomes possible to model correlations. For example, in a logical join expression the quantifier can provide a binding
  * of the record being currently consumed by the join's outer to other (inner) parts of the data flow that are also rooted
  * at the owning (join) expression.
  */
 public abstract class Quantifier implements Bindable {
     /**
-     * For Each quantifier. Conceptually flows one record at a time from the expression it ranges over to
+     * A quantifier that conceptually flows one record at a time from the expression it ranges over to
      * the owning expression.
      */
     public static final class ForEach extends Quantifier {
@@ -83,13 +83,13 @@ public abstract class Quantifier implements Bindable {
     }
 
     /**
-     * Existential quantifier. Conceptually flows exactly one record containing a boolean to the owning
-     * expression indicating whether the sub graph the quantifier ranges over produced a non-empty or an empty
+     * A quantifier that conceptually flows exactly one record containing a boolean to the owning
+     * expression indicating whether the sub-graph that the quantifier ranges over produced a non-empty or an empty
      * result. When the semantics of this quantifiers are realized in an execution strategy that strategy should
-     * facilitate an early out mechanism as the result will be {@code record(true)} as soon as the sub graph produces
+     * facilitate a boolean "short-circuit" mechanism as the result will be {@code record(true)} as soon as the sub-graph produces
      * the first record.
      */
-    @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and heshCode() should be overwritten which is not necessary
+    @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and hashCode() should be overwritten which is not necessary
     public static final class Existential extends Quantifier {
         private final ExpressionRef<? extends RelationalExpression> rangesOver;
 
@@ -117,20 +117,20 @@ public abstract class Quantifier implements Bindable {
      * @return a for-each quantifier ranging over the given expression reference
      */
     @Nonnull
-    public static Existential existential(final ExpressionRef<? extends RelationalExpression> rangesOver) {
+    public static Existential existential(@Nonnull final ExpressionRef<? extends RelationalExpression> rangesOver) {
         return new Existential(rangesOver);
     }
 
     /**
      * Physical quantifier. This kind of quantifier is the conduit between two {@link RecordQueryPlan}s. It does
-     * not have an associated semantics as by that time all semantics and execution details must have been subsumed
+     * not have any associated semantics; all semantics and execution details must be subsumed
      * by the query plans themselves.
      */
-    @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and heshCode() should be overwritten which is not necessary
+    @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and hashCode() should be overwritten which is not necessary
     public static final class Physical extends Quantifier {
         private final ExpressionRef<? extends RecordQueryPlan> rangesOver;
 
-        private Physical(final ExpressionRef<? extends RecordQueryPlan> rangesOver) {
+        private Physical(@Nonnull final ExpressionRef<? extends RecordQueryPlan> rangesOver) {
             this.rangesOver = rangesOver;
         }
 
@@ -148,12 +148,12 @@ public abstract class Quantifier implements Bindable {
     }
 
     /**
-     * Factory method to create a physical quantifier over a given expression reference containing record plans.
+     * Factory method to create a physical quantifier over a given expression reference containing query plans.
      * @param rangesOver expression reference to {@link RecordQueryPlan}s
-     * @return a physical quantifier ranging over the given expression reference
+     * @return a physical quantifier ranging over the given reference
      */
     @Nonnull
-    public static Physical physical(final ExpressionRef<? extends RecordQueryPlan> rangesOver) {
+    public static Physical physical(@Nonnull final ExpressionRef<? extends RecordQueryPlan> rangesOver) {
         return new Physical(rangesOver);
     }
 
@@ -164,12 +164,12 @@ public abstract class Quantifier implements Bindable {
      * @return a physical quantifier ranging over a new expression reference containing the given expression reference
      */
     @Nonnull
-    public static Physical physical(final RecordQueryPlan rangesOverPlan) {
+    public static Physical physical(@Nonnull final RecordQueryPlan rangesOverPlan) {
         return new Physical(GroupExpressionRef.of(rangesOverPlan));
     }
 
     /**
-     * Getter to retrieve the expression reference the quantifier ranges over.
+     * Return the reference that the quantifier ranges over.
      * @return {@link ExpressionRef} this quantifier ranges over
      */
     @Nonnull
@@ -177,7 +177,8 @@ public abstract class Quantifier implements Bindable {
 
     /**
      * Return a short hand string for the quantifier. As a quantifier's semantics is usually quite subtle and should
-     * not distract from expressions when e.g. a data flow is visualized the returned string should be _short_.
+     * not distract from expressions. For example, when a data flow is visualized the returned string should be <em>short</em>.
+``
      * @return a short string representing the quantifier.
      */
     @Nonnull
@@ -192,9 +193,9 @@ public abstract class Quantifier implements Bindable {
     }
 
     /**
-     * This method allows for computation of {@link PlannerProperty}s across the data flow graph.
+     * Allow the computation of {@link PlannerProperty}s across the quantifiers in the data flow graph.
      * @param visitor the planner property that is being computed
-     * @param <U> the type of the property we are computing
+     * @param <U> the type of the property being computed
      * @return the property
      */
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
@@ -124,7 +124,7 @@ public abstract class Quantifier implements Bindable {
     /**
      * Physical quantifier. This kind of quantifier is the conduit between two {@link RecordQueryPlan}s. It does
      * not have an associated semantics as by that time all semantics and execution details must have been subsumed
-     * by the record plans themselves.
+     * by the query plans themselves.
      */
     @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and heshCode() should be overwritten which is not necessary
     public static final class Physical extends Quantifier {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifier.java
@@ -1,0 +1,224 @@
+/*
+ * Quantifier.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp;
+
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * A quantifier is a conduit facilitating the data flow between the output of one {@link RelationalExpression} R and the
+ * consumption of that data by another {@link RelationalExpression} S. S is said to own the quantifier, while the
+ * quantifier is said to range over R. Quantifiers come in very few but very distinct flavors. All flavors are
+ * implemented by static inner final classes as to emulate a sealed trait.
+ *
+ * Quantifiers separate what it means to be producing versus consuming records. The expression a quantifier ranges over
+ * produces records, the quantifier flows information (according to the flavor) which is then consumed by the expression
+ * containing or owning the quantifier. That expression can consume the data in a way independent of how the data was
+ * produced in the first place.
+ *
+ * A quantifier works closely with the expression that owns it. Depending on the semantics of the owning expression
+ * it becomes possible to model correlations,  e.g. for a logical join expression the quantifier can provide a binding
+ * of the record being currently consumed by the join's outer to other (inner) parts of the data flow that are also rooted
+ * at the owning (join) expression.
+ */
+public abstract class Quantifier implements Bindable {
+    /**
+     * For Each quantifier. Conceptually flows one record at a time from the expression it ranges over to
+     * the owning expression.
+     */
+    public static final class ForEach extends Quantifier {
+        private final ExpressionRef<? extends RelationalExpression> rangesOver;
+
+        private ForEach(ExpressionRef<? extends RelationalExpression> rangesOver) {
+            this.rangesOver = rangesOver;
+        }
+
+        @Override
+        @Nonnull
+        public ExpressionRef<? extends RelationalExpression> getRangesOver() {
+            return rangesOver;
+        }
+
+        @Override
+        @Nonnull
+        public String getShorthand() {
+            return "ƒ";
+        }
+    }
+
+    /**
+     * Factory method to create a for-each quantifier over a given expression reference containing relational
+     * expressions.
+     * @param rangesOver expression reference to {@link RelationalExpression}s
+     * @return a for-each quantifier ranging over the given expression reference
+     */
+    @Nonnull
+    public static ForEach forEach(final ExpressionRef<? extends RelationalExpression> rangesOver) {
+        return new ForEach(rangesOver);
+    }
+
+    /**
+     * Existential quantifier. Conceptually flows exactly one record containing a boolean to the owning
+     * expression indicating whether the sub graph the quantifier ranges over produced a non-empty or an empty
+     * result. When the semantics of this quantifiers are realized in an execution strategy that strategy should
+     * facilitate an early out mechanism as the result will be {@code record(true)} as soon as the sub graph produces
+     * the first record.
+     */
+    @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and heshCode() should be overwritten which is not necessary
+    public static final class Existential extends Quantifier {
+        private final ExpressionRef<? extends RelationalExpression> rangesOver;
+
+        private Existential(final ExpressionRef<? extends RelationalExpression> rangesOver) {
+            this.rangesOver = rangesOver;
+        }
+
+        @Override
+        @Nonnull
+        public ExpressionRef<? extends RelationalExpression> getRangesOver() {
+            return rangesOver;
+        }
+
+        @Override
+        @Nonnull
+        public String getShorthand() {
+            return "∃";
+        }
+    }
+
+    /**
+     * Factory method to create an existential quantifier over a given expression reference containing relational
+     * expressions.
+     * @param rangesOver expression reference to {@link RelationalExpression}s
+     * @return a for-each quantifier ranging over the given expression reference
+     */
+    @Nonnull
+    public static Existential existential(final ExpressionRef<? extends RelationalExpression> rangesOver) {
+        return new Existential(rangesOver);
+    }
+
+    /**
+     * Physical quantifier. This kind of quantifier is the conduit between two {@link RecordQueryPlan}s. It does
+     * not have an associated semantics as by that time all semantics and execution details must have been subsumed
+     * by the record plans themselves.
+     */
+    @SuppressWarnings("squid:S2160") // sonarqube thinks .equals() and heshCode() should be overwritten which is not necessary
+    public static final class Physical extends Quantifier {
+        private final ExpressionRef<? extends RecordQueryPlan> rangesOver;
+
+        private Physical(final ExpressionRef<? extends RecordQueryPlan> rangesOver) {
+            this.rangesOver = rangesOver;
+        }
+
+        @Override
+        @Nonnull
+        public ExpressionRef<? extends RecordQueryPlan> getRangesOver() {
+            return rangesOver;
+        }
+
+        @Override
+        @Nonnull
+        public String getShorthand() {
+            return "𝓅";
+        }
+    }
+
+    /**
+     * Factory method to create a physical quantifier over a given expression reference containing record plans.
+     * @param rangesOver expression reference to {@link RecordQueryPlan}s
+     * @return a physical quantifier ranging over the given expression reference
+     */
+    @Nonnull
+    public static Physical physical(final ExpressionRef<? extends RecordQueryPlan> rangesOver) {
+        return new Physical(rangesOver);
+    }
+
+    /**
+     * Factory method to create a physical quantifier over newly created expression reference containing the given
+     * record plan.
+     * @param rangesOverPlan {@link RecordQueryPlan} the new quantifier should range over.
+     * @return a physical quantifier ranging over a new expression reference containing the given expression reference
+     */
+    @Nonnull
+    public static Physical physical(final RecordQueryPlan rangesOverPlan) {
+        return new Physical(GroupExpressionRef.of(rangesOverPlan));
+    }
+
+    /**
+     * Getter to retrieve the expression reference the quantifier ranges over.
+     * @return {@link ExpressionRef} this quantifier ranges over
+     */
+    @Nonnull
+    public abstract ExpressionRef<? extends RelationalExpression> getRangesOver();
+
+    /**
+     * Return a short hand string for the quantifier. As a quantifier's semantics is usually quite subtle and should
+     * not distract from expressions when e.g. a data flow is visualized the returned string should be _short_.
+     * @return a short string representing the quantifier.
+     */
+    @Nonnull
+    public abstract String getShorthand();
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> bindTo(@Nonnull final ExpressionMatcher<? extends Bindable> matcher) {
+        Stream<PlannerBindings> bindings = matcher.matchWith(this);
+        return bindings.flatMap(outerBindings -> matcher.getChildrenMatcher().matches(ImmutableList.of(getRangesOver()))
+                .map(outerBindings::mergedWith));
+    }
+
+    /**
+     * This method allows for computation of {@link PlannerProperty}s across the data flow graph.
+     * @param visitor the planner property that is being computed
+     * @param <U> the type of the property we are computing
+     * @return the property
+     */
+    @Nullable
+    public <U> U acceptPropertyVisitor(@Nonnull PlannerProperty<U> visitor) {
+        if (visitor.shouldVisit(this)) {
+            return visitor.evaluateAtQuantifier(this, getRangesOver().acceptPropertyVisitor(visitor));
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ForEach)) {
+            return false;
+        }
+        final ForEach forEach = (ForEach)o;
+        return Objects.equals(getRangesOver(), forEach.getRangesOver());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRangesOver());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifiers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifiers.java
@@ -1,0 +1,97 @@
+/*
+ * Quantifier.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp;
+
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier.Existential;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier.ForEach;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier.Physical;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Auxiliary class containing factory methods and helpers fro {@link Quantifier}.
+ */
+public class Quantifiers {
+    /**
+     * Factory method to create a list of for-each quantifiers given a list of expression references these quantifiers should range over.
+     * @param rangesOverExpressions iterable {@link ExpressionRef}s of {@link RelationalExpression}s
+     * @param <E> type parameter to constrain expressions to {@link RelationalExpression}
+     * @return a list of for-each quantifiers where each quantifier ranges over an expression reference contained in the list of
+     *         references of relational expressions passed in in order of the references in that iterable.
+     */
+    @Nonnull
+    public static <E extends RelationalExpression> List<ForEach> forEachQuantifiers(final Iterable<ExpressionRef<E>> rangesOverExpressions) {
+        return fromExpressions(rangesOverExpressions, Quantifier::forEach);
+    }
+
+    /**
+     * Factory method to create a list of existential quantifiers given a list of expression references these quantifiers should range over.
+     * @param rangesOverPlans iterable {@link ExpressionRef}s of of {@link RelationalExpression}s.
+     * @param <E> type parameter to constrain expressions to {@link RelationalExpression}
+     * @return a list of physical quantifiers where each quantifier ranges over an expression reference contained in the list of
+     *         references of relational expressions passed in in order of the references in that iterable.
+     */
+    @Nonnull
+    public static <E extends RelationalExpression> List<Existential> existentialQuantifiers(final Iterable<? extends ExpressionRef<E>> rangesOverPlans) {
+        return fromExpressions(rangesOverPlans, Quantifier::existential);
+    }
+
+    /**
+     * Factory method to create a list of physical quantifiers given a list of expression references these quantifiers should range over.
+     * @param rangesOverPlans iterable {@link ExpressionRef}s of {@link RecordQueryPlan}
+     * @param <E> type parameter to constrain expressions to {@link RecordQueryPlan}
+     * @return a list of physical quantifiers where each quantifier ranges over an expression reference contained in the list of
+     *         references of record query plans passed in in order of the references in that iterable.
+     */
+    @Nonnull
+    public static <E extends RecordQueryPlan> List<Physical> fromPlans(final Iterable<? extends ExpressionRef<E>> rangesOverPlans) {
+        return fromExpressions(rangesOverPlans, Quantifier::physical);
+    }
+
+    /**
+     * Factory method to create a list of quantifiers given a list of expression references these quantifiers should range over.
+     * @param rangesOverExpressions iterable of {@link ExpressionRef}s the quantifiers will be created to range over
+     * @param creator lambda to to be called for each expression reference contained in {@code rangesOverExpression}s
+     *        to create the actual quantifier. This allows for callers to create different kinds of quantifier based
+     *        on needs.
+     * @param <E> type parameter to constrain expressions to {@link RelationalExpression}
+     * @param <Q> the type of the quantifier to be created
+     * @return a list of quantifiers where each quantifier ranges over an expression reference contained in the iterable of
+     *         references passed in in order of iteration.
+     */
+    @Nonnull
+    public static <E extends RelationalExpression, Q extends Quantifier> List<Q> fromExpressions(final Iterable<? extends ExpressionRef<E>> rangesOverExpressions,
+                                                                                                 final Function<ExpressionRef<E>, Q> creator) {
+        return StreamSupport
+                .stream(rangesOverExpressions.spliterator(), false)
+                .map(creator)
+                .collect(Collectors.toList());
+    }
+
+    private Quantifiers() {
+        // prevent instantiation
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifiers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Quantifiers.java
@@ -1,5 +1,5 @@
 /*
- * Quantifier.java
+ * Quantifiers.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -32,59 +32,55 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
- * Auxiliary class containing factory methods and helpers fro {@link Quantifier}.
+ * Auxiliary class containing factory methods and helpers for {@link Quantifier}.
  */
 public class Quantifiers {
     /**
-     * Factory method to create a list of for-each quantifiers given a list of expression references these quantifiers should range over.
+     * Create a list of for-each quantifiers from a list of references to range over.
      * @param rangesOverExpressions iterable {@link ExpressionRef}s of {@link RelationalExpression}s
      * @param <E> type parameter to constrain expressions to {@link RelationalExpression}
-     * @return a list of for-each quantifiers where each quantifier ranges over an expression reference contained in the list of
-     *         references of relational expressions passed in in order of the references in that iterable.
+     * @return a list of for-each quantifiers where each quantifier ranges over one of the given references
      */
     @Nonnull
-    public static <E extends RelationalExpression> List<ForEach> forEachQuantifiers(final Iterable<ExpressionRef<E>> rangesOverExpressions) {
+    public static <E extends RelationalExpression> List<ForEach> forEachQuantifiers(@Nonnull final Iterable<ExpressionRef<E>> rangesOverExpressions) {
         return fromExpressions(rangesOverExpressions, Quantifier::forEach);
     }
 
     /**
-     * Factory method to create a list of existential quantifiers given a list of expression references these quantifiers should range over.
+     * Create a list of existential quantifiers from a list of expression references these quantifiers should range over.
      * @param rangesOverPlans iterable {@link ExpressionRef}s of of {@link RelationalExpression}s.
      * @param <E> type parameter to constrain expressions to {@link RelationalExpression}
-     * @return a list of physical quantifiers where each quantifier ranges over an expression reference contained in the list of
-     *         references of relational expressions passed in in order of the references in that iterable.
+     * @return a list of physical quantifiers where each quantifier ranges over one of the given references
      */
     @Nonnull
-    public static <E extends RelationalExpression> List<Existential> existentialQuantifiers(final Iterable<? extends ExpressionRef<E>> rangesOverPlans) {
+    public static <E extends RelationalExpression> List<Existential> existentialQuantifiers(@Nonnull final Iterable<? extends ExpressionRef<E>> rangesOverPlans) {
         return fromExpressions(rangesOverPlans, Quantifier::existential);
     }
 
     /**
-     * Factory method to create a list of physical quantifiers given a list of expression references these quantifiers should range over.
+     * Create a list of physical quantifiers given a list of references these quantifiers should range over.
      * @param rangesOverPlans iterable {@link ExpressionRef}s of {@link RecordQueryPlan}
      * @param <E> type parameter to constrain expressions to {@link RecordQueryPlan}
-     * @return a list of physical quantifiers where each quantifier ranges over an expression reference contained in the list of
-     *         references of record query plans passed in in order of the references in that iterable.
+     * @return a list of physical quantifiers where each quantifier ranges over a reference contained in the given iterable
      */
     @Nonnull
-    public static <E extends RecordQueryPlan> List<Physical> fromPlans(final Iterable<? extends ExpressionRef<E>> rangesOverPlans) {
+    public static <E extends RecordQueryPlan> List<Physical> fromPlans(@Nonnull final Iterable<? extends ExpressionRef<E>> rangesOverPlans) {
         return fromExpressions(rangesOverPlans, Quantifier::physical);
     }
 
     /**
-     * Factory method to create a list of quantifiers given a list of expression references these quantifiers should range over.
+     * Create a list of quantifiers given a list of references these quantifiers should range over.
      * @param rangesOverExpressions iterable of {@link ExpressionRef}s the quantifiers will be created to range over
      * @param creator lambda to to be called for each expression reference contained in {@code rangesOverExpression}s
      *        to create the actual quantifier. This allows for callers to create different kinds of quantifier based
      *        on needs.
      * @param <E> type parameter to constrain expressions to {@link RelationalExpression}
      * @param <Q> the type of the quantifier to be created
-     * @return a list of quantifiers where each quantifier ranges over an expression reference contained in the iterable of
-     *         references passed in in order of iteration.
+     * @return a list of quantifiers where each quantifier ranges over an reference contained in the given iterable
      */
     @Nonnull
-    public static <E extends RelationalExpression, Q extends Quantifier> List<Q> fromExpressions(final Iterable<? extends ExpressionRef<E>> rangesOverExpressions,
-                                                                                                 final Function<ExpressionRef<E>, Q> creator) {
+    public static <E extends RelationalExpression, Q extends Quantifier> List<Q> fromExpressions(@Nonnull final Iterable<? extends ExpressionRef<E>> rangesOverExpressions,
+                                                                                                 @Nonnull final Function<ExpressionRef<E>, Q> creator) {
         return StreamSupport
                 .stream(rangesOverExpressions.spliterator(), false)
                 .map(creator)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/explain/PlannerGraphProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/explain/PlannerGraphProperty.java
@@ -20,10 +20,8 @@
 
 package com.apple.foundationdb.record.query.plan.temp.explain;
 
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.GraphExporter.ClusterProvider;
 import com.apple.foundationdb.record.query.plan.temp.explain.GraphExporter.ComponentAttributeProvider;
@@ -36,7 +34,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.io.CharStreams;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.InputStream;
@@ -251,21 +248,6 @@ public class PlannerGraphProperty implements PlannerProperty<PlannerGraph> {
         this.renderSingleGroups = renderSingleGroups;
     }
 
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
-    }
-
     @Nonnull
     @Override
     public PlannerGraph evaluateAtExpression(@Nonnull final RelationalExpression expression, @Nonnull final List<PlannerGraph> childGraphs) {
@@ -330,13 +312,5 @@ public class PlannerGraphProperty implements PlannerProperty<PlannerGraph> {
         } else { // !renderSingleGroups && memberResults.size() == 1
             return Iterables.getOnlyElement(memberResults);
         }
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public PlannerGraph evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final PlannerGraph rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/explain/PlannerGraphProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/explain/PlannerGraphProperty.java
@@ -20,8 +20,10 @@
 
 package com.apple.foundationdb.record.query.plan.temp.explain;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.GraphExporter.ClusterProvider;
 import com.apple.foundationdb.record.query.plan.temp.explain.GraphExporter.ComponentAttributeProvider;
@@ -34,6 +36,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.io.CharStreams;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.InputStream;
@@ -258,6 +261,11 @@ public class PlannerGraphProperty implements PlannerProperty<PlannerGraph> {
         return true;
     }
 
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
+        return true;
+    }
+
     @Nonnull
     @Override
     public PlannerGraph evaluateAtExpression(@Nonnull final RelationalExpression expression, @Nonnull final List<PlannerGraph> childGraphs) {
@@ -322,5 +330,13 @@ public class PlannerGraphProperty implements PlannerProperty<PlannerGraph> {
         } else { // !renderSingleGroups && memberResults.size() == 1
             return Iterables.getOnlyElement(memberResults);
         }
+    }
+
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public PlannerGraph evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final PlannerGraph rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/FullUnorderedScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/FullUnorderedScanExpression.java
@@ -21,12 +21,12 @@
 package com.apple.foundationdb.record.query.plan.temp.expressions;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.List;
 
 /**
  * A planner expression representing a full, unordered scan of the records by primary key, which is the logical version
@@ -44,8 +44,8 @@ import java.util.Iterator;
 public class FullUnorderedScanExpression implements RelationalExpression {
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/IndexEntrySourceScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/IndexEntrySourceScanExpression.java
@@ -21,16 +21,16 @@
 package com.apple.foundationdb.record.query.plan.temp.expressions;
 
 import com.apple.foundationdb.record.IndexScanType;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.IndexEntrySource;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
 import com.apple.foundationdb.record.query.plan.temp.rules.LogicalToPhysicalScanRule;
+import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -63,8 +63,8 @@ public class IndexEntrySourceScanExpression implements RelationalExpression {
 
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalDistinctExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalDistinctExpression.java
@@ -23,11 +23,12 @@ package com.apple.foundationdb.record.query.plan.temp.expressions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
-import com.google.common.collect.Iterators;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
-import java.util.Iterator;
+import java.util.List;
 
 /**
  * A relational planner expression representing a stream of unique records. This expression has a single child which
@@ -39,14 +40,14 @@ import java.util.Iterator;
 @API(API.Status.EXPERIMENTAL)
 public class LogicalDistinctExpression implements RelationalExpressionWithChildren {
     @Nonnull
-    private ExpressionRef<RelationalExpression> inner;
+    private Quantifier.ForEach inner;
 
     public LogicalDistinctExpression(@Nonnull RelationalExpression inner) {
         this(GroupExpressionRef.of(inner));
     }
 
     public LogicalDistinctExpression(@Nonnull ExpressionRef<RelationalExpression> inner) {
-        this.inner = inner;
+        this.inner = Quantifier.forEach(inner);
     }
 
     @Override
@@ -56,8 +57,8 @@ public class LogicalDistinctExpression implements RelationalExpressionWithChildr
 
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(inner);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(inner);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalFilterExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalFilterExpression.java
@@ -23,14 +23,16 @@ package com.apple.foundationdb.record.query.plan.temp.expressions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
 import com.apple.foundationdb.record.query.plan.temp.view.Source;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
-import com.google.common.collect.Iterators;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -45,7 +47,7 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
     @Nonnull
     private final QueryPredicate filter;
     @Nonnull
-    private final ExpressionRef<RelationalExpression> inner;
+    private final Quantifier.ForEach inner;
 
     public LogicalFilterExpression(@Nonnull Source baseSource,
                                    @Nonnull QueryPredicate filter,
@@ -58,13 +60,13 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
                                    @Nonnull ExpressionRef<RelationalExpression> inner) {
         this.baseSource = baseSource;
         this.filter = filter;
-        this.inner = inner;
+        this.inner = Quantifier.forEach(inner);
     }
 
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(inner);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(inner);
     }
 
     @Override
@@ -84,8 +86,9 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
     }
 
     @Nonnull
-    public RelationalExpression getInner() {
-        return inner.get();
+    @VisibleForTesting
+    public Quantifier getInner() {
+        return inner;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalSortExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalSortExpression.java
@@ -23,14 +23,13 @@ package com.apple.foundationdb.record.query.plan.temp.expressions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.view.Element;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -46,7 +45,7 @@ public class LogicalSortExpression implements RelationalExpressionWithChildren {
     private final List<Element> sort;
     private final boolean reverse;
     @Nonnull
-    private final ExpressionRef<RelationalExpression> inner;
+    private final Quantifier.ForEach inner;
 
     public LogicalSortExpression(@Nonnull List<Element> sort, boolean reverse, @Nonnull RelationalExpression inner) {
         this(sort, reverse, GroupExpressionRef.of(inner));
@@ -66,13 +65,13 @@ public class LogicalSortExpression implements RelationalExpressionWithChildren {
         this.grouping = grouping;
         this.sort = sort;
         this.reverse = reverse;
-        this.inner = inner;
+        this.inner = Quantifier.forEach(inner);
     }
 
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Iterators.singletonIterator(inner);
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(inner);
     }
 
     @Override
@@ -108,8 +107,8 @@ public class LogicalSortExpression implements RelationalExpressionWithChildren {
     }
 
     @Nonnull
-    public RelationalExpression getInner() {
-        return inner.get();
+    private Quantifier getInner() {
+        return inner;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalUnorderedUnionExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalUnorderedUnionExpression.java
@@ -22,11 +22,13 @@ package com.apple.foundationdb.record.query.plan.temp.expressions;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.apple.foundationdb.record.query.plan.temp.Quantifiers;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 
 import javax.annotation.Nonnull;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A relational planner expression that represents an unimplemented unordered union of its children.
@@ -35,21 +37,21 @@ import java.util.List;
 @API(API.Status.EXPERIMENTAL)
 public class LogicalUnorderedUnionExpression implements RelationalExpressionWithChildren {
     @Nonnull
-    private List<ExpressionRef<RelationalExpression>> expressionChildren;
+    private List<Quantifier.ForEach> children;
 
     public LogicalUnorderedUnionExpression(@Nonnull List<ExpressionRef<RelationalExpression>> expressionChildren) {
-        this.expressionChildren = expressionChildren;
+        this.children = Quantifiers.forEachQuantifiers(expressionChildren);
     }
 
     @Override
     public int getRelationalChildCount() {
-        return expressionChildren.size();
+        return children.size();
     }
 
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return expressionChildren.iterator();
+    public List<? extends Quantifier> getQuantifiers() {
+        return children;
     }
 
     @Override
@@ -58,19 +60,19 @@ public class LogicalUnorderedUnionExpression implements RelationalExpressionWith
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (o == this) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
-        if (o == null || o.getClass() != getClass())  {
+        if (!(o instanceof LogicalUnorderedUnionExpression)) {
             return false;
         }
-        LogicalUnorderedUnionExpression that = (LogicalUnorderedUnionExpression)o;
-        return expressionChildren.equals(that.expressionChildren);
+        final LogicalUnorderedUnionExpression that = (LogicalUnorderedUnionExpression)o;
+        return children.equals(that.children);
     }
 
     @Override
     public int hashCode() {
-        return expressionChildren.hashCode();
+        return Objects.hash(children);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AllChildrenMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AllChildrenMatcher.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 
 import javax.annotation.Nonnull;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -49,13 +48,13 @@ public class AllChildrenMatcher implements ExpressionChildrenMatcher {
 
     @Nonnull
     @Override
-    public Stream<PlannerBindings> matches(@Nonnull Iterator<? extends Bindable> childIterator) {
+    public Stream<PlannerBindings> matches(@Nonnull List<? extends Bindable> children) {
         Stream<PlannerBindings> bindingStream = Stream.of(PlannerBindings.empty());
 
         // The children need to be merged in the same order that they appear to satisfy the contract of
         // PlannerBindings.getAll().
-        while (childIterator.hasNext()) {
-            List<PlannerBindings> individualBindings = childIterator.next().bindTo(childMatcher).collect(Collectors.toList());
+        for (final Bindable child : children) {
+            final List<PlannerBindings> individualBindings = child.bindTo(childMatcher).collect(Collectors.toList());
             if (individualBindings.isEmpty()) {
                 return Stream.empty();
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildMatcher.java
@@ -24,10 +24,8 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 
 import javax.annotation.Nonnull;
-import java.util.Iterator;
-import java.util.Spliterators;
+import java.util.List;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * An expression children matcher that tries to match any child to the given {@link ExpressionMatcher}, producing a
@@ -45,10 +43,10 @@ public class AnyChildMatcher implements ExpressionChildrenMatcher {
 
     @Nonnull
     @Override
-    public Stream<PlannerBindings> matches(@Nonnull Iterator<? extends Bindable> childIterator) {
-        Stream<? extends Bindable> childStream = StreamSupport.stream(
-                Spliterators.spliteratorUnknownSize(childIterator, 0), false);
-        return childStream.flatMap(child -> child.bindTo(childMatcher));
+    public Stream<PlannerBindings> matches(@Nonnull List<? extends Bindable> children) {
+        return children
+                .stream()
+                .flatMap(child -> child.bindTo(childMatcher));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildWithRestMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildWithRestMatcher.java
@@ -24,11 +24,9 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
-import com.google.common.collect.Lists;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -56,9 +54,7 @@ public class AnyChildWithRestMatcher implements ExpressionChildrenMatcher {
 
     @Nonnull
     @Override
-    public Stream<PlannerBindings> matches(@Nonnull Iterator<? extends Bindable> childIterator) {
-        List<Bindable> children = Lists.newArrayList(childIterator);
-
+    public Stream<PlannerBindings> matches(@Nonnull List<? extends Bindable> children) {
         Stream.Builder<Stream<PlannerBindings>> streams = Stream.builder();
         for (int i = 0; i < children.size(); i++) {
             Bindable child = children.get(i);
@@ -69,7 +65,7 @@ public class AnyChildWithRestMatcher implements ExpressionChildrenMatcher {
             Stream<PlannerBindings> childBindings = child.bindTo(selectedChildMatcher);
             // The otherChildrenMatcher is an AllChildrenMatcher wrapping a ReferenceMatcher, so it is guaranteed to
             // produce a single set of PlannerBindings.
-            Optional<PlannerBindings> otherBindings = otherChildrenMatcher.matches(otherChildren.iterator()).findFirst();
+            Optional<PlannerBindings> otherBindings = otherChildrenMatcher.matches(otherChildren).findFirst();
             if (!otherBindings.isPresent()) {
                 throw new RecordCoreException("invariant violated: couldn't match reference matcher to one of the other children");
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildrenMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/AnyChildrenMatcher.java
@@ -23,7 +23,7 @@ package com.apple.foundationdb.record.query.plan.temp.matchers;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 
 import javax.annotation.Nonnull;
-import java.util.Iterator;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -37,7 +37,7 @@ public class AnyChildrenMatcher implements ExpressionChildrenMatcher {
 
     @Nonnull
     @Override
-    public Stream<PlannerBindings> matches(@Nonnull Iterator<? extends Bindable> childIterator) {
+    public Stream<PlannerBindings> matches(@Nonnull List<? extends Bindable> children) {
         return Stream.of(PlannerBindings.empty());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionChildrenMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionChildrenMatcher.java
@@ -25,19 +25,19 @@ import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 
 import javax.annotation.Nonnull;
-import java.util.Iterator;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
  * An {@code ExpressionChildrenMatcher} describes how to match the children of a {@link RelationalExpression} (i.e., the
- * references returned by the {@link RelationalExpression#getPlannerExpressionChildren()} method). Bindings can be
+ * references returned by the {@link RelationalExpression#getQuantifiers()} method). Bindings can be
  * retrieved from the rule call using the {@code ExpressionChildMatcher} that produced them.
  *
  * <p>
  * In most cases, the most natural way to bind to the children of a planner expression is by defining a matcher for each
  * child. This behavior is implemented in the {@link ListChildrenMatcher} and exposed by the
  * {@link TypeMatcher#of(Class, ExpressionMatcher[])} helper method. However, this does not work when there is no
- * <i>a priori</i> bound on the number of children returned by {@link RelationalExpression#getPlannerExpressionChildren()}
+ * <i>a priori</i> bound on the number of children returned by {@link RelationalExpression#getQuantifiers()}
  * For example, an {@link com.apple.foundationdb.record.query.expressions.AndComponent} can have an arbitrary number of
  * other {@code QueryComponent}s as children.
  * </p>
@@ -56,9 +56,9 @@ public interface ExpressionChildrenMatcher {
      * Apply this matcher to the children provided by the given iterator and produce a stream of possible bindings.
      * If the match is not successful, produce an empty stream. Note that this method should not generally match to the
      * children themselves; instead, it should delegate that work to one or more inner {@link ExpressionMatcher}s.
-     * @param childIterator an iterator of references to the children of a planner expression
+     * @param children a list of references to the children of a planner expression
      * @return a stream of the possible bindings from applying this match to the children in the given iterator
      */
     @Nonnull
-    Stream<PlannerBindings> matches(@Nonnull Iterator<? extends Bindable> childIterator);
+    Stream<PlannerBindings> matches(@Nonnull List<? extends Bindable> children);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ExpressionMatcher.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.temp.matchers;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 
@@ -85,7 +86,7 @@ public interface ExpressionMatcher<T extends Bindable> {
     Stream<PlannerBindings> matchWith(@Nonnull ExpressionRef<? extends RelationalExpression> ref);
 
     /**
-     * Attempt to match this matcher against the given expression reference.
+     * Attempt to match this matcher against the given {@link ExpressionMatcher}.
      * Note that implementations of {@code matchWith()} should only attempt to match the given root with this planner
      * expression and should not call into the {@link ExpressionChildrenMatcher} returned by {@link #getChildrenMatcher()}
      * or attempt to access children of the given expression.
@@ -95,7 +96,26 @@ public interface ExpressionMatcher<T extends Bindable> {
     @Nonnull
     Stream<PlannerBindings> matchWith(@Nonnull RelationalExpression expression);
 
+    /**
+     * Attempt to match this matcher against the given {@link QueryPredicate}.
+     * Note that implementations of {@code matchWith()} should only attempt to match the given root with this planner
+     * expression and should not call into the {@link ExpressionChildrenMatcher} returned by {@link #getChildrenMatcher()}
+     * or attempt to access children of the given expression.
+     * @param predicate a predicate to match with
+     * @return a stream of {@link PlannerBindings} containing the matched bindings, or an empty stream is no match was found
+     */
     @Nonnull
     Stream<PlannerBindings> matchWith(@Nonnull QueryPredicate predicate);
 
+
+    /**
+     * Attempt to match this matcher against the given {@link Quantifier}.
+     * Note that implementations of {@code matchWith()} should only attempt to match the given root with this planner
+     * expression and should not call into the {@link ExpressionChildrenMatcher} returned by {@link #getChildrenMatcher()}
+     * or attempt to access children of the given expression.
+     * @param quantifier a quantifier to match with
+     * @return a stream of {@link PlannerBindings} containing the matched bindings, or an empty stream is no match was found
+     */
+    @Nonnull
+    Stream<PlannerBindings> matchWith(@Nonnull Quantifier quantifier);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/QuantifierMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/QuantifierMatcher.java
@@ -43,8 +43,7 @@ public class QuantifierMatcher<T extends Quantifier> extends TypeMatcher<T> {
      * Matches a {@link com.apple.foundationdb.record.query.plan.temp.Quantifier.ForEach} quantifier together
      * with the given matcher for its {@code rangesOver()}.
      * @param rangesOverMatcher matcher for the rangesOver expression reference
-     * @return a matcher matching a for each quantifier together with the given matcher for expression reference
-     *         it ranges over.
+     * @return a matcher matching a for each quantifier together with the given matcher for reference it ranges over.
      */
     @Nonnull
     public static QuantifierMatcher<Quantifier.ForEach> forEach(@Nonnull ExpressionMatcher<? extends Bindable> rangesOverMatcher) {
@@ -55,8 +54,7 @@ public class QuantifierMatcher<T extends Quantifier> extends TypeMatcher<T> {
      * Matches a {@link com.apple.foundationdb.record.query.plan.temp.Quantifier.Existential} quantifier together
      * with the given matcher for its {@code rangesOver()}.
      * @param rangesOverMatcher matcher for the rangesOver expression reference
-     * @return a matcher matching an existential quantifier together with the given matcher for the expression reference
-     *         it ranges over.
+     * @return a matcher matching an existential quantifier together with the given matcher for the reference it ranges over
      */
     @Nonnull
     public static QuantifierMatcher<Quantifier.Existential> existential(@Nonnull ExpressionMatcher<? extends Bindable> rangesOverMatcher) {
@@ -67,8 +65,7 @@ public class QuantifierMatcher<T extends Quantifier> extends TypeMatcher<T> {
      * Matches a {@link com.apple.foundationdb.record.query.plan.temp.Quantifier.Physical} quantifier together
      * with the given matcher for its {@code rangesOver()}.
      * @param rangesOverMatcher matcher for the rangesOver expression reference
-     * @return a matcher matching a physical quantifier together with the given matcher for the expression reference
-     *         it ranges over.
+     * @return a matcher matching a physical quantifier together with the given matcher for the reference it ranges over
      */
     @Nonnull
     public static QuantifierMatcher<Quantifier.Physical> physical(@Nonnull ExpressionMatcher<? extends Bindable> rangesOverMatcher) {
@@ -81,8 +78,7 @@ public class QuantifierMatcher<T extends Quantifier> extends TypeMatcher<T> {
      * @param quantifierClass class specific flavor of quantifier to match
      * @param rangesOverMatcher matcher for the rangesOver expression reference
      * @param <Q> class of specific flavor of quantifier to match
-     * @return a matcher matching a for each quantifier together with the given matcher for the expression reference
-     *         it ranges over.
+     * @return a matcher matching a for each quantifier together with the given matcher for the reference it ranges over
      */
     @Nonnull
     public static <Q extends Quantifier> QuantifierMatcher<Q> ofKind(@Nonnull Class<? extends Q> quantifierClass,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/QuantifierMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/QuantifierMatcher.java
@@ -1,0 +1,92 @@
+/*
+ * QuantifierMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp.matchers;
+
+import com.apple.foundationdb.record.query.plan.temp.Bindable;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Matches a subclass of {@link com.apple.foundationdb.record.query.plan.temp.Quantifier} and a given matcher against the children.
+ * @param <T> the type of {@link com.apple.foundationdb.record.query.plan.temp.Quantifier} to match against
+ */
+public class QuantifierMatcher<T extends Quantifier> extends TypeMatcher<T> {
+    /**
+     * Private constructor. Use static factory methods.
+     * @param quantifierClass the class of the quantifier
+     * @param childrenMatcher matcher for children
+     */
+    private QuantifierMatcher(@Nonnull final Class<? extends T> quantifierClass, @Nonnull final ExpressionChildrenMatcher childrenMatcher) {
+        super(quantifierClass, childrenMatcher);
+    }
+
+    /**
+     * Matches a {@link com.apple.foundationdb.record.query.plan.temp.Quantifier.ForEach} quantifier together
+     * with the given matcher for its {@code rangesOver()}.
+     * @param rangesOverMatcher matcher for the rangesOver expression reference
+     * @return a matcher matching a for each quantifier together with the given matcher for expression reference
+     *         it ranges over.
+     */
+    @Nonnull
+    public static QuantifierMatcher<Quantifier.ForEach> forEach(@Nonnull ExpressionMatcher<? extends Bindable> rangesOverMatcher) {
+        return ofKind(Quantifier.ForEach.class, rangesOverMatcher);
+    }
+
+    /**
+     * Matches a {@link com.apple.foundationdb.record.query.plan.temp.Quantifier.Existential} quantifier together
+     * with the given matcher for its {@code rangesOver()}.
+     * @param rangesOverMatcher matcher for the rangesOver expression reference
+     * @return a matcher matching an existential quantifier together with the given matcher for the expression reference
+     *         it ranges over.
+     */
+    @Nonnull
+    public static QuantifierMatcher<Quantifier.Existential> existential(@Nonnull ExpressionMatcher<? extends Bindable> rangesOverMatcher) {
+        return ofKind(Quantifier.Existential.class, rangesOverMatcher);
+    }
+
+    /**
+     * Matches a {@link com.apple.foundationdb.record.query.plan.temp.Quantifier.Physical} quantifier together
+     * with the given matcher for its {@code rangesOver()}.
+     * @param rangesOverMatcher matcher for the rangesOver expression reference
+     * @return a matcher matching a physical quantifier together with the given matcher for the expression reference
+     *         it ranges over.
+     */
+    @Nonnull
+    public static QuantifierMatcher<Quantifier.Physical> physical(@Nonnull ExpressionMatcher<? extends Bindable> rangesOverMatcher) {
+        return ofKind(Quantifier.Physical.class, rangesOverMatcher);
+    }
+
+    /**
+     * Matches a subclass of {@link com.apple.foundationdb.record.query.plan.temp.Quantifier} together
+     * with the given matcher for its {@code rangesOver()}.
+     * @param quantifierClass class specific flavor of quantifier to match
+     * @param rangesOverMatcher matcher for the rangesOver expression reference
+     * @param <Q> class of specific flavor of quantifier to match
+     * @return a matcher matching a for each quantifier together with the given matcher for the expression reference
+     *         it ranges over.
+     */
+    @Nonnull
+    public static <Q extends Quantifier> QuantifierMatcher<Q> ofKind(@Nonnull Class<? extends Q> quantifierClass,
+                                                                     @Nonnull ExpressionMatcher<? extends Bindable> rangesOverMatcher) {
+        return new QuantifierMatcher<>(quantifierClass, AnyChildMatcher.anyMatching(rangesOverMatcher));
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ReferenceMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/ReferenceMatcher.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.temp.matchers;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 
@@ -40,7 +41,7 @@ import java.util.stream.Stream;
  * that the type parameter is general enough to cover every possible type of {@code PlannerExpression} that might be behind
  * any reference that it could be matched to. In general, the programmer will be certain that a reference would contain
  * a particular type because an expression of a certain type is always found in a particular position of the iterator
- * returned by {@link RelationalExpression#getPlannerExpressionChildren()}. For example, it would be safe to use a
+ * returned by {@link RelationalExpression#getQuantifiers()}. For example, it would be safe to use a
  * {@code ReferenceMatcher<QueryComponent>} to match against the second planner expression child of a
  * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan} because that child is necessarily a
  * {@code QueryComponent}; note that there is no way for the type system to know that, so the programmer must track
@@ -77,6 +78,12 @@ public class ReferenceMatcher<T extends RelationalExpression> implements Express
     @Nonnull
     @Override
     public Stream<PlannerBindings> matchWith(@Nonnull QueryPredicate predicate) {
+        return Stream.empty();
+    }
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> matchWith(@Nonnull final Quantifier quantifier) {
         return Stream.empty();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/TypeMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/TypeMatcher.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.temp.matchers;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 import com.google.common.collect.ImmutableList;
@@ -67,7 +68,7 @@ public class TypeMatcher<T extends Bindable> implements ExpressionMatcher<T> {
 
     @SafeVarargs
     public static <U extends Bindable> TypeMatcher<U> of(@Nonnull Class<? extends U> expressionClass,
-                                                                  @Nonnull ExpressionMatcher<? extends Bindable>... children) {
+                                                         @Nonnull ExpressionMatcher<? extends Bindable>... children) {
         ImmutableList.Builder<ExpressionMatcher<? extends Bindable>> builder = ImmutableList.builder();
         for (ExpressionMatcher<? extends Bindable> child : children) {
             builder.add(child);
@@ -76,7 +77,7 @@ public class TypeMatcher<T extends Bindable> implements ExpressionMatcher<T> {
     }
 
     public static <U extends Bindable> TypeMatcher<U> of(@Nonnull Class<? extends U> expressionClass,
-                                                                  @Nonnull ExpressionChildrenMatcher childrenMatcher) {
+                                                         @Nonnull ExpressionChildrenMatcher childrenMatcher) {
         return new TypeMatcher<>(expressionClass, childrenMatcher);
     }
 
@@ -90,18 +91,25 @@ public class TypeMatcher<T extends Bindable> implements ExpressionMatcher<T> {
     @Nonnull
     @Override
     public Stream<PlannerBindings> matchWith(@Nonnull RelationalExpression expression) {
-        if (expressionClass.isInstance(expression)) {
-            return Stream.of(PlannerBindings.from(this, expression));
-        } else {
-            return Stream.empty();
-        }
+        return matchClassWith(expression);
     }
 
     @Nonnull
     @Override
     public Stream<PlannerBindings> matchWith(@Nonnull QueryPredicate predicate) {
-        if (expressionClass.isInstance(predicate)) {
-            return Stream.of(PlannerBindings.from(this, predicate));
+        return matchClassWith(predicate);
+    }
+
+    @Nonnull
+    @Override
+    public Stream<PlannerBindings> matchWith(@Nonnull final Quantifier quantifier) {
+        return matchClassWith(quantifier);
+    }
+
+    @Nonnull
+    private Stream<PlannerBindings> matchClassWith(final Bindable bindable) {
+        if (expressionClass.isInstance(bindable)) {
+            return Stream.of(PlannerBindings.from(this, bindable));
         } else {
             return Stream.empty();
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
@@ -30,16 +29,13 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A property that determines whether the expression may produce duplicate entries. If the given expression is a
@@ -54,21 +50,6 @@ public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
 
     private CreatesDuplicatesProperty(@Nonnull PlanContext context) {
         this.context = context;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
     }
 
     @Nonnull
@@ -112,14 +93,5 @@ public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
     public static boolean evaluate(@Nonnull RelationalExpression expression, @Nonnull PlanContext context) {
         // Won't actually be null for relational planner expressions.
         return expression.acceptPropertyVisitor(new CreatesDuplicatesProperty(context));
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public Boolean evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Boolean rangesOverResult) {
-        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
-        // insist that rangesOverResult is never null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
@@ -118,7 +118,8 @@ public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
     @Override
     @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public Boolean evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Boolean rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
+        // insist that rangesOverResult is never null
         return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
@@ -29,13 +30,16 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A property that determines whether the expression may produce duplicate entries. If the given expression is a
@@ -59,6 +63,11 @@ public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
 
     @Override
     public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
         return true;
     }
 
@@ -103,5 +112,13 @@ public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
     public static boolean evaluate(@Nonnull RelationalExpression expression, @Nonnull PlanContext context) {
         // Won't actually be null for relational planner expressions.
         return expression.acceptPropertyVisitor(new CreatesDuplicatesProperty(context));
+    }
+
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Boolean evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Boolean rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/ElementPredicateCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/ElementPredicateCountProperty.java
@@ -118,7 +118,8 @@ public class ElementPredicateCountProperty implements PlannerProperty<Integer> {
     @Override
     @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
+        // insist that rangesOverResult is never null
         return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/ElementPredicateCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/ElementPredicateCountProperty.java
@@ -21,21 +21,17 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
 import com.apple.foundationdb.record.query.predicates.AndOrPredicate;
 import com.apple.foundationdb.record.query.predicates.ElementPredicate;
 import com.apple.foundationdb.record.query.predicates.NotPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A property that counts the number of {@link ElementPredicate}s that appear in a planner expression tree.
@@ -45,21 +41,6 @@ import java.util.Objects;
 @API(API.Status.EXPERIMENTAL)
 public class ElementPredicateCountProperty implements PlannerProperty<Integer> {
     private static final ElementPredicateCountProperty INSTANCE = new ElementPredicateCountProperty();
-
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
-    }
 
     @Nonnull
     @Override
@@ -112,14 +93,5 @@ public class ElementPredicateCountProperty implements PlannerProperty<Integer> {
             return Integer.MAX_VALUE;
         }
         return result;
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
-        // insist that rangesOverResult is never null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/ElementPredicateCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/ElementPredicateCountProperty.java
@@ -21,7 +21,9 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
@@ -31,7 +33,9 @@ import com.apple.foundationdb.record.query.predicates.NotPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A property that counts the number of {@link ElementPredicate}s that appear in a planner expression tree.
@@ -49,6 +53,11 @@ public class ElementPredicateCountProperty implements PlannerProperty<Integer> {
 
     @Override
     public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
         return true;
     }
 
@@ -103,5 +112,13 @@ public class ElementPredicateCountProperty implements PlannerProperty<Integer> {
             return Integer.MAX_VALUE;
         }
         return result;
+    }
+
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/FieldWithComparisonCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/FieldWithComparisonCountProperty.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.expressions.ComponentWithChildren;
 import com.apple.foundationdb.record.query.expressions.ComponentWithNoChildren;
 import com.apple.foundationdb.record.query.expressions.ComponentWithSingleChild;
@@ -30,13 +29,10 @@ import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A property that counts the number of {@link FieldWithComparison}s that appear in a planner expression tree.
@@ -46,21 +42,6 @@ import java.util.Objects;
 @API(API.Status.EXPERIMENTAL)
 public class FieldWithComparisonCountProperty implements PlannerProperty<Integer> {
     private static final FieldWithComparisonCountProperty INSTANCE = new FieldWithComparisonCountProperty();
-
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
-    }
 
     @Nonnull
     @Override
@@ -117,13 +98,5 @@ public class FieldWithComparisonCountProperty implements PlannerProperty<Integer
             return Integer.MAX_VALUE;
         }
         return result;
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/FieldWithComparisonCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/FieldWithComparisonCountProperty.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.expressions.ComponentWithChildren;
 import com.apple.foundationdb.record.query.expressions.ComponentWithNoChildren;
 import com.apple.foundationdb.record.query.expressions.ComponentWithSingleChild;
@@ -29,10 +30,13 @@ import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A property that counts the number of {@link FieldWithComparison}s that appear in a planner expression tree.
@@ -50,6 +54,11 @@ public class FieldWithComparisonCountProperty implements PlannerProperty<Integer
 
     @Override
     public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
         return true;
     }
 
@@ -108,5 +117,13 @@ public class FieldWithComparisonCountProperty implements PlannerProperty<Integer
             return Integer.MAX_VALUE;
         }
         return result;
+    }
+
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -33,19 +32,16 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
-import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.FullUnorderedScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
 import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -60,21 +56,6 @@ public class RecordTypesProperty implements PlannerProperty<Set<String>> {
 
     private RecordTypesProperty(@Nonnull PlanContext context) {
         this.context = context;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
     }
 
     @Nonnull
@@ -160,13 +141,5 @@ public class RecordTypesProperty implements PlannerProperty<Set<String>> {
     @Nonnull
     public static Set<String> evaluate(@Nonnull PlanContext context, @Nonnull RelationalExpression ref) {
         return ref.acceptPropertyVisitor(new RecordTypesProperty(context));
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public Set<String> evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Set<String> rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -32,6 +33,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.FullUnorderedScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
@@ -40,8 +42,10 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpre
 import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -65,6 +69,11 @@ public class RecordTypesProperty implements PlannerProperty<Set<String>> {
 
     @Override
     public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
         return true;
     }
 
@@ -151,5 +160,13 @@ public class RecordTypesProperty implements PlannerProperty<Set<String>> {
     @Nonnull
     public static Set<String> evaluate(@Nonnull PlanContext context, @Nonnull RelationalExpression ref) {
         return ref.acceptPropertyVisitor(new RecordTypesProperty(context));
+    }
+
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Set<String> evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Set<String> rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RelationalExpressionDepthProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RelationalExpressionDepthProperty.java
@@ -20,18 +20,22 @@
 
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -59,6 +63,11 @@ public class RelationalExpressionDepthProperty implements PlannerProperty<Intege
 
     @Override
     public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
         return true;
     }
 
@@ -90,4 +99,11 @@ public class RelationalExpressionDepthProperty implements PlannerProperty<Intege
         return expression.acceptPropertyVisitor(this);
     }
 
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RelationalExpressionDepthProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RelationalExpressionDepthProperty.java
@@ -20,22 +20,18 @@
 
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalTypeFilterExpression;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -54,21 +50,6 @@ public class RelationalExpressionDepthProperty implements PlannerProperty<Intege
 
     public RelationalExpressionDepthProperty(@Nonnull Set<Class<? extends RelationalExpression>> types) {
         this.types = types;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
     }
 
     @Nonnull
@@ -97,13 +78,5 @@ public class RelationalExpressionDepthProperty implements PlannerProperty<Intege
 
     public int evaluate(@Nonnull RelationalExpression expression) {
         return expression.acceptPropertyVisitor(this);
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/TypeFilterCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/TypeFilterCountProperty.java
@@ -20,17 +20,13 @@
 
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A property that determines the sum, over all elements of a {@code PlannerExpression} tree, of the number of record
@@ -46,21 +42,6 @@ import java.util.Objects;
  */
 public class TypeFilterCountProperty implements PlannerProperty<Integer> {
     private static final TypeFilterCountProperty INSTANCE = new TypeFilterCountProperty();
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
-    }
 
     @Nonnull
     @Override
@@ -93,14 +74,5 @@ public class TypeFilterCountProperty implements PlannerProperty<Integer> {
             return 0;
         }
         return result;
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
-        // insist that rangesOverResult is never null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/TypeFilterCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/TypeFilterCountProperty.java
@@ -20,13 +20,17 @@
 
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A property that determines the sum, over all elements of a {@code PlannerExpression} tree, of the number of record
@@ -50,6 +54,11 @@ public class TypeFilterCountProperty implements PlannerProperty<Integer> {
 
     @Override
     public boolean shouldVisit(@Nonnull RelationalExpression expression) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
         return true;
     }
 
@@ -84,5 +93,13 @@ public class TypeFilterCountProperty implements PlannerProperty<Integer> {
             return 0;
         }
         return result;
+    }
+
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/TypeFilterCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/TypeFilterCountProperty.java
@@ -99,7 +99,8 @@ public class TypeFilterCountProperty implements PlannerProperty<Integer> {
     @Override
     @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
+        // insist that rangesOverResult is never null
         return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/UnmatchedFieldsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/UnmatchedFieldsProperty.java
@@ -133,7 +133,8 @@ public class UnmatchedFieldsProperty implements PlannerProperty<Integer> {
     @Override
     @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
+        // insist that rangesOverResult is never null
         return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/UnmatchedFieldsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/UnmatchedFieldsProperty.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
@@ -30,11 +31,14 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A property for counting the total number of {@link KeyExpression} columns (i.e., field-like {@code KeyExpression}s
@@ -67,6 +71,11 @@ public class UnmatchedFieldsProperty implements PlannerProperty<Integer> {
 
     @Override
     public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
         return true;
     }
 
@@ -118,5 +127,13 @@ public class UnmatchedFieldsProperty implements PlannerProperty<Integer> {
             return Integer.MAX_VALUE;
         }
         return result;
+    }
+
+    @Nonnull
+    @Override
+    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
+    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
+        // since we do visit expression references in this property we can insist on rangesOverResult not being null
+        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/UnmatchedFieldsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/UnmatchedFieldsProperty.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
@@ -31,14 +30,11 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
-import com.apple.foundationdb.record.query.plan.temp.Quantifier;
-import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A property for counting the total number of {@link KeyExpression} columns (i.e., field-like {@code KeyExpression}s
@@ -62,21 +58,6 @@ public class UnmatchedFieldsProperty implements PlannerProperty<Integer> {
 
     public UnmatchedFieldsProperty(@Nonnull PlanContext context) {
         this.planContext = context;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull RelationalExpression expression) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull ExpressionRef<? extends RelationalExpression> ref) {
-        return true;
-    }
-
-    @Override
-    public boolean shouldVisit(@Nonnull final Quantifier quantifier) {
-        return true;
     }
 
     @Nonnull
@@ -127,14 +108,5 @@ public class UnmatchedFieldsProperty implements PlannerProperty<Integer> {
             return Integer.MAX_VALUE;
         }
         return result;
-    }
-
-    @Nonnull
-    @Override
-    @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-    public Integer evaluateAtQuantifier(@Nonnull final Quantifier quantifier, @Nullable final Integer rangesOverResult) {
-        // since we visit the expression reference under the quantifier, and don't return null ourselves, we can
-        // insist that rangesOverResult is never null
-        return Objects.requireNonNull(rangesOverResult);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterEx
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
@@ -50,7 +51,10 @@ public class CombineFilterRule extends PlannerRule<LogicalFilterExpression> {
     private static final ExpressionMatcher<LogicalFilterExpression> root = TypeWithPredicateMatcher.ofPredicate(
             LogicalFilterExpression.class,
             firstMatcher,
-            TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class, secondMatcher, childMatcher));
+            QuantifierMatcher.forEach(
+                    TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
+                            secondMatcher,
+                            QuantifierMatcher.forEach(childMatcher))));
 
     public CombineFilterRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithElementWithComparisonRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FilterWithElementWithComparisonRule.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.FullUnorderedSc
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
 import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
@@ -48,7 +49,10 @@ import java.util.Optional;
 public class FilterWithElementWithComparisonRule extends PlannerRule<LogicalFilterExpression> {
     private static final ExpressionMatcher<ElementPredicate> filterMatcher = TypeMatcher.of(ElementPredicate.class);
     private static final ExpressionMatcher<FullUnorderedScanExpression> scanMatcher = TypeMatcher.of(FullUnorderedScanExpression.class);
-    private static final ExpressionMatcher<LogicalFilterExpression> root = TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class, filterMatcher, scanMatcher);
+    private static final ExpressionMatcher<LogicalFilterExpression> root =
+            TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
+                    filterMatcher,
+                    QuantifierMatcher.forEach(scanMatcher));
 
     public FilterWithElementWithComparisonRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindPossibleIndexForAndPredicateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FindPossibleIndexForAndPredicateRule.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterEx
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildWithRestMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
 import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
@@ -54,8 +55,10 @@ public class FindPossibleIndexForAndPredicateRule extends PlannerRule<LogicalFil
     private static ExpressionMatcher<AndPredicate> andFilterMatcher = TypeMatcher.of(AndPredicate.class,
             AnyChildWithRestMatcher.anyMatchingWithRest(fieldMatcher, residualFieldsMatcher));
     private static ExpressionMatcher<FullUnorderedScanExpression> scanMatcher = TypeMatcher.of(FullUnorderedScanExpression.class);
-    private static ExpressionMatcher<LogicalFilterExpression> root = TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
-            andFilterMatcher, scanMatcher);
+    private static ExpressionMatcher<LogicalFilterExpression> root =
+            TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
+                    andFilterMatcher,
+                    QuantifierMatcher.forEach(scanMatcher));
 
     public FindPossibleIndexForAndPredicateRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FlattenNestedAndPredicateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FlattenNestedAndPredicateRule.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.query.plan.temp.matchers.AllChildrenMatcher
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildWithRestMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
@@ -69,7 +70,7 @@ public class FlattenNestedAndPredicateRule extends PlannerRule<LogicalFilterExpr
                     AnyChildWithRestMatcher.anyMatchingWithRest(
                             TypeMatcher.of(AndPredicate.class, AllChildrenMatcher.allMatching(andChildrenMatcher)),
                     otherInnerComponentsMatcher)),
-            inner);
+            QuantifierMatcher.forEach(inner));
 
 
     public FlattenNestedAndPredicateRule() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctRule.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.properties.CreatesDuplicatesProperty;
 
@@ -52,7 +53,9 @@ public class ImplementDistinctRule extends PlannerRule<LogicalDistinctExpression
     @Nonnull
     private static final ExpressionMatcher<RecordQueryPlan> innerMatcher = TypeMatcher.of(RecordQueryPlan.class, AnyChildrenMatcher.ANY);
     @Nonnull
-    private static final ExpressionMatcher<LogicalDistinctExpression> root = TypeMatcher.of(LogicalDistinctExpression.class, innerMatcher);
+    private static final ExpressionMatcher<LogicalDistinctExpression> root =
+            TypeMatcher.of(LogicalDistinctExpression.class,
+                    QuantifierMatcher.forEach(innerMatcher));
 
     public ImplementDistinctRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementFilterRule.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterEx
 import com.apple.foundationdb.record.query.plan.temp.matchers.AllChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
@@ -45,8 +46,10 @@ import javax.annotation.Nonnull;
 public class ImplementFilterRule extends PlannerRule<LogicalFilterExpression> {
     private static final ExpressionMatcher<RecordQueryPlan> innerMatcher = TypeMatcher.of(RecordQueryPlan.class, AllChildrenMatcher.allMatching(ReferenceMatcher.anyRef()));
     private static final ExpressionMatcher<QueryPredicate> filterMatcher = TypeMatcher.of(QueryPredicate.class, AnyChildrenMatcher.ANY);
-    private static final ExpressionMatcher<LogicalFilterExpression> root = TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
-            filterMatcher, innerMatcher);
+    private static final ExpressionMatcher<LogicalFilterExpression> root =
+            TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
+                    filterMatcher,
+                    QuantifierMatcher.forEach(innerMatcher));
 
     public ImplementFilterRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.properties.RecordTypesProperty;
 import com.google.common.collect.Sets;
@@ -44,7 +45,9 @@ import java.util.Set;
 public class ImplementTypeFilterRule extends PlannerRule<LogicalTypeFilterExpression> {
     private static ExpressionMatcher<RecordQueryPlan> childMatcher = TypeMatcher.of(RecordQueryPlan.class,
             AnyChildrenMatcher.ANY);
-    private static ExpressionMatcher<LogicalTypeFilterExpression> root = TypeMatcher.of(LogicalTypeFilterExpression.class, childMatcher);
+    private static ExpressionMatcher<LogicalTypeFilterExpression> root =
+            TypeMatcher.of(LogicalTypeFilterExpression.class,
+                    QuantifierMatcher.forEach(childMatcher));
 
     public ImplementTypeFilterRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AllChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 
@@ -44,8 +45,9 @@ public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnorderedUni
     @Nonnull
     private static final ExpressionMatcher<RecordQueryPlan> childMatcher = TypeMatcher.of(RecordQueryPlan.class, AllChildrenMatcher.allMatching(ReferenceMatcher.anyRef()));
     @Nonnull
-    private static final ExpressionMatcher<LogicalUnorderedUnionExpression> root = TypeMatcher.of(LogicalUnorderedUnionExpression.class,
-            AllChildrenMatcher.allMatching(childMatcher));
+    private static final ExpressionMatcher<LogicalUnorderedUnionExpression> root =
+            TypeMatcher.of(LogicalUnorderedUnionExpression.class,
+                    AllChildrenMatcher.allMatching(QuantifierMatcher.forEach(childMatcher)));
 
     public ImplementUnorderedUnionRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/OrToUnorderedUnionRule.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AllChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
@@ -54,7 +55,10 @@ public class OrToUnorderedUnionRule extends PlannerRule<LogicalFilterExpression>
     @Nonnull
     private static final ReferenceMatcher<RelationalExpression> innerMatcher = ReferenceMatcher.anyRef();
     @Nonnull
-    private static final ExpressionMatcher<LogicalFilterExpression> root = TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class, orMatcher, innerMatcher);
+    private static final ExpressionMatcher<LogicalFilterExpression> root =
+            TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
+                    orMatcher,
+                    QuantifierMatcher.forEach(innerMatcher));
 
     public OrToUnorderedUnionRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushConjunctElementWithComparisonIntoExistingScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushConjunctElementWithComparisonIntoExistingScanRule.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterEx
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildWithRestMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
 import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
@@ -51,7 +52,10 @@ public class PushConjunctElementWithComparisonIntoExistingScanRule extends Plann
     private static final ExpressionMatcher<AndPredicate> andMatcher = TypeMatcher.of(AndPredicate.class,
             AnyChildWithRestMatcher.anyMatchingWithRest(filterMatcher, otherFilterMatchers));
     private static final ExpressionMatcher<IndexEntrySourceScanExpression> indexScanMatcher = TypeMatcher.of(IndexEntrySourceScanExpression.class);
-    private static final ExpressionMatcher<LogicalFilterExpression> root = TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class, andMatcher, indexScanMatcher);
+    private static final ExpressionMatcher<LogicalFilterExpression> root =
+            TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
+                    andMatcher,
+                    QuantifierMatcher.forEach(indexScanMatcher));
 
     public PushConjunctElementWithComparisonIntoExistingScanRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushDistinctFilterBelowFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushDistinctFilterBelowFilterRule.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 
@@ -40,9 +41,12 @@ import javax.annotation.Nonnull;
  */
 public class PushDistinctFilterBelowFilterRule extends PlannerRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> {
     private static final ExpressionMatcher<ExpressionRef<RecordQueryPlan>> innerMatcher = ReferenceMatcher.anyRef();
-    private static final ExpressionMatcher<RecordQueryPredicateFilterPlan> filterPlanMatcher = TypeMatcher.of(
-            RecordQueryPredicateFilterPlan.class, innerMatcher);
-    private static final ExpressionMatcher<RecordQueryUnorderedPrimaryKeyDistinctPlan> root = TypeMatcher.of(RecordQueryUnorderedPrimaryKeyDistinctPlan.class, filterPlanMatcher);
+    private static final ExpressionMatcher<RecordQueryPredicateFilterPlan> filterPlanMatcher =
+            TypeMatcher.of(RecordQueryPredicateFilterPlan.class,
+                    QuantifierMatcher.physical(innerMatcher));
+    private static final ExpressionMatcher<RecordQueryUnorderedPrimaryKeyDistinctPlan> root =
+            TypeMatcher.of(RecordQueryUnorderedPrimaryKeyDistinctPlan.class,
+                    QuantifierMatcher.physical(filterPlanMatcher));
 
     public PushDistinctFilterBelowFilterRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushElementWithComparisonIntoExistingScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushElementWithComparisonIntoExistingScanRule.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourceScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
 import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
@@ -42,7 +43,10 @@ import java.util.Optional;
 public class PushElementWithComparisonIntoExistingScanRule extends PlannerRule<LogicalFilterExpression> {
     private static final ExpressionMatcher<ElementPredicate> filterMatcher = TypeMatcher.of(ElementPredicate.class);
     private static final ExpressionMatcher<IndexEntrySourceScanExpression> indexScanMatcher = TypeMatcher.of(IndexEntrySourceScanExpression.class);
-    private static final ExpressionMatcher<LogicalFilterExpression> root = TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class, filterMatcher, indexScanMatcher);
+    private static final ExpressionMatcher<LogicalFilterExpression> root =
+            TypeWithPredicateMatcher.ofPredicate(LogicalFilterExpression.class,
+                    filterMatcher,
+                    QuantifierMatcher.forEach(indexScanMatcher));
 
     public PushElementWithComparisonIntoExistingScanRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushSortIntoExistingIndexRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushSortIntoExistingIndexRule.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourc
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalSortExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
 
@@ -40,7 +41,9 @@ import java.util.Optional;
 @API(API.Status.EXPERIMENTAL)
 public class PushSortIntoExistingIndexRule extends PlannerRule<LogicalSortExpression> {
     private static final ExpressionMatcher<IndexEntrySourceScanExpression> indexScanMatcher = TypeMatcher.of(IndexEntrySourceScanExpression.class);
-    private static final ExpressionMatcher<LogicalSortExpression> root = TypeMatcher.of(LogicalSortExpression.class, indexScanMatcher);
+    private static final ExpressionMatcher<LogicalSortExpression> root =
+            TypeMatcher.of(LogicalSortExpression.class,
+                    QuantifierMatcher.forEach(indexScanMatcher));
 
     public PushSortIntoExistingIndexRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushTypeFilterBelowFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/PushTypeFilterBelowFilterRule.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.matchers.AnyChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
@@ -49,8 +50,12 @@ public class PushTypeFilterBelowFilterRule extends PlannerRule<RecordQueryTypeFi
     private static final ExpressionMatcher<ExpressionRef<RecordQueryPlan>> innerMatcher = ReferenceMatcher.anyRef();
     private static final ExpressionMatcher<QueryPredicate> filterMatcher = TypeMatcher.of(QueryPredicate.class, AnyChildrenMatcher.ANY);
     private static final ExpressionMatcher<RecordQueryPredicateFilterPlan> filterPlanMatcher =
-            TypeWithPredicateMatcher.ofPredicate(RecordQueryPredicateFilterPlan.class, filterMatcher, innerMatcher);
-    private static final ExpressionMatcher<RecordQueryTypeFilterPlan> root = TypeMatcher.of(RecordQueryTypeFilterPlan.class, filterPlanMatcher);
+            TypeWithPredicateMatcher.ofPredicate(RecordQueryPredicateFilterPlan.class,
+                    filterMatcher,
+                    QuantifierMatcher.physical(innerMatcher));
+    private static final ExpressionMatcher<RecordQueryTypeFilterPlan> root =
+            TypeMatcher.of(RecordQueryTypeFilterPlan.class,
+                    QuantifierMatcher.physical(filterPlanMatcher));
 
     public PushTypeFilterBelowFilterRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveRedundantTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveRedundantTypeFilterRule.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.properties.RecordTypesProperty;
@@ -43,7 +44,9 @@ import java.util.Set;
 @API(API.Status.EXPERIMENTAL)
 public class RemoveRedundantTypeFilterRule extends PlannerRule<LogicalTypeFilterExpression> {
     private static ExpressionMatcher<ExpressionRef<RelationalExpression>> childMatcher = ReferenceMatcher.anyRef();
-    private static ExpressionMatcher<LogicalTypeFilterExpression> root = TypeMatcher.of(LogicalTypeFilterExpression.class, childMatcher);
+    private static ExpressionMatcher<LogicalTypeFilterExpression> root =
+            TypeMatcher.of(LogicalTypeFilterExpression.class,
+                    QuantifierMatcher.forEach(childMatcher));
 
     public RemoveRedundantTypeFilterRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/SortToIndexRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/SortToIndexRule.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.query.plan.temp.expressions.IndexEntrySourc
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalSortExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
+import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.view.ViewExpressionComparisons;
 
@@ -43,7 +44,8 @@ import java.util.Optional;
 @API(API.Status.EXPERIMENTAL)
 public class SortToIndexRule extends PlannerRule<LogicalSortExpression> {
     private static final ExpressionMatcher<FullUnorderedScanExpression> innerMatcher = TypeMatcher.of(FullUnorderedScanExpression.class);
-    private static final ExpressionMatcher<LogicalSortExpression> root = TypeMatcher.of(LogicalSortExpression.class, innerMatcher);
+    private static final ExpressionMatcher<LogicalSortExpression> root =
+            TypeMatcher.of(LogicalSortExpression.class, QuantifierMatcher.forEach(innerMatcher));
 
     public SortToIndexRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AndOrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AndOrPredicate.java
@@ -53,9 +53,9 @@ public abstract class AndOrPredicate implements QueryPredicate {
 
     @Override
     @Nonnull
-    public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> binding) {
-        Stream<PlannerBindings> bindings = binding.matchWith(this);
-        return bindings.flatMap(outerBindings -> binding.getChildrenMatcher().matches(getChildren().iterator())
+    public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> matcher) {
+        Stream<PlannerBindings> bindings = matcher.matchWith(this);
+        return bindings.flatMap(outerBindings -> matcher.getChildrenMatcher().matches(getChildren())
                 .map(outerBindings::mergedWith));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/ElementPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/ElementPredicate.java
@@ -76,8 +76,8 @@ public class ElementPredicate implements QueryPredicate {
 
     @Override
     @Nonnull
-    public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> binding) {
-        return  binding.matchWith(this);
+    public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> matcher) {
+        return  matcher.matchWith(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/NotPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/NotPredicate.java
@@ -27,7 +27,7 @@ import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 import com.apple.foundationdb.record.query.plan.temp.view.SourceEntry;
-import com.google.common.collect.Iterators;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -71,9 +71,9 @@ public class NotPredicate implements QueryPredicate {
 
     @Override
     @Nonnull
-    public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> binding) {
-        Stream<PlannerBindings> bindings = binding.matchWith(this);
-        return bindings.flatMap(outerBindings -> binding.getChildrenMatcher().matches(Iterators.singletonIterator(getChild()))
+    public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> matcher) {
+        Stream<PlannerBindings> bindings = matcher.matchWith(this);
+        return bindings.flatMap(outerBindings -> matcher.getChildrenMatcher().matches(ImmutableList.of(getChild()))
                 .map(outerBindings::mergedWith));
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/MemoExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/MemoExpressionTest.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -171,7 +170,7 @@ public class MemoExpressionTest {
         @Nonnull
         private final String identity;
         @Nonnull
-        private final List<ExpressionRef<SyntheticPlannerExpression>> childRefs;
+        private final List<Quantifier.ForEach> quantifiers;
 
         public SyntheticPlannerExpression(@Nonnull String identity) {
             this(identity, Collections.emptyList());
@@ -180,13 +179,13 @@ public class MemoExpressionTest {
         public SyntheticPlannerExpression(@Nonnull String identity,
                                           @Nonnull List<ExpressionRef<SyntheticPlannerExpression>> children) {
             this.identity = identity;
-            this.childRefs = children;
+            this.quantifiers = Quantifiers.forEachQuantifiers(children);
         }
 
         @Nonnull
         @Override
-        public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-            return childRefs.iterator();
+        public List<? extends Quantifier> getQuantifiers() {
+            return quantifiers;
         }
 
         @Override
@@ -206,12 +205,11 @@ public class MemoExpressionTest {
                 return false;
             }
             SyntheticPlannerExpression that = (SyntheticPlannerExpression)o;
-            if (!Objects.equals(identity, that.identity) ||
-                    childRefs.size() != that.childRefs.size()) {
+            if (!Objects.equals(identity, that.identity) || quantifiers.size() != that.quantifiers.size()) {
                 return false;
             }
-            for (int i = 0; i < childRefs.size(); i++) {
-                if (!childRefs.get(i).get().equals(that.childRefs.get(i).get())) {
+            for (int i = 0; i < quantifiers.size(); i++) {
+                if (!quantifiers.get(i).getRangesOver().get().equals(that.quantifiers.get(i).getRangesOver().get())) {
                     return false;
                 }
             }
@@ -220,7 +218,11 @@ public class MemoExpressionTest {
 
         @Override
         public int hashCode() {
-            return Objects.hash(identity, childRefs.stream().map(ExpressionRef::get).collect(Collectors.toList()));
+            return Objects.hash(identity,
+                    quantifiers.stream()
+                            .map(Quantifier.ForEach::getRangesOver)
+                            .map(ExpressionRef::get)
+                            .collect(Collectors.toList()));
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/predicates/QueryPredicateTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/predicates/QueryPredicateTest.java
@@ -71,7 +71,7 @@ public class QueryPredicateTest {
 
         @Nonnull
         @Override
-        public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> binding) {
+        public Stream<PlannerBindings> bindTo(@Nonnull ExpressionMatcher<? extends Bindable> matcher) {
             return Stream.empty();
         }
     }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
@@ -33,7 +33,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithNoChildren;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.tuple.Tuple;
 import com.geophile.z.SpatialIndex;
@@ -45,7 +45,7 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -179,8 +179,8 @@ public abstract class GeophileSpatialObjectQueryPlan implements RecordQueryPlanW
 
     @Nonnull
     @Override
-    public Iterator<? extends ExpressionRef<? extends RelationalExpression>> getPlannerExpressionChildren() {
-        return Collections.emptyIterator();
+    public List<? extends Quantifier> getQuantifiers() {
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
… representation used by the cascades planner

Introduces the concept of a quantifier as per issue #950. This PR addresses the following areas:
* introduce a class `Quantifier` as well as `Quantifiers` (helper class)
* replace the children of a relational expression with a list of quantifiers. The quantifiers now range over an expression ref each (previously representing the children of the expression).
* adapt matchers and planner rules to make use of quantifiers as there is semantics encoded in quantifiers  that the planner rules must be aware of.
* various clean ups and fixes.