### PR TITLE
Fix typo in QueryableKeyExpression.evalForQuery that was checking the …

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/QueryableKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/QueryableKeyExpression.java
@@ -53,7 +53,7 @@ public interface QueryableKeyExpression extends KeyExpression {
             throw new RecordCoreException("Should evaluate to single key only");
         }
         Key.Evaluated key = keys.get(0);
-        if (keys.size() != 1) {
+        if (key.size() != 1) {
             throw new RecordCoreException("Should evaluate to single key only");
         }
         return key.getObject(0);


### PR DESCRIPTION
… same condition twice.

The error was highlighted by IntelliJ.