### PR TITLE
Fixes #1061: Fix the instruction document of building Record Layer

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -4,6 +4,54 @@
 
 Before contributing to the Record Layer, please see the [contribution guide](https://github.com/FoundationDB/fdb-record-layer/blob/master/CONTRIBUTING.md).
 
+## Configuring IntelliJ
+
+1. Fork and clone the [repository](https://github.com/FoundationDB/fdb-record-layer).
+
+1. Run
+
+        ./gradlew package
+
+    on the root directory of the local clone.
+    
+1. *(Skip if you are not interested in running the tests.)*\
+ Install FDB on your development machine. The latest FDB binaries can be found on
+the [FoundationDB website](https://www.foundationdb.org/download/).
+
+1. Install and launch [IntelliJ IDEA](https://www.jetbrains.com/idea/). This document is based on Version 2020.2.3.
+
+1. In the "Welcome to IntelliJ IDEA" window, click "Open or import" and open the project's root directory. (If you do not see the welcome window, File > Open can do the same.)
+
+1. In the Gradle tool window (expand by clicking the Gradle button on right top), click ![the Reload All Gradle Projects button](https://resources.jetbrains.com/help/img/idea/2020.2/icons.actions.refresh.svg) on the toolbar.
+
+1. Build > Build Project.
+
+1. Preferences > Editor > General > Auto Import > Optimize imports on the fly (for current project)
+
+1. *(This is optional, but useful.)*\
+ Preferences > Build, Execution, and Deployment > Build Tools > Maven > Importing > Automatically download > Sources
+
+**Now you have configured IntelliJ successfully!**
+
+*(Skip if you are not interested in running the tests.)*\
+To verify that you have a working configuration, pick some tests that depend on FDB (such as those in the `FDBRecordStoreQueryTest` fixture), and check you can run them from IntelliJ.
+
+If this does not work smoothly for you, please create a [new issue](https://github.com/FoundationDB/fdb-record-layer/issues/new) or ask in [the forum](https://forums.foundationdb.org/c/using-layers).
+
+### Behind the Scene
+
+*(This section explains what happened above and why, in case you are interested.)*
+
+The `./gradlew package` command (Step 2) generates the protobuf files.
+
+If you are used to opening older `.ipr`-based IntelliJ projects, the process for opening this project will be somewhat different. Instead of selecting the `fdb-record-layer.ipr` file, open the project's root directory; IntelliJ will find the project configuration in the `.idea` directory.
+
+The Record Layer project does not use the Gradle IDEA plugin, unlike many similar projects. Instead, it uses IntelliJ IDEA's builtin Gradle support to compile the project and run the tests; the repository will run a "sync" with the Gradle configuration when you load Gradle project (Step 6).
+
+If you make changes to most IntelliJ settings, they will save over the files that are checked into Git. These changes can be shared by committing the updated files.
+
+However, there are a few settings that we use for consistency that are saved in the user-specific `workspace.xml` file. These settings must be enabled manually by each developer. (Step 8, 9)
+
 ## Building the Core
 
 To do the full suite of checks and tests run:
@@ -16,35 +64,6 @@ If you enable the local repo in whatever uses the Record Layer, the following wi
 ```
 ./gradlew publishToMavenLocal
 ```
-
-## Configuring IntelliJ
-
-The Record Layer project does not use the Gradle IDEA plugin, unlike many similar projects. Instead, it uses IntelliJ IDEA's builtin Gradle support to compile the project and run the tests; the repository will run a "sync" with the Gradle configuration every time the project is opened or a file referenced from `build.gradle` is changed.
-
-If you are used to opening older `.ipr`-based IntelliJ projects, the process for opening this project will be somewhat different. Instead of selecting the `fdb-record-layer.ipr` file, open the project's root directory; IntelliJ will find the project configuration in the `.idea` directory.
-
-If you make changes to most IntelliJ settings, they will save over the files that are checked into Git. These changes can be shared by committing the updated files.
-
-There are a few settings that we use for consistency that are saved in the user-specific `workspace.xml` file. These settings must be enabled manually by each developer:
-
-* Preferences > Editor > General > Auto Import > Optimize imports on the fly (for current project)
-
-* (optional, but useful) Preferences > Build, Execution, and Deployment > Build Tools > Maven > Importing > Automatically download > Sources
-
-Before attempting to build anything, exit IntelliJ and build once from the command line. This will generate the protobuf files.
-
-```
-./gradlew package
-```
-
-Launch IntelliJ again and Build > Build Project should succeed.
-
-To verify that you have a working configuration, pick some tests that depend on FDB (such as those in the `FDBRecordStoreQueryTest` fixture), and check that you can run them from IntelliJ.
-
-## Running the tests
-
-In order to run the tests you will need to have FDB installed on your development machine. The latest FDB binaries can be found on
-the [FoundationDB website](https://www.foundationdb.org/download/).
 
 ## Configuring tests for a non-standard FDB cluster file location
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -38,13 +38,11 @@ To verify that you have a working configuration, pick some tests that depend on 
 
 If this does not work smoothly for you, please create a [new issue](https://github.com/FoundationDB/fdb-record-layer/issues/new) or ask in [the forum](https://forums.foundationdb.org/c/using-layers).
 
-### Behind the Scene
+### Behind the Scenes
 
 *(This section explains what happened above and why, in case you are interested.)*
 
 The `./gradlew package` command (Step 2) generates the protobuf files.
-
-If you are used to opening older `.ipr`-based IntelliJ projects, the process for opening this project will be somewhat different. Instead of selecting the `fdb-record-layer.ipr` file, open the project's root directory; IntelliJ will find the project configuration in the `.idea` directory.
 
 The Record Layer project does not use the Gradle IDEA plugin, unlike many similar projects. Instead, it uses IntelliJ IDEA's builtin Gradle support to compile the project and run the tests; the repository will run a "sync" with the Gradle configuration when you load Gradle project (Step 6).
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix the instruction document of building Record Layer [(Issue #1061)](https://github.com/FoundationDB/fdb-record-layer/issues/1061)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
"Building the Record Layer / Configuring IntelliJ" document is not updated with the last IntelliJ for a while, which made the new developers unable to build the project following the instructions. We need to find out the correct process and document it clearly to help developers onboard painlessly.

I've also updated `.idea/compiler.xml` to what I got after the process. 

Tip: it's easier to view the changes in rich diff
<img width="789" alt="image" src="https://user-images.githubusercontent.com/5558370/97512335-7d911f80-1946-11eb-83eb-81ba34477fe5.png">
