### PR TITLE
Fixes #962: Reuse Ciphers vs. creating them new each time...

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Fixes #962: Reuse Ciphers vs. creating them new each time... [(Issue #962)](https://github.com/FoundationDB/fdb-record-layer/issues/962)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MappedPool.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MappedPool.java
@@ -1,0 +1,117 @@
+/*
+ * MappedPool.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.common;
+
+import com.apple.foundationdb.annotation.API;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import javax.annotation.Nonnull;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * MappedPool Class Attempts to reuse objects organized by keys.
+ * This class can be used for objects that require thread safety but our expensive to create.
+ * The number of keys in the ConcurrentHashMap are unbounded but the queue for each key is bounded to 64.
+ *
+ *  Examples include Ciphers and Compressors
+ *
+ * @param <K> key
+ * @param <V> value type to be pooled
+ * @param <E> exception that can be throw, must extend Exception
+ */
+@API(API.Status.EXPERIMENTAL)
+public class MappedPool<K, V, E extends Exception> {
+    protected static final int DEFAULT_POOL_SIZE = 64;
+    protected static final int DEFAULT_MAX_ENTRIES = 64;
+    protected final Cache<K, Queue<V>> pool;
+    protected Callable<Queue<V>> loader;
+    private final MappedPoolProvider<K,V,E> mappedPoolProvider;
+
+    public MappedPool(MappedPoolProvider<K,V,E> mappedPoolProvider) {
+        this(mappedPoolProvider, DEFAULT_POOL_SIZE);
+    }
+
+    public MappedPool(MappedPoolProvider<K,V,E> mappedPoolProvider, int poolSize) {
+        this(mappedPoolProvider, poolSize, DEFAULT_MAX_ENTRIES);
+    }
+
+    public MappedPool(MappedPoolProvider<K,V,E> mappedPoolProvider, int defaultPoolSize, int maxEntries) {
+        this.pool = CacheBuilder.newBuilder().maximumSize(maxEntries).build();
+        this.loader = () -> new ArrayBlockingQueue<>(defaultPoolSize);
+        this.mappedPoolProvider = mappedPoolProvider;
+    }
+
+    public V poll(@Nonnull K key) throws E {
+        try {
+            V next = pool.get(key, loader).poll();
+            return next == null ? mappedPoolProvider.get(key) : next;
+        } catch (ExecutionException ee) {
+            return mappedPoolProvider.get(key);
+        }
+    }
+
+    /**
+     * Offer a key with a value knowing that the queue is bounded and might not accept the offer.
+     *
+     * @param key key
+     * @param value value offered
+     * @return boolean if offer was added to pool
+     */
+    public boolean offer(@Nonnull K key, @Nonnull V value) {
+        try {
+            return pool.get(key, loader).offer(value);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Set<K> getKeys() {
+        return pool.asMap().keySet();
+    }
+
+    /**
+     * Pool size for the key.
+     *
+     * @param key key
+     * @return size of pool
+     */
+    public int getPoolSize(K key) {
+        Queue<V> queue = pool.getIfPresent(key);
+        return queue == null ? 0 : queue.size();
+    }
+
+    /**
+     * Function with Exceptions to provide the pool.
+     *
+     * @param <K> key
+     * @param <V> value type to be pooled
+     * @param <E> exception that can be throw, must extend Exception
+     */
+    public interface MappedPoolProvider<K,V,E extends Exception> {
+        V get(K key) throws E;
+    }
+
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/MappedPoolTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/MappedPoolTest.java
@@ -33,7 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-/** Tests of the MappedPool.
+/**
+ * Tests of the {@link MappedPool}.
  *
  */
 public class MappedPoolTest {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/MappedPoolTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/MappedPoolTest.java
@@ -1,0 +1,75 @@
+/*
+ * MappedPoolTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.common;
+
+import org.junit.jupiter.api.Test;
+import javax.crypto.Cipher;
+import java.security.GeneralSecurityException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/** Tests of the MappedPool.
+ *
+ */
+public class MappedPoolTest {
+
+    public static String CIPHER = "DES/ECB/PKCS5Padding";
+    public static MappedPool<String, Cipher, GeneralSecurityException> MAPPED_POOL = new MappedPool<>(Cipher::getInstance);
+
+    @Test
+    public void testCipherPool() throws Exception {
+        Cipher lastCipher = null;
+        for (int i = 0; i < 100; i++) {
+            Cipher cipher = MAPPED_POOL.poll(CIPHER);
+            if (lastCipher != null) {
+                assertSame(cipher, lastCipher);
+                lastCipher = cipher;
+            }
+            assertNotNull(cipher);
+            assertTrue(MAPPED_POOL.offer(CIPHER, cipher));
+        }
+        assertEquals(1, MAPPED_POOL.getPoolSize(CIPHER));
+        assertThat(MAPPED_POOL.getKeys(), hasItem(CIPHER));
+    }
+
+    @Test
+    public void testMaxPoolSize() throws Exception {
+        Cipher[] ciphers = new Cipher[1000];
+        for (int i = 0; i < 1000; i++) {
+            ciphers[i] = MAPPED_POOL.poll(CIPHER);
+        }
+        for (int i = 0; i < MappedPool.DEFAULT_POOL_SIZE; i++) {
+            assertTrue(MAPPED_POOL.offer(CIPHER, ciphers[i]));
+        }
+        for (int i = MappedPool.DEFAULT_POOL_SIZE; i < 1000; i++) {
+            assertFalse(MAPPED_POOL.offer(CIPHER, ciphers[i]));
+        }
+        assertEquals(64, MAPPED_POOL.getPoolSize(CIPHER));
+    }
+
+}


### PR DESCRIPTION
Attempt to reuse ciphers vs. creating them each time in the record layer.  The ciphers are used on saveRecord and loadRecord.