### PR TITLE
Make some internals related to merging of covering indexes more accessible

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
@@ -52,7 +52,7 @@ public class IntersectionCursor<T> extends IntersectionCursorBase<T, T> {
     }
 
     @Override
-    T getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
+    protected T getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
         return cursorStates.get(0).getResult().get();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
@@ -58,7 +58,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
     }
 
     @Override
-    void setFirstChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setFirstChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         byte[] asBytes = continuation.toBytes();
         if (asBytes == null && !continuation.isEnd()) { // first cursor has not started
             builder.setFirstStarted(false);
@@ -71,7 +71,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
     }
 
     @Override
-    void setSecondChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setSecondChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         byte[] asBytes = continuation.toBytes();
         if (asBytes == null && !continuation.isEnd()) { // second cursor not started
             builder.setSecondStarted(false);
@@ -84,7 +84,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
     }
 
     @Override
-    void addOtherChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void addOtherChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         final RecordCursorProto.IntersectionContinuation.CursorState cursorState;
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
@@ -104,7 +104,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
 
     @Override
     @Nonnull
-    RecordCursorProto.IntersectionContinuation.Builder newProtoBuilder() {
+    protected RecordCursorProto.IntersectionContinuation.Builder newProtoBuilder() {
         return RecordCursorProto.IntersectionContinuation.newBuilder();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
@@ -50,7 +50,7 @@ public class IntersectionMultiCursor<T> extends IntersectionCursorBase<T, List<T
 
     @Override
     @Nonnull
-    List<T> getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
+    protected List<T> getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
         List<T> result = new ArrayList<>(cursorStates.size());
         cursorStates.forEach(cursorState -> result.add(cursorState.getResult().get()));
         return result;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorContinuation.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.google.protobuf.Message;
 
@@ -37,8 +39,10 @@ import java.util.List;
  * polymorphism).
  *
  * @param <B> the builder for message type of the continuation proto message
+ * @param <C> type of the continuation
  */
-abstract class MergeCursorContinuation<B extends Message.Builder, C extends RecordCursorContinuation> implements RecordCursorContinuation {
+@API(API.Status.INTERNAL)
+public abstract class MergeCursorContinuation<B extends Message.Builder, C extends RecordCursorContinuation> implements RecordCursorContinuation {
     @Nonnull
     private final List<C> continuations; // all continuations must themselves be immutable
     @Nullable
@@ -54,22 +58,22 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
     /**
      * Fill in the Protobuf builder with the information from the first child. For backwards-compatibility reasons,
      * cursors may handle this differently than the other children. This method will be called before
-     * {@link #setSecondChild(B, C)} and all calls to {@link #addOtherChild(B, C)}.
+     * {@link #setSecondChild} and all calls to {@link #addOtherChild}.
      *
      * @param builder a builder for the Protobuf continuation
      * @param continuation the first child's continuation
      */
-    abstract void setFirstChild(@Nonnull B builder, @Nonnull C continuation);
+    protected abstract void setFirstChild(@Nonnull B builder, @Nonnull C continuation);
 
     /**
      * Fill in the Protobuf builder with the information from the second child. For backwards-compatibility reasons,
      * cursors may handle this differently than the other children. This method will be called after
-     * {@link #setFirstChild(B, C)} and before all calls to {@link #addOtherChild(B, C)}.
+     * {@link #setFirstChild} and before all calls to {@link #addOtherChild}.
      *
      * @param builder a builder for the Protobuf continuation
      * @param continuation the second child's continuation
      */
-    abstract void setSecondChild(@Nonnull B builder, @Nonnull C continuation);
+    protected abstract void setSecondChild(@Nonnull B builder, @Nonnull C continuation);
 
     /**
      * Fill in the Protobuf builder with the information for a child other than the first or second child. For
@@ -79,7 +83,7 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
      * @param builder a builder for the Protobuf continuation
      * @param continuation a child other than the first or second child
      */
-    abstract void addOtherChild(@Nonnull B builder, @Nonnull C continuation);
+    protected abstract void addOtherChild(@Nonnull B builder, @Nonnull C continuation);
 
     /**
      * Get a new builder instance for the Protobuf message associated with this continuation. This should typically
@@ -88,10 +92,10 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
      * @return a new builder for the underlying Protobuf message type
      */
     @Nonnull
-    abstract B newProtoBuilder();
+    protected abstract B newProtoBuilder();
 
     @Nonnull
-    Message toProto() {
+    protected Message toProto() {
         if (cachedProto == null) {
             B builder = newProtoBuilder();
             final Iterator<C> continuationIterator = continuations.iterator();
@@ -107,6 +111,7 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
 
     @Nullable
     @Override
+    @SpotBugsSuppressWarnings("EI")
     public byte[] toBytes() {
         if (isEnd()) {
             return null;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorEndContinuation;
@@ -38,7 +39,8 @@ import java.util.function.Function;
  *
  * @param <T> the type of elements returned by the underlying cursor
  */
-class MergeCursorState<T> implements AutoCloseable {
+@API(API.Status.INTERNAL)
+public class MergeCursorState<T> implements AutoCloseable {
     @Nonnull
     private final RecordCursor<T> cursor;
     @Nullable
@@ -48,7 +50,7 @@ class MergeCursorState<T> implements AutoCloseable {
     @Nullable
     private RecordCursorResult<T> result;
 
-    MergeCursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuation) {
+    protected MergeCursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuation) {
         this.cursor = cursor;
         this.continuation = continuation;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
@@ -118,7 +118,7 @@ public class ProbableIntersectionCursor<T> extends MergeCursor<T, T, ProbableInt
 
     @Override
     @Nonnull
-    CompletableFuture<List<ProbableIntersectionCursorState<T>>> computeNextResultStates() {
+    protected CompletableFuture<List<ProbableIntersectionCursorState<T>>> computeNextResultStates() {
         final long startComputingStateTime = System.currentTimeMillis();
         final AtomicReference<ProbableIntersectionCursorState<T>> resultStateRef = new AtomicReference<>();
         return AsyncUtil.whileTrue(() -> whenAny(getCursorStates()).thenApply(vignore -> {
@@ -171,19 +171,19 @@ public class ProbableIntersectionCursor<T> extends MergeCursor<T, T, ProbableInt
 
     @Override
     @Nonnull
-    T getNextResult(@Nonnull List<ProbableIntersectionCursorState<T>> resultStates) {
+    protected T getNextResult(@Nonnull List<ProbableIntersectionCursorState<T>> resultStates) {
         return resultStates.get(0).getResult().get();
     }
 
     @Override
     @Nonnull
-    NoNextReason mergeNoNextReasons() {
+    protected NoNextReason mergeNoNextReasons() {
         return getStrongestNoNextReason(getCursorStates());
     }
 
     @Override
     @Nonnull
-    ProbableIntersectionCursorContinuation getContinuationObject() {
+    protected ProbableIntersectionCursorContinuation getContinuationObject() {
         return ProbableIntersectionCursorContinuation.from(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorContinuation.java
@@ -54,23 +54,23 @@ class ProbableIntersectionCursorContinuation extends MergeCursorContinuation<Pro
     }
 
     @Override
-    void setFirstChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+    protected void setFirstChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
         addChild(builder, continuation);
     }
 
     @Override
-    void setSecondChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+    protected void setSecondChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
         addChild(builder, continuation);
     }
 
     @Override
-    void addOtherChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+    protected void addOtherChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
         addChild(builder, continuation);
     }
 
     @Nonnull
     @Override
-    ProbableIntersectionContinuation.Builder newProtoBuilder() {
+    protected ProbableIntersectionContinuation.Builder newProtoBuilder() {
         return ProbableIntersectionContinuation.newBuilder();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
@@ -71,7 +71,7 @@ public class UnionCursor<T> extends UnionCursorBase<T, KeyedMergeCursorState<T>>
 
     @Nonnull
     @Override
-    CompletableFuture<List<KeyedMergeCursorState<T>>> computeNextResultStates() {
+    protected CompletableFuture<List<KeyedMergeCursorState<T>>> computeNextResultStates() {
         final List<KeyedMergeCursorState<T>> cursorStates = getCursorStates();
         return whenAll(cursorStates).thenApply(vignore -> {
             boolean anyHasNext = false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
@@ -52,7 +52,7 @@ abstract class UnionCursorBase<T, S extends MergeCursorState<T>> extends MergeCu
 
     @Override
     @Nonnull
-    UnionCursorContinuation getContinuationObject() {
+    protected UnionCursorContinuation getContinuationObject() {
         return UnionCursorContinuation.from(this);
     }
 
@@ -67,7 +67,7 @@ abstract class UnionCursorBase<T, S extends MergeCursorState<T>> extends MergeCu
      */
     @Override
     @Nonnull
-    T getNextResult(@Nonnull List<S> chosenStates) {
+    protected T getNextResult(@Nonnull List<S> chosenStates) {
         return chosenStates.get(0).getResult().get();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
@@ -57,7 +57,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
     }
 
     @Override
-    void setFirstChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setFirstChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         if (continuation.isEnd()) {
             builder.setFirstExhausted(true);
         } else {
@@ -69,7 +69,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
     }
 
     @Override
-    void setSecondChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setSecondChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         if (continuation.isEnd()) {
             builder.setSecondExhausted(true);
         } else {
@@ -81,7 +81,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
     }
 
     @Override
-    void addOtherChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void addOtherChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         RecordCursorProto.UnionContinuation.CursorState cursorState;
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
@@ -100,7 +100,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
 
     @Override
     @Nonnull
-    RecordCursorProto.UnionContinuation.Builder newProtoBuilder() {
+    protected RecordCursorProto.UnionContinuation.Builder newProtoBuilder() {
         return RecordCursorProto.UnionContinuation.newBuilder();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
@@ -65,7 +65,7 @@ public class UnorderedUnionCursor<T> extends UnionCursorBase<T, MergeCursorState
 
     @Nonnull
     @Override
-    CompletableFuture<List<MergeCursorState<T>>> computeNextResultStates() {
+    protected CompletableFuture<List<MergeCursorState<T>>> computeNextResultStates() {
         final long startComputingStateTime = System.currentTimeMillis();
         final List<MergeCursorState<T>> cursorStates = getCursorStates();
         AtomicReference<MergeCursorState<T>> nextStateRef = new AtomicReference<>();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -1530,7 +1530,7 @@ public class RecordQueryPlanner implements QueryPlanner {
     }
     
     @Nullable
-    public RecordQueryPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull String indexName) {
+    public RecordQueryCoveringIndexPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull String indexName) {
         final Index index = metaData.getIndex(indexName);
         KeyExpression indexExpr = index.getRootExpression();
         if (indexExpr instanceof GroupingKeyExpression) {
@@ -1542,7 +1542,7 @@ public class RecordQueryPlanner implements QueryPlanner {
     }
 
     @Nullable
-    public RecordQueryPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull Index index, @Nonnull KeyExpression indexExpr) {
+    public RecordQueryCoveringIndexPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull Index index, @Nonnull KeyExpression indexExpr) {
         final Collection<RecordType> recordTypes = metaData.recordTypesForIndex(index);
         if (recordTypes.size() != 1) {
             // Unfortunately, since we materialize partial records, we need a unique type for them.


### PR DESCRIPTION
* The `MergeCursor` family of classes / methods was package-protected, which made use outside of cursors impossible. Make them `public` / `protected` as appropriate.

* The `RecordQueryCoveringIndexPlan` result of `planCoveringAggregateIndex` can expose the lambda it uses to turn index entries into queried records.