### PR TITLE
Resolves #1102: Regenerate .idea/compiler.xml

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -40,14 +40,35 @@
     </wildcardResourcePatterns>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0-rc6/4586e4191111b24135ffac93d3e1a91e91bf71d3/auto-service-1.0-rc6.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service-annotations/1.0-rc6/32c6a6313217c949396376d9caddb6b8c8f4e7c3/auto-service-annotations-1.0-rc6.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/0.10/c8f153ebe04a17183480ab4016098055fb474364/auto-common-0.10.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/27.0.1-jre/bd41a290787b5301e63929676d792c507bbc00ae/guava-27.0.1-jre.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/b421526c5f297295adef1c886e5246c39d4ac629/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-qual/2.5.2/cea74543d5904a30861a61b4643a5f2bb372efc4/checker-qual-2.5.2.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.2.0/88e3c593e9b3586e1c6177f89267da6fc6986f0c/error_prone_annotations-2.2.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/ed28ded51a8b1c6b112568def5f4b455e6809019/j2objc-annotations-1.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.17/f97ce6decaea32b36101e37979f8b647f00681fb/animal-sniffer-annotations-1.17.jar" />
+        </processorPath>
+        <module name="fdb-record-layer.fdb-record-layer-core.main" />
+        <module name="fdb-record-layer.fdb-record-layer-spatial.main" />
+        <module name="fdb-record-layer.fdb-record-layer-core.test" />
+        <module name="fdb-record-layer.fdb-record-layer-icu.main" />
+      </profile>
     </annotationProcessing>
-    <bytecodeTargetLevel>
+    <bytecodeTargetLevel target="1.8">
       <module name="examples_integrationTest" target="1.8" />
       <module name="examples_main" target="1.8" />
       <module name="examples_test" target="1.8" />
       <module name="fdb-extensions_integrationTest" target="1.8" />
       <module name="fdb-extensions_main" target="1.8" />
       <module name="fdb-extensions_test" target="1.8" />
+      <module name="fdb-record-layer" target="11" />
       <module name="fdb-record-layer-core-shaded_integrationTest" target="1.8" />
       <module name="fdb-record-layer-core-shaded_main" target="1.8" />
       <module name="fdb-record-layer-core-shaded_test" target="1.8" />
@@ -60,6 +81,8 @@
       <module name="fdb-record-layer-spatial_integrationTest" target="1.8" />
       <module name="fdb-record-layer-spatial_main" target="1.8" />
       <module name="fdb-record-layer-spatial_test" target="1.8" />
+      <module name="fdb-record-layer.main" target="11" />
+      <module name="fdb-record-layer.test" target="11" />
       <module name="fdb-record-layer_main" target="1.8" />
       <module name="fdb-record-layer_test" target="1.8" />
     </bytecodeTargetLevel>


### PR DESCRIPTION
This regenerates the `.idea` configuration for the compiler. This was done by just importing the probject into the IDE and then letting it edit the file. This basically just sets the dependencies, etc., and a few language target things. We may have to regenerate this file again, but this should stop this change from being accidentally included in future PRs.