### PR TITLE
Fixes #1046: Setting a time limit can lead to "split record without start" error when reading data

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Record scans with a time limit could result in errors or missing versions [(Issue #1046)](https://github.com/FoundationDB/fdb-record-layer/issues/1046)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
@@ -411,9 +411,18 @@ public class ExecuteProperties {
         }
 
         @Nonnull
+        public IsolationLevel getIsolationLevel() {
+            return isolationLevel;
+        }
+
+        @Nonnull
         public Builder setSkip(int skip) {
             this.skip = skip;
             return this;
+        }
+
+        public int getSkip() {
+            return skip;
         }
 
         @Nonnull
@@ -423,9 +432,42 @@ public class ExecuteProperties {
         }
 
         @Nonnull
+        public Builder clearReturnedRowLimit() {
+            return setReturnedRowLimit(Integer.MAX_VALUE);
+        }
+
+        public int getReturnedRowLimit() {
+            return rowLimit;
+        }
+
+        public int getReturnedRowLimitOrMax() {
+            return rowLimit == ReadTransaction.ROW_LIMIT_UNLIMITED ? Integer.MAX_VALUE : rowLimit;
+        }
+
+        @Nonnull
+        public Builder clearSkipAndAdjustLimit() {
+            if (skip != 0) {
+                if (rowLimit != ReadTransaction.ROW_LIMIT_UNLIMITED) {
+                    setReturnedRowLimit(rowLimit + skip);
+                }
+                setSkip(0);
+            }
+            return this;
+        }
+
+        @Nonnull
         public Builder setTimeLimit(long timeLimit) {
             this.timeLimit = validateAndNormalizeTimeLimit(timeLimit);
             return this;
+        }
+
+        @Nonnull
+        public Builder clearTimeLimit() {
+            return setTimeLimit(UNLIMITED_TIME);
+        }
+
+        public long getTimeLimit() {
+            return timeLimit;
         }
 
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1123,16 +1123,18 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     return new FDBRawRecord(primaryKey, kv.getValue(), null, sizeInfo);
                 });
             } else {
-                // Adjust limit to twice the supplied limit in case there are versions in the records
                 final ScanProperties finalScanProperties = scanProperties
                         .with(executeProperties -> {
-                            final ExecuteProperties adjustedExecuteProperties = executeProperties.clearSkipAndAdjustLimit().clearState();
-                            int returnedRowLimit = adjustedExecuteProperties.getReturnedRowLimitOrMax();
+                            final ExecuteProperties.Builder builder = executeProperties.toBuilder()
+                                    .clearTimeLimit()
+                                    .clearSkipAndAdjustLimit()
+                                    .clearState();
+                            int returnedRowLimit = builder.getReturnedRowLimitOrMax();
                             if (returnedRowLimit != Integer.MAX_VALUE) {
-                                return adjustedExecuteProperties.setReturnedRowLimit(2 * returnedRowLimit);
-                            } else {
-                                return adjustedExecuteProperties;
+                                // Adjust limit to twice the supplied limit in case there are versions in the records
+                                builder.setReturnedRowLimit(2 * returnedRowLimit);
                             }
+                            return builder.build();
                         });
                 rawRecords = new SplitHelper.KeyValueUnsplitter(context, recordsSubspace, keyValuesBuilder
                         .setScanProperties(finalScanProperties).build(),


### PR DESCRIPTION
The issue here is that in the code as it was originally, if the meta-data does not allow split records, then the time limit was enforced on the key value cursor. (If you had split records, then the time limit was removed on the very bottom key value cursor, and then only enforced in the wrapping cursor (the "key value unsplitter").) This meant that if you had versionstamps enabled, it was possible for the limiter to stop midway through, between a record and its version (if the time limit was hit at just the wrong time). Now, this removes the time limit from the key value cursor (always) and instead enforces that limit in the wrapping cursor so that it will always stop after reading a full record. This was already being done for the other kinds of limits, but not the time limit.

This fixes #1046.