### PR TITLE
Resolves #1019: Avoid repeating index endpoints conflicts

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,7 +30,7 @@ Additionally, builds for the project now require JDK 11. The project is still ta
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Avoid repeating index endpoints conflicts [(Issue #1019)](https://github.com/FoundationDB/fdb-record-layer/issues/1019)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -538,8 +538,12 @@ public class OnlineIndexer implements AutoCloseable {
             throw new MetaDataException("Store does not have the same metadata");
         }
         final IndexMaintainer maintainer = store.getIndexMaintainer(index);
+        final boolean isIdempotent = maintainer.isIdempotent();
         final ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder()
-                .setIsolationLevel(IsolationLevel.SERIALIZABLE);
+                .setIsolationLevel(
+                        isIdempotent ?
+                        IsolationLevel.SNAPSHOT :
+                        IsolationLevel.SERIALIZABLE);
         if (respectLimit) {
             executeProperties.setReturnedRowLimit(limit);
         }
@@ -588,6 +592,9 @@ public class OnlineIndexer implements AutoCloseable {
                 return AsyncUtil.READY_TRUE;
             }
             // add this index to the transaction
+            if (isIdempotent) {
+                store.addRecordReadConflict(rec.getPrimaryKey());
+            }
             if (timer != null) {
                 timer.increment(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED);
             }
@@ -1015,11 +1022,19 @@ public class OnlineIndexer implements AutoCloseable {
     @Nonnull
     private CompletableFuture<TupleRange> buildEndpoints(@Nonnull FDBRecordStore store, @Nonnull RangeSet rangeSet,
                                                          @Nullable AtomicLong recordsScanned) {
+        boolean isIdempotent = store.getIndexMaintainer(index).isIdempotent();
+        final IsolationLevel isolationLevel =
+                isIdempotent ?
+                // if idempotent: since double indexing is harmless, we can skip the range conflict protection. At worse,
+                // some records will be re-indexed.
+                IsolationLevel.SNAPSHOT :
+                IsolationLevel.SERIALIZABLE;
         final ExecuteProperties limit1 = ExecuteProperties.newBuilder()
                 .setReturnedRowLimit(1)
-                .setIsolationLevel(IsolationLevel.SERIALIZABLE)
+                .setIsolationLevel(isolationLevel)
                 .build();
         final ScanProperties forward = new ScanProperties(limit1);
+
         RecordCursor<FDBStoredRecord<Message>> beginCursor = store.scanRecords(recordsRange, null, forward);
         CompletableFuture<Tuple> begin = beginCursor.onNext().thenCompose(result -> {
             if (result.hasNext()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1025,8 +1025,10 @@ public class OnlineIndexer implements AutoCloseable {
         boolean isIdempotent = store.getIndexMaintainer(index).isIdempotent();
         final IsolationLevel isolationLevel =
                 isIdempotent ?
-                // if idempotent: since double indexing is harmless, we can skip the range conflict protection. At worse,
-                // some records will be re-indexed.
+                // If idempotent: since double indexing is harmless, we can use individual records protection instead of
+                // a range conflict one - which means that new records, added to the range while indexing the SNAPSHOT,
+                // will not cause a conflict during the commit. At worse, few records (if added after marking WRITE_ONLY but
+                // before this method's query) will be re-indexed.
                 IsolationLevel.SNAPSHOT :
                 IsolationLevel.SERIALIZABLE;
         final ExecuteProperties limit1 = ExecuteProperties.newBuilder()

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerConflictsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerConflictsTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -100,11 +101,11 @@ public class OnlineIndexerConflictsTest extends OnlineIndexerTest {
                 ).collect(Collectors.toList());
 
         List<TestRecords1Proto.MyOtherRecord> otherRecords =
-                LongStream.range(0, 7).mapToObj(val -> TestRecords1Proto.MyOtherRecord.newBuilder().setRecNo(val * 2 + 1).setNumValue2((int) val + 1).build()
+                LongStream.range(0, 7).mapToObj(val -> TestRecords1Proto.MyOtherRecord.newBuilder().setRecNo(val * 2 + 1).setNumValue2((int)val + 1).build()
                 ).collect(Collectors.toList());
 
         List<TestRecords1Proto.MyOtherRecord> otherRecordsOverwrite =
-                LongStream.range(0, 7).mapToObj(val -> TestRecords1Proto.MyOtherRecord.newBuilder().setRecNo(val * 2 + 1).setNumValue2((int) val + 101).build()
+                LongStream.range(0, 7).mapToObj(val -> TestRecords1Proto.MyOtherRecord.newBuilder().setRecNo(val * 2 + 1).setNumValue2((int)val + 101).build()
                 ).collect(Collectors.toList());
 
         Index index = new Index("newIndex", field("num_value_2"), IndexTypes.VALUE);
@@ -147,7 +148,7 @@ public class OnlineIndexerConflictsTest extends OnlineIndexerTest {
     }
 
     @Test
-    public void testAddRecordToRangeWhileIndexedIdempotentFailure() {
+    public void testModifyRecordInRangeWhileIndexedIdempotentFailure() {
 
         List<TestRecords1Proto.MySimpleRecord> records =
                 LongStream.range(0, 20).mapToObj(val -> TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2((int)val + 1).build()
@@ -194,5 +195,58 @@ public class OnlineIndexerConflictsTest extends OnlineIndexerTest {
             }
         }
     }
-}
 
+    @Test
+    public void testAddRecordOutsideRangeWhileIndexedIdempotent() {
+
+        List<TestRecords1Proto.MySimpleRecord> records =
+                LongStream.range(0, 20).mapToObj(val -> TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2((int)val + 1).build()
+                ).collect(Collectors.toList());
+
+        Index index = new Index("newIndex", field("num_value_2"), IndexTypes.VALUE);
+        FDBRecordStoreTestBase.RecordMetaDataHook hookAdd = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+
+        openSimpleMetaData();
+        try (FDBRecordContext context = openContext()) {
+            for (int i = 2; i <= 8; i++) {
+                // even numbers from 4 to 16
+                recordStore.saveRecord(records.get(i * 2));
+            }
+            context.commit();
+        }
+        openSimpleMetaData(hookAdd);
+        try (FDBRecordContext context = openContext()) {
+            context.commit();
+        }
+
+        int[] inserts = {2, 1, 18, 19};
+        for (int i = 0; i < inserts.length; i++) {
+            int record_i = inserts[i];
+
+            try (FDBRecordContext context1 = openContext()) {
+                try (OnlineIndexer indexer =
+                             OnlineIndexer.newBuilder()
+                                     .setRecordStore(recordStore)
+                                     .setIndex("newIndex")
+                                     .build()) {
+                    indexer.buildEndpoints(recordStore).thenApply(tupleRange -> {
+                        return indexer.buildRange(recordStore, Key.Evaluated.fromTuple(tupleRange.getLow()), Key.Evaluated.fromTuple(tupleRange.getHigh()));
+                    }).join();
+
+                    try (FDBRecordContext context2 = openContext()) {
+                        recordStore.saveRecord(records.get(record_i));
+                        // This record is added outside of the indexer's range
+                        context2.commit();
+                    }
+                    context1.commit();
+                }
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                recordStore.clearAndMarkIndexWriteOnly(index).join();
+                context.commit();
+            }
+        }
+    }
+
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerConflictsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerConflictsTest.java
@@ -1,0 +1,198 @@
+/*
+ * OnlineIndexerConflictsTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link OnlineIndexer}. Checking different db manipulations during the indexing process.
+ */
+
+@Tag(Tags.RequiresFDB)
+public class OnlineIndexerConflictsTest extends OnlineIndexerTest {
+
+    @Test
+    public void testAddRecordToRangeWhileIndexedIdempotent() {
+
+        List<TestRecords1Proto.MySimpleRecord> records =
+                LongStream.range(0, 20).mapToObj(val -> TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2((int)val + 1).build()
+                ).collect(Collectors.toList());
+
+        Index index = new Index("newIndex", field("num_value_2"), IndexTypes.VALUE);
+        FDBRecordStoreTestBase.RecordMetaDataHook hookAdd = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+
+        openSimpleMetaData();
+        try (FDBRecordContext context = openContext()) {
+            for (int i = 2; i <= 8; i++) {
+                // even numbers from 4 to 16
+                recordStore.saveRecord(records.get(i * 2));
+            }
+            context.commit();
+        }
+        openSimpleMetaData(hookAdd);
+        try (FDBRecordContext context = openContext()) {
+            context.commit();
+        }
+
+        int[] inserts = {2, 5, 11, 17, 15};
+        for (int i = 0; i < inserts.length; i++) {
+            int record_i = inserts[i];
+
+            try (FDBRecordContext context1 = openContext()) {
+                try (OnlineIndexer indexer =
+                             OnlineIndexer.newBuilder()
+                                     .setRecordStore(recordStore)
+                                     .setIndex("newIndex")
+                                     .build()) {
+                    indexer.buildRange(recordStore, null, null).join();
+                    try (FDBRecordContext context2 = openContext()) {
+                        recordStore.saveRecord(records.get(record_i));
+                        // This record might be added in the indexer's range, but the transaction still commits because it doesn't
+                        // change any existing records.
+                        context2.commit();
+                    }
+                    context1.commit();
+                }
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                recordStore.clearAndMarkIndexWriteOnly(index).join();
+                context.commit();
+            }
+        }
+    }
+
+    @Test
+    public void testAddRecordToRangeWhileIndexedOtherType() {
+
+        List<TestRecords1Proto.MySimpleRecord> records =
+                LongStream.range(0, 7).mapToObj(val -> TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val * 2).setNumValue2((int)val + 1).build()
+                ).collect(Collectors.toList());
+
+        List<TestRecords1Proto.MyOtherRecord> otherRecords =
+                LongStream.range(0, 7).mapToObj(val -> TestRecords1Proto.MyOtherRecord.newBuilder().setRecNo(val * 2 + 1).setNumValue2((int) val + 1).build()
+                ).collect(Collectors.toList());
+
+        List<TestRecords1Proto.MyOtherRecord> otherRecordsOverwrite =
+                LongStream.range(0, 7).mapToObj(val -> TestRecords1Proto.MyOtherRecord.newBuilder().setRecNo(val * 2 + 1).setNumValue2((int) val + 101).build()
+                ).collect(Collectors.toList());
+
+        Index index = new Index("newIndex", field("num_value_2"), IndexTypes.VALUE);
+        FDBRecordStoreTestBase.RecordMetaDataHook hookAdd = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+
+        openSimpleMetaData();
+        try (FDBRecordContext context = openContext()) {
+            records.forEach(recordStore::saveRecord);
+            otherRecords.forEach(recordStore::saveRecord);
+            context.commit();
+        }
+        openSimpleMetaData(hookAdd);
+        try (FDBRecordContext context = openContext()) {
+            context.commit();
+        }
+
+        otherRecordsOverwrite.forEach(rec -> {
+
+            try (FDBRecordContext context1 = openContext()) {
+                try (OnlineIndexer indexer =
+                             OnlineIndexer.newBuilder()
+                                     .setRecordStore(recordStore)
+                                     .setIndex("newIndex")
+                                     .build()) {
+                    indexer.buildRange(recordStore, null, null).join();
+                    try (FDBRecordContext context2 = openContext()) {
+                        recordStore.saveRecord(rec);
+                        // This record's type is different than the indexer's, so both commits should succeed
+                        context2.commit();
+                    }
+                    context1.commit();
+                }
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                recordStore.clearAndMarkIndexWriteOnly(index).join();
+                context.commit();
+            }
+        });
+    }
+
+    @Test
+    public void testAddRecordToRangeWhileIndexedIdempotentFailure() {
+
+        List<TestRecords1Proto.MySimpleRecord> records =
+                LongStream.range(0, 20).mapToObj(val -> TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2((int)val + 1).build()
+                ).collect(Collectors.toList());
+
+        Index index = new Index("newIndex", field("num_value_2"), IndexTypes.VALUE);
+        FDBRecordStoreTestBase.RecordMetaDataHook hookAdd = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+
+        openSimpleMetaData();
+        try (FDBRecordContext context = openContext()) {
+            for (int i = 2; i <= 8; i++) {
+                // even numbers from 4 to 16
+                recordStore.saveRecord(records.get(i * 2));
+            }
+            context.commit();
+        }
+        openSimpleMetaData(hookAdd);
+        try (FDBRecordContext context = openContext()) {
+            context.commit();
+        }
+
+        int[] inserts = {10, 4, 16};
+        for (int i = 0; i < inserts.length; i++) {
+            int record_i = inserts[i];
+
+            try (FDBRecordContext context1 = openContext()) {
+                try (OnlineIndexer indexer =
+                             OnlineIndexer.newBuilder()
+                                     .setRecordStore(recordStore)
+                                     .setIndex("newIndex")
+                                     .build()) {
+                    indexer.buildRange(recordStore, null, null).join();
+                    try (FDBRecordContext context2 = openContext()) {
+                        recordStore.saveRecord(records.get(record_i));
+                        context2.commit();
+                    }
+                    assertThrows(FDBExceptions.FDBStoreTransactionConflictException.class, context1::commit);
+                }
+            }
+
+            try (FDBRecordContext context = openContext()) {
+                recordStore.clearAndMarkIndexWriteOnly(index).join();
+                context.commit();
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
While setting endpoints for indexer, repeating conflicts with other transaction could prevent the job from running.

   resolution: Since the store is marked WRITE_ONLY while determining endpoints and reading the records,
   is seems safe to ignore conflicts caused by insertion of new records - as the inseration should already
   imply valid index entries.