### PR TITLE
Fixes #1054: "make unbuilt index readable" exception blocks opening a record store

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -14,7 +14,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** "make unbuilt index readable" exception blocks opening a record store [(Issue #1054)](https://github.com/FoundationDB/fdb-record-layer/issues/1054)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -914,11 +914,11 @@ public class MoreAsyncUtil {
     }
 
     /**
-     * Handle when <code>futureSupplier</code> has exception when supplying a future, or the future is completed
+     * Handle when <code>futureSupplier</code> encounters an exception when supplying a future, or the future is completed
      * exceptionally. Unlike the "handle" in CompletableFuture, <code>handlerOnException</code> is not executed if
      * the future is successful.
-     * @param futureSupplier the supplier of future which need to be handled
-     * @param handlerOnException the hanlder when the future has
+     * @param futureSupplier the supplier of future which needs to be handled
+     * @param handlerOnException the handler when the future encounters an exception
      * @param <V> the result type of the future
      * @return future that completes exceptionally if the handler has exception
      */

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -885,8 +885,8 @@ public class MoreAsyncUtil {
      * @param future future to compose the handler onto
      * @param handler handler bi-function to compose onto the passed future
      * @param exceptionMapper function for mapping the underlying exception to a {@link RuntimeException}
-     * @param <V> return type of original future
-     * @param <T> return type of final future
+     * @param <V> type of original future
+     * @param <T> type of final future
      * @return future with same completion properties as the future returned by the handler
      * @see AsyncUtil#composeHandle(CompletableFuture, BiFunction)
      */
@@ -911,6 +911,32 @@ public class MoreAsyncUtil {
                 throw getRuntimeException(handlerSyncException, exceptionMapper);
             }
         });
+    }
+
+    /**
+     * Handle when <code>futureSupplier</code> has exception when supplying a future, or the future is completed
+     * exceptionally. Unlike the "handle" in CompletableFuture, <code>handlerOnException</code> is not executed if
+     * the future is successful.
+     * @param futureSupplier the supplier of future which need to be handled
+     * @param handlerOnException the hanlder when the future has
+     * @param <V> the result type of the future
+     * @return future that completes exceptionally if the handler has exception
+     */
+    public static <V> CompletableFuture<V> handleOnException(Supplier<CompletableFuture<V>> futureSupplier,
+                                                             Function<Throwable, CompletableFuture<V>> handlerOnException) {
+        try {
+            return AsyncUtil.composeHandle(futureSupplier.get(), (futureResult, futureException) -> {
+                if (futureException != null) {
+                    // This is for the case where future completes exceptionally
+                    return handlerOnException.apply(futureException);
+                } else {
+                    return CompletableFuture.completedFuture(futureResult);
+                }
+            });
+        } catch (Exception e) {
+            // This is for the case where futureSupplier.get() throws an error.
+            return handlerOnException.apply(e);
+        }
     }
 
     private static RuntimeException getRuntimeException(@Nonnull Throwable exception,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -2536,6 +2536,17 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public CompletableFuture<Boolean> markIndexReadable(@Nonnull Index index) {
+        return markIndexReadable(index, false);
+    }
+
+    /**
+     * When <code>force</code> is <code>true</code>, it checks unbuilt range and uniqueness violation and logs them,
+     * but it marks the index as readable regardless. This option is provided because the subspace might have been used
+     * by another index earlier and there is reason to not {@link #clearIndexData(Index)}. This is preferred in production
+     * comparing to {@link #uncheckedMarkIndexReadable(String)} which does not verify at all.
+     */
+    @Nonnull
+    private CompletableFuture<Boolean> markIndexReadable(@Nonnull Index index, boolean force) {
         if (recordStoreStateRef.get() == null) {
             return preloadRecordStoreStateAsync().thenCompose(vignore -> markIndexReadable(index));
         }
@@ -2552,26 +2563,17 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     CompletableFuture<Optional<Range>> builtFuture = firstUnbuiltRange(index);
                     CompletableFuture<Optional<RecordIndexUniquenessViolation>> uniquenessFuture = scanUniquenessViolations(index, 1).first();
                     return CompletableFuture.allOf(builtFuture, uniquenessFuture).thenApply(vignore -> {
-                        Optional<Range> firstUnbuilt = context.join(builtFuture);
-                        Optional<RecordIndexUniquenessViolation> uniquenessViolation = context.join(uniquenessFuture);
-                        if (firstUnbuilt.isPresent()) {
-                            throw new IndexNotBuiltException("Attempted to make unbuilt index readable" , firstUnbuilt.get(),
-                                    LogMessageKeys.INDEX_NAME, index.getName(),
-                                    "unbuiltRangeBegin", ByteArrayUtil2.loggable(firstUnbuilt.get().begin),
-                                    "unbuiltRangeEnd", ByteArrayUtil2.loggable(firstUnbuilt.get().end),
-                                    subspaceProvider.logKey(), subspaceProvider.toString(context),
-                                    LogMessageKeys.SUBSPACE_KEY, index.getSubspaceKey());
-                        } else if (uniquenessViolation.isPresent()) {
-                            RecordIndexUniquenessViolation wrapped = new RecordIndexUniquenessViolation("Uniqueness violation when making index readable",
-                                                                                                        uniquenessViolation.get());
-                            wrapped.addLogInfo(
-                                    LogMessageKeys.INDEX_NAME, index.getName(),
-                                    subspaceProvider.logKey(), subspaceProvider.toString(context));
-                            throw wrapped;
-                        } else {
-                            updateIndexState(index.getName(), indexKey, IndexState.READABLE);
-                            return true;
+                        try {
+                            verifyIndexReadable(index, builtFuture, uniquenessFuture);
+                        } catch (Exception e) {
+                            if (force) {
+                                logExceptionAsWarn("force marking index readable with exception", e);
+                            } else {
+                                throw e;
+                            }
                         }
+                        updateIndexState(index.getName(), indexKey, IndexState.READABLE);
+                        return true;
                     });
                 } else {
                     return AsyncUtil.READY_FALSE;
@@ -2606,12 +2608,45 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return markIndexReadable(getRecordMetaData().getIndex(indexName));
     }
 
+    private void logExceptionAsWarn(String message, Throwable exception) {
+        if (exception instanceof LoggableException) {
+            LoggableException loggable = (LoggableException) exception;
+            LOGGER.warn(KeyValueLogMessage.build(message)
+                            .addKeysAndValues(loggable.getLogInfo()).toString(),
+                    loggable);
+        } else {
+            LOGGER.warn(message, exception);
+        }
+    }
+
+    private void verifyIndexReadable(final @Nonnull Index index,
+                                     final CompletableFuture<Optional<Range>> builtFuture,
+                                     final CompletableFuture<Optional<RecordIndexUniquenessViolation>> uniquenessFuture)
+            throws RecordCoreException {
+        Optional<Range> firstUnbuilt = context.join(builtFuture);
+        Optional<RecordIndexUniquenessViolation> uniquenessViolation = context.join(uniquenessFuture);
+        if (firstUnbuilt.isPresent()) {
+            throw new IndexNotBuiltException("Attempted to make unbuilt index readable" , firstUnbuilt.get(),
+                    LogMessageKeys.INDEX_NAME, index.getName(),
+                    "unbuiltRangeBegin", ByteArrayUtil2.loggable(firstUnbuilt.get().begin),
+                    "unbuiltRangeEnd", ByteArrayUtil2.loggable(firstUnbuilt.get().end),
+                    subspaceProvider.logKey(), subspaceProvider.toString(context),
+                    LogMessageKeys.SUBSPACE_KEY, index.getSubspaceKey());
+        } else if (uniquenessViolation.isPresent()) {
+            RecordIndexUniquenessViolation wrapped = new RecordIndexUniquenessViolation("Uniqueness violation when making index readable",
+                    uniquenessViolation.get());
+            wrapped.addLogInfo(
+                    LogMessageKeys.INDEX_NAME, index.getName(),
+                    subspaceProvider.logKey(), subspaceProvider.toString(context));
+            throw wrapped;
+        }
+    }
+
     /**
      * Marks the index with the given name as readable without checking to see if it is
      * ready. This is dangerous to do if one has not first verified that the
      * index is ready to be readable as it can cause half-built indexes to be
      * used within queries and can thus produce inconsistent results.
-     *
      * @param indexName the name of the index to mark readable
      * @return a future that will contain <code>true</code> if the store was modified
      * and <code>false</code> otherwise
@@ -3057,7 +3092,14 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     Index index = indexItem.getKey();
                     List<RecordType> recordTypes = indexItem.getValue();
                     IndexState indexState = newStates.getOrDefault(index, IndexState.READABLE);
-                    work.add(rebuildOrMarkIndex(index, indexState, recordTypes, reason, oldMetaDataVersion));
+                    final CompletableFuture<Void> rebuildOrMarkIndexSafely = MoreAsyncUtil.handleOnException(
+                            () -> rebuildOrMarkIndex(index, indexState, recordTypes, reason, oldMetaDataVersion),
+                            exception -> {
+                                // If there is anything issue, simply mark the index as disabled without blocking checkVersion
+                                logExceptionAsWarn("unable build index", exception);
+                                return markIndexDisabled(index).thenApply(b -> null);
+                            });
+                    work.add(rebuildOrMarkIndexSafely);
                 } else {
                     break;
                 }
@@ -3119,7 +3161,10 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             }
         }
 
-        return markIndexReadable(index).thenApply(b -> null);
+        // The index states is supposed to be empty (i.e. readable) because this is a new index. But unfortunately, the
+        // index state is keyed by index name which can be reused. So we need to mark the index readable. In such case,
+        // the built range is unlikely to be full so we should force it.
+        return markIndexReadable(index, true).thenApply(b -> null);
     }
 
     /**


### PR DESCRIPTION
This happens when check version tries to `rebuildIndexWithNoRecord` but the index was not readable (probably related to reusing index name, also see #794 which was reverted)

There are two things need to be fixed:

1. In such situation it should mark the index to readable regardless

2. In any case, marking index as readable should not block the critical path (`checkVersion`), whose failure can people unable to do anything with the record store.