### PR TITLE
Resolves #958: VersionstampSaveBehavior could have option to match version argument precisely

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** `VersionstampSaveBehavior.IF_PRESENT` allows the user to specify that a record should be saved with a version only if one is explicitly provided [(Issue #958)](https://github.com/FoundationDB/fdb-record-layer/issues/958)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -453,8 +453,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 throw recordCoreException("Nonnull version supplied with a NO_VERSION behavior: " + version);
             }
             return null;
-        }
-        if (version == null && (behavior.equals(VersionstampSaveBehavior.WITH_VERSION) || metaData.isStoreRecordVersions())) {
+        } else if (behavior.equals(VersionstampSaveBehavior.IF_PRESENT)) {
+            return version;
+        } else if (version == null && (behavior.equals(VersionstampSaveBehavior.WITH_VERSION) || metaData.isStoreRecordVersions())) {
             return FDBRecordVersion.incomplete(context.claimLocalVersion());
         }
         return version;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -317,6 +317,17 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
         /**
          * Always save the record with a version. If a null version is provided, then the record store will chose
          * a new version.
+         *
+         * <p>
+         * Note: due to <a href="https://github.com/FoundationDB/fdb-record-layer/issues/964">Issue #964</a>, on some
+         * older record stores, namely those that were originally created with a {@linkplain FDBRecordStore#getFormatVersion()
+         * format version} below {@link FDBRecordStore#SAVE_VERSION_WITH_RECORD_FORMAT_VERSION}, records written with a
+         * version on stores where {@link com.apple.foundationdb.record.RecordMetaData#isStoreRecordVersions()} is
+         * {@code false} will not return the version with a record when read, even though the version will be stored.
+         * Users can avoid this by either migrating data to a new store or by setting {@code isStoreRecordVersions()}
+         * to {@code true} in the meta-data and then supplying the {@link #NO_VERSION} when saving any records that
+         * do not need an associated version.
+         * </p>
          */
         WITH_VERSION,
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -299,13 +299,34 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
     /**
      * Provided during record save (via {@link #saveRecord(Message, FDBRecordVersion, VersionstampSaveBehavior)}),
      * directs the behavior of the save w.r.t. the record's version.
-     * In the presence of a version, either <code>DEFAULT</code> or <code>WITH_VERSION</code> can be used.
+     * In the presence of a version, either {@code DEFAULT} or {@code WITH_VERSION} can be used.
      * For safety, <code>NO_VERSION</code> should only be used with a null version.
      */
     enum VersionstampSaveBehavior {
-        DEFAULT,        // Follow rules dictated by the metadata
-        NO_VERSION,     // Explicitly do NOT save a version
-        WITH_VERSION,   // Explicitly save a version even if meta-data says not to
+        /**
+         * Match the behavior dictated by the meta-data. If {@link com.apple.foundationdb.record.RecordMetaData#isStoreRecordVersions()}
+         * returns {@code true}, this will always store the record with a version (like {@link #WITH_VERSION}). Otherwise,
+         * it will store the record with the provided version if given or with no version if not.
+         */
+        DEFAULT,
+        /**
+         * Do not save the record with a version. If a non-null version is provided to {@link #saveRecord(Message, FDBRecordVersion, VersionstampSaveBehavior)},
+         * then an error will be thrown.
+         */
+        NO_VERSION,
+        /**
+         * Always save the record with a version. If a null version is provided, then the record store will chose
+         * a new version.
+         */
+        WITH_VERSION,
+        /**
+         * Save a record with a version if and only if a non-null version is passed to {@link #saveRecord(Message, FDBRecordVersion, VersionstampSaveBehavior)}.
+         * In this mode, the record store will never assign a version to the record, but it will always use the
+         * version provided (or store the record with no version if {@code null}). This is useful if one is copying
+         * data from one record store to another and one wants to preserve the versions (including non-versions) for each
+         * record.
+         */
+        IF_PRESENT,
     }
 
     /**


### PR DESCRIPTION
This adds a new `VersionstampSaveBehavior` setting, `IF_PRESENT`, which only saves a version with a record if the provided version is not `null`. This is useful for times when you want to, say, copy the data from one store to another precisely, so the default behavior, where creating a
a version if not set explicitly, isn't desired.

In doing this, I also filed #964 because the test I wrote seemed to expose this. It's possible this behavior is correct "enough", but I'm not super happy with #964 as it is right now.

This resolves #958.