### PR TITLE
Backport #1097 to 2.10.48 branch

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Count indexes can be cleared when decremented to zero [(Issue #737)](https://github.com/FoundationDB/fdb-record-layer/issues/737)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -110,6 +110,18 @@ public class IndexOptions {
      */
     public static final String BITMAP_VALUE_ENTRY_SIZE_OPTION = "bitmapValueEntrySize";
 
+    /**
+     * Whether to remove index entry for {@link IndexTypes#COUNT} type indexes when they decrement to zero.
+     *
+     * This makes the existence of zero-valued entries in the index in the face of updates and deletes
+     * closer to what it would be if the index were rebuilt, but still not always the same.
+     * In particular,<ul>
+     *   <li>A {@code SUM} index will not have entries for groups all of whose indexed values are zero.</li>
+     *   <li>Changing the option for an existing index from {@code false} to {@code true} does not clear any entries.</li>
+     * </ul>
+     */
+    public static final String CLEAR_WHEN_ZERO = "clearWhenZero";
+
     private IndexOptions() {
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -215,6 +215,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @SuppressWarnings("squid:S2386")
     @SpotBugsSuppressWarnings("MS_MUTABLE_ARRAY")
     public static final byte[] LITTLE_ENDIAN_INT64_MINUS_ONE = new byte[] { -1, -1, -1, -1, -1, -1, -1, -1 };
+    @SuppressWarnings("squid:S2386")
+    @SpotBugsSuppressWarnings("MS_MUTABLE_ARRAY")
+    public static final byte[] INT64_ZERO = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     protected int formatVersion;
     protected int userVersion;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
@@ -20,8 +20,8 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
-import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.MutationType;
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.FunctionNames;
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
+import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
@@ -72,19 +73,23 @@ public class AtomicMutationIndexMaintainer extends StandardIndexMaintainer {
         this.mutation = mutation;
     }
 
+    protected static boolean getClearWhenZero(@Nonnull Index index) {
+        return index.getBooleanOption(IndexOptions.CLEAR_WHEN_ZERO, false);
+    }
+
     @SuppressWarnings({"deprecation","squid:CallToDeprecatedMethod"})
     protected static AtomicMutation getAtomicMutation(@Nonnull Index index) {
         if (IndexTypes.COUNT.equals(index.getType())) {
-            return AtomicMutation.Standard.COUNT;
+            return getClearWhenZero(index) ? AtomicMutation.Standard.COUNT_CLEAR_WHEN_ZERO : AtomicMutation.Standard.COUNT;
         }
         if (IndexTypes.COUNT_UPDATES.equals(index.getType())) {
             return AtomicMutation.Standard.COUNT_UPDATES;
         }
         if (IndexTypes.COUNT_NOT_NULL.equals(index.getType())) {
-            return AtomicMutation.Standard.COUNT_NOT_NULL;
+            return getClearWhenZero(index) ? AtomicMutation.Standard.COUNT_NOT_NULL_CLEAR_WHEN_ZERO : AtomicMutation.Standard.COUNT_NOT_NULL;
         }
         if (IndexTypes.SUM.equals(index.getType())) {
-            return AtomicMutation.Standard.SUM_LONG;
+            return getClearWhenZero(index) ? AtomicMutation.Standard.SUM_LONG_CLEAR_WHEN_ZERO : AtomicMutation.Standard.SUM_LONG;
         }
         if (IndexTypes.MIN_EVER_TUPLE.equals(index.getType())) {
             return AtomicMutation.Standard.MIN_EVER_TUPLE;
@@ -165,6 +170,10 @@ public class AtomicMutationIndexMaintainer extends StandardIndexMaintainer {
                 }
             } else {
                 state.transaction.mutate(mutationType, key, param);
+                final byte[] compareAndClear = mutation.getCompareAndClearParam();
+                if (compareAndClear != null) {
+                    state.transaction.mutate(MutationType.COMPARE_AND_CLEAR, key, compareAndClear);
+                }
             }
             if (state.store.getTimer() != null) {
                 state.store.getTimer().recordSinceNanoTime(FDBStoreTimer.Events.MUTATE_INDEX_ENTRY, startTime);


### PR DESCRIPTION
Resolves #737: Count indexes should be cleared when decremented to zero (#1097)

This takes the approach suggested in the comment of making this an optional behavior defaulting to off, for the reasons stated there: it avoids incompatible changes and makes `SUM` and `COUNT` symmetrical.