### PR TITLE
Resolves #1012: BITMAP_VALUE index cursors can be bit-wise merged

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -34,12 +34,12 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** BITMAP_VALUE index cursors can be bit-wise merged [(Issue #1012)](https://github.com/FoundationDB/fdb-record-layer/issues/1012)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Result type of planCoveringAggregateIndex has changed, requiring a recompile of callers [(Issue #1012)](https://github.com/FoundationDB/fdb-record-layer/issues/1012)
 
 // end next release
 -->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -532,6 +532,8 @@ public class FDBStoreTimer extends StoreTimer {
         PLAN_PK_DISTINCT("number of unordered distinct plans by primary key", false),
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan}. */
         PLAN_FETCH("number of fetch from partial record plans", false),
+        /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan}. */
+        PLAN_COMPOSED_BITMAP_INDEX("number of composed bitmap plans", false),
         /** The number of records given given to any filter within any plan. */
         QUERY_FILTER_GIVEN("number of records given to any filter within any plan", false),
         /** The number of records passed by any filter within any plan. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursor.java
@@ -52,7 +52,7 @@ public class IntersectionCursor<T> extends IntersectionCursorBase<T, T> {
     }
 
     @Override
-    T getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
+    protected T getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
         return cursorStates.get(0).getResult().get();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
@@ -58,7 +58,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
     }
 
     @Override
-    void setFirstChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setFirstChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         byte[] asBytes = continuation.toBytes();
         if (asBytes == null && !continuation.isEnd()) { // first cursor has not started
             builder.setFirstStarted(false);
@@ -71,7 +71,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
     }
 
     @Override
-    void setSecondChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setSecondChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         byte[] asBytes = continuation.toBytes();
         if (asBytes == null && !continuation.isEnd()) { // second cursor not started
             builder.setSecondStarted(false);
@@ -84,7 +84,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
     }
 
     @Override
-    void addOtherChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void addOtherChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         final RecordCursorProto.IntersectionContinuation.CursorState cursorState;
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
@@ -104,7 +104,7 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
 
     @Override
     @Nonnull
-    RecordCursorProto.IntersectionContinuation.Builder newProtoBuilder() {
+    protected RecordCursorProto.IntersectionContinuation.Builder newProtoBuilder() {
         return RecordCursorProto.IntersectionContinuation.newBuilder();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionMultiCursor.java
@@ -50,7 +50,7 @@ public class IntersectionMultiCursor<T> extends IntersectionCursorBase<T, List<T
 
     @Override
     @Nonnull
-    List<T> getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
+    protected List<T> getNextResult(@Nonnull List<KeyedMergeCursorState<T>> cursorStates) {
         List<T> result = new ArrayList<>(cursorStates.size());
         cursorStates.forEach(cursorState -> result.add(cursorState.getResult().get()));
         return result;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorContinuation.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.google.protobuf.Message;
 
@@ -37,8 +39,10 @@ import java.util.List;
  * polymorphism).
  *
  * @param <B> the builder for message type of the continuation proto message
+ * @param <C> type of the continuation
  */
-abstract class MergeCursorContinuation<B extends Message.Builder, C extends RecordCursorContinuation> implements RecordCursorContinuation {
+@API(API.Status.INTERNAL)
+public abstract class MergeCursorContinuation<B extends Message.Builder, C extends RecordCursorContinuation> implements RecordCursorContinuation {
     @Nonnull
     private final List<C> continuations; // all continuations must themselves be immutable
     @Nullable
@@ -54,22 +58,22 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
     /**
      * Fill in the Protobuf builder with the information from the first child. For backwards-compatibility reasons,
      * cursors may handle this differently than the other children. This method will be called before
-     * {@link #setSecondChild(B, C)} and all calls to {@link #addOtherChild(B, C)}.
+     * {@link #setSecondChild} and all calls to {@link #addOtherChild}.
      *
      * @param builder a builder for the Protobuf continuation
      * @param continuation the first child's continuation
      */
-    abstract void setFirstChild(@Nonnull B builder, @Nonnull C continuation);
+    protected abstract void setFirstChild(@Nonnull B builder, @Nonnull C continuation);
 
     /**
      * Fill in the Protobuf builder with the information from the second child. For backwards-compatibility reasons,
      * cursors may handle this differently than the other children. This method will be called after
-     * {@link #setFirstChild(B, C)} and before all calls to {@link #addOtherChild(B, C)}.
+     * {@link #setFirstChild} and before all calls to {@link #addOtherChild}.
      *
      * @param builder a builder for the Protobuf continuation
      * @param continuation the second child's continuation
      */
-    abstract void setSecondChild(@Nonnull B builder, @Nonnull C continuation);
+    protected abstract void setSecondChild(@Nonnull B builder, @Nonnull C continuation);
 
     /**
      * Fill in the Protobuf builder with the information for a child other than the first or second child. For
@@ -79,7 +83,7 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
      * @param builder a builder for the Protobuf continuation
      * @param continuation a child other than the first or second child
      */
-    abstract void addOtherChild(@Nonnull B builder, @Nonnull C continuation);
+    protected abstract void addOtherChild(@Nonnull B builder, @Nonnull C continuation);
 
     /**
      * Get a new builder instance for the Protobuf message associated with this continuation. This should typically
@@ -88,10 +92,10 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
      * @return a new builder for the underlying Protobuf message type
      */
     @Nonnull
-    abstract B newProtoBuilder();
+    protected abstract B newProtoBuilder();
 
     @Nonnull
-    Message toProto() {
+    protected Message toProto() {
         if (cachedProto == null) {
             B builder = newProtoBuilder();
             final Iterator<C> continuationIterator = continuations.iterator();
@@ -107,6 +111,7 @@ abstract class MergeCursorContinuation<B extends Message.Builder, C extends Reco
 
     @Nullable
     @Override
+    @SpotBugsSuppressWarnings("EI")
     public byte[] toBytes() {
         if (isEnd()) {
             return null;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursorState.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorEndContinuation;
@@ -38,7 +39,8 @@ import java.util.function.Function;
  *
  * @param <T> the type of elements returned by the underlying cursor
  */
-class MergeCursorState<T> implements AutoCloseable {
+@API(API.Status.INTERNAL)
+public class MergeCursorState<T> implements AutoCloseable {
     @Nonnull
     private final RecordCursor<T> cursor;
     @Nullable
@@ -48,7 +50,7 @@ class MergeCursorState<T> implements AutoCloseable {
     @Nullable
     private RecordCursorResult<T> result;
 
-    MergeCursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuation) {
+    protected MergeCursorState(@Nonnull RecordCursor<T> cursor, @Nonnull RecordCursorContinuation continuation) {
         this.cursor = cursor;
         this.continuation = continuation;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursor.java
@@ -118,7 +118,7 @@ public class ProbableIntersectionCursor<T> extends MergeCursor<T, T, ProbableInt
 
     @Override
     @Nonnull
-    CompletableFuture<List<ProbableIntersectionCursorState<T>>> computeNextResultStates() {
+    protected CompletableFuture<List<ProbableIntersectionCursorState<T>>> computeNextResultStates() {
         final long startComputingStateTime = System.currentTimeMillis();
         final AtomicReference<ProbableIntersectionCursorState<T>> resultStateRef = new AtomicReference<>();
         return AsyncUtil.whileTrue(() -> whenAny(getCursorStates()).thenApply(vignore -> {
@@ -171,19 +171,19 @@ public class ProbableIntersectionCursor<T> extends MergeCursor<T, T, ProbableInt
 
     @Override
     @Nonnull
-    T getNextResult(@Nonnull List<ProbableIntersectionCursorState<T>> resultStates) {
+    protected T getNextResult(@Nonnull List<ProbableIntersectionCursorState<T>> resultStates) {
         return resultStates.get(0).getResult().get();
     }
 
     @Override
     @Nonnull
-    NoNextReason mergeNoNextReasons() {
+    protected NoNextReason mergeNoNextReasons() {
         return getStrongestNoNextReason(getCursorStates());
     }
 
     @Override
     @Nonnull
-    ProbableIntersectionCursorContinuation getContinuationObject() {
+    protected ProbableIntersectionCursorContinuation getContinuationObject() {
         return ProbableIntersectionCursorContinuation.from(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorContinuation.java
@@ -54,23 +54,23 @@ class ProbableIntersectionCursorContinuation extends MergeCursorContinuation<Pro
     }
 
     @Override
-    void setFirstChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+    protected void setFirstChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
         addChild(builder, continuation);
     }
 
     @Override
-    void setSecondChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+    protected void setSecondChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
         addChild(builder, continuation);
     }
 
     @Override
-    void addOtherChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
+    protected void addOtherChild(@Nonnull ProbableIntersectionContinuation.Builder builder, @Nonnull BloomFilterCursorContinuation continuation) {
         addChild(builder, continuation);
     }
 
     @Nonnull
     @Override
-    ProbableIntersectionContinuation.Builder newProtoBuilder() {
+    protected ProbableIntersectionContinuation.Builder newProtoBuilder() {
         return ProbableIntersectionContinuation.newBuilder();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursor.java
@@ -71,7 +71,7 @@ public class UnionCursor<T> extends UnionCursorBase<T, KeyedMergeCursorState<T>>
 
     @Nonnull
     @Override
-    CompletableFuture<List<KeyedMergeCursorState<T>>> computeNextResultStates() {
+    protected CompletableFuture<List<KeyedMergeCursorState<T>>> computeNextResultStates() {
         final List<KeyedMergeCursorState<T>> cursorStates = getCursorStates();
         return whenAll(cursorStates).thenApply(vignore -> {
             boolean anyHasNext = false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorBase.java
@@ -52,7 +52,7 @@ abstract class UnionCursorBase<T, S extends MergeCursorState<T>> extends MergeCu
 
     @Override
     @Nonnull
-    UnionCursorContinuation getContinuationObject() {
+    protected UnionCursorContinuation getContinuationObject() {
         return UnionCursorContinuation.from(this);
     }
 
@@ -67,7 +67,7 @@ abstract class UnionCursorBase<T, S extends MergeCursorState<T>> extends MergeCu
      */
     @Override
     @Nonnull
-    T getNextResult(@Nonnull List<S> chosenStates) {
+    protected T getNextResult(@Nonnull List<S> chosenStates) {
         return chosenStates.get(0).getResult().get();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
@@ -57,7 +57,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
     }
 
     @Override
-    void setFirstChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setFirstChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         if (continuation.isEnd()) {
             builder.setFirstExhausted(true);
         } else {
@@ -69,7 +69,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
     }
 
     @Override
-    void setSecondChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void setSecondChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         if (continuation.isEnd()) {
             builder.setSecondExhausted(true);
         } else {
@@ -81,7 +81,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
     }
 
     @Override
-    void addOtherChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+    protected void addOtherChild(@Nonnull RecordCursorProto.UnionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
         RecordCursorProto.UnionContinuation.CursorState cursorState;
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
@@ -100,7 +100,7 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
 
     @Override
     @Nonnull
-    RecordCursorProto.UnionContinuation.Builder newProtoBuilder() {
+    protected RecordCursorProto.UnionContinuation.Builder newProtoBuilder() {
         return RecordCursorProto.UnionContinuation.newBuilder();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnorderedUnionCursor.java
@@ -65,7 +65,7 @@ public class UnorderedUnionCursor<T> extends UnionCursorBase<T, MergeCursorState
 
     @Nonnull
     @Override
-    CompletableFuture<List<MergeCursorState<T>>> computeNextResultStates() {
+    protected CompletableFuture<List<MergeCursorState<T>>> computeNextResultStates() {
         final long startComputingStateTime = System.currentTimeMillis();
         final List<MergeCursorState<T>> cursorStates = getCursorStates();
         AtomicReference<MergeCursorState<T>> nextStateRef = new AtomicReference<>();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -1530,7 +1530,7 @@ public class RecordQueryPlanner implements QueryPlanner {
     }
     
     @Nullable
-    public RecordQueryPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull String indexName) {
+    public RecordQueryCoveringIndexPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull String indexName) {
         final Index index = metaData.getIndex(indexName);
         KeyExpression indexExpr = index.getRootExpression();
         if (indexExpr instanceof GroupingKeyExpression) {
@@ -1542,7 +1542,7 @@ public class RecordQueryPlanner implements QueryPlanner {
     }
 
     @Nullable
-    public RecordQueryPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull Index index, @Nonnull KeyExpression indexExpr) {
+    public RecordQueryCoveringIndexPlan planCoveringAggregateIndex(@Nonnull RecordQuery query, @Nonnull Index index, @Nonnull KeyExpression indexExpr) {
         final Collection<RecordType> recordTypes = metaData.recordTypesForIndex(index);
         if (recordTypes.size() != 1) {
             // Unfortunately, since we materialize partial records, we need a unique type for them.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -209,6 +209,24 @@ public class RecordQueryPlanner implements QueryPlanner {
     }
 
     /**
+     * Get the {@link RecordMetaData} for this planner.
+     * @return the meta-data
+     */
+    @Nonnull
+    public RecordMetaData getRecordMetaData() {
+        return metaData;
+    }
+
+    /**
+     * Get the {@link RecordStoreState} for this planner.
+     * @return the record store state
+     */
+    @Nonnull
+    public RecordStoreState getRecordStoreState() {
+        return recordStoreState;
+    }
+
+    /**
      * Create a plan to get the results of the provided query.
      *
      * @param query a query for records on this planner's metadata

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
@@ -1,0 +1,335 @@
+/*
+ * ComposedBitmapIndex.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.bitmap;
+
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.IndexAggregateGroupKeys;
+import com.apple.foundationdb.record.provider.foundationdb.IndexFunctionHelper;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.BitmapValueIndexMaintainer;
+import com.apple.foundationdb.record.query.QueryToKeyMatcher;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.AndOrComponent;
+import com.apple.foundationdb.record.query.expressions.ComponentWithComparison;
+import com.apple.foundationdb.record.query.expressions.FieldWithComparison;
+import com.apple.foundationdb.record.query.expressions.NotComponent;
+import com.apple.foundationdb.record.query.expressions.OrComponent;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.expressions.QueryKeyExpressionWithComparison;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
+import com.apple.foundationdb.record.query.plan.planning.FilterSatisfiedMask;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Transform a tree of Boolean expressions into a tree of bitwise operations on streams of bitmaps.
+ *
+ * So, {@code AND} turns into {@code BITAND} and {@code OR} into {@code BITOR}, with the leaves of the streams
+ * being scans of a {@code BITMAP_VALUE} index keyed by the leaf condition.
+ *
+ * Optional additional grouping predicates for all indexes are also preserved.
+ */
+public class ComposedBitmapIndexAggregate {
+    @Nonnull
+    private final Node root;
+
+    ComposedBitmapIndexAggregate(@Nonnull Node root) {
+        this.root = root;
+    }
+
+    /**
+     * Try to build a composed bitmap for the given aggregate function and filters.
+     * <p>
+     * The function should use a supported aggregate function (currently {@value BitmapValueIndexMaintainer#AGGREGATE_FUNCTION_NAME})
+     * and the bitmap-indexed position field grouped by any common fields.
+     * The filter should supply equality conditions to the common fields.
+     * The filter can include additional equality conditions on various other fields for which there are appropriate bitmap indexes, in a Boolean
+     * expression that will be transformed into a set the corresponding bit operations on the bitmaps.
+     * The filter can also include range conditions on the position field.
+     * </p>
+     * @param recordStore the record store containing the indexed data
+     * @param recordTypeNames the record types on which the indexes are defined
+     * @param indexAggregateFunction the function giving the desired position and grouping
+     * @param filter conditions on the groups and position
+     * @return an {@code Optional} composed bitmap or {@code Optional.empty} if there conditions could not be satisfied
+     */
+    @Nonnull
+    public static Optional<ComposedBitmapIndexAggregate> tryBuild(@Nonnull FDBRecordStore recordStore,
+                                                                  @Nonnull List<String> recordTypeNames,
+                                                                  @Nonnull IndexAggregateFunction indexAggregateFunction,
+                                                                  @Nonnull QueryComponent filter) {
+        List<QueryComponent> groupFilters = new ArrayList<>();
+        List<QueryComponent> indexFilters = new ArrayList<>();
+        if (!separateGroupFilters(filter, indexAggregateFunction, groupFilters, indexFilters) || indexFilters.isEmpty()) {
+            return Optional.empty();
+        }
+        Builder builder = new Builder(recordStore, recordTypeNames, groupFilters, indexAggregateFunction);
+        return builder.tryBuild(indexFilters.size() > 1 ? Query.and(indexFilters) : indexFilters.get(0))
+            .map(ComposedBitmapIndexAggregate::new);
+    }
+
+    /**
+     * Try to turn this composed bitmap into an executable plan.
+     * @param query a base query over the target record types
+     * @param recordMetaData the record meta-data for planning
+     * @param planner a query planner to use to construct the plans
+     * @return an {@code Optional} query plan or {@code Optional.empty} if planning is not possible
+     */
+    @Nonnull
+    public Optional<ComposedBitmapIndexQueryPlan> tryPlan(@Nonnull RecordQuery.Builder query,
+                                                          @Nonnull RecordMetaData recordMetaData,
+                                                          @Nonnull RecordQueryPlanner planner) {
+        final List<RecordQueryCoveringIndexPlan> indexScans = new ArrayList<>();
+        final Map<IndexNode, ComposedBitmapIndexQueryPlan.IndexComposer> indexComposers = new IdentityHashMap<>();
+        return Optional.ofNullable(plan(root, query, recordMetaData, planner, indexScans, indexComposers))
+                .map(composer -> new ComposedBitmapIndexQueryPlan(indexScans, composer));
+    }
+
+    private static boolean separateGroupFilters(@Nonnull QueryComponent filter,
+                                                @Nonnull IndexAggregateFunction indexAggregateFunction,
+                                                @Nonnull List<QueryComponent> groupFilters,
+                                                @Nonnull List<QueryComponent> indexFilters) {
+        QueryToKeyMatcher matcher = new QueryToKeyMatcher(filter);
+        FilterSatisfiedMask filterMask = FilterSatisfiedMask.of(filter);
+        QueryToKeyMatcher.Match match = matcher.matchesCoveringKey(((GroupingKeyExpression)indexAggregateFunction.getOperand()).getGroupingSubKey(), filterMask);
+        if (match.getType() != QueryToKeyMatcher.MatchType.EQUALITY) {
+            return false;   // Did not manage to fully restrict the grouping key.
+        }
+        // The position key(s) can also be constrained with inequalities and those go among the group filters.
+        matcher.matchesCoveringKey(((GroupingKeyExpression)indexAggregateFunction.getOperand()).getGroupedSubKey(), filterMask);
+        if (filterMask.allSatisfied()) {
+            return false;   // Not enough conditions left over.
+        }
+        for (FilterSatisfiedMask child : filterMask.getChildren()) {
+            if (child.allSatisfied()) {
+                groupFilters.add(child.getFilter());
+            } else {
+                indexFilters.add(child.getFilter());
+            }
+        }
+        return true;
+    }
+
+    @Nullable
+    private ComposedBitmapIndexQueryPlan.ComposerBase plan(@Nonnull Node node, @Nonnull RecordQuery.Builder query,
+                                                           @Nonnull RecordMetaData recordMetaData, @Nonnull RecordQueryPlanner planner,
+                                                           @Nonnull List<RecordQueryCoveringIndexPlan> indexScans,
+                                                           @Nonnull Map<IndexNode, ComposedBitmapIndexQueryPlan.IndexComposer> indexComposers) {
+        if (node instanceof OperatorNode) {
+            final OperatorNode operatorNode = (OperatorNode) node;
+            final List<ComposedBitmapIndexQueryPlan.ComposerBase> children = new ArrayList<>();
+            for (Node n : operatorNode.operands) {
+                ComposedBitmapIndexQueryPlan.ComposerBase plan = plan(n, query, recordMetaData, planner, indexScans, indexComposers);
+                if (plan == null) {
+                    return null;
+                }
+                children.add(plan);
+            }
+            switch (operatorNode.operator) {
+                case AND:
+                    return new ComposedBitmapIndexQueryPlan.AndComposer(children);
+                case OR:
+                    return new ComposedBitmapIndexQueryPlan.OrComposer(children);
+                case NOT:
+                    return new ComposedBitmapIndexQueryPlan.NotComposer(children.get(0));
+                default:
+                    throw new IllegalArgumentException("Unknown operator node: " + node);
+            }
+        } else if (node instanceof IndexNode) {
+            return indexComposers.computeIfAbsent((IndexNode)node, indexNode -> {
+                query.setFilter(indexNode.filter);
+                final Index index = recordMetaData.getIndex(indexNode.indexName);
+                final KeyExpression wholeKey = ((GroupingKeyExpression)index.getRootExpression()).getWholeKey();
+                final RecordQueryCoveringIndexPlan indexScan = planner.planCoveringAggregateIndex(query.build(), index, wholeKey);
+                if (indexScan == null) {
+                    return null;
+                }
+                final int position = indexScans.size();
+                indexScans.add(indexScan);
+                return new ComposedBitmapIndexQueryPlan.IndexComposer(position);
+            });
+        } else {
+            throw new IllegalArgumentException("Unknown node type: " + node);
+        }
+    }
+
+    static class Node {
+    }
+
+    static class OperatorNode extends Node {
+        enum Operator { AND, OR, NOT }
+
+        @Nonnull
+        private final Operator operator;
+        @Nonnull
+        private final List<Node> operands;
+
+        OperatorNode(@Nonnull Operator operator, @Nonnull List<Node> operands) {
+            this.operator = operator;
+            this.operands = operands;
+        }
+    }
+
+    // Note that the same IndexNode can occur multiple times in the tree, if the same condition subexpression appears
+    // multiple times in the filter.
+    static class IndexNode extends Node {
+        @Nonnull
+        private final QueryComponent filter;
+        @Nonnull
+        private final IndexAggregateGroupKeys groupKeys;
+        @Nonnull
+        private final String indexName;
+
+        IndexNode(@Nonnull QueryComponent filter, @Nonnull IndexAggregateGroupKeys groupKeys, @Nonnull String indexName) {
+            this.filter = filter;
+            this.groupKeys = groupKeys;
+            this.indexName = indexName;
+        }
+    }
+
+    static class Builder {
+        @Nonnull
+        private final FDBRecordStore recordStore;
+        @Nonnull
+        private final List<String> recordTypeNames;
+        @Nonnull
+        private final List<QueryComponent> groupFilters;
+        @Nonnull
+        private final IndexAggregateFunction indexAggregateFunction;
+        @Nullable
+        private Map<KeyExpression, Index> bitmapIndexes;
+        @Nullable
+        private Map<QueryComponent, IndexNode> indexNodes;
+
+        Builder(@Nonnull final FDBRecordStore recordStore, @Nonnull List<String> recordTypeNames,
+                @Nonnull List<QueryComponent> groupFilters, @Nonnull IndexAggregateFunction indexAggregateFunction) {
+            this.recordStore = recordStore;
+            this.recordTypeNames = recordTypeNames;
+            this.groupFilters = groupFilters;
+            this.indexAggregateFunction = indexAggregateFunction;
+        }
+
+        @Nonnull
+        Optional<Node> tryBuild(@Nonnull QueryComponent indexFilter) {
+            if (indexFilter instanceof ComponentWithComparison) {
+                return indexScan(indexFilter);
+            }
+            if (indexFilter instanceof AndOrComponent) {
+                final AndOrComponent andOrComponent = (AndOrComponent) indexFilter;
+                List<Node> childNodes = new ArrayList<>(andOrComponent.getChildren().size());
+                for (QueryComponent child : andOrComponent.getChildren()) {
+                    Optional<Node> childNode = tryBuild(child);
+                    if (!childNode.isPresent()) {
+                        return Optional.empty();
+                    }
+                    childNodes.add(childNode.get());
+                }
+                final OperatorNode.Operator operator = indexFilter instanceof OrComponent ? OperatorNode.Operator.OR : OperatorNode.Operator.AND;
+                return Optional.of(new OperatorNode(operator, childNodes));
+            }
+            if (indexFilter instanceof NotComponent) {
+                return tryBuild(((NotComponent) indexFilter).getChild())
+                        .map(childNode -> new OperatorNode(OperatorNode.Operator.NOT, Collections.singletonList(childNode)));
+            }
+            return Optional.empty();
+        }
+
+        @Nonnull
+        Optional<Node> indexScan(@Nonnull QueryComponent indexFilter) {
+            if (bitmapIndexes == null) {
+                bitmapIndexes = findBitmapIndexes(indexAggregateFunction.getName());
+                indexNodes = new HashMap<>();
+                if (bitmapIndexes.isEmpty()) {
+                    return Optional.empty();
+                }
+            }
+            IndexNode existing = indexNodes.get(indexFilter);
+            if (existing != null) {
+                return Optional.of(existing);
+            }
+            final KeyExpression additionalKey;
+            if (indexFilter instanceof FieldWithComparison) {
+                additionalKey = Key.Expressions.field(((FieldWithComparison) indexFilter).getFieldName());
+            } else if (indexFilter instanceof QueryKeyExpressionWithComparison) {
+                additionalKey = ((QueryKeyExpressionWithComparison) indexFilter).getKeyExpression();
+            } else {
+                return Optional.empty();
+            }
+            GroupingKeyExpression groupKeyExpression = (GroupingKeyExpression)indexAggregateFunction.getOperand();
+            GroupingKeyExpression fullKey = Key.Expressions.concat(groupKeyExpression.getGroupingSubKey(), additionalKey, groupKeyExpression.getGroupedSubKey())
+                    .group(groupKeyExpression.getGroupedCount());
+            Index index = bitmapIndexes.get(fullKey);
+            if (index == null) {
+                return Optional.empty();
+            }
+            final QueryComponent fullFilter;
+            if (groupFilters.isEmpty()) {
+                fullFilter = indexFilter;
+            } else {
+                List<QueryComponent> allFilters = new ArrayList<>(groupFilters.size() + 1);
+                allFilters.addAll(groupFilters);
+                allFilters.add(indexFilter);
+                fullFilter = Query.and(allFilters);
+            }
+            // Allow conditions on the position field as well.
+            final KeyExpression fullOperand = new GroupingKeyExpression(fullKey.getWholeKey(), 0);
+            return IndexAggregateGroupKeys.conditionsToGroupKeys(fullOperand, fullFilter)
+                    .map(groupKeys -> {
+                        final IndexNode indexNode = new IndexNode(fullFilter, groupKeys, index.getName());
+                        indexNodes.put(indexFilter, indexNode);
+                        return indexNode;
+                    });
+        }
+
+        @Nonnull
+        Map<KeyExpression, Index> findBitmapIndexes(@Nonnull String aggregateFunction) {
+            final String indexType;
+            if (BitmapValueIndexMaintainer.AGGREGATE_FUNCTION_NAME.equals(aggregateFunction)) {
+                indexType = IndexTypes.BITMAP_VALUE;
+            } else {
+                return Collections.emptyMap();
+            }
+            return IndexFunctionHelper.indexesForRecordTypes(recordStore, recordTypeNames)
+                    .filter(index -> index.getType().equals(indexType))
+                    .filter(recordStore::isIndexReadable)
+                    .collect(Collectors.toMap(Index::getRootExpression, Function.identity()));
+        }
+
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
@@ -274,10 +274,10 @@ public class ComposedBitmapIndexAggregate {
         Optional<Node> indexScan(@Nonnull QueryComponent indexFilter) {
             if (bitmapIndexes == null) {
                 bitmapIndexes = findBitmapIndexes(indexAggregateFunction.getName());
-                indexNodes = new HashMap<>();
                 if (bitmapIndexes.isEmpty()) {
                     return Optional.empty();
                 }
+                indexNodes = new HashMap<>();
             }
             IndexNode existing = indexNodes.get(indexFilter);
             if (existing != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
@@ -84,7 +84,7 @@ public class ComposedBitmapIndexAggregate {
     public static Optional<ComposedBitmapIndexQueryPlan> tryPlan(@Nonnull RecordQueryPlanner planner,
                                                                  @Nonnull RecordQuery query,
                                                                  @Nonnull IndexAggregateFunction indexAggregateFunction) {
-        if (query.getFilter() == null) {
+        if (query.getFilter() == null || query.getSort() != null) {
             return Optional.empty();
         }
         return tryBuild(planner, query.getRecordTypes(), indexAggregateFunction, query.getFilter())

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexContinuation.java
@@ -1,0 +1,155 @@
+/*
+ * ComposedBitmapIndexContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.bitmap;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.ByteArrayContinuation;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorEndContinuation;
+import com.apple.foundationdb.record.RecordCursorProto;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.provider.foundationdb.cursors.MergeCursorContinuation;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.BitmapValueIndexMaintainer;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link RecordCursor} doing as bit-wise merge of bitmaps from two or more {@code BITMAP_VALUE} indexes.
+ *
+ * The bit operations can correspond to a Boolean expression over those indexes' rightmost grouping keys.
+ *
+ * @see BitmapValueIndexMaintainer
+ */
+@API(API.Status.EXPERIMENTAL)
+class ComposedBitmapIndexContinuation extends MergeCursorContinuation<RecordCursorProto.ComposedBitmapIndexContinuation.Builder, RecordCursorContinuation> {
+    @Nonnull
+    private static final RecordCursorProto.ComposedBitmapIndexContinuation.CursorState EXHAUSTED_PROTO = RecordCursorProto.ComposedBitmapIndexContinuation.CursorState.newBuilder()
+            .setExhausted(true)
+            .build();
+
+    @Nonnull
+    private static final RecordCursorProto.ComposedBitmapIndexContinuation.CursorState START_PROTO = RecordCursorProto.ComposedBitmapIndexContinuation.CursorState.newBuilder()
+            .setExhausted(false)
+            .build();
+
+    protected ComposedBitmapIndexContinuation(@Nonnull List<RecordCursorContinuation> continuations, @Nullable Message originalProto) {
+        super(continuations, originalProto);
+    }
+
+    @Override
+    protected void setFirstChild(@Nonnull RecordCursorProto.ComposedBitmapIndexContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        addChild(builder, continuation);
+    }
+
+    @Override
+    protected void setSecondChild(@Nonnull RecordCursorProto.ComposedBitmapIndexContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        addChild(builder, continuation);
+
+    }
+
+    @Override
+    protected void addOtherChild(@Nonnull RecordCursorProto.ComposedBitmapIndexContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        addChild(builder, continuation);
+
+    }
+
+    private void addChild(@Nonnull RecordCursorProto.ComposedBitmapIndexContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
+        RecordCursorProto.ComposedBitmapIndexContinuation.CursorState cursorState;
+        if (continuation.isEnd()) {
+            cursorState = EXHAUSTED_PROTO;
+        } else {
+            final byte[] asBytes = continuation.toBytes();
+            if (asBytes == null) {
+                cursorState = START_PROTO;
+            } else {
+                cursorState = RecordCursorProto.ComposedBitmapIndexContinuation.CursorState.newBuilder()
+                        .setContinuation(ByteString.copyFrom(asBytes))
+                        .build();
+            }
+        }
+        builder.addChildState(cursorState);
+    }
+
+    @Nonnull
+    @Override
+    protected RecordCursorProto.ComposedBitmapIndexContinuation.Builder newProtoBuilder() {
+        return RecordCursorProto.ComposedBitmapIndexContinuation.newBuilder();
+    }
+
+    @Override
+    public boolean isEnd() {
+        return getContinuations().stream().allMatch(RecordCursorContinuation::isEnd);
+    }
+
+    public RecordCursorContinuation getContinuation(int i) {
+        return getContinuations().get(i);
+    }
+
+    @Nonnull
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    static ComposedBitmapIndexContinuation from(@Nullable byte[] bytes, int numberOfChildren) {
+        if (bytes == null) {
+            return new ComposedBitmapIndexContinuation(Collections.nCopies(numberOfChildren, RecordCursorStartContinuation.START), null);
+        }
+        try {
+            return from(RecordCursorProto.ComposedBitmapIndexContinuation.parseFrom(bytes), numberOfChildren);
+        } catch (InvalidProtocolBufferException ex) {
+            throw new RecordCoreException("invalid continuation", ex)
+                    .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
+        } catch (RecordCoreArgumentException ex) {
+            throw ex.addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(bytes));
+        }
+    }
+
+    @Nonnull
+    static ComposedBitmapIndexContinuation from(@Nonnull RecordCursorProto.ComposedBitmapIndexContinuation parsed, int numberOfChildren) {
+        ImmutableList.Builder<RecordCursorContinuation> builder = ImmutableList.builder();
+        for (RecordCursorProto.ComposedBitmapIndexContinuation.CursorState state : parsed.getChildStateList()) {
+            if (state.hasContinuation()) {
+                builder.add(ByteArrayContinuation.fromNullable(state.getContinuation().toByteArray()));
+            } else if (state.getExhausted()) {
+                builder.add(RecordCursorEndContinuation.END);
+            } else {
+                builder.add(RecordCursorStartContinuation.START);
+            }
+        }
+        ImmutableList<RecordCursorContinuation> children = builder.build();
+        if (children.size() != numberOfChildren) {
+            throw new RecordCoreArgumentException("invalid continuation (expected continuation count does not match read)")
+                    .addLogInfo(LogMessageKeys.EXPECTED_CHILD_COUNT, numberOfChildren)
+                    .addLogInfo(LogMessageKeys.READ_CHILD_COUNT, children.size());
+        }
+        return new ComposedBitmapIndexContinuation(children, parsed);
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
@@ -1,0 +1,165 @@
+/*
+ * ComposedBitmapIndexCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.bitmap;
+
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.cursors.MergeCursor;
+import com.apple.foundationdb.record.provider.foundationdb.cursors.MergeCursorState;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.BitmapValueIndexMaintainer;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * A {@link RecordCursor} doing as bit-wise merge of bitmaps from two or more {@code BITMAP_VALUE} indexes.
+ *
+ * The bit operations can correspond to a Boolean expression over those indexes' rightmost grouping keys.
+ *
+ * @see BitmapValueIndexMaintainer
+ */
+class ComposedBitmapIndexCursor extends MergeCursor<IndexEntry, IndexEntry, MergeCursorState<IndexEntry>> {
+    @Nonnull
+    private final Composer composer;
+
+    /**
+     * Function for generating a bitmap from several others, all of the same size.
+     */
+    @FunctionalInterface
+    public interface Composer {
+        /**
+         * Generate a bitmap from several others.
+         * @param bitmaps a list of bitmaps or {@code null} if the corresponding input is absent / empty
+         * @param size the common size of the bitmaps
+         * @return a new bitmap formed from the inputs or {@code null} to represent an empty (all zero) bitmap
+         */
+        @Nullable
+        byte[] compose(@Nonnull List<byte[]> bitmaps, int size);
+    }
+
+    protected ComposedBitmapIndexCursor(@Nonnull List<MergeCursorState<IndexEntry>> cursorStates, @Nullable FDBStoreTimer timer, @Nonnull Composer composer) {
+        super(cursorStates, timer);
+        this.composer = composer;
+    }
+
+    @Nonnull
+    @Override
+    protected CompletableFuture<List<MergeCursorState<IndexEntry>>> computeNextResultStates() {
+        final List<MergeCursorState<IndexEntry>> cursorStates = getCursorStates();
+        return whenAll(cursorStates).thenApply(vignore -> {
+            boolean anyHasNext = false;
+            for (MergeCursorState<IndexEntry> cursorState : cursorStates) {
+                if (cursorState.getResult().hasNext()) {
+                    anyHasNext = true;
+                } else if (cursorState.getResult().getNoNextReason().isLimitReached()) {
+                    // Stop if any has reached limit.
+                    return Collections.emptyList();
+                }
+            }
+            if (anyHasNext) {
+                final List<MergeCursorState<IndexEntry>> resultStates = new ArrayList<>();
+                long nextPosition = Long.MAX_VALUE;
+                for (MergeCursorState<IndexEntry> cursorState : cursorStates) {
+                    if (cursorState.getResult().hasNext()) {
+                        final IndexEntry indexEntry = cursorState.getResult().get();
+                        final Tuple indexKey = indexEntry.getKey();
+                        final long position = indexKey.getLong(indexKey.size() - 1);
+                        if (nextPosition > position) {
+                            resultStates.clear();
+                            nextPosition = position;
+                        }
+                        if (nextPosition == position) {
+                            resultStates.add(cursorState);
+                        }
+                    }
+                }
+                return resultStates;
+            } else {
+                return Collections.emptyList();
+            }
+        });
+    }
+
+    @Nonnull
+    @Override
+    protected IndexEntry getNextResult(@Nonnull List<MergeCursorState<IndexEntry>> resultStates) {
+        final List<MergeCursorState<IndexEntry>> cursorStates = getCursorStates();
+        final IndexEntry firstEntry = resultStates.get(0).getResult().get();
+        final int size = firstEntry.getValue().getBytes(0).length;
+        final List<byte[]> bitmaps = new ArrayList<>(cursorStates.size());
+        for (MergeCursorState<IndexEntry> cursorState : cursorStates) {
+            if (resultStates.contains(cursorState)) {
+                byte[] bitmap = cursorState.getResult().get().getValue().getBytes(0);
+                if (bitmap.length != size) {
+                    throw new RecordCoreException("Index bitmaps are not all the same size");
+                }
+                bitmaps.add(bitmap);
+            } else {
+                bitmaps.add(null);
+            }
+        }
+        final byte[] composed = composer.compose(bitmaps, size);
+        return new IndexEntry(firstEntry.getIndex(), firstEntry.getKey(), Tuple.fromList(Collections.singletonList(composed)));
+    }
+
+    @Nonnull
+    @Override
+    protected NoNextReason mergeNoNextReasons() {
+        return getStrongestNoNextReason(getCursorStates());
+    }
+
+    @Nonnull
+    @Override
+    protected RecordCursorContinuation getContinuationObject() {
+        return new ComposedBitmapIndexContinuation(getChildContinuations(), null);
+    }
+
+    @Nonnull
+    public static ComposedBitmapIndexCursor create(@Nonnull List<Function<byte[], RecordCursor<IndexEntry>>> cursorFunctions,
+                                                   @Nonnull Composer composer,
+                                                   @Nullable byte[] byteContinuation,
+                                                   @Nullable FDBStoreTimer timer) {
+        if (cursorFunctions.size() < 2) {
+            throw new RecordCoreArgumentException("not enough child cursors provided to UnionCursor")
+                    .addLogInfo(LogMessageKeys.CHILD_COUNT, cursorFunctions.size());
+        }
+        final List<MergeCursorState<IndexEntry>> cursorStates = new ArrayList<>(cursorFunctions.size());
+        final ComposedBitmapIndexContinuation continuation = ComposedBitmapIndexContinuation.from(byteContinuation, cursorFunctions.size());
+        int i = 0;
+        for (Function<byte[], RecordCursor<IndexEntry>> cursorFunction : cursorFunctions) {
+            cursorStates.add(MergeCursorState.from(cursorFunction, continuation.getContinuation(i)));
+            i++;
+        }
+        return new ComposedBitmapIndexCursor(cursorStates, timer, composer);
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
@@ -41,7 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 /**
- * A {@link RecordCursor} doing as bit-wise merge of bitmaps from two or more {@code BITMAP_VALUE} indexes.
+ * A {@link RecordCursor} doing a bit-wise merge of bitmaps from two or more {@code BITMAP_VALUE} indexes.
  *
  * The bit operations can correspond to a Boolean expression over those indexes' rightmost grouping keys.
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
@@ -86,6 +86,8 @@ class ComposedBitmapIndexCursor extends MergeCursor<IndexEntry, IndexEntry, Merg
                 }
             }
             if (anyHasNext) {
+                // Result states are all those that share the minimum next position,
+                // whose bitmaps need to be merged to produce the next stream element.
                 final List<MergeCursorState<IndexEntry>> resultStates = new ArrayList<>();
                 long nextPosition = Long.MAX_VALUE;
                 for (MergeCursorState<IndexEntry> cursorState : cursorStates) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexCursor.java
@@ -149,7 +149,7 @@ class ComposedBitmapIndexCursor extends MergeCursor<IndexEntry, IndexEntry, Merg
                                                    @Nullable byte[] byteContinuation,
                                                    @Nullable FDBStoreTimer timer) {
         if (cursorFunctions.size() < 2) {
-            throw new RecordCoreArgumentException("not enough child cursors provided to UnionCursor")
+            throw new RecordCoreArgumentException("not enough child cursors provided to ComposedBitmapIndexCursor")
                     .addLogInfo(LogMessageKeys.CHILD_COUNT, cursorFunctions.size());
         }
         final List<MergeCursorState<IndexEntry>> cursorStates = new ArrayList<>(cursorFunctions.size());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
@@ -327,6 +327,10 @@ public class ComposedBitmapIndexQueryPlan implements RecordQueryPlanWithNoChildr
         }
     }
 
+    // The specific binary operators are mostly the same, except that AND bails out early on empty and they use a different
+    // bit operator in the inner loop. There could be an abstract method for that operation, but it would be invoked
+    // inside the loop, which seems to less the chances for the whole being compiled well.
+
     static class AndComposer extends OperatorComposer {
         public AndComposer(@Nonnull List<ComposerBase> children) {
             super(children);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
@@ -1,0 +1,496 @@
+/*
+ * ComposedBitmapIndexQueryPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.bitmap;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithNoChildren;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
+import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
+import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A query plan implementing a bit-wise merge of two or more covering index scans of {@code BITMAP_VALUE} indexes.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class ComposedBitmapIndexQueryPlan implements RecordQueryPlanWithNoChildren {
+
+    @Nonnull
+    // NOTE: These aren't children in the sense of RecordQueryPlanWithChildren
+    // for the same reason as RecordQueryCoveringIndexPlan isn't RecordQueryPlanWithChild.
+    private final List<RecordQueryCoveringIndexPlan> indexPlans;
+    @Nonnull
+    private final ComposerBase composer;
+
+    ComposedBitmapIndexQueryPlan(@Nonnull List<RecordQueryCoveringIndexPlan> indexPlans, @Nonnull ComposerBase composer) {
+        this.indexPlans = indexPlans;
+        this.composer = composer;
+    }
+
+    @Nonnull
+    public List<RecordQueryCoveringIndexPlan> getIndexPlans() {
+        return indexPlans;
+    }
+
+    @Nonnull
+    public ComposerBase getComposer() {
+        return composer;
+    }
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context,
+                                                                         @Nullable byte[] continuation, @Nonnull ExecuteProperties executeProperties) {
+        final ExecuteProperties scanExecuteProperties = executeProperties.getSkip() > 0 ? executeProperties.clearSkipAndAdjustLimit() : executeProperties;
+        final List<Function<byte[], RecordCursor<IndexEntry>>> cursorFunctions = indexPlans.stream()
+                .map(RecordQueryCoveringIndexPlan::getIndexPlan)
+                .map(scan -> (Function<byte[], RecordCursor<IndexEntry>>) childContinuation -> scan.executeEntries(store, context, childContinuation, scanExecuteProperties))
+                .collect(Collectors.toList());
+        return ComposedBitmapIndexCursor.create(cursorFunctions, composer, continuation, store.getTimer())
+                // Composers can return null bitmaps when empty, which is then left out of the result set.
+                .filter(indexEntry -> indexEntry.getValue().get(0) != null)
+                .map(indexPlans.get(0).indexEntryToQueriedRecord(store));
+    }
+
+    @Override
+    public boolean isReverse() {
+        return false;
+    }
+
+    @Override
+    public boolean hasRecordScan() {
+        return false;
+    }
+
+    @Override
+    public boolean hasFullRecordScan() {
+        return false;
+    }
+
+    @Override
+    public boolean hasIndexScan(@Nonnull String indexName) {
+        return indexPlans.stream().anyMatch(p -> p.hasIndexScan(indexName));
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getUsedIndexes() {
+        return indexPlans.stream().map(RecordQueryPlan::getUsedIndexes).flatMap(Set::stream).collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean hasLoadBykeys() {
+        return false;
+    }
+
+    @Override
+    public void logPlanStructure(StoreTimer timer) {
+        timer.increment(FDBStoreTimer.Counts.PLAN_COMPOSED_BITMAP_INDEX);
+        for (RecordQueryPlan indexPlan : indexPlans) {
+            indexPlan.logPlanStructure(timer);
+        }
+    }
+
+    @Override
+    public int getComplexity() {
+        int complexity = 1;
+        for (RecordQueryPlan child : indexPlans) {
+            complexity += child.getComplexity();
+        }
+        return complexity;
+    }
+
+    @Override
+    public int planHash() {
+        return PlanHashable.planHash(indexPlans) + composer.planHash();
+    }
+
+    @Nonnull
+    @Override
+    public PlannerGraph rewritePlannerGraph(@Nonnull List<? extends PlannerGraph> childGraphs) {
+        return PlannerGraph.fromNodeAndChildGraphs(
+                new PlannerGraph.OperatorNodeWithInfo(this, NodeInfo.COMPOSED_BITMAP_OPERATOR),
+                childGraphs);
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return indexPlans.stream().map(RecordQueryPlan::getCorrelatedTo).flatMap(Set::stream).collect(Collectors.toSet());
+    }
+
+    @Nonnull
+    @Override
+    public ComposedBitmapIndexQueryPlan rebase(@Nonnull AliasMap translationMap) {
+        return new ComposedBitmapIndexQueryPlan(indexPlans.stream().map(i -> i.rebase(translationMap)).collect(Collectors.toList()), composer);
+    }
+
+    @Override
+    public boolean equalsWithoutChildren(@Nonnull RelationalExpression other, @Nonnull AliasMap equivalences) {
+        if (this == other) {
+            return true;
+        }
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+        ComposedBitmapIndexQueryPlan that = (ComposedBitmapIndexQueryPlan) other;
+        if (!composer.equals(that.composer)) {
+            return false;
+        }
+        List<RecordQueryCoveringIndexPlan> otherIndexPlans = that.indexPlans;
+        if (indexPlans.size() != otherIndexPlans.size()) {
+            return false;
+        }
+        for (int i = 0; i < indexPlans.size(); i++) {
+            if (!indexPlans.get(i).equalsWithoutChildren(otherIndexPlans.get(i), equivalences)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCodeWithoutChildren() {
+        return Objects.hash(indexPlans, composer);
+    }
+
+    @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(Object other) {
+        return structuralEquals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return structuralHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return composer.toString(indexPlans);
+    }
+
+    /**
+     * Plan extension of {@link ComposedBitmapIndexCursor.Composer}.
+     */
+    @VisibleForTesting
+    public abstract static class ComposerBase implements ComposedBitmapIndexCursor.Composer, PlanHashable {
+        @Nonnull
+        abstract String toString(@Nullable List<?> sources);
+
+        @Override
+        public String toString() {
+            return toString(null);
+        }
+    }
+
+    static class IndexComposer extends ComposerBase {
+        private final int position;
+
+        IndexComposer(int position) {
+            this.position = position;
+        }
+
+        @Nonnull
+        @Override
+        String toString(@Nullable List<?> sources) {
+            if (sources == null) {
+                return String.format("[%d]", position);
+            } else {
+                return sources.get(position).toString();
+            }
+        }
+
+        @Nullable
+        @Override
+        public byte[] compose(@Nonnull List<byte[]> bitmaps, int size) {
+            return bitmaps.get(position);
+        }
+
+        @Override
+        public int planHash() {
+            return position;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            IndexComposer that = (IndexComposer) o;
+            return position == that.position;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(position);
+        }
+    }
+
+    abstract static class OperatorComposer extends ComposerBase {
+        @Nonnull
+        private final List<ComposerBase> children;
+
+        OperatorComposer(@Nonnull List<ComposerBase> children) {
+            this.children = children;
+        }
+
+        @Nonnull
+        abstract String operator();
+
+        @Nonnull
+        @Override
+        String toString(@Nullable List<?> sources) {
+            return children.stream().map(child -> child.toString(sources)).collect(Collectors.joining(" " + operator() + " "));
+        }
+
+        @Nullable
+        @Override
+        public byte[] compose(@Nonnull List<byte[]> bitmaps, int size) {
+            final List<byte[]> operands = new ArrayList<>(children.size());
+            for (ComposerBase child : children) {
+                operands.add(child.compose(bitmaps, size));
+            }
+            return operate(operands, new byte[size]);
+        }
+
+        @Nullable
+        abstract byte[] operate(@Nonnull List<byte[]> operands, @Nonnull byte[] result);
+
+        @Override
+        public int planHash() {
+            return PlanHashable.planHash(children) + operator().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            OperatorComposer that = (OperatorComposer) o;
+            return children.equals(that.children) &&
+                    operator().equals(that.operator());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(children) + operator().hashCode();
+        }
+    }
+
+    static class AndComposer extends OperatorComposer {
+        public AndComposer(@Nonnull List<ComposerBase> children) {
+            super(children);
+        }
+
+        @Nonnull
+        @Override
+        String operator() {
+            return "BITAND";
+        }
+
+        @Nullable
+        @Override
+        byte[] operate(@Nonnull List<byte[]> operands, @Nonnull byte[] result) {
+            boolean first = true;
+            boolean empty = true;
+            for (final byte[] operand : operands) {
+                if (operand == null) {
+                    return null;
+                }
+                if (first) {
+                    System.arraycopy(operand, 0, result, 0, result.length);
+                    empty = first = false;
+                } else {
+                    empty = true;
+                    for (int j = 0; j < result.length; j++) {
+                        final byte b = (byte) (result[j] & operand[j]);
+                        result[j] = b;
+                        if (empty && b != 0) {
+                            empty = false;
+                        }
+                    }
+                }
+            }
+            return empty ? null : result;
+        }
+    }
+
+    static class OrComposer extends OperatorComposer {
+        public OrComposer(@Nonnull List<ComposerBase> children) {
+            super(children);
+        }
+
+        @Nonnull
+        @Override
+        String operator() {
+            return "BITOR";
+        }
+
+        @Nullable
+        @Override
+        byte[] operate(@Nonnull List<byte[]> operands, @Nonnull byte[] result) {
+            boolean first = true;
+            boolean empty = true;
+            for (final byte[] operand : operands) {
+                if (operand == null) {
+                    continue;
+                }
+                if (first) {
+                    System.arraycopy(operand, 0, result, 0, result.length);
+                    empty = first = false;
+                } else {
+                    empty = true;
+                    for (int j = 0; j < result.length; j++) {
+                        final byte b = (byte) (result[j] | operand[j]);
+                        result[j] = b;
+                        if (empty && b != 0) {
+                            empty = false;
+                        }
+                    }
+                }
+            }
+            return empty ? null : result;
+        }
+    }
+
+    static class XorComposer extends OperatorComposer {
+        public XorComposer(@Nonnull List<ComposerBase> children) {
+            super(children);
+        }
+
+        @Nonnull
+        @Override
+        String operator() {
+            return "BITXOR";
+        }
+
+        @Nullable
+        @Override
+        byte[] operate(@Nonnull List<byte[]> operands, @Nonnull byte[] result) {
+            boolean first = true;
+            boolean empty = true;
+            for (final byte[] operand : operands) {
+                if (operand == null) {
+                    continue;
+                }
+                if (first) {
+                    System.arraycopy(operand, 0, result, 0, result.length);
+                    empty = first = false;
+                } else {
+                    empty = true;
+                    for (int j = 0; j < result.length; j++) {
+                        final byte b = (byte) (result[j] ^ operand[j]);
+                        result[j] = b;
+                        if (empty && b != 0) {
+                            empty = false;
+                        }
+                    }
+                }
+            }
+            return empty ? null : result;
+        }
+    }
+
+    static class NotComposer extends ComposerBase {
+        @Nonnull
+        private final ComposerBase child;
+
+        NotComposer(@Nonnull ComposerBase child) {
+            this.child = child;
+        }
+
+        @Nonnull
+        @Override
+        String toString(@Nullable List<?> sources) {
+            return "BITNOT " + child.toString(sources);
+        }
+
+        @Nullable
+        @Override
+        public byte[] compose(@Nonnull List<byte[]> bitmaps, int size) {
+            final byte[] operand = child.compose(bitmaps, size);
+            final byte[] result = new byte[size];
+            if (operand == null) {
+                Arrays.fill(result, (byte)0xFF);
+            } else {
+                for (int i = 0; i < result.length; i++) {
+                    result[i] = (byte)~operand[i];
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public int planHash() {
+            return child.planHash();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            NotComposer that = (NotComposer) o;
+            return child.equals(that.child);
+        }
+
+        @Override
+        public int hashCode() {
+            return child.hashCode();
+        }
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes relating to bitmap operations over {@code BITMAP_VALUE} index entries.
+ */
+package com.apple.foundationdb.record.query.plan.bitmap;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/explain/NodeInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/explain/NodeInfo.java
@@ -144,7 +144,11 @@ public class NodeInfo {
             NodeIcon.COMPUTATION_OPERATOR,
             "Union All",
             "A union all operator processes its two or more inputs and returns the unioned multiset of all input records (duplicates are preserved). The operator does not required its inputs to be compatible ordered.");
-
+    public static final NodeInfo COMPOSED_BITMAP_OPERATOR = new NodeInfo(
+            "ComposedBitmapOperator",
+            NodeIcon.COMPUTATION_OPERATOR,
+            "Composed Bitmap",
+            "A set of Boolean conditions on BITMAP_VALUE indexed bitmaps which are combined into a single bitmap by bitwise operations.");
 
     private final String id;
     private final String iconId;

--- a/fdb-record-layer-core/src/main/proto/record_cursor.proto
+++ b/fdb-record-layer-core/src/main/proto/record_cursor.proto
@@ -99,7 +99,6 @@ message ComposedBitmapIndexContinuation {
     message CursorState {
         optional bytes continuation = 1;
         optional bool exhausted = 2;
-        optional bytes bloom_filter = 3;
     }
     repeated CursorState child_state = 1;
 }

--- a/fdb-record-layer-core/src/main/proto/record_cursor.proto
+++ b/fdb-record-layer-core/src/main/proto/record_cursor.proto
@@ -94,3 +94,12 @@ message OrElseContinuation {
     optional State state = 1;
     optional bytes continuation = 2;
 }
+
+message ComposedBitmapIndexContinuation {
+    message CursorState {
+        optional bytes continuation = 1;
+        optional bool exhausted = 2;
+        optional bytes bloom_filter = 3;
+    }
+    repeated CursorState child_state = 1;
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexTest.java
@@ -20,11 +20,14 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.FunctionNames;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecords1Proto;
@@ -33,9 +36,18 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
+import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexAggregate;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.common.collect.ImmutableMap;
@@ -44,6 +56,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -51,8 +64,18 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.compositeBitmap;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.coveringIndexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTupleString;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScanType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -64,12 +87,12 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     @Test
     public void basic() {
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, REC_NO_BY_STR_NUM3_HOOK);
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
             saveRecords(100, 200);
             commit(context);
         }
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, REC_NO_BY_STR_NUM3_HOOK);
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
             assertThat(
                     collectOnBits(recordStore.scanIndex(
                             recordStore.getRecordMetaData().getIndex("rec_no_by_str_num3"), IndexScanType.BY_GROUP,
@@ -94,12 +117,12 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     @Test
     public void aggregateFunction() {
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, REC_NO_BY_STR_NUM3_HOOK);
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
             saveRecords(100, 200);
             commit(context);
         }
         try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, REC_NO_BY_STR_NUM3_HOOK);
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
             final IndexAggregateFunction aggregateFunction = new IndexAggregateFunction(FunctionNames.BITMAP_VALUE, REC_NO_BY_STR_NUM3, null);
             assertThat(
                     collectOnBits(recordStore.evaluateAggregateFunction(
@@ -242,11 +265,168 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
         }
     }
 
+    @Test
+    public void andQuery() {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            saveRecords(100, 200);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            setupPlanner(null);
+            final RecordQueryPlan queryPlan = plan(BITMAP_VALUE_REC_NO_BY_STR, Query.and(
+                    Query.field("str_value_indexed").equalsValue("odd"),
+                    Query.field("num_value_2").equalsValue(3),
+                    Query.field("num_value_3_indexed").equalsValue(4)));
+            assertThat(queryPlan, compositeBitmap(hasToString("[0] BITAND [1]"), Arrays.asList(
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num2"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 3],[odd, 3]]"))))),
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num3"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 4],[odd, 4]]"))))))));
+            assertEquals(1339577615, queryPlan.planHash());
+            assertThat(
+                    collectOnBits(queryPlan.execute(recordStore).map(FDBQueriedRecord::getIndexEntry)),
+                    equalTo(IntStream.range(100, 200).boxed()
+                            .filter(i -> (i & 1) == 1)
+                            .filter(i -> (i % 7) == 3 && (i % 5) == 4)
+                            .collect(Collectors.toList())));
+        }
+    }
+
+    @Test
+    public void andQueryPosition() {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            saveRecords(100, 200);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            setupPlanner(null);
+            final RecordQueryPlan queryPlan = plan(BITMAP_VALUE_REC_NO_BY_STR, Query.and(
+                    Query.field("str_value_indexed").equalsValue("odd"),
+                    Query.field("num_value_2").equalsValue(3),
+                    Query.field("num_value_3_indexed").equalsValue(4),
+                    Query.field("rec_no").greaterThan(150)));
+            assertThat(queryPlan, compositeBitmap(hasToString("[0] BITAND [1]"), Arrays.asList(
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num2"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("([odd, 3, 150],[odd, 3]]"))))),
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num3"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("([odd, 4, 150],[odd, 4]]"))))))));
+            assertEquals(-1911273393, queryPlan.planHash());
+            assertThat(
+                    collectOnBits(queryPlan.execute(recordStore).map(FDBQueriedRecord::getIndexEntry)),
+                    equalTo(IntStream.range(151, 200).boxed()
+                            .filter(i -> (i & 1) == 1)
+                            .filter(i -> (i % 7) == 3 && (i % 5) == 4)
+                            .collect(Collectors.toList())));
+        }
+    }
+
+    @Test
+    public void andOrQuery() {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            saveRecords(100, 200);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            setupPlanner(null);
+            final RecordQueryPlan queryPlan = plan(BITMAP_VALUE_REC_NO_BY_STR, Query.and(
+                    Query.field("str_value_indexed").equalsValue("odd"),
+                    Query.field("num_value_2").equalsValue(3),
+                    Query.or(Query.field("num_value_3_indexed").equalsValue(2),
+                             Query.field("num_value_3_indexed").equalsValue(4))));
+            assertThat(queryPlan, compositeBitmap(hasToString("[0] BITAND [1] BITOR [2]"), Arrays.asList(
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num2"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 3],[odd, 3]]"))))),
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num3"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 2],[odd, 2]]"))))),
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num3"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 4],[odd, 4]]"))))))));
+            assertEquals(1173292541, queryPlan.planHash());
+            assertThat(
+                    collectOnBits(queryPlan.execute(recordStore).map(FDBQueriedRecord::getIndexEntry)),
+                    equalTo(IntStream.range(100, 200).boxed()
+                            .filter(i -> (i & 1) == 1)
+                            .filter(i -> (i % 7) == 3 && ((i % 5) == 2 || (i % 5) == 4))
+                            .collect(Collectors.toList())));
+        }
+    }
+
+    @Test
+    public void andOrQueryWithContinuation() {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            saveRecords(100, 200);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            setupPlanner(null);
+            final RecordQueryPlan queryPlan = plan(BITMAP_VALUE_REC_NO_BY_STR, Query.and(
+                    Query.field("str_value_indexed").equalsValue("odd"),
+                    Query.field("num_value_2").equalsValue(3),
+                    Query.or(Query.field("num_value_3_indexed").equalsValue(1),
+                             Query.field("num_value_3_indexed").equalsValue(4))));
+            List<Integer> onBits = new ArrayList<>();
+            int ntimes = 0;
+            byte[] continuation = null;
+            do {
+                RecordCursor<IndexEntry> cursor = queryPlan.execute(recordStore, EvaluationContext.EMPTY, continuation, ExecuteProperties.newBuilder().setReturnedRowLimit(2).build())
+                        .map(FDBQueriedRecord::getIndexEntry);
+                RecordCursorResult<IndexEntry> cursorResult = cursor.forEachResult(i -> onBits.addAll(collectOnBits(i.get()))).join();
+                ntimes++;
+                continuation = cursorResult.getContinuation().toBytes();
+            } while (continuation != null);
+            assertThat(
+                    onBits,
+                    equalTo(IntStream.range(100, 200).boxed()
+                            .filter(i -> (i & 1) == 1)
+                            .filter(i -> (i % 7) == 3 && ((i % 5) == 1 || (i % 5) == 4))
+                            .collect(Collectors.toList())));
+            assertThat(ntimes, equalTo(4));
+        }
+    }
+
+    @Test
+    public void andOrQueryWithDuplicate() {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            saveRecords(100, 200);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, REC_NO_BY_STR_NUMS_HOOK);
+            setupPlanner(null);
+            final RecordQueryPlan queryPlan = plan(BITMAP_VALUE_REC_NO_BY_STR, Query.and(
+                    Query.field("str_value_indexed").equalsValue("odd"),
+                    Query.or(
+                            Query.and(
+                                    Query.field("num_value_2").equalsValue(3),
+                                    Query.field("num_value_3_indexed").equalsValue(0)),
+                            Query.and(
+                                    Query.field("num_value_2").equalsValue(3),
+                                    Query.field("num_value_3_indexed").equalsValue(4)))));
+            assertThat(queryPlan, compositeBitmap(hasToString("[0] BITAND [1] BITOR [0] BITAND [2]"), Arrays.asList(
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num2"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 3],[odd, 3]]"))))),
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num3"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 0],[odd, 0]]"))))),
+                    coveringIndexScan(indexScan(allOf(indexName("rec_no_by_str_num3"), indexScanType(IndexScanType.BY_GROUP), bounds(hasTupleString("[[odd, 4],[odd, 4]]"))))))));
+            assertEquals(1788540340, queryPlan.planHash());
+            assertThat(
+                    collectOnBits(queryPlan.execute(recordStore).map(FDBQueriedRecord::getIndexEntry)),
+                    equalTo(IntStream.range(100, 200).boxed()
+                            .filter(i -> (i & 1) == 1)
+                            .filter(i -> ((i % 7) == 3 && (i % 5) == 0) || ((i % 7) == 3 && (i % 5) == 4))
+                            .collect(Collectors.toList())));
+        }
+    }
+
+    protected static final KeyExpression REC_NO_BY_STR = concatenateFields("str_value_indexed", "rec_no").group(1);
+    protected static final KeyExpression REC_NO_BY_STR_NUM2 = concatenateFields("str_value_indexed", "num_value_2", "rec_no").group(1);
     protected static final KeyExpression REC_NO_BY_STR_NUM3 = concatenateFields("str_value_indexed", "num_value_3_indexed", "rec_no").group(1);
     protected static final Map<String, String> SMALL_BITMAP_OPTIONS = Collections.singletonMap(IndexOptions.BITMAP_VALUE_ENTRY_SIZE_OPTION, "16");
-    protected static final RecordMetaDataHook REC_NO_BY_STR_NUM3_HOOK = metadata -> {
-        metadata.addIndex(metadata.getRecordType("MySimpleRecord"), new Index("rec_no_by_str_num3", REC_NO_BY_STR_NUM3, IndexTypes.BITMAP_VALUE, SMALL_BITMAP_OPTIONS));
+    protected static final RecordMetaDataHook REC_NO_BY_STR_NUMS_HOOK = metadata -> {
+        final RecordTypeBuilder recordType = metadata.getRecordType("MySimpleRecord");
+        metadata.addIndex(recordType, new Index("rec_no_by_str_num2", REC_NO_BY_STR_NUM2, IndexTypes.BITMAP_VALUE, SMALL_BITMAP_OPTIONS));
+        metadata.addIndex(recordType, new Index("rec_no_by_str_num3", REC_NO_BY_STR_NUM3, IndexTypes.BITMAP_VALUE, SMALL_BITMAP_OPTIONS));
     };
+    protected static final IndexAggregateFunction BITMAP_VALUE_REC_NO_BY_STR = new IndexAggregateFunction(FunctionNames.BITMAP_VALUE, REC_NO_BY_STR, null);
 
     protected void saveRecords(int start, int end) {
         for (int recNo = start; recNo < end; recNo++) {
@@ -254,6 +434,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
                     .setRecNo(recNo)
                     .setStrValueIndexed((recNo & 1) == 1 ? "odd" : "even")
                     .setNumValueUnique(recNo + 1000)
+                    .setNumValue2(recNo % 7)
                     .setNumValue3Indexed(recNo % 5)
                     .build());
         }
@@ -282,6 +463,15 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
             }
         }
         return result;
+    }
+
+    protected RecordQueryPlan plan(@Nonnull IndexAggregateFunction function, @Nonnull QueryComponent filter) {
+        return ComposedBitmapIndexAggregate.tryBuild(recordStore, Collections.singletonList("MySimpleRecord"), function, filter)
+                .flatMap(composed -> composed.tryPlan(RecordQuery.newBuilder()
+                                .setRecordType("MySimpleRecord")
+                                .setRequiredResults(Collections.singletonList(Key.Expressions.field("rec_no"))),
+                        recordStore.getRecordMetaData(), (RecordQueryPlanner)planner))
+                .orElseThrow(() -> new IllegalStateException("Cannot plan query"));
     }
 
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/ComposedBitmapIndexMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/ComposedBitmapIndexMatcher.java
@@ -1,0 +1,79 @@
+/*
+ * ComposedBitmapIndexMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.match;
+
+import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * A plan matcher for {@link ComposedBitmapIndexQueryPlan}.
+ */
+public class ComposedBitmapIndexMatcher extends TypeSafeMatcher<RecordQueryPlan> {
+    @Nonnull
+    private final Matcher<ComposedBitmapIndexQueryPlan.ComposerBase> composerMatcher;
+    @Nonnull
+    private final List<Matcher<RecordQueryPlan>> childMatchers;
+
+    public ComposedBitmapIndexMatcher(@Nonnull Matcher<ComposedBitmapIndexQueryPlan.ComposerBase> composerMatcher,
+                                      @Nonnull List<Matcher<RecordQueryPlan>> childMatchers) {
+        this.composerMatcher = composerMatcher;
+        this.childMatchers = childMatchers;
+    }
+
+    @Override
+    public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
+        if (!(plan instanceof ComposedBitmapIndexQueryPlan)) {
+            return false;
+        }
+        ComposedBitmapIndexQueryPlan composedBitmapPlan = (ComposedBitmapIndexQueryPlan)plan;
+        if (!composerMatcher.matches(composedBitmapPlan.getComposer())) {
+            return false;
+        }
+        List<RecordQueryCoveringIndexPlan> childPlans = composedBitmapPlan.getIndexPlans();
+        if (childPlans.size() != childMatchers.size()) {
+            return false;
+        }
+        for (int i = 0; i < childMatchers.size(); i++) {
+            if (!childMatchers.get(i).matches(childPlans.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("ComposedBitmapIndexQueryPlan(");
+        composerMatcher.describeTo(description);
+        for (Matcher<RecordQueryPlan> childMatcher : childMatchers) {
+            description.appendText(", ");
+            childMatcher.describeTo(description);
+        }
+        description.appendText(")");
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithComparisons;
@@ -224,5 +225,10 @@ public class PlanMatchers {
 
     public static Matcher<RecordQueryPlan> hasNoDescendant(@Nonnull Matcher<RecordQueryPlan> matcher) {
         return not(descendant(matcher));
+    }
+
+    public static Matcher<RecordQueryPlan> compositeBitmap(@Nonnull Matcher<ComposedBitmapIndexQueryPlan.ComposerBase> composerMatcher,
+                                                           @Nonnull List<Matcher<RecordQueryPlan>> childMatchers) {
+        return new ComposedBitmapIndexMatcher(composerMatcher, childMatchers);
     }
 }


### PR DESCRIPTION
Overall approach:
* Given a set of `BITMAP_VALUE` indexes differing in the finest grouping key.
* Given a query with:
  - Equality conditions on the coarser grouping keys.
  - A Boolean expression over conditions on the finest keys.
  - Optional inequalities on the position value.
* Produce a plan that:
  - Does covering index entry scans for each of the sub-conditions.
  - Combines the streams of bitmaps from those scans using the bit-wise analogues of the Boolean operators among them.
  - Filters out any bitmaps that end up empty (such as for `AND` with no shared positions within the position range of that bitmap) to cut down result size.


Questions for @normen662: 
* Is it correct for `ComposedBitmapIndexQueryPlan` to not have child plans or should `RecordQueryCoveringIndexPlan` really be `RecordQueryPlanWithChild` too? How do these fit into the `Quantifier` scheme?