### PR TITLE
Fixes #977: RecordMetaData#recordTypesForIndex is N^2 with Universal index probing...

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Fixes #977: RecordMetaData#recordTypesForIndex is N^2 with Universal index probing [(Issue #977)](https://github.com/FoundationDB/fdb-record-layer/issues/977)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
N^2 shows up with a decent number of indexes and lots of and/or predicate action.

![Screen Shot 2020-06-17 at 4 52 36 PM](https://user-images.githubusercontent.com/1850293/84962343-7e25c980-b0bb-11ea-8fa9-31e1ab74f726.png)