### PR TITLE
Resolves #1024: synchronize subsitutions to the group references

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -155,8 +155,7 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
 
             RecordQueryPlan modifiedChild = child.accept(visitor);
             if (child != modifiedChild) { // intentional use of reference equality, since equals() might not be conservative enough for plans
-                childGroup.clear();
-                childGroup.insert(modifiedChild);
+                childGroup.replace(modifiedChild);
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/GroupExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/GroupExpressionRef.java
@@ -91,6 +91,11 @@ public class GroupExpressionRef<T extends RelationalExpression> implements Expre
         throw new UngettableReferenceException("tried to dereference GroupExpressionRef with " + members.size() + " members");
     }
 
+    public synchronized boolean replace(@Nonnull T newValue) {
+        clear();
+        return insert(newValue);
+    }
+
     @Override
     public boolean insert(@Nonnull T newValue) {
         if (!containsInMemo(newValue)) {


### PR DESCRIPTION
This PR synchronizes mutations to the `HashSet` backing the `GroupExpressionRef`.