### PR TITLE
Resolves #1039: partition residual filters into index fiters and true…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Covering filter optimizations and index-applicable filters are now considered as advantageous during planning [(Issue #1039)](https://github.com/FoundationDB/fdb-record-layer/issues/1039)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -34,19 +34,22 @@ public class RecordQueryPlannerConfiguration {
     private final QueryPlanner.IndexScanPreference indexScanPreference;
     private final boolean attemptFailedInJoinAsOr;
     private final int complexityThreshold;
-    private boolean checkForDuplicateConditions;
-    private boolean deferFetchAfterUnionAndIntersection;
+    private final boolean checkForDuplicateConditions;
+    private final boolean deferFetchAfterUnionAndIntersection;
+    private final boolean optimizeForIndexFilters;
 
     private RecordQueryPlannerConfiguration(@Nonnull QueryPlanner.IndexScanPreference indexScanPreference,
                                             boolean attemptFailedInJoinAsOr,
                                             int complexityThreshold,
                                             boolean checkForDuplicateConditions,
-                                            boolean deferFetchAfterUnionAndIntersection) {
+                                            boolean deferFetchAfterUnionAndIntersection,
+                                            boolean optimizeForIndexFilters) {
         this.indexScanPreference = indexScanPreference;
         this.attemptFailedInJoinAsOr = attemptFailedInJoinAsOr;
         this.complexityThreshold = complexityThreshold;
         this.checkForDuplicateConditions = checkForDuplicateConditions;
         this.deferFetchAfterUnionAndIntersection = deferFetchAfterUnionAndIntersection;
+        this.optimizeForIndexFilters = optimizeForIndexFilters;
     }
 
     /**
@@ -94,13 +97,23 @@ public class RecordQueryPlannerConfiguration {
         return checkForDuplicateConditions;
     }
 
-    /*
+    /**
      * Get whether the query planner should attempt to delay the fetch of the whole record until after union,
-     * intersection, and primary key distinct operators, as implemented in the various {@link RecordQueryPlannerSubstitutionVisitor}s.
+     * intersection, and primary key distinct operators, as implemented in the various
+     * {@link com.apple.foundationdb.record.query.plan.visitor.RecordQueryPlannerSubstitutionVisitor}s.
      * @return whether the planner should delay the fetch of the whole record until after union, intersection, and primary key distinct operators
      */
     public boolean shouldDeferFetchAfterUnionAndIntersection() {
         return deferFetchAfterUnionAndIntersection;
+    }
+
+    /**
+     * Get whether the query planner should attempt to consider the applicability of filters that could then be
+     * evaluated on index entries into the planning process.
+     * @return whether the planner should optimize for index filters
+     */
+    public boolean shouldOptimizeForIndexFilters() {
+        return optimizeForIndexFilters;
     }
 
     @Nonnull
@@ -123,12 +136,15 @@ public class RecordQueryPlannerConfiguration {
         private int complexityThreshold = RecordQueryPlanner.DEFAULT_COMPLEXITY_THRESHOLD;
         private boolean checkForDuplicateConditions = false;
         private boolean deferFetchAfterUnionAndIntersection = false;
+        private boolean optimizeForIndexFilters = false;
 
         public Builder(@Nonnull RecordQueryPlannerConfiguration configuration) {
             this.indexScanPreference = configuration.indexScanPreference;
             this.attemptFailedInJoinAsOr = configuration.attemptFailedInJoinAsOr;
             this.complexityThreshold = configuration.complexityThreshold;
             this.checkForDuplicateConditions = configuration.checkForDuplicateConditions;
+            this.deferFetchAfterUnionAndIntersection = configuration.deferFetchAfterUnionAndIntersection;
+            this.optimizeForIndexFilters = configuration.optimizeForIndexFilters;
         }
 
         public Builder() {
@@ -159,8 +175,13 @@ public class RecordQueryPlannerConfiguration {
             return this;
         }
 
+        public Builder setOptimizeForIndexFilters(final boolean optimizeForIndexFilters) {
+            this.optimizeForIndexFilters = optimizeForIndexFilters;
+            return this;
+        }
+
         public RecordQueryPlannerConfiguration build() {
-            return new RecordQueryPlannerConfiguration(indexScanPreference, attemptFailedInJoinAsOr, complexityThreshold, checkForDuplicateConditions, deferFetchAfterUnionAndIntersection);
+            return new RecordQueryPlannerConfiguration(indexScanPreference, attemptFailedInJoinAsOr, complexityThreshold, checkForDuplicateConditions, deferFetchAfterUnionAndIntersection, optimizeForIndexFilters);
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/RankComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/RankComparisons.java
@@ -100,7 +100,7 @@ public class RankComparisons {
     }
 
     @Nullable
-    public List<QueryComponent> planComparisonSubsitutes(@Nullable List<QueryComponent> components) {
+    public List<QueryComponent> planComparisonSubstitutes(@Nullable List<QueryComponent> components) {
         if (components == null || comparisons.isEmpty()) {
             return components;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexTest.java
@@ -1116,8 +1116,7 @@ public class RankIndexTest extends FDBRecordStoreTestBase {
                 .build();
         planner.setIndexScanPreference(QueryPlanner.IndexScanPreference.PREFER_SCAN);
         RecordQueryPlan plan = planner.plan(query);
-        assertEquals("Scan(([buffaloes, 100],[buffaloes]]) | [HeaderRankedRecord]" +
-                        " | score LESS_THAN $__rank_0 WHERE __rank_0 = score_by_nested_id.score_for_rank_else_skip(buffaloes, 2)",
+        assertEquals("Scan(([buffaloes, 100],[buffaloes]]) | [HeaderRankedRecord] | score LESS_THAN $__rank_0 WHERE __rank_0 = score_by_nested_id.score_for_rank_else_skip(buffaloes, 2)",
                 plan.toString());
 
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -386,6 +386,15 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
                 .build());
     }
 
+    protected void setOptimizeForIndexFilters(boolean shouldOptimizeForIndexFilters) {
+        assertTrue(planner instanceof RecordQueryPlanner);
+        RecordQueryPlanner recordQueryPlanner = (RecordQueryPlanner) planner;
+        recordQueryPlanner.setConfiguration(recordQueryPlanner.getConfiguration()
+                .asBuilder()
+                .setOptimizeForIndexFilters(shouldOptimizeForIndexFilters)
+                .build());
+    }
+
     protected static class Holder<T> {
         public T value;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
@@ -251,9 +251,13 @@ public class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase 
                 .build();
         setupPlanner(indexTypes);
         RecordQueryPlan plan = planner.plan(query);
-        assertThat(plan, filter(PredicateMatchers.equivalentTo(query.getFilter()),
-                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), unbounded()))));
-        assertEquals(735933204, plan.planHash());
+        assertThat(plan,
+                filter(PredicateMatchers.equivalentTo(Query.field("num_value_2").equalsValue(0)),
+                        fetch(
+                                filter(PredicateMatchers.equivalentTo(Query.field("num_value_3_indexed").notEquals(1)),
+                                        coveringIndexScan(
+                                                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), unbounded())))))));
+        assertEquals(-2013739934, plan.planHash());
 
         AtomicInteger lastNumValue3 = new AtomicInteger(Integer.MIN_VALUE);
         int returned = querySimpleRecordStore(hook, plan, EvaluationContext::empty,


### PR DESCRIPTION
… residuals

During planning in the heuristic planner we partition `unsatisfiedFilters` into `unsatisfiedFilters` aka `residuals` and `indexFilters` which can be applied on index records. We use that information to favor an index scan over a wider index if there are index filters that can be applied that would allow us to filter records before we fetch them.