### PR TITLE
Resolves #1076: [bug] Continuation unused in scanIndex with EndpointT…

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -227,8 +227,13 @@ public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements Bas
                 prefixLength++;
             }
 
+            if (lowEndpoint == EndpointType.PREFIX_STRING || highEndpoint == EndpointType.PREFIX_STRING) {
+                prefixLength = prefixLength - 1;
+            }
+
             final boolean reverse = scanProperties.isReverse();
             if (continuation != null) {
+
                 final byte[] continuationBytes = new byte[prefixLength + continuation.length];
                 System.arraycopy(lowBytes, 0, continuationBytes, 0, prefixLength);
                 System.arraycopy(continuation, 0, continuationBytes, prefixLength, continuation.length);


### PR DESCRIPTION
A `PREFIX_STRING` provided by the user is encoded with null termination. When scanning using endpoint type `PREFIX_STRING`, on continuations, this is concatenated with the last key from the previous scan. In so doing, the prefix's null terminator should not be included. 

e.g. suppose there were four keys:

`cata
catb
catc
catd`

.. and `PREFIX_STRING` was `cat`, then the objective is to find all four tuples with key prefixed by `cat`.

if the first scan located two tuples `cata` and `catb`, and then paused (for any reason), then, the second scan would continue where the first left off. In which case, the "last key" in the continuation structure would be `b` (the suffix after `cat`).

the bug was: a null terminator was included between `cat` and `b`, resulting in continuing from `cat\0b`.  That resulted in failed scans; rather than proceeding to keys `catc` and `catd`, the scan would restart at the beginning `cata`.

the solution is to not include the null terminator when concatenating the last key suffix with the prefix. 