### PR TITLE
Resolves #997: Need QueryableKeyExpression with getColumnSize() > 1

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/QueryableKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/QueryableKeyExpression.java
@@ -53,7 +53,7 @@ public interface QueryableKeyExpression extends KeyExpression {
             throw new RecordCoreException("Should evaluate to single key only");
         }
         Key.Evaluated key = keys.get(0);
-        if (keys.size() != 1) {
+        if (key.size() != 1) {
             throw new RecordCoreException("Should evaluate to single key only");
         }
         return key.getObject(0);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/QueryableKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/QueryableKeyExpression.java
@@ -53,17 +53,24 @@ public interface QueryableKeyExpression extends KeyExpression {
             throw new RecordCoreException("Should evaluate to single key only");
         }
         Key.Evaluated key = keys.get(0);
+        if (evalForQueryAsTuple()) {
+            return key.toTuple();
+        }
         if (key.size() != 1) {
             throw new RecordCoreException("Should evaluate to single key only");
         }
         return key.getObject(0);
     }
 
+    default boolean evalForQueryAsTuple() {
+        return getColumnSize() > 1;
+    }
+
     @Nonnull
     Element toElement(@Nonnull Source rootSource);
 
     /**
-     * Get a function to be applied to the comparison operand before compairing it with the application of the key expression
+     * Get a function to be applied to the comparison operand before comparing it with the application of the key expression
      * to the record.
      * @return a conversion function or {@code null} for no conversion
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithComparison.java
@@ -48,7 +48,7 @@ public class QueryKeyExpressionWithComparison implements ComponentWithComparison
 
     public QueryKeyExpressionWithComparison(@Nonnull QueryableKeyExpression keyExpression, @Nonnull Comparisons.Comparison comparison) {
         this.keyExpression = keyExpression;
-        this.comparison = comparison;
+        this.comparison = keyExpression.evalForQueryAsTuple() ? new Comparisons.MultiColumnComparison(comparison) : comparison;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/ScanComparisonsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/ScanComparisonsTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan;
 import com.apple.foundationdb.record.Bindings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.tuple.Tuple;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -145,6 +146,14 @@ public class ScanComparisonsTest {
         comparisons.addInequalityComparison(new Comparisons.ParameterComparison(Comparisons.Type.GREATER_THAN, "p2"));
         checkRange("([zzz],>", comparisons, context("p1", "xxx", "p2", "zzz"));
         checkRange("[[zzz],>", comparisons, context("p1", "zzz", "p2", "xxx"));
+    }
+
+    @Test
+    public void multiColumn() throws Exception {
+        ScanComparisons.Builder comparisons = new ScanComparisons.Builder();
+        comparisons.addEqualityComparison(new Comparisons.NullComparison(Comparisons.Type.IS_NULL));
+        comparisons.addInequalityComparison(new Comparisons.MultiColumnComparison(new Comparisons.SimpleComparison(Comparisons.Type.LESS_THAN, Tuple.from("xxx", "yyy"))));
+        checkRange("([null, null],[null, xxx, yyy])", comparisons, context());
     }
 
 }


### PR DESCRIPTION
The tricky part is threading through a provenance of the comparison operand for the range builder, in order to know whether it's really meant to be spread. Probably there is some type-system-like abstraction missing here. I'm open to suggestions that aren't significantly more disruptive than this is.