### PR TITLE
Resolves #737: Count indexes should be cleared when decremented to zero

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Count indexes can be cleared when decremented to zero [(Issue #737)](https://github.com/FoundationDB/fdb-record-layer/issues/737)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -110,6 +110,11 @@ public class IndexOptions {
      */
     public static final String BITMAP_VALUE_ENTRY_SIZE_OPTION = "bitmapValueEntrySize";
 
+    /**
+     * Whether to remove index entry for {@link IndexTypes#COUNT} type indexes when they decrement to zero.
+     */
+    public static final String CLEAR_WHEN_ZERO = "clearWhenZero";
+
     private IndexOptions() {
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -112,6 +112,13 @@ public class IndexOptions {
 
     /**
      * Whether to remove index entry for {@link IndexTypes#COUNT} type indexes when they decrement to zero.
+     *
+     * This makes the existence of zero-valued entries in the index in the face of updates and deletes
+     * closer to what it would be if the index were rebuilt, but still not always the same.
+     * In particular,<ul>
+     *   <li>A {@code SUM} index will not have entries for groups all of whose indexed values are zero.</li>
+     *   <li>Changing the option for an existing index from {@code false} to {@code true} does not clear any entries.</li>
+     * </ul>
      */
     public static final String CLEAR_WHEN_ZERO = "clearWhenZero";
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -215,6 +215,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @SuppressWarnings("squid:S2386")
     @SpotBugsSuppressWarnings("MS_MUTABLE_ARRAY")
     public static final byte[] LITTLE_ENDIAN_INT64_MINUS_ONE = new byte[] { -1, -1, -1, -1, -1, -1, -1, -1 };
+    @SuppressWarnings("squid:S2386")
+    @SpotBugsSuppressWarnings("MS_MUTABLE_ARRAY")
+    public static final byte[] INT64_ZERO = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     protected int formatVersion;
     protected int userVersion;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
@@ -155,8 +155,6 @@ public class AtomicMutationIndexMaintainer extends StandardIndexMaintainer {
                 }
             }
 
-            final byte[] compareAndClear = mutation.getCompareAndClearParam();
-
             final byte[] key = state.indexSubspace.pack(groupKey);
             if (AtomicMutation.Standard.MAX_EVER_VERSION.equals(mutation)) {
                 if (groupedValue.getKey().hasIncompleteVersionstamp()) {
@@ -172,6 +170,7 @@ public class AtomicMutationIndexMaintainer extends StandardIndexMaintainer {
                 }
             } else {
                 state.transaction.mutate(mutationType, key, param);
+                final byte[] compareAndClear = mutation.getCompareAndClearParam();
                 if (compareAndClear != null) {
                     state.transaction.mutate(MutationType.COMPARE_AND_CLEAR, key, compareAndClear);
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
@@ -107,6 +108,9 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
                     validateVersionInGroupedKeys();
                 } else {
                     validateNotVersion();
+                }
+                if (AtomicMutationIndexMaintainer.getClearWhenZero(index) && mutation.getCompareAndClearParam() == null) {
+                    throw new MetaDataException(String.format("%s index does not support clearWhenZero", index.getType()));
                 }
             }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -114,6 +114,11 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
                 }
             }
 
+            // NOTE: There is no override of validateChangedOptions for CLEAR_WHEN_ZERO.
+            // Turning it on does not immediately clear to zero without a rebuild.
+            // But it is still valid, provided one understands the option to mean that the clear happens at decrement time.
+            // A system requiring that it become clear immediately can arrange for the index to be rebuilt.
+
             @Override
             public void validateIndexForRecordType(@Nonnull RecordType recordType, @Nonnull MetaDataValidator metaDataValidator) {
                 final List<Descriptors.FieldDescriptor> fields = metaDataValidator.validateIndexForRecordType(index, recordType);


### PR DESCRIPTION
This takes the approach suggested in the comment of making this an optional behavior defaulting to off, for the reasons stated there: it avoids incompatible changes and makes `SUM` and `COUNT` symmetrical.