### PR TITLE
Resolves #949: Useful system keys should be exposed through a more useful API

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Certain system keys are exposed through the new `FDBSystemOperations` API [(Issue #949)](https://github.com/FoundationDB/fdb-record-layer/issues/949)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.TransactionOptions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.system.SystemKeyspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
 import javax.annotation.Nonnull;
@@ -143,9 +144,9 @@ public class DatabaseClientLogEvents {
             if (events == null) {
                 return versionRangeProducer.apply(tr).thenCompose(versions -> {
                     final Long startVersion = versions[0];
-                    final byte[] startKey = startVersion == null ? FDBClientLogEvents.EVENT_KEY_PREFIX : FDBClientLogEvents.eventKeyForVersion(startVersion);
+                    final byte[] startKey = startVersion == null ? SystemKeyspace.CLIENT_LOG_KEY_PREFIX : FDBClientLogEvents.eventKeyForVersion(startVersion);
                     final Long endVersion = versions[1];
-                    final byte[] endKey = endVersion == null ? ByteArrayUtil.strinc(FDBClientLogEvents.EVENT_KEY_PREFIX) : FDBClientLogEvents.eventKeyForVersion(endVersion);
+                    final byte[] endKey = endVersion == null ? ByteArrayUtil.strinc(SystemKeyspace.CLIENT_LOG_KEY_PREFIX) : FDBClientLogEvents.eventKeyForVersion(endVersion);
                     events = new DatabaseClientLogEvents(startKey, endKey);
                     return loopBody();
                 });

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/system/SystemKeyspace.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/system/SystemKeyspace.java
@@ -1,0 +1,101 @@
+/*
+ * SystemKeyspace.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.system;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Keys living in the FDB system and special keyspace. These keys are used to communicate system configuration
+ * information and related information between the FoundationDB server and client. This API is {@link API.Status#INTERNAL}
+ * and should not be consumed directly by adopters. They should instead generally be referenced through wrapper
+ * functions that exist in this project and in the Record Layer core project.
+ *
+ * <p>
+ * There is currently a project to provide a framework for FoundationDB clients to make use of the special
+ * key space API. As that project develops, this class may become unnecessary. See:
+ * <a href="https://github.com/apple/foundationdb/blob/master/design/special-key-space.md">Special-Key-Space</a>.
+ * </p>
+ */
+@SpotBugsSuppressWarnings(value = "MS_MUTABLE_ARRAY", justification = "array copying is expensive")
+@API(API.Status.INTERNAL)
+public class SystemKeyspace {
+
+    // Key prefixes for the various system and special key subspaces
+
+    /**
+     * The prefix under which all FDB system and special data live. Regular user operations typically cannot read keys
+     * with this prefix unless they set special options except in special circumstances.
+     */
+    private static final byte[] SYSTEM_PREFIX = {(byte)0xff};
+
+    /**
+     * The prefix under which FDB system data that is sharded like regular data lives. The data in the FDB system
+     * keyspace that begins with {@code \xff} but not {@code \xff\x02} is handled somewhat specially as certain database
+     * operations rely on knowing the contents during recoveries, etc. However, because those data are not sharded, they
+     * are fundamentally limited in size. So, to allow for more system data to be stored in FDB, the {@code \xff\x02}
+     * keyspace exists, which are handled more like regular data (in that placement and shard splitting or merging are
+     * handled by the data distributor). For a client, this is mostly just trivia, but it seems necessary to explain why
+     * certain keys are prefixed like this.
+     */
+    private static final byte[] SYSTEM_2_PREFIX = {(byte)0xff, 0x02};
+
+    /**
+     * The prefix under which "special" keys live. Unlike the data in the range [{@code \xff}, {@code \xff\xff}), which
+     * are stored in the database but are just off limits to regular client operations, the keys prefixed with
+     * {@code \xff\xff} don't "really" exist, but they are instead instructions to the client used to retrieve some
+     * special information. For example, they might be used to read and return client configuration information. They
+     * may not read any actual data from the database or (sometimes) even make any network calls at all.
+     */
+    private static final byte[] SPECIAL_PREFIX = {(byte)0xff, (byte)0xff};
+
+    // System keys
+
+    public static final byte[] METADATA_VERSION_KEY = systemPrefixedKey("/metadataVersion");
+    public static final byte[] PRIMARY_DATACENTER_KEY = systemPrefixedKey("/primaryDatacenter");
+
+    public static final byte[] TIMEKEEPER_KEY_PREFIX = system2PrefixedKey("/timeKeeper/map/");
+    public static final byte[] CLIENT_LOG_KEY_PREFIX = system2PrefixedKey("/fdbClientInfo/client_latency/");
+
+    // Special keys
+
+    public static final byte[] CONNECTION_STR_KEY = specialPrefixedKey("/connection_string");
+    public static final byte[] CLUSTER_FILE_PATH_KEY = specialPrefixedKey("/cluster_file_path");
+
+    private static byte[] systemPrefixedKey(@Nonnull String key) {
+        return ByteArrayUtil.join(SYSTEM_PREFIX, key.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private static byte[] system2PrefixedKey(@Nonnull String key) {
+        return ByteArrayUtil.join(SYSTEM_2_PREFIX, key.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private static byte[] specialPrefixedKey(@Nonnull String key) {
+        return ByteArrayUtil.join(SPECIAL_PREFIX, key.getBytes(StandardCharsets.US_ASCII));
+    }
+
+    private SystemKeyspace() {
+    }
+}

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/system/SystemKeyspace.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/system/SystemKeyspace.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,11 +63,12 @@ public class SystemKeyspace {
     private static final byte[] SYSTEM_2_PREFIX = {(byte)0xff, 0x02};
 
     /**
-     * The prefix under which "special" keys live. Unlike the data in the range [{@code \xff}, {@code \xff\xff}), which
-     * are stored in the database but are just off limits to regular client operations, the keys prefixed with
-     * {@code \xff\xff} don't "really" exist, but they are instead instructions to the client used to retrieve some
-     * special information. For example, they might be used to read and return client configuration information. They
+     * The prefix under which "special" keys live. The data in the range {@code \xff\xff} does not "really" exist,
+     * but instead acts as instructions to the client used to retrieve some special information.
+     * For example, they might be used to read and return client configuration information. They
      * may not read any actual data from the database or (sometimes) even make any network calls at all.
+     * Note: This is in contrast to the rest of {@code \xff}, which is stored in the database, but is off limits to
+     * regular client operations. 
      */
     private static final byte[] SPECIAL_PREFIX = {(byte)0xff, (byte)0xff};
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/system/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/system/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/system/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/system/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for interacting with the system keyspace. In FoundationDB, those are keys beginning with the literal byte
+ * {@code 0xff}. These keys are used by the system to store configuration information as well as to provide endpoints
+ * for executing special functions (e.g., locking the database).
+ *
+ * <p>
+ * The contents of this package should generally be considered experimental. There is also a project to expose these
+ * special keys in a more systematic way. See:
+ * <a href="https://github.com/apple/foundationdb/blob/master/design/special-key-space.md">Special key space</a>.
+ * </p>
+ */
+package com.apple.foundationdb.system;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -263,9 +263,12 @@ public class FDBDatabase {
     }
 
     /**
-     * Get the path to the cluster file that this database was created with. May return <code>null</code> if using the
-     * default cluster file.
+     * Get the path to the cluster file that this database was created with. Will return <code>null</code> if using the
+     * default cluster file. To get the resolved cluster file path for databases created with the default path, use
+     * {@link FDBSystemOperations#getClusterFilePath(FDBDatabaseRunner)} instead.
+     *
      * @return The path to the cluster file.
+     * @see FDBSystemOperations#getClusterFilePath(FDBDatabaseRunner)
      */
     @Nullable
     public String getClusterFile() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -37,6 +37,7 @@ import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.util.MapUtils;
+import com.apple.foundationdb.system.SystemKeyspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.common.annotations.VisibleForTesting;
@@ -88,7 +89,6 @@ import java.util.stream.Collectors;
 @API(API.Status.STABLE)
 public class FDBRecordContext extends FDBTransactionContext implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBRecordContext.class);
-    private static final byte[] META_DATA_VERSION_STAMP_KEY = new byte[]{(byte)0xff, '/', 'm', 'e', 't', 'a', 'd', 'a', 't', 'a', 'V', 'e', 'r', 's', 'i', 'o', 'n'};
     private static final byte[] META_DATA_VERSION_STAMP_VALUE = new byte[FDBRecordVersion.GLOBAL_VERSION_LENGTH + Integer.BYTES];
     private static final long UNSET_VERSION = 0L;
 
@@ -978,7 +978,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
             ensureActive();
             return CompletableFuture.completedFuture(null);
         }
-        return readTransaction(isolationLevel.isSnapshot()).get(META_DATA_VERSION_STAMP_KEY).handle((val, err) -> {
+        return readTransaction(isolationLevel.isSnapshot()).get(SystemKeyspace.METADATA_VERSION_KEY).handle((val, err) -> {
             if (err == null) {
                 return val;
             } else {
@@ -1023,7 +1023,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     public void setMetaDataVersionStamp() {
         ensureActive();
         dirtyMetaDataVersionStamp = true;
-        transaction.mutate(MutationType.SET_VERSIONSTAMPED_VALUE, META_DATA_VERSION_STAMP_KEY, META_DATA_VERSION_STAMP_VALUE);
+        transaction.mutate(MutationType.SET_VERSIONSTAMPED_VALUE, SystemKeyspace.METADATA_VERSION_KEY, META_DATA_VERSION_STAMP_VALUE);
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -408,6 +408,8 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_END_SYNC_SESSION("wait for ending a synchronized session"),
         /** Wait for editing a header user field. */
         WAIT_EDIT_HEADER_USER_FIELD("wait to edit a header user field"),
+        /** Wait to read a key from the FDB system keyspace. */
+        WAIT_LOAD_SYSTEM_KEY("wait for reading a key from the FDB system keyspace"),
         ;
 
         private final String title;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class FDBSystemOperations {
 
     /**
      * Get the primary datacenter of the underlying cluster. This will return the datacenter ID (if set)
-     * of the datacenter currently serving as the primary, which is (by definition) is where the transaction
+     * of the datacenter currently serving as the primary, which (by definition) is where the transaction
      * subsystem will be recruited. This is mostly relevant for
      * <a href="https://apple.github.io/foundationdb/configuration.html#configuring-regions">multi-region configurations</a>,
      * where this value might change if the cluster decides that it needs to fail over to a secondary region. The returned

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
@@ -1,0 +1,211 @@
+/*
+ * FDBSystemDatabase.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.system.SystemKeyspace;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * View of an FoundationDB database used for accessing system and special keys. These are special keys defined within
+ * special system keyspaces that contain information about the underlying FoundationDB cluster, about the client
+ * configuration, or other information available through another API.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class FDBSystemOperations {
+
+    @Nullable
+    private static String nullableUtf8(@Nullable byte[] bytes) {
+        return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private static <T> T asyncToSync(@Nonnull FDBRecordContext context, @Nonnull CompletableFuture<T> operation) {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY, operation);
+    }
+
+    private static <T> T asyncToSync(@Nonnull FDBDatabaseRunner runner, @Nonnull CompletableFuture<T> operation) {
+        return runner.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY, operation);
+    }
+
+    /**
+     * Get the primary datacenter of the underlying cluster. This will return the datacenter ID (if set)
+     * of the datacenter currently serving as the primary, which is (by definition) is where the transaction
+     * subsystem will be recruited. This is mostly relevant for
+     * <a href="https://apple.github.io/foundationdb/configuration.html#configuring-regions">multi-region configurations</a>,
+     * where this value might change if the cluster decides that it needs to fail over to a secondary region. The returned
+     * datacenter ID will be {@code null} if the server's datacenter has not been set.
+     *
+     * <p>
+     * Note that this operation must read this information from the database's storage and uses its own transaction.
+     * </p>
+     *
+     * @param runner a runner to use to perform the operation
+     * @return a future that will complete with the primary datacenter of the cluster for the database underlying {@code runner}
+     */
+    @Nonnull
+    public static CompletableFuture<String> getPrimaryDatacenterAsync(@Nonnull FDBDatabaseRunner runner) {
+        return runner.runAsync(context -> {
+            final Transaction tr = context.ensureActive();
+            tr.options().setReadSystemKeys();
+            return tr.get(SystemKeyspace.PRIMARY_DATACENTER_KEY).thenApply(FDBSystemOperations::nullableUtf8);
+        });
+    }
+
+    /**
+     * Get the primary datacenter of the underlying cluster. This is a blocking version of
+     * {@link #getPrimaryDatacenterAsync(FDBDatabaseRunner)}.
+     *
+     * @param runner a runner to use to perform the operation
+     * @return the primary datacenter of the database underlying {@code runner}
+     */
+    @Nullable
+    public static String getPrimaryDatacenter(@Nonnull FDBDatabaseRunner runner) {
+        return asyncToSync(runner, getPrimaryDatacenterAsync(runner));
+    }
+
+    /**
+     * Get the connection string used to connect to the FDB cluster. This string essentially contains the contents of
+     * the cluster file, though it may change if the cluster's coordinators change. Note that even though this
+     * operation requires having a database connection (in the transaction) and returns a future (as the client
+     * may schedule to complete the work at a later time), it does not actually perform any network calls but reads
+     * the value from the client's local memory.
+     *
+     * <p>
+     * For more information, see the documentation on the
+     * <a href="https://apple.github.io/foundationdb/administration.html#cluster-file-format">cluster file format</a>
+     * in the FoundationDB documentation.
+     * </p>
+     *
+     * @param context a transaction to use to perform the operation
+     * @return a future that will contain the current cluster connection string
+     */
+    @Nonnull
+    public static CompletableFuture<String> getConnectionStringAsync(@Nonnull FDBRecordContext context) {
+        return context.ensureActive().get(SystemKeyspace.CONNECTION_STR_KEY).thenApply(FDBSystemOperations::nullableUtf8);
+    }
+
+    /**
+     * Get the connection string used to connect to the FDB cluster. This operates like
+     * {@link #getConnectionStringAsync(FDBRecordContext)}, but it will use the provided runner to create a new
+     * transaction and retry if necessary.
+     *
+     * @param runner a runner to use to perform the operation
+     * @return a future that will contain the current cluster connection string
+     * @see #getConnectionStringAsync(FDBRecordContext)
+     */
+    @Nonnull
+    public static CompletableFuture<String> getConnectionStringAsync(@Nonnull FDBDatabaseRunner runner) {
+        return runner.runAsync(FDBSystemOperations::getConnectionStringAsync);
+    }
+
+    /**
+     * Get the connection string used to connect to the FDB cluster. This is a synchronous version of
+     * {@link #getConnectionStringAsync(FDBRecordContext)}
+     *
+     * @param context a transaction to use to perform the operation
+     * @return the current cluster connection string
+     * @see #getConnectionStringAsync(FDBRecordContext)
+     */
+    @Nullable
+    public static String getConnectionString(@Nonnull FDBRecordContext context) {
+        return asyncToSync(context, getConnectionStringAsync(context));
+    }
+
+    /**
+     * Get the connection string used to connect to the FDB cluster. This is a synchronous version of
+     * {@link #getConnectionStringAsync(FDBDatabaseRunner)}
+     *
+     * @param runner a runner to use to perform the operation
+     * @return the current cluster connection string
+     * @see #getConnectionStringAsync(FDBDatabaseRunner)
+     * @see #getConnectionStringAsync(FDBRecordContext)
+     */
+    @Nullable
+    public static String getConnectionString(@Nonnull FDBDatabaseRunner runner) {
+        return asyncToSync(runner, getConnectionStringAsync(runner));
+    }
+
+    /**
+     * Get the file system path to the cluster file used. Note that this differs from the value that is returned by
+     * {@link FDBDatabase#getClusterFile()} in that that function may return {@code null} if the cluster file is set to
+     * the system default. This function, however, requests the information from the native client, and so it will
+     * return the resolved cluster file (e.g., returning the path to the system default instead of {@code null}).
+     * Note that even though this operation returns a future, it does not need to perform any network calls but instead
+     * answers this question from the client's local memory.
+     *
+     * @param context a transaction to use to perform the operation
+     * @return a future that will contain the cluster file path
+     * @see FDBDatabase#getClusterFile()
+     */
+    @Nonnull
+    public static CompletableFuture<String> getClusterFilePathAsync(@Nonnull FDBRecordContext context) {
+        return context.ensureActive().get(SystemKeyspace.CLUSTER_FILE_PATH_KEY).thenApply(FDBSystemOperations::nullableUtf8);
+    }
+
+    /**
+     * Get the file system path to the cluster file used. This operates like
+     * {@link #getClusterFilePathAsync(FDBRecordContext)}, but it will use the provided runner to create a transaction
+     * and to handle performing any retries (if necessary).
+     *
+     * @param runner a runner to use to perform the operation
+     * @return a future that will contain the cluster file path
+     * @see #getClusterFilePathAsync(FDBRecordContext)
+     */
+    @Nonnull
+    public static CompletableFuture<String> getClusterFilePathAsync(@Nonnull FDBDatabaseRunner runner) {
+        return runner.runAsync(FDBSystemOperations::getClusterFilePathAsync);
+    }
+
+    /**
+     * Get the file system path to the cluster file used. This is a synchronous version of
+     * {@link #getClusterFilePathAsync(FDBRecordContext)}.
+     *
+     * @param context a transaction to use to perform the operation
+     * @return the cluster file path
+     * @see #getClusterFilePathAsync(FDBRecordContext)
+     */
+    @Nullable
+    public static String getClusterFilePath(@Nonnull FDBRecordContext context) {
+        return asyncToSync(context, getClusterFilePathAsync(context));
+    }
+
+    /**
+     * Get the file system path to the cluster file used. This is a synchronous version of
+     * {@link #getClusterFilePathAsync(FDBDatabaseRunner)}.
+     *
+     * @param runner a transaction to use to perform the operation
+     * @return the cluster file path
+     * @see #getClusterFilePathAsync(FDBDatabaseRunner)
+     * @see #getClusterFilePathAsync(FDBRecordContext)
+     */
+    @Nullable
+    public static String getClusterFilePath(@Nonnull FDBDatabaseRunner runner) {
+        return asyncToSync(runner, getClusterFilePathAsync(runner));
+    }
+
+    private FDBSystemOperations() {
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
@@ -117,7 +117,6 @@ public class FDBSystemOperations {
      * @param runner a runner to use to perform the operation
      * @return the current cluster connection string
      * @see #getConnectionStringAsync(FDBDatabaseRunner)
-     * @see #getConnectionStringAsync(FDBDatabaseRunner)
      */
     @Nullable
     public static String getConnectionString(@Nonnull FDBDatabaseRunner runner) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperationsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperationsTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperationsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperationsTest.java
@@ -1,0 +1,109 @@
+/*
+ * FDBSystemOperationsTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.test.Tags;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class for {@link FDBSystemOperations}.
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBSystemOperationsTest extends FDBTestBase {
+    private FDBDatabase fdb;
+    private FDBStoreTimer timer;
+
+    @BeforeEach
+    public void setup() {
+        fdb = FDBDatabaseFactory.instance().getDatabase();
+        timer = new FDBStoreTimer();
+    }
+
+    private <T> T run(@Nonnull Function<FDBDatabaseRunner, T> operation) {
+        try (FDBDatabaseRunner runner = fdb.newRunner(timer, null)) {
+            return operation.apply(runner);
+        }
+    }
+
+    @Test
+    public void primaryDatacenter() {
+        // Because we don't know what the data-center was set to run the test, the best this test
+        // can do is validate that this doesn't throw an error.
+        run(FDBSystemOperations::getPrimaryDatacenter);
+    }
+
+    @Test
+    public void clusterFilePath() {
+        String clusterFilePath = run(FDBSystemOperations::getClusterFilePath);
+        assertNotNull(clusterFilePath);
+
+        // This may or may not match the database's cluster file path, as that can be null if the
+        // database is using the default cluster file.
+        File file = new File(clusterFilePath);
+        assertTrue(file.exists(), "cluster file should exist");
+    }
+
+    @Test
+    public void fakeClusterFilePath() throws IOException {
+        String fakeClusterFilePath = FDBTestBase.createFakeClusterFile("readClusterFilePath");
+        final FDBDatabase fakeDatabase = FDBDatabaseFactory.instance().getDatabase(fakeClusterFilePath);
+        final String readClusterFilePath;
+        try (FDBDatabaseRunner runner = fakeDatabase.newRunner()) {
+            readClusterFilePath = FDBSystemOperations.getClusterFilePath(runner);
+        }
+        assertEquals(fakeClusterFilePath, readClusterFilePath);
+    }
+
+    @Test
+    public void clusterConnectionString() {
+        String connectionString = run(FDBSystemOperations::getConnectionString);
+        assertNotNull(connectionString);
+    }
+
+    @Test
+    public void fakeClusterConnectionString() throws IOException {
+        final String fakeClusterFilePath = FDBTestBase.createFakeClusterFile("readConnectionString");
+        String fakeConnectionString;
+        try (BufferedReader reader = new BufferedReader(new FileReader(fakeClusterFilePath))) {
+            fakeConnectionString = reader.readLine();
+        }
+
+        final FDBDatabase fakeDatabase = FDBDatabaseFactory.instance().getDatabase(fakeClusterFilePath);
+        String readConnectionString;
+        try (FDBDatabaseRunner runner = fakeDatabase.newRunner()) {
+            readConnectionString = FDBSystemOperations.getConnectionString(runner);
+        }
+        assertEquals(fakeConnectionString, readConnectionString);
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperationsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperationsTest.java
@@ -68,8 +68,9 @@ public class FDBSystemOperationsTest extends FDBTestBase {
         String clusterFilePath = run(FDBSystemOperations::getClusterFilePath);
         assertNotNull(clusterFilePath);
 
-        // This may or may not match the database's cluster file path, as that can be null if the
-        // database is using the default cluster file.
+        // Note that fdb.getClusterFile() returns null if the client is configured to use the default
+        // system cluster file, so this test can't compare the results of fdb.getClusterFile() to
+        // clusterFilePath to check correctness. The best it can do is make sure the file exists.
         File file = new File(clusterFilePath);
         assertTrue(file.exists(), "cluster file should exist");
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
@@ -67,7 +67,7 @@ public abstract class FDBTestBase {
     public static String createFakeClusterFile(String prefix) throws IOException {
         File clusterFile = File.createTempFile(prefix, ".cluster");
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(clusterFile))) {
-            writer.write("fake:fdbcluster@127.0.0.1:65537\n");
+            writer.write("fake:fdbcluster@127.0.0.1:65535\n");
         }
         return clusterFile.getAbsolutePath();
     }


### PR DESCRIPTION
This creates a new set of constants for the system keys that we care about, and then it changes the instances
that were already referencing system keys, and then I added a new class, `FDBSystemOperations`, that allows
a user to use these features.

I'm not...super happy with this API, though. Unlike many operations, it wasn't sufficient to provide a context
for some of these operations, as you might need to set some extra options. But then to provide the user
a way to provide their own retry policies (and things like a timer, etc.), it felt like the least bad way
to pass that information, though we don't use a runner like this in other contexts.

This resolves #949.