### PR TITLE
Resolves #1110: Covering aggregate scans and duplicates

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
@@ -217,8 +217,7 @@ public class ComposedBitmapIndexAggregate {
                 queryBuilder.setFilter(indexNode.filter);
                 final Index index = planner.getRecordMetaData().getIndex(indexNode.indexName);
                 final KeyExpression wholeKey = ((GroupingKeyExpression)index.getRootExpression()).getWholeKey();
-                final RecordQueryCoveringIndexPlan indexScan = planner.planCoveringAggregateIndex(queryBuilder.build(), index,
-                        wholeKey, true); // Partial view of repeated field is okay for composition.
+                final RecordQueryCoveringIndexPlan indexScan = planner.planCoveringAggregateIndex(queryBuilder.build(), index, wholeKey);
                 if (indexScan == null) {
                     return null;
                 }


### PR DESCRIPTION
The `planCoveringAggregateIndex` mini-planner doesn't need to have the same restrictions about repeated fields because they were taken care of when building the index and from the scan we will just reconstitute single-element lists for each unique value.