### PR TITLE
Resolve 1107:  Add persistent continuation to 'indexing by index'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ atlassian-ide-plugin.xml
 .idea/compiler.xml
 .idea/gradle.xml
 .idea/jarRepositories.xml
+.idea/shelf
 
 # Eclipse specific files/directories
 .classpath

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Feature** Count indexes can be cleared when decremented to zero [(Issue #737)](https://github.com/FoundationDB/fdb-record-layer/issues/737)
 * **Feature** Allow creating a target index by iterating a source index of the same type [(Issue #1078)](https://github.com/FoundationDB/fdb-record-layer/issues/1078)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Add persistent continuation to indexing by index & parallel indexing [(Issue #1107)](https://github.com/FoundationDB/fdb-record-layer/issues/1107)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Feature** Count indexes can be cleared when decremented to zero [(Issue #737)](https://github.com/FoundationDB/fdb-record-layer/issues/737)
 * **Feature** Allow creating a target index by iterating a source index of the same type [(Issue #1078)](https://github.com/FoundationDB/fdb-record-layer/issues/1078)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Add persistent continuation to indexing by index & parallel indexing [(Issue #1107)](https://github.com/FoundationDB/fdb-record-layer/issues/1107)
+* **Feature** Add persistent continuation and parallel indexing to indexing by index [(Issue #1107)](https://github.com/FoundationDB/fdb-record-layer/issues/1107)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -150,6 +150,8 @@ public enum LogMessageKeys {
 
     // comparisons
     COMPARISON_VALUE("comparison_value"),
+    EXPECTED("expected"),
+    ACTUAL("actual"),
     // functional index keys
     FUNCTION("function"),
     INDEX_KEY("index_key"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -3535,11 +3535,14 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         tr.clear(indexSecondarySubspace(index).range());
         tr.clear(indexRangeSubspace(index).range());
         tr.clear(indexUniquenessViolationsSubspace(index).range());
-        // Under the index build subspace, there are two lower level subspaces, the lock space and the scanned records
-        // subspace. We are not supposed to clear the lock subspace, which is used to run online index jobs which may
-        // invoke this method. But we should clear the scanned records subspace, which, roughly speaking, counts how
-        // many records of this store are covered in index range subspace.
+        // Under the index build subspace, there are 3 lower level subspaces, the lock space, the scanned records
+        // subspace, and the type/stamp subspace. We are not supposed to clear the lock subspace, which is used to
+        // run online index jobs which may invoke this method. We should clear:
+        // * the scanned records subspace. Which, roughly speaking, counts how many records of this store are covered in
+        // index range subspace.
+        // * the type/stamp subspace. Which indicates which type of indexing is in progress.
         tr.clear(OnlineIndexer.indexBuildScannedRecordsSubspace(this, index).range());
+        tr.clear(Range.startsWith(OnlineIndexer.indexBuildTypeSubspace(this, index).pack()));
     }
 
     public void removeFormerIndex(FormerIndex formerIndex) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.util.LoggableException;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,7 +121,6 @@ public class IndexingThrottle {
         }
     }
 
-    @VisibleForTesting
     void decreaseLimit(@Nonnull FDBException fdbException,
                        @Nullable List<Object> additionalLogMessageKeyValues) {
         limit = Math.max(1, (3 * limit) / 4);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -429,7 +429,7 @@ public class OnlineIndexer implements AutoCloseable {
     public CompletableFuture<Void> rebuildIndexAsync(@Nonnull FDBRecordStore store) {
         return AsyncUtil.composeHandle( getIndexer().rebuildIndexAsync(store),
                 (ignore, ex) ->
-                        handleIndexerReturnOrFallback(ex, () -> getIndexer().rebuildIndexAsync(store)));
+                        handleIndexerReturnOrFallback(ex, () -> getIndexer().setFallbackMode().rebuildIndexAsync(store)));
     }
 
     /**
@@ -565,7 +565,7 @@ public class OnlineIndexer implements AutoCloseable {
     CompletableFuture<Void> buildIndexAsync(boolean markReadable) {
         return AsyncUtil.composeHandle(getIndexer().buildIndexAsync(markReadable),
                 (ignore, ex) ->
-                        handleIndexerReturnOrFallback(ex, () -> getIndexer().buildIndexAsync(markReadable)));
+                        handleIndexerReturnOrFallback(ex, () -> getIndexer().setFallbackMode().buildIndexAsync(markReadable)));
     }
 
     @Nonnull
@@ -576,6 +576,11 @@ public class OnlineIndexer implements AutoCloseable {
     @Nonnull
     protected static Subspace indexBuildScannedRecordsSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
         return IndexingBase.indexBuildScannedRecordsSubspace(store, index);
+    }
+
+    @Nonnull
+    protected static Subspace indexBuildTypeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        return IndexingBase.indexBuildTypeSubspace(store, index);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/proto/index_build.proto
+++ b/fdb-record-layer-core/src/main/proto/index_build.proto
@@ -21,20 +21,20 @@
 syntax = "proto2";
 
 package com.apple.foundationdb.record;
-import "google/protobuf/descriptor.proto";
-
-option java_outer_classname = "IndexMetaDataProto";
+option java_outer_classname = "IndexBuildProto";
 
 // This stamp indicates an ongoing indexing process. It will be used to assure a coherent indexing
 // continuation - which continued by another process.
-message IndexMetaDataIndexingStamp {
+
+message IndexBuildIndexingStamp {
   enum Method {
     INVALID    = 0;   // let zero be invalid
     BY_RECORDS = 1;   // indexing by records - scanning all records in a record store
     BY_INDEX   = 2;   // indexing by a source index. When source index points to all possible records of the target index.
   };
-  optional Method method      = 1;
-  optional string sourceIndex = 2; // relevant only to BY_INDEX method
-}
+  optional Method method = 1;
+  optional bytes source_index_subspace_key = 2; // relevant only with BY_INDEX method
+  optional int32 source_index_last_modified_version = 3; // only with BY_INDEX method
+ }
 
 

--- a/fdb-record-layer-core/src/main/proto/index_metadata.proto
+++ b/fdb-record-layer-core/src/main/proto/index_metadata.proto
@@ -1,0 +1,40 @@
+/*
+  * index_metadata.proto
+  *
+  * This source file is part of the FoundationDB open source project
+  *
+  * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+syntax = "proto2";
+
+package com.apple.foundationdb.record;
+import "google/protobuf/descriptor.proto";
+
+option java_outer_classname = "IndexMetaDataProto";
+
+// This stamp indicates an ongoing indexing process. It will be used to assure a coherent indexing
+// continuation - which continued by another process.
+message IndexMetaDataIndexingStamp {
+  enum Method {
+    INVALID    = 0;   // let zero be invalid
+    BY_RECORDS = 1;   // indexing by records - scanning all records in a record store
+    BY_INDEX   = 2;   // indexing by a source index. When source index points to all possible records of the target index.
+  };
+  optional Method method      = 1;
+  optional string sourceIndex = 2; // relevant only to BY_INDEX method
+}
+
+

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -872,13 +872,13 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             future = indexBuilder.buildIndexAsync();
             int pass = 0;
             while (!future.isDone() && timer.getCount(FDBStoreTimer.Events.COMMIT) < 10 && pass++ < 100) {
+                Thread.sleep(100);
                 assertThat("Should have invoked the configuration loader at least once", indexBuilder.getConfigLoaderInvocationCount(), greaterThan(0));
                 assertEquals(indexBuilder.getLimit(), limit - indexBuilder.getConfigLoaderInvocationCount());
                 assertEquals(indexBuilder.getConfig().getMaxRetries(), 3);
                 assertEquals(indexBuilder.getConfig().getRecordsPerSecond(), 10000);
                 assertEquals(indexBuilder.getConfig().getProgressLogIntervalMillis(), DEFAULT_PROGRESS_LOG_INTERVAL);
                 assertEquals(indexBuilder.getConfig().getIncreaseLimitAfter(), DO_NOT_RE_INCREASE_LIMIT);
-                Thread.sleep(100);
             }
             assertThat("Should have done several transactions in a few seconds", pass, lessThan(100));
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -934,8 +934,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
             assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
 
-            assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE));
-            assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
+            assertEquals(199, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE));
+            assertEquals(1, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT)); // last item
 
             recordStore.clearAndMarkIndexWriteOnly("newIndex").join();
             context.commit();
@@ -977,6 +977,10 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         }
         assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertEquals(200, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE));
+        // this includes two endpoints + one range = total of 3 terminations by count
+        // - note that (last, null] endpoint is en empty range
+        assertEquals(3, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
+        // this is the range between the endpoints - 199 items in (first, last] interval
+        assertEquals(198, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE));
     }
 }


### PR DESCRIPTION
        In the records store:
        * an indexing type stamp will ensure that a continuation is only allowed for the same indexing type
        * the rangeSet is now used to correlated indexing by index (similarly to indexing by records)