### PR TITLE
Fixes #1032: In-as-or optimization can infinitely recurse if normalization as "OR" preserves "IN"

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** A planner optimization to allow more efficiently planing IN queries used to be able to cause an infinite recursion at plan time [(Issue #1032)](https://github.com/FoundationDB/fdb-record-layer/issues/1032)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -410,7 +410,11 @@ public class RecordQueryPlanner implements QueryPlanner {
             boolean canSort = inExtractor.setSort(planContext.query.getSort(), planContext.query.isSortReverse());
             if (!canSort && getConfiguration().shouldAttemptFailedInJoinAsOr()) {
                 // Can't implement as an in join because of the sort order. Try as an OR instead.
-                withInAsOr = planFilter(planContext, normalizeAndOrForInAsOr(inExtractor.asOr()));
+                // Only try if extracting the OR actually changes the filter to avoid recursing infinitely.
+                final QueryComponent asOr = normalizeAndOrForInAsOr(inExtractor.asOr());
+                if (!filter.equals(asOr)) {
+                    withInAsOr = planFilter(planContext, asOr);
+                }
             }
         } else if (needOrdering) {
             inExtractor.sortByClauses();


### PR DESCRIPTION
This fixes addresses the problem by having the planner decide not to try and plan the query again if extracting the IN did not actually change the filter. In this way, it will keep recursing until it either removes the IN, plans the sort, or the component stops changing. At present, I can only think of cases where the first "in" extraction results in an "OR" or the component doesn't change (i.e., I think this should only ever recurse zero or one times), but I could be missing something.

There are two commits here. The first refactors some of the tests around this feature to make a new one easier to write, and the second commit introduces a test that exercises this path and then fixes the bug. (I have validated locally that the new test fails (with a `StackOverflow` error) without the planner fix.)

This fixes #1032.