### PR TITLE
Fixes #952: Local version cache is keyed only by Tuple (i.e., primary key) not subspace

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,6 +19,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 ### NEXT_RELEASE
 
 * **Bug fix** False positive of uniqueness violations prevents building indexes [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
+* **Bug fix** Incomplete record versions are no longer cached in a way that can lead to cache entries for one record store polluting the values for another [(Issue #952)](https://github.com/FoundationDB/fdb-record-layer/issues/952)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
@@ -36,6 +37,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Breaking change** Requires a minimum FoundationDB client and server version of 6.2 [(Issue #702)](https://github.com/FoundationDB/fdb-record-layer/issues/702)
 * **Breaking change** Builds now require JDK 11 [(Issue #910)](https://github.com/FoundationDB/fdb-record-layer/issues/910)
 * **Breaking change** `FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolation` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in replace of `updateOneKey` [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
+* **Breaking change** Methods interacting with the local version cache on an `FDBRecordContext` have been removed as they were previously unsafe and should have been internal only [(Issue #952)](https://github.com/FoundationDB/fdb-record-layer/issues/952)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -37,7 +37,6 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
-import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Utf8;
 import org.apache.commons.lang3.tuple.Pair;
@@ -135,7 +134,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @Nonnull
     private AtomicInteger localVersion;
     @Nonnull
-    private ConcurrentNavigableMap<Tuple, Integer> localVersionCache;
+    private ConcurrentNavigableMap<byte[], Integer> localVersionCache;
     @Nonnull
     private ConcurrentNavigableMap<byte[], Pair<MutationType, byte[]>> versionMutationCache;
     @Nullable
@@ -159,7 +158,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         super(fdb, transaction, config.getTimer());
         this.transactionCreateTime = System.currentTimeMillis();
         this.localVersion = new AtomicInteger(0);
-        this.localVersionCache = new ConcurrentSkipListMap<>();
+        this.localVersionCache = new ConcurrentSkipListMap<>(ByteArrayUtil::compareUnsigned);
         this.versionMutationCache = new ConcurrentSkipListMap<>(ByteArrayUtil::compareUnsigned);
         this.transactionId = getSanitizedId(config);
 
@@ -1091,36 +1090,43 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Register that a specific primary key used a given local version.
-     * This can then be retrieved from the context using {@link #getLocalVersion(Tuple) getLocalVersion}.
-     * @param primaryKey key to associate with the local version
+     * Register that a record used a given local version.
+     * This can then be retrieved from the context using {@link #getLocalVersion(byte[]) getLocalVersion}.
+     * The key provided should be the full key to the version, including any subspace
+     * prefix bytes.
+     *
+     * @param recordVersionKey key to associate with the local version
      * @param version the local version of the key
      */
-    public void addToLocalVersionCache(@Nonnull Tuple primaryKey, int version) {
-        localVersionCache.put(primaryKey, version);
+    void addToLocalVersionCache(@Nonnull byte[] recordVersionKey, int version) {
+        localVersionCache.put(recordVersionKey, version);
     }
 
     /**
-     * Remove the local version associated with a single primary key.
+     * Remove the local version associated with a single record version key.
+     * The key provided should be the full key to where the version is stored, including any
+     * subspace prefix bytes.
      *
-     * @param primaryKey the key associated with the local version being cleared
+     * @param recordVersionKey the key associated with the local version being cleared
      * @return whether the key was already in the local version cache
      */
-    public boolean removeLocalVersion(@Nonnull Tuple primaryKey) {
-        return localVersionCache.remove(primaryKey) != null;
+    boolean removeLocalVersion(@Nonnull byte[] recordVersionKey) {
+        return localVersionCache.remove(recordVersionKey) != null;
     }
 
     /**
-     * Get a local version assigned to some primary key used within this context.
-     * If the key has not been associated with any version using
-     * {@link #addToLocalVersionCache(Tuple, int) addToLocalVersion}, then this
+     * Get a local version assigned to some record used within this context.
+     * The key provided should be the full key to where the version is stored, including any
+     * subspace prefix bytes. If the key has not been associated with any version using
+     * {@link #addToLocalVersionCache(byte[], int) addToLocalVersion}, then this
      * will return an unset {@link Optional}.
-     * @param primaryKey key to retrieve the local version of
+     *
+     * @param recordVersionKey key to retrieve the local version of
      * @return the associated version or an unset {@link Optional}
      */
     @Nonnull
-    public Optional<Integer> getLocalVersion(@Nonnull Tuple primaryKey) {
-        return Optional.ofNullable(localVersionCache.get(primaryKey));
+    Optional<Integer> getLocalVersion(@Nonnull byte[] recordVersionKey) {
+        return Optional.ofNullable(localVersionCache.get(recordVersionKey));
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TestKeySpace.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TestKeySpace.java
@@ -47,6 +47,7 @@ public class TestKeySpace {
                             .addSubdirectory(new DirectoryLayerDirectory("indexTest", "indexTest")
                                     .addSubdirectory(new KeySpaceDirectory("leaderboard", KeySpaceDirectory.KeyType.LONG, 8L))
                                     .addSubdirectory(new KeySpaceDirectory("version", KeySpaceDirectory.KeyType.LONG, 9L))
+                                    .addSubdirectory(new KeySpaceDirectory("version2", KeySpaceDirectory.KeyType.LONG, 10L))
                             )
                             .addSubdirectory(new DirectoryLayerDirectory("synchronizedsession", "synchronizedsession")
                                     .addSubdirectory(new KeySpaceDirectory("lock", KeySpaceDirectory.KeyType.LONG))


### PR DESCRIPTION
This changes the local version cache to be keyed by `byte[]` rather than by `Tuple`. Then the exact key (in the database) is used to represent the cache entry rather than the record's primary key. This allows multiple stores to be opened in the same transaction and for them to interact with versioned records with the same primary key in each store without having cache entries from one store pollute the cache entries of the other.

This meant changing the API. The previous API was just wrong, in that there was absolutely no way to protect oneself from the bug identified in #952, so it has just been removed (despite the fact that this violates are claims of API stability). These APIs probably should have been marked `INTERNAL` anyway, but I believe they pre-date the API stability annotations, which is why they weren't. I put this against master rather than 2.9 as it is a bug fix that could bite someone who doesn't want to upgrade to 2.9 (despite the API breaking), but perhaps it should be rebased onto that branch if 2.9 is soon.

This fixes #952.