### PR TITLE
Fixes #980: Event analysis is fooled by incomplete version stamps

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Event analysis is fooled by incomplete version stamps [(Issue #980)](https://github.com/FoundationDB/fdb-record-layer/issues/980)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Fixes #962: Reuse Ciphers vs. creating them new each time... [(Issue #962)](https://github.com/FoundationDB/fdb-record-layer/issues/962)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -137,7 +138,7 @@ public class TupleKeyCountTree {
         count++;
         if (itemPosition < items.size()) {
             final Object childObject = items.get(itemPosition);
-            final int byteSize = childObject == UNPARSEABLE ? bytes.length - bytePosition : Tuple.from(childObject).getPackedSize();
+            final int byteSize = childObject == UNPARSEABLE ? bytes.length - bytePosition : TupleHelpers.packedSizeAsTupleItem(childObject);
             final byte[] childBytes = Arrays.copyOfRange(bytes, bytePosition, bytePosition + byteSize);
             TupleKeyCountTree child = children.computeIfAbsent(childBytes, b -> newChild(b, childObject));
             child.addInternal(items, itemPosition + 1, bytes, bytePosition + byteSize);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleHelpers.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.tuple;
 
+import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.annotation.API;
 
 import javax.annotation.Nonnull;
@@ -120,6 +121,22 @@ public class TupleHelpers {
             return - number.doubleValue();
         }
         throw new IllegalArgumentException("Not an allowed number type from a Tuple: " + number.getClass());
+    }
+
+    /**
+     * Get the number of bytes that an object would occupy as an element of an encoded {@link Tuple}.
+     * Unlike {@link Tuple#getPackedSize()}, this does not include the extra space an incomplete {@link Versionstamp} would add to the end to record its position.
+     * @param item an item of a tuple
+     * @return the number of bytes in the encoded form of the item
+     */
+    public static int packedSizeAsTupleItem(Object item) {
+        int size = Tuple.from(item).getPackedSize();
+        if (item instanceof Versionstamp) {
+            if (!((Versionstamp)item).isComplete()) {
+                size -= FDB.instance().getAPIVersion() < 520 ? Short.BYTES : Integer.BYTES;
+            }
+        }
+        return size;
     }
 
     private TupleHelpers() {


### PR DESCRIPTION
Add a new TupleHelper that knows about the extra bytes.