### PR TITLE
Resolves #967: Upgrade guava and protobuf versions for 2.9

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -41,6 +41,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Breaking change** `FDBRecordStore` does not have `addUniquenessCheck` anymore, which is replaced by `checkUniqueness` in `StandardIndexMaintainer` now; `IndexMaintainer` does not have `updateUniquenessViolations` anymore, which is replaced by `addUniquenessViolation` and `removeUniquenessViolationsAsync` in `StandardIndexMaintainer` now; `StandardIndexMaintainer` now has `updateOneKeyAsync` in replace of `updateOneKey` [(Issue #901)](https://github.com/FoundationDB/fdb-record-layer/issues/901)
 * **Breaking change** Methods interacting with the local version cache on an `FDBRecordContext` have been removed as they were previously unsafe and should have been internal only [(Issue #952)](https://github.com/FoundationDB/fdb-record-layer/issues/952)
 * **Breaking change** `OrElseCursor` has a new continuation format that is incompatible with the previous continuation format [(Issue #974)](https://github.com/FoundationDB/fdb-record-layer/issues/974)
+* **Breaking change** Guava and protobuf dependency versions have been upgraded to 29.0 and 3.12.2 respectively [(Issue #967)](https://github.com/FoundationDB/fdb-record-layer/issues/967)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 
 // end next release

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -21,6 +21,8 @@
 apply plugin: 'com.github.johnrengelman.shadow'
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
+// Necessary until deprecation warnings in generated proto code are fixed
+// See: https://github.com/protocolbuffers/protobuf/issues/7271
 if (!hasProperty('coreNotStrict')) {
     apply from: rootProject.file('gradle/strict.gradle')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,12 +34,12 @@ jsr305Version=3.0.2
 slf4jVersion=1.7.30
 commonsLang3Version=3.10
 log4jVersion=2.13.1
-guavaVersion=28.1-jre
+guavaVersion=29.0-jre
 autoServiceVersion=1.0-rc6
 junitVersion=5.6.2
 jacocoVersion=0.8.5
 
 protobuf2Version=2.6.1
-protobuf3Version=3.6.1
+protobuf3Version=3.12.2
 
 mavenLocalEnabled=false


### PR DESCRIPTION
There is only one breaking change in Guava 29.0 that isn't in 28.2, the previous version, according to its release notes, and it has to do with GWT-RPC code: https://github.com/google/guava/releases/tag/v29.0 We don't use the guava-gwt code directly, so the only people who would be affected would be a consumer of this library who also uses guava-gwt.

No callouts in the proto3 versions since 2.6.0 for Java that I could find that suggest that upgrading to 3.12.2 wouldn't be a good idea. I had thought that this version might allow us to remove the `-PcoreNotStrict` stuff, as I thought I saw some chatter about deprecation warnings being fixed in some newer 3.x protoc versions, but it appears that it's still an issue. I think this is what we're hitting: https://github.com/protocolbuffers/protobuf/issues/7271 (See also: https://github.com/protocolbuffers/protobuf/issues/7433.)

This resolves #967.