### PR TITLE
Resolve #703, OnlineIndexer should limit amount of work by transactio…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -33,7 +33,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** OnlineIndexer limits amount of work by transaction size [(Issue #703)](https://github.com/FoundationDB/fdb-record-layer/issues/703)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -570,10 +570,10 @@ public class FDBStoreTimer extends StoreTimer {
         ONLINE_INDEX_BUILDER_RECORDS_SCANNED("number of records scanned by online index build", false),
         /** The number of records indexed by {@link OnlineIndexer}. */
         ONLINE_INDEX_BUILDER_RECORDS_INDEXED("number of records indexed by online index build", false),
-        /** The number of {@link OnlineIndexer} ranges defined by scanned record count limit. */
-        ONLINE_INDEX_BUILDER_RANGE_BY_COUNT("number of indexer iterations terminated by scan limit", false),
-        /** The number of {@link OnlineIndexer} ranges defined by transaction write size limit. */
-        ONLINE_INDEX_BUILDER_RANGE_BY_SIZE("number of indexer iterations terminated by write limit", false),
+        /** The number of {@link OnlineIndexer} range scans terminated after hitting the scan limit. */
+        ONLINE_INDEX_BUILDER_RANGES_BY_COUNT("number of indexer iterations terminated by scan limit", false),
+        /** The number of {@link OnlineIndexer} range scans terminated after hitting the size limit. */
+        ONLINE_INDEX_BUILDER_RANGES_BY_SIZE("number of indexer iterations terminated by write limit", false),
         /** The number of times that a leaderboard update adds a time window. */
         TIME_WINDOW_LEADERBOARD_ADD_WINDOW("number of leaderboard windows added", false),
         /** The number of times that a leaderboard update deleted a time window. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -570,6 +570,10 @@ public class FDBStoreTimer extends StoreTimer {
         ONLINE_INDEX_BUILDER_RECORDS_SCANNED("number of records scanned by online index build", false),
         /** The number of records indexed by {@link OnlineIndexer}. */
         ONLINE_INDEX_BUILDER_RECORDS_INDEXED("number of records indexed by online index build", false),
+        /** The number of indexer range termination by scan limit {@link OnlineIndexer}. */
+        ONLINE_INDEX_BUILDER_RANGE_BY_COUNT("number of indexer iterations terminated by scan limit", false),
+        /** The number of indexer range termination by write limit {@link OnlineIndexer}. */
+        ONLINE_INDEX_BUILDER_RANGE_BY_SIZE("number of indexer iterations terminated by write limit", false),
         /** The number of times that a leaderboard update adds a time window. */
         TIME_WINDOW_LEADERBOARD_ADD_WINDOW("number of leaderboard windows added", false),
         /** The number of times that a leaderboard update deleted a time window. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -570,9 +570,9 @@ public class FDBStoreTimer extends StoreTimer {
         ONLINE_INDEX_BUILDER_RECORDS_SCANNED("number of records scanned by online index build", false),
         /** The number of records indexed by {@link OnlineIndexer}. */
         ONLINE_INDEX_BUILDER_RECORDS_INDEXED("number of records indexed by online index build", false),
-        /** The number of {@link OnlineIndexer} records scanned in a single iteration/transaction. */
+        /** The number of {@link OnlineIndexer} ranges defined by scanned record count limit. */
         ONLINE_INDEX_BUILDER_RANGE_BY_COUNT("number of indexer iterations terminated by scan limit", false),
-        /** The number of {@link OnlineIndexer} bytes to write in a single iteration/transaction. */
+        /** The number of {@link OnlineIndexer} ranges defined by transaction write size limit. */
         ONLINE_INDEX_BUILDER_RANGE_BY_SIZE("number of indexer iterations terminated by write limit", false),
         /** The number of times that a leaderboard update adds a time window. */
         TIME_WINDOW_LEADERBOARD_ADD_WINDOW("number of leaderboard windows added", false),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -570,9 +570,9 @@ public class FDBStoreTimer extends StoreTimer {
         ONLINE_INDEX_BUILDER_RECORDS_SCANNED("number of records scanned by online index build", false),
         /** The number of records indexed by {@link OnlineIndexer}. */
         ONLINE_INDEX_BUILDER_RECORDS_INDEXED("number of records indexed by online index build", false),
-        /** The number of indexer range termination by scan limit {@link OnlineIndexer}. */
+        /** The number of {@link OnlineIndexer} records scanned in a single iteration/transaction. */
         ONLINE_INDEX_BUILDER_RANGE_BY_COUNT("number of indexer iterations terminated by scan limit", false),
-        /** The number of indexer range termination by write limit {@link OnlineIndexer}. */
+        /** The number of {@link OnlineIndexer} bytes to write in a single iteration/transaction. */
         ONLINE_INDEX_BUILDER_RANGE_BY_SIZE("number of indexer iterations terminated by write limit", false),
         /** The number of times that a leaderboard update adds a time window. */
         TIME_WINDOW_LEADERBOARD_ADD_WINDOW("number of leaderboard windows added", false),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
@@ -73,6 +73,11 @@ public class FDBTransactionContext {
         return executor;
     }
 
+    @Nonnull
+    public CompletableFuture<Long> getApproximateTransactionSize() {
+        return transaction.getApproximateSize();
+    }
+
     @Nullable
     public FDBStoreTimer getTimer() {
         return timer;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -601,16 +601,16 @@ public class OnlineIndexer implements AutoCloseable {
             }
 
             return updateMaintainer.thenCompose(vignore ->
-                    context.getApproximateTransactionSize().thenCompose(size -> {
+                    context.getApproximateTransactionSize().thenApply(size -> {
                         if (size >= config.getMaxWriteLimitBytes()) {
                             // the transaction becomes too big - stop iterating
                             if (timer != null) {
                                 timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE);
                             }
                             lastResult.set(result);
-                            return AsyncUtil.READY_FALSE;
+                            return false;
                         }
-                        return AsyncUtil.READY_TRUE;
+                        return true;
                     }));
 
         }), cursor.getExecutor()

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -571,7 +571,7 @@ public class OnlineIndexer implements AutoCloseable {
             if (!result.hasNext()) {
                 // end of the cursor list
                 if (timer != null) {
-                    timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_COUNT);
+                    timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT);
                 }
                 lastResult.set(result);
                 return AsyncUtil.READY_FALSE;
@@ -605,7 +605,7 @@ public class OnlineIndexer implements AutoCloseable {
                         if (size >= config.getMaxWriteLimitBytes()) {
                             // the transaction becomes too big - stop iterating
                             if (timer != null) {
-                                timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE);
+                                timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE);
                             }
                             lastResult.set(result);
                             return false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -37,6 +37,7 @@ import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCoreStorageException;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.RecordStoreState;
@@ -126,6 +127,10 @@ public class OnlineIndexer implements AutoCloseable {
      * Default number of records to attempt to run in a single transaction.
      */
     public static final int DEFAULT_LIMIT = 100;
+    /**
+     * Default transaction write size limit. Note that the actual write might be "a little" bigger.
+     */
+    public static final int DEFAULT_WRITE_SIZE = 900 * 1024;
     /**
      * Default limit to the number of records to attempt in a single second.
      */
@@ -558,27 +563,55 @@ public class OnlineIndexer implements AutoCloseable {
         // Note: This runs all of the updates in serial in order to not invoke a race condition
         // in the rank code that was causing incorrect results. If everything were thread safe,
         // a larger pipeline size would be possible.
-        return cursor.forEachResultAsync(result -> {
+
+        final AtomicReference<RecordCursorResult<FDBStoredRecord<Message>>> holder = new AtomicReference<>(RecordCursorResult.exhausted());
+        final FDBRecordContext context = store.getContext();
+        return AsyncUtil.whileTrue(() -> cursor.onNext().thenCompose(result -> {
+
+            if (!result.hasNext()) {
+                // end of the cursor list
+                if (timer != null) {
+                    timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_COUNT);
+                }
+                holder.set(result);
+                return AsyncUtil.READY_FALSE;
+            }
+
+            // here: implement forEachResultAsync
             final FDBStoredRecord<Message> rec = result.get();
             empty.set(false);
             if (timer != null) {
                 timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED);
             }
             recordsScannedCounter.incrementAndGet();
-            if (recordTypes.contains(rec.getRecordType())) {
-                if (timer != null) {
-                    timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED);
-                }
-                if (syntheticPlan == null) {
-                    return maintainer.update(null, rec);
-                } else {
-                    // Pipeline size is 1, since not all maintainers are thread-safe.
-                    return syntheticPlan.execute(store, rec).forEachAsync(syntheticRecord -> maintainer.update(null, syntheticRecord), 1);
-                }
-            } else {
-                return AsyncUtil.DONE;
+            if (!recordTypes.contains(rec.getRecordType())) {
+                // This record is not our type, swipe left
+                return AsyncUtil.READY_TRUE;
             }
-        }).thenCompose(noNextResult -> {
+            // here: add this index to the transaction
+            if (timer != null) {
+                timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED);
+            }
+            return (syntheticPlan == null ?
+                    maintainer.update(null, rec) :
+                    syntheticPlan.execute(store, rec)
+                            .forEachAsync(syntheticRecord -> maintainer.update(null, syntheticRecord), 1)
+                    ).thenCompose(vignore ->
+                    context.getApproximateTransactionSize().thenCompose(size -> {
+                        if (size >= config.getMaxWriteSize()) {
+                            // the transaction becomes too big - stop iterating
+                            if (timer != null) {
+                                timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE);
+                            }
+                            holder.set(result);
+                            return AsyncUtil.READY_FALSE;
+                        }
+                        return AsyncUtil.READY_TRUE;
+                    }));
+
+        }), cursor.getExecutor()).thenCompose(vIgnore -> {
+            RecordCursorResult<FDBStoredRecord<Message>> noNextResult = holder.get();
+
             long recordsScannedInTransaction = recordsScannedCounter.get();
             if (recordsScanned != null) {
                 recordsScanned.addAndGet(recordsScannedInTransaction);
@@ -1417,17 +1450,19 @@ public class OnlineIndexer implements AutoCloseable {
     @API(API.Status.UNSTABLE)
     public static class Config {
         private final int maxLimit;
+        private final int maxWriteSize;
         private final int maxRetries;
         private final int recordsPerSecond;
         private final long progressLogIntervalMillis;
         private final int increaseLimitAfter;
 
-        private Config(int maxLimit, int maxRetries, int recordsPerSecond, long progressLogIntervalMillis, int increaseLimitAfter) {
+        private Config(int maxLimit, int maxRetries, int recordsPerSecond, long progressLogIntervalMillis, int increaseLimitAfter, int maxWriteSize) {
             this.maxLimit = maxLimit;
             this.maxRetries = maxRetries;
             this.recordsPerSecond = recordsPerSecond;
             this.progressLogIntervalMillis = progressLogIntervalMillis;
             this.increaseLimitAfter = increaseLimitAfter;
+            this.maxWriteSize = maxWriteSize;
         }
 
         /**
@@ -1474,6 +1509,16 @@ public class OnlineIndexer implements AutoCloseable {
             return increaseLimitAfter;
         }
 
+        /**
+         * Get the approximate size limit, represents a desired max transaction message size. Note that the actual write
+         * might be "a little" larger than this limit.
+         * @return a the efficient write size. Typically a transaction will be submitted when it becomes bigger than
+         * this value.
+         */
+        public long getMaxWriteSize() {
+            return maxWriteSize;
+        }
+
         @Nonnull
         public static Builder newBuilder() {
             return new Builder();
@@ -1487,6 +1532,7 @@ public class OnlineIndexer implements AutoCloseable {
         public Builder toBuilder() {
             return Config.newBuilder()
                     .setMaxLimit(this.maxLimit)
+                    .setWriteSize(this.maxWriteSize)
                     .setIncreaseLimitAfter(this.increaseLimitAfter)
                     .setProgressLogIntervalMillis(this.progressLogIntervalMillis)
                     .setRecordsPerSecond(this.recordsPerSecond)
@@ -1500,6 +1546,7 @@ public class OnlineIndexer implements AutoCloseable {
         @API(API.Status.UNSTABLE)
         public static class Builder {
             private int maxLimit = DEFAULT_LIMIT;
+            private int maxWriteSize = DEFAULT_WRITE_SIZE;
             private int maxRetries = DEFAULT_MAX_RETRIES;
             private int recordsPerSecond = DEFAULT_RECORDS_PER_SECOND;
             private long progressLogIntervalMillis = DEFAULT_PROGRESS_LOG_INTERVAL;
@@ -1519,6 +1566,19 @@ public class OnlineIndexer implements AutoCloseable {
             @Nonnull
             public Builder setMaxLimit(int limit) {
                 this.maxLimit = limit;
+                return this;
+            }
+
+            /**
+             * Set the maximum transaction size in a single transaction.
+             *
+             * The default limit is {@link #DEFAULT_WRITE_SIZE} = {@value #DEFAULT_WRITE_SIZE}.
+             * @param limit the approximate maximum write size in one transaction
+             * @return this builder
+             */
+            @Nonnull
+            public Builder setWriteSize(int limit) {
+                this.maxWriteSize = limit;
                 return this;
             }
 
@@ -1582,7 +1642,7 @@ public class OnlineIndexer implements AutoCloseable {
              */
             @Nonnull
             public Config build() {
-                return new Config(maxLimit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter);
+                return new Config(maxLimit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter, maxWriteSize);
             }
         }
     }
@@ -1613,6 +1673,7 @@ public class OnlineIndexer implements AutoCloseable {
         @Nonnull
         protected Function<Config, Config> configLoader = old -> old;
         protected int limit = DEFAULT_LIMIT;
+        protected int maxWriteSize = DEFAULT_WRITE_SIZE;
         protected int maxRetries = DEFAULT_MAX_RETRIES;
         protected int recordsPerSecond = DEFAULT_RECORDS_PER_SECOND;
         private long progressLogIntervalMillis = DEFAULT_PROGRESS_LOG_INTERVAL;
@@ -1804,6 +1865,28 @@ public class OnlineIndexer implements AutoCloseable {
         @Nonnull
         public Builder setLimit(int limit) {
             this.limit = limit;
+            return this;
+        }
+
+        /**
+         * Get the approximate maximum transaction write size. Note that the actual size might be "a little" bigger.
+         * @return the requested write size. Index iteration stops when exceeding this size.
+         */
+        @Nonnull
+        public int getMaxWriteSize() {
+            return maxWriteSize;
+        }
+
+        /**
+         * Set the approximate maximum transaction write size. Note that the actual size might be "a little" bigger.
+         * he default limit is {@link #DEFAULT_WRITE_SIZE} = {@value #DEFAULT_WRITE_SIZE}.
+         * @param max the desired max write size
+         * @return this builder
+         */
+
+        @Nonnull
+        public Builder setMaxWriteSize(int max) {
+            this.maxWriteSize = max;
             return this;
         }
 
@@ -2304,7 +2387,7 @@ public class OnlineIndexer implements AutoCloseable {
          */
         public OnlineIndexer build() {
             validate();
-            Config conf = new Config(limit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter);
+            Config conf = new Config(limit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter, maxWriteSize);
             return new OnlineIndexer(runner, recordStoreBuilder, index, recordTypes, configLoader, conf, syntheticIndex,
                     indexStatePrecondition, useSynchronizedSession, leaseLengthMillis, trackProgress);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -885,7 +885,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
     }
 
     @Test
-    public void testOnlineIndexerBuilderWriteLimitBytes() {
+    public void testOnlineIndexerBuilderWriteLimitBytes() throws Exception {
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 200).mapToObj( val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2((int)val + 1).build()
         ).collect(Collectors.toList());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -936,8 +936,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
             assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
 
-            assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE));
-            assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_COUNT));
+            assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE));
+            assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
 
             recordStore.clearAndMarkIndexWriteOnly("newIndex").join();
             context.commit();
@@ -960,8 +960,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
 
                 Key.Evaluated key = indexer.buildUnbuiltRange(Key.Evaluated.scalar(0L), Key.Evaluated.scalar(25L)).join();
                 assertEquals(1, key.getLong(0));
-                assertEquals(1, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE));
-                assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_COUNT));
+                assertEquals(1, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE));
+                assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
             }
             recordStore.clearAndMarkIndexWriteOnly("newIndex").join();
             context.commit();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
-import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
@@ -696,98 +695,6 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             }
 
             context.commit();
-        }
-    }
-    
-    @Test
-    public void testOnlineIndexBuilderWriteLimitBytes() throws Exception {
-        try (FDBRecordContext context = openContext()) {
-            uncheckedOpenSimpleRecordStore(context, BASIC_HOOK);
-            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_EXISTS).join();
-            context.commit();
-        }
-
-        saveManyRecords(BASIC_HOOK, 250, 250);
-
-        try (FDBRecordContext context = openContext()) {
-            uncheckedOpenSimpleRecordStore(context, BASIC_HOOK);
-            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
-
-            assertEquals(250, recordStore.getSnapshotRecordCountForRecordType("MySimpleRecord").join().intValue());
-            assertEquals(250, recordStore.getSnapshotRecordCountForRecordType("MyOtherRecord").join().intValue());
-        }
-
-        RecordMetaDataHook hook = metaData -> {
-            BASIC_HOOK.apply(metaData);
-            metaData.addIndex("MySimpleRecord", "newIndex", "num_value_2");
-        };
-
-        try (FDBRecordContext context = openContext()) {
-            uncheckedOpenSimpleRecordStore(context, hook);
-            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
-
-            assertTrue(recordStore.isIndexWriteOnly("newIndex"));
-
-            timer.reset();
-
-            // Build in this transaction.
-            try (OnlineIndexer indexer =
-                         OnlineIndexer.newBuilder()
-                                 .setRecordStore(recordStore)
-                                 .setIndex("newIndex")
-                                 .setLimit(100000)
-                                 .setMaxWriteLimitBytes(1)
-                                 .build()) {
-                // this call will "flatten" the staccato iterations to a whole range. Testing compatibility.
-                indexer.rebuildIndex(recordStore);
-            }
-            recordStore.markIndexReadable("newIndex").join();
-
-            assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
-            assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-
-            assertEquals(IntStream.range(0, 250).mapToObj(i -> Tuple.from(i, 1, i)).collect(Collectors.toList()),
-                    recordStore.scanIndex(recordStore.getRecordMetaData().getIndex("newIndex"),
-                            IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).map(IndexEntry::getKey).asList().join());
-            assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE));
-            assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_COUNT));
-
-            context.commit();
-        }
-
-        try (FDBRecordContext context = openContext()) {
-            uncheckedOpenSimpleRecordStore(context, hook);
-            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
-
-            assertTrue(recordStore.isIndexReadable("newIndex"));
-
-            recordStore.clearAndMarkIndexWriteOnly("newIndex").join();
-            context.commit();
-        }
-
-        try (FDBRecordContext context = openContext()) {
-            uncheckedOpenSimpleRecordStore(context, hook);
-            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
-
-            assertTrue(recordStore.isIndexWriteOnly("newIndex"));
-
-            timer.reset();
-
-            // verify a single rec with size limit
-            try (OnlineIndexer indexer =
-                         OnlineIndexer.newBuilder()
-                                 .setRecordStore(recordStore)
-                                 .setIndex("newIndex")
-                                 .setLimit(100000)
-                                 .setMaxWriteLimitBytes(1)
-                                 .build()) {
-                Key.Evaluated key = indexer.buildUnbuiltRange(Key.Evaluated.scalar(0L), Key.Evaluated.scalar(25L)).join();
-                assertEquals(1, key.getLong(0));
-                assertEquals(1, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE));
-                assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_COUNT));
-
-                context.commit();
-            }
         }
     }
 }


### PR DESCRIPTION
…n size

    While interating, limit range to the one record beyond a predefined max write size.
    Add FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGE_BY_SIZE/COUNT to count the number of cases
    of terminating a range by size vs. by count limit.