### PR TITLE
Resolve #1120: FDB Lucene Directory Implementation

### DIFF
--- a/fdb-record-layer-lucene/README.md
+++ b/fdb-record-layer-lucene/README.md
@@ -1,0 +1,14 @@
+# FoundationDB Record Layer Lucene Index
+
+The lucene index implementation on the record layer consists of two key components.  The first component is a Directory implementation backed by an FDB KeySpace.
+
+* **Directory Implementation** 
+
+A <a href="https://lucene.apache.org/core/7_6_0/core/org/apache/lucene/store/Directory.html">Directory</a> provides an abstraction layer for storing a list of files. A directory contains only files (no sub-folder hierarchy). Implementing classes must comply with the following:
+A file in a directory can be created (createOutput(java.lang.String, org.apache.lucene.store.IOContext)), appended to, then closed.
+A file open for writing may not be available for read access until the corresponding IndexOutput is closed.
+Once a file is created it must only be opened for input (openInput(java.lang.String, org.apache.lucene.store.IOContext)), or deleted (deleteFile(java.lang.String)). Calling createOutput(java.lang.String, org.apache.lucene.store.IOContext) on an existing file must throw FileAlreadyExistsException.
+
+## Documentation
+
+* [Documentation Home](docs/index.md)

--- a/fdb-record-layer-lucene/docs/index.md
+++ b/fdb-record-layer-lucene/docs/index.md
@@ -1,0 +1,15 @@
+# FoundationDB Record Layer Lucene Index Documentation
+
+## Data Layout
+
+### Sequence Space 
+#### {Directory Bytes}{indexspace}{key=0 value={atomic integer}}
+This first section stores the atomic integer to make sure temporary files prior to renaming are unique.
+
+### Metadata Space 
+#### {Directory Bytes}{indexspace}{1}[{key=file123, value={id=1, size=2018, blockSize=1024}},{key=file12345, value={id=2, size=124, blockSize=1024}}]
+The metadata is keyed by filename and in the value it provides the total size, the block size, and an id to lookup the data.
+
+### Data Space 
+#### {Directory Bytes}{indexspace}{2}[{key=(1,1), value=byte[]},{key=(1,2), value=byte[]},{key=(2,1), value=byte[]}]
+The data section is keyed via the files id in the metadata directory coupled with a block number.

--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -1,0 +1,68 @@
+/*
+ * fdb-record-layer-lucene.gradle
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply from: rootProject.file('gradle/proto.gradle')
+apply from: rootProject.file('gradle/publishing.gradle')
+if (!hasProperty('coreNotStrict')) {
+    apply from: rootProject.file('gradle/strict.gradle')
+}
+
+def coreProject = ":${ext.coreProjectName}"
+dependencies {
+    compile project(coreProject)
+    compile "org.apache.lucene:lucene-core:${luceneVersion}"
+    compile "org.apache.lucene:lucene-queryparser:${luceneVersion}"
+    compile "org.apache.lucene:lucene-analyzers-common:${luceneVersion}"
+    compile "org.apache.lucene:lucene-suggest:${luceneVersion}"
+    compile "org.apache.lucene:lucene-highlighter:${luceneVersion}"
+    testCompile project(path: coreProject, configuration: 'tests')
+    testCompileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
+    compileOnly "com.google.auto.service:auto-service:${autoServiceVersion}"
+    annotationProcessor "com.google.auto.service:auto-service:${autoServiceVersion}"
+    testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
+    testRuntime "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+    testCompile "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+}
+
+def skipFDB = System.getenv('SKIP_FDB_TESTS') != null && System.getenv('SKIP_FDB_TESTS') == 'true'
+def skipSlow = System.getenv('SKIP_SLOW_TESTS') != null && System.getenv('SKIP_SLOW_TESTS') == 'true'
+test {
+    useJUnitPlatform {
+        if (skipFDB) {
+            excludeTags 'RequiresFDB'
+        }
+        if (skipSlow) {
+            excludeTags 'Slow'
+        }
+    }
+}
+
+publishing {
+    publications {
+        library(MavenPublication) {
+            pom {
+                description = 'Lucene index support for fdb-record-layer'
+            }
+        }
+    }
+}

--- a/fdb-record-layer-lucene/gradle.properties
+++ b/fdb-record-layer-lucene/gradle.properties
@@ -1,0 +1,21 @@
+#
+# gradle.properties
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+luceneVersion=7.7.2

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -1,0 +1,407 @@
+/*
+ * FDBDirectory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.base.Verify;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.NoLockFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Directory implementation backed by FDB which attempts to
+ * model a file system on top of FoundationDB.
+ *
+ * A few interesting details:
+ *
+ * <ul>
+ *     <li>Each segment written in Lucene once flushed is <b>immutable</b>.</li>
+ *     <li>As more data is written into Lucene, files are continually merged via a <a href="https://lucene.apache.org/core/7_6_0/core/org/apache/lucene/index/MergePolicy.html">MergePolicy</a></li>
+ * </ul>
+ *
+ * @see <a href="https://lucene.apache.org/core/7_6_0/core/org/apache/lucene/store/Directory.html">Directory</a>
+ */
+@API(API.Status.EXPERIMENTAL)
+@NotThreadSafe
+public class FDBDirectory extends Directory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBDirectory.class);
+    public static final int DEFAULT_BLOCK_SIZE = 16_384;
+    private final AtomicLong nextTempFileCounter = new AtomicLong();
+    private final Transaction txn;
+    private final Subspace subspace;
+    private final Subspace metaSubspace;
+    private final Subspace dataSubspace;
+    private final byte[] sequenceSubspaceKey;
+
+    private final LockFactory lockFactory;
+    private final int blockSize;
+    private final Cache<String, FDBLuceneFileReference> fileReferenceCache;
+    private final Cache<Pair<Long, Integer>, CompletableFuture<byte[]>> blockCache;
+    private final Map<String, Long> reads;
+
+    public FDBDirectory(@Nonnull Subspace subspace, @Nonnull Transaction txn) {
+        this(subspace, txn, NoLockFactory.INSTANCE);
+    }
+
+    FDBDirectory(@Nonnull Subspace subspace, @Nonnull Transaction txn, @Nonnull LockFactory lockFactory) {
+        this(subspace, txn, lockFactory, DEFAULT_BLOCK_SIZE);
+    }
+
+    FDBDirectory(@Nonnull Subspace subspace, @Nonnull Transaction txn, @Nonnull LockFactory lockFactory, int blockSize) {
+        Verify.verify(subspace != null);
+        Verify.verify(txn != null);
+        Verify.verify(lockFactory != null);
+        this.txn = txn;
+        this.subspace = subspace;
+        final Subspace sequenceSubspace = subspace.subspace(Tuple.from(0));
+        this.sequenceSubspaceKey = sequenceSubspace.pack();
+        this.metaSubspace = subspace.subspace(Tuple.from(1));
+        this.dataSubspace = subspace.subspace(Tuple.from(2));
+        this.lockFactory = lockFactory;
+        this.blockSize = blockSize;
+        this.fileReferenceCache = CacheBuilder.newBuilder().initialCapacity(128).maximumSize(1024).recordStats().build();
+        this.blockCache = CacheBuilder.newBuilder().concurrencyLevel(16).initialCapacity(128).maximumSize(1024).recordStats().build();
+        this.reads = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Sets increment if not set yet and waits till completed to return
+     * Returns and increments the increment if its already set.
+     * @return current increment value
+     */
+    public synchronized long getIncrement() {
+        return txn.get(sequenceSubspaceKey).thenApply(
+            (value) -> {
+                if (value == null) {
+                    txn.set(sequenceSubspaceKey, Tuple.from(1L).pack());
+                    return 1L;
+                } else {
+                    long sequence = Tuple.fromBytes(value).getLong(0) + 1;
+                    txn.set(sequenceSubspaceKey, Tuple.from(sequence).pack());
+                    return sequence;
+                }
+            }).join();
+    }
+
+    /**
+     * Checks the cache for  the file reference.
+     * If the file is in the cache it returns the cached value.
+     * If not there then it checks the subspace for it.
+     * If its there the file is added to the cache and returned to caller
+     * If the file doesn't exist in the subspace it returns null.
+     *
+     * @param name name for the file reference
+     * @return FDBLuceneFileReference
+     */
+    @Nullable
+    public CompletableFuture<FDBLuceneFileReference> getFDBLuceneFileReference(@Nonnull final String name) {
+        LOGGER.trace("getFDBLuceneFileReference {}", name);
+        FDBLuceneFileReference fileReference = this.fileReferenceCache.getIfPresent(name);
+        if (fileReference == null) {
+            return txn.get(metaSubspace.pack(name))
+                    .thenApplyAsync((value) -> {
+                            FDBLuceneFileReference fetchedref = value == null ? null : new FDBLuceneFileReference(Tuple.fromBytes(value));
+                            if (fetchedref != null) {
+                                this.fileReferenceCache.put(name, fetchedref);
+                            }
+                            return fetchedref;
+                        }
+                    );
+        } else {
+            return CompletableFuture.completedFuture(fileReference);
+        }
+    }
+
+    /**
+     * Puts a file reference in the meta subspace and in the cache under the given name.
+     * @param name name for the file reference
+     * @param reference the file reference being inserted
+     */
+    public void writeFDBLuceneFileReference(@Nonnull final String name, @Nonnull final FDBLuceneFileReference reference) {
+        LOGGER.trace("writeFDBLuceneFileReference {}", reference);
+        txn.set(metaSubspace.pack(name), reference.getTuple().pack());
+        fileReferenceCache.put(name, reference);
+    }
+
+    /**
+     * Writes data to the given block under the given id.
+     * @param id id for the data
+     * @param block block for the data to be stored in
+     * @param value the data to be stored
+     */
+    public void writeData(long id, int block, @Nonnull byte[] value) {
+        LOGGER.trace("writeData id={}, block={}, valueSize={}", id, block, value.length);
+        Verify.verify(value.length <= blockSize);
+        txn.set(dataSubspace.pack(Tuple.from(id, block)), value);
+    }
+
+    /**
+     * Reads known data from the directory.
+     * @param resourceDescription Description should be non-null, opaque string describing this resource; used for logging
+     * @param referenceFuture the reference where the data supposedly lives
+     * @param block the block where the data is stored
+     * @return Completable future of the data returned
+     * @throws IOException if blockCache fails to get the data from the block
+     * @throws NullPointerException if a reference with that id hasn't been written yet.
+     */
+    @Nonnull
+    public CompletableFuture<byte[]> readBlock(@Nonnull String resourceDescription, @Nonnull CompletableFuture<FDBLuceneFileReference> referenceFuture, int block) throws IOException {
+        try {
+            LOGGER.trace("readBlock resourceDescription={}, block={}", resourceDescription, block);
+            final FDBLuceneFileReference reference = referenceFuture.join(); // Tried to fully pipeline this but the reality is that this is mostly cached after listAll, delete, etc.
+            Long id = reference.getId();
+            return blockCache.get(Pair.of(id, block),
+                    () -> {
+                        Long value = reads.getOrDefault(resourceDescription + ":" + id, 0L);
+                        value += 1;
+                        reads.put(resourceDescription + ":" + id, value);
+                    return txn.get(dataSubspace.pack(Tuple.from(id, block)));
+                }
+            );
+        } catch (ExecutionException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Lists all file names in the subspace. Puts all references in the cache.
+     * Logs the count of references, and the total size of the data.
+     * All references are put into the cache because each composite file will be required to serve a query and the file references are small.
+     *
+     * @return String list of names of lucene file references
+     */
+    @Override
+    @Nonnull
+    public String[] listAll() {
+        List<String> outList = new ArrayList<>();
+        List<String> displayList = null;
+
+        long totalSize = 0L;
+        for (KeyValue kv : txn.getRange(metaSubspace.range())) {
+            String name = metaSubspace.unpack(kv.getKey()).getString(0);
+            outList.add(name);
+            FDBLuceneFileReference fileReference = new FDBLuceneFileReference(Tuple.fromBytes(kv.getValue()));
+            // Only composite files and segments are prefetched.
+            if (name.endsWith(".cfs") || name.endsWith(".si") || name.endsWith(".cfe")) {
+                try {
+                    readBlock(name, CompletableFuture.completedFuture(fileReference), 0);
+                } catch (IOException ioe) {
+                    LOGGER.warn("Cannot Prefetch resource={}", name);
+                    LOGGER.warn("Prefetch Error", ioe);
+                }
+            }
+            this.fileReferenceCache.put(name, fileReference);
+            if (LOGGER.isDebugEnabled()) {
+                if (displayList == null) {
+                    displayList = new ArrayList<>();
+                }
+                if (kv.getValue() != null) {
+                    displayList.add(name + "(" + fileReference.getSize() + ")");
+                    totalSize += fileReference.getSize();
+                }
+            }
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("listAllFiles -> count={}, totalSize={}", outList.size(), totalSize);
+            LOGGER.debug("Files -> {}", displayList);
+        }
+
+        return outList.toArray(new String[0]);
+    }
+
+    /**
+     * deletes the file reference under the provided name.
+     * @param name the name for the file reference
+     */
+    @Override
+    public void deleteFile(@Nonnull String name) throws IOException {
+        LOGGER.trace("deleteFile -> {}", name);
+        boolean deleted = getFDBLuceneFileReference(name).thenApplyAsync(
+                (value) -> {
+                    if (value == null) {
+                        return false;
+                    }
+                    txn.clear(metaSubspace.pack(name));
+                    txn.clear(dataSubspace.subspace(Tuple.from(value.getId())).range());
+                    this.fileReferenceCache.invalidate(name);
+                    return true;
+                }
+        ).join();
+        if (!deleted) {
+            throw new NoSuchFileException(name);
+        }
+    }
+
+    /**
+     * Returns the size of the given file under the given name.
+     * @param name the name of the file reference
+     * @return long value of the size of the file
+     * @throws NoSuchFileException if the file reference doesn't exist.
+     */
+    @Override
+    public long fileLength(@Nonnull String name) throws NoSuchFileException {
+        LOGGER.trace("fileLength -> {}", name);
+        FDBLuceneFileReference reference = getFDBLuceneFileReference(name).join();
+        if (reference == null) {
+            throw new NoSuchFileException(name);
+        }
+        return reference.getSize();
+    }
+
+    /**
+     * Create new output for a file.
+     * @param name the filename to create
+     * @param ioContext the IOContext from Lucene
+     * @return IndexOutput FDB Backed Index Output FDBIndexOutput
+     */
+    @Override
+    @Nonnull
+    public IndexOutput createOutput(@Nonnull final String name, @Nullable final IOContext ioContext) {
+        LOGGER.trace("createOutput -> {}", name);
+        return new FDBIndexOutput(name, name, this);
+    }
+
+    /**
+     * Lucene uses temporary files internally that are actually serialized onto disk.  Once on disk,
+     * the files can be renamed.
+     *
+     * @param prefix prefix
+     * @param suffix suffix
+     * @param ioContext ioContext
+     * @return IndexOutput
+     */
+    @Override
+    @Nonnull
+    public IndexOutput createTempOutput(@Nonnull final String prefix, @Nonnull final String suffix, @Nonnull final IOContext ioContext) {
+        LOGGER.trace("createTempOutput -> prefix={}, suffix={}", prefix, suffix);
+        return createOutput(getTempFileName(prefix, suffix, this.nextTempFileCounter.getAndIncrement()), ioContext);
+    }
+
+    @Nonnull
+    protected static String getTempFileName(@Nonnull String prefix, @Nonnull String suffix, long counter) {
+        return IndexFileNames.segmentFileName(prefix, suffix + "_" + Long.toString(counter, 36), "tmp");
+    }
+
+    @Override
+    public void sync(@Nonnull final Collection<String> collection) {
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("sync -> {}", String.join(", ", collection));
+        }
+    }
+
+    @Override
+    public void syncMetaData() throws IOException {
+        LOGGER.trace("syncMetaData");
+    }
+
+    /**
+     * It is the caller's responsibility to make the dest (destination) does not exist.
+     *
+     * @param source source
+     * @param dest desc
+     */
+    @Override
+    public void rename(@Nonnull final String source, @Nonnull final String dest) {
+        LOGGER.trace("rename -> source={}, dest={}", source, dest);
+        final byte[] key = metaSubspace.pack(source);
+        txn.get(key).thenAcceptAsync( (value) -> {
+            this.fileReferenceCache.invalidate(source);
+            txn.set(metaSubspace.pack(dest), value);
+            txn.clear(key);
+        }).join();
+    }
+
+    @Override
+    @Nonnull
+    public IndexInput openInput(@Nonnull final String name, @Nonnull final IOContext ioContext) throws IOException {
+        LOGGER.trace("openInput -> name={}", name);
+        return new FDBIndexInput(name, this);
+    }
+
+    @Override
+    @Nonnull
+    public Lock obtainLock(@Nonnull final String lockName) throws IOException {
+        LOGGER.trace("obtainLock -> {}", lockName);
+        return lockFactory.obtainLock(null, lockName);
+    }
+
+    /**
+     * No Op that reports in debug mode the block and file reference cache stats.
+     */
+    @Override
+    public void close() {
+        LOGGER.debug("close called blockCacheStats={}, referenceCacheStats={}", blockCache.stats(), fileReferenceCache.stats());
+    }
+
+    /**
+     * We delete inline vs. batching them together.
+     *
+     * @return Emtpy set of strings
+     */
+    @Override
+    @Nonnull
+    public Set<String> getPendingDeletions() {
+        LOGGER.trace("getPendingDeletions");
+        return Collections.emptySet();
+    }
+
+    public int getBlockSize() {
+        return blockSize;
+    }
+
+    public Transaction getTxn() {
+        return txn;
+    }
+
+    public Subspace getSubspace() {
+        return subspace;
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -1,0 +1,252 @@
+/*
+ * FDBIndexInput.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.annotation.API;
+import org.apache.lucene.store.IndexInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Class that handles reading data cut into blocks (KeyValue) backed by an FDB keyspace.
+ *
+ * @see <a href="https://lucene.apache.org/core/7_6_0/core/org/apache/lucene/store/IndexInput.html">IndexInput</a>
+ */
+@API(API.Status.EXPERIMENTAL)
+public class FDBIndexInput extends IndexInput {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBIndexInput.class);
+    private final String resourceDescription;
+    private final FDBDirectory fdbDirectory;
+    private final CompletableFuture<FDBLuceneFileReference> reference;
+    /*
+     * Position within the current block
+     */
+    private long position;
+    private CompletableFuture<byte[]> currentData;
+    private int currentBlock;
+    private final long initialOffset;
+    private int numberOfSeeks = 0;
+
+    /**
+     * Constructor to create an FDBIndexInput from a file referenced in the metadata keyspace.
+     *
+     * This constructor will begin an asynchronous query (lookahead) to the first block.
+     *
+     * @param resourceDescription opaque description of file; used for logging
+     * @param fdbDirectory FDB directory mapping
+     * @throws IOException exception
+     */
+    public FDBIndexInput(@Nonnull final String resourceDescription, @Nonnull final FDBDirectory fdbDirectory) throws IOException {
+        this(resourceDescription, fdbDirectory, fdbDirectory.getFDBLuceneFileReference(resourceDescription), 0L,
+                0L, 0, null);
+    }
+
+    /**
+     * Constructor that is utilized by splice calls to take into account initial offsets and modifications to length.
+     *
+     * @param resourceDescription opaque description of file; used for logging
+     * @param fdbDirectory FDB directory mapping
+     * @param reference future Reference
+     * @param initalOffset initialOffset
+     * @param position currentBlockPosition
+     * @param currentBlock block
+     * @param currentData future with CurrentData Fetch
+     * @throws IOException exception
+     */
+    public FDBIndexInput(@Nonnull final String resourceDescription, @Nonnull final FDBDirectory fdbDirectory,
+                         @Nonnull CompletableFuture<FDBLuceneFileReference> reference, long initalOffset, long position,
+                         int currentBlock, @Nullable CompletableFuture<byte[]> currentData) throws IOException {
+        super(resourceDescription);
+        LOGGER.trace("init() -> {}", resourceDescription);
+        this.resourceDescription = resourceDescription;
+        this.fdbDirectory = fdbDirectory;
+        this.reference = reference;
+        this.position = position;
+        this.currentBlock = currentBlock;
+        this.currentData = currentData;
+        this.initialOffset = initalOffset;
+        if (currentData == null) {
+            numberOfSeeks++;
+            this.currentData = fdbDirectory.readBlock(resourceDescription, reference, currentBlock);
+        } else {
+            seek(position);
+        }
+    }
+
+    /**
+     *
+     * Close IndexInput (NoOp).
+     */
+    @Override
+    public void close() {
+        LOGGER.trace("close() -> resource={}, numberOfSeeks={}", resourceDescription, numberOfSeeks);
+    }
+
+    /**
+     * The current relative position not including any offsets provided by slices.
+     *
+     * @return current relative position
+     */
+    @Override
+    public long getFilePointer() {
+        LOGGER.trace("getFilePointer() -> resource={}, position={}", resourceDescription, position);
+        return position;
+    }
+
+    /**
+     * Seeks to the offset provided.  That actual seek offset will take into account the
+     * absolute position taking into account if the IndexInput has been Sliced.
+     *
+     * If the currentBlock is the same block after the offset, no physical seek will occur.
+     *
+     * @param offset positionToSeekTo
+     * @throws IOException exception
+     */
+    @Override
+    public void seek(final long offset) throws IOException {
+        LOGGER.trace("seek -> resource={}, offset={}", resourceDescription, offset);
+        if (currentBlock != getBlock(offset)) {
+            this.position = offset;
+            this.currentBlock = getBlock(position);
+            numberOfSeeks++;
+            LOGGER.trace("actual seek -> resource={}, offset={}", resourceDescription, offset);
+            this.currentData = fdbDirectory.readBlock(resourceDescription, reference, currentBlock); // Physical Seek
+        } else {
+            this.position = offset;     // Logical Seek
+        }
+    }
+
+    /**
+     * The total length of the input provided by MetaData stored in the metadata keyspace.
+     *
+     * @return length
+     */
+    @Override
+    public long length() {
+        LOGGER.trace("length -> resource={}", resourceDescription);
+        return reference.join().getSize();
+    }
+
+    /**
+     *
+     * This takes an existing FDBIndexInput and provides a new initial offset plus
+     * a FDBLuceneFileReference that is not <b>not</b> backed in the metadata keyspace.
+     *
+     * @param sliceDescription new resourceDescription of Slice
+     * @param offset offset
+     * @param length length
+     * @return indexInput
+     * @throws IOException exception
+     */
+    @Override
+    @Nonnull
+    public IndexInput slice(@Nonnull String sliceDescription, long offset, long length) throws IOException {
+        LOGGER.trace("slice -> resource={}, desc={}, offset={}, length={}", resourceDescription, sliceDescription, offset, length);
+        return new FDBIndexInput(resourceDescription, fdbDirectory, CompletableFuture.completedFuture(
+                new FDBLuceneFileReference(reference.join().getId(), length, reference.join().getBlockSize())),
+                offset + initialOffset, 0L, currentBlock, currentData
+                );
+    }
+
+    /**
+     *
+     * The relative position plus any initial offsets provided (slice).
+     *
+     * @return postion+initialOffset
+     */
+    private long absolutePosition() {
+        return position + initialOffset;
+    }
+
+    /**
+     * Read a byte based on the current relative position taking into account the
+     * absolute position (slice).
+     *
+     * If the next byte will be on another block, asynchronously call read ahead.
+     *
+     * @return byte
+     * @throws IOException exception
+     */
+    @Override
+    public byte readByte() throws IOException {
+        LOGGER.trace("readByte resource={}", resourceDescription);
+        try {
+            int probe = (int)(absolutePosition() % reference.join().getBlockSize());
+            position++;
+            assert currentData.join() != null : "current Data is null: " + resourceDescription + " " + reference.join().getId();
+            return currentData.join()[probe];
+        } finally {
+            if (absolutePosition() % reference.join().getBlockSize() == 0) {
+                currentBlock++;
+                numberOfSeeks++;
+                this.currentData = fdbDirectory.readBlock(resourceDescription, reference, currentBlock);
+            }
+        }
+    }
+
+    /**
+     * Read bytes based on the offset and taking into account the absolute position.
+     *
+     * Perform asynchronous read aheads when required.
+     *
+     * @param bytes bytes
+     * @param offset offset
+     * @param length length
+     * @throws IOException exception
+     */
+    @Override
+    public void readBytes(@Nonnull final byte[] bytes, final int offset, final int length) throws IOException {
+        LOGGER.trace("readBytes resource={}, offset={}, length={}", resourceDescription, offset, length);
+        int bytesRead = 0;
+        long blockSize = reference.join().getBlockSize();
+        while (bytesRead < length) {
+            long inBlockPosition = (absolutePosition() % blockSize);
+            int toRead = (int) (length - bytesRead + inBlockPosition > blockSize ? blockSize - inBlockPosition : length - bytesRead);
+            System.arraycopy(currentData.join(), (int)inBlockPosition, bytes, bytesRead + offset, toRead);
+            bytesRead += toRead;
+            position += toRead;
+            if (absolutePosition() % blockSize == 0) {
+                currentBlock++;
+                numberOfSeeks++;
+                LOGGER.trace("hard seek resource={}, currentBlock={}, offset={}, length={}, position={}, initialOffset={}",
+                        resourceDescription, currentBlock, offset, length, position, initialOffset);
+                this.currentData = fdbDirectory.readBlock(resourceDescription, reference, currentBlock);
+            }
+        }
+
+    }
+
+    /**
+     * Retrieve the appropriate indexed block taking into account the absolute position
+     * (possible splice offsets) and dividing by the block size stored in the metadata keyspace.
+     *
+     * @param position current position (not counting offset)
+     * @return block
+     */
+    private int getBlock(long position) {
+        return (int) ( (position + initialOffset) / reference.join().getBlockSize());
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
@@ -1,0 +1,173 @@
+/*
+ * FDBIndexOutput.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IndexOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.zip.CRC32;
+
+/**
+ *
+ * Implementation of IndexOutput representing the writing of data
+ * in Lucene to a file.
+ *
+ * @see <a href="https://lucene.apache.org/core/7_6_0/core/org/apache/lucene/store/IndexOutput.html">IndexOutput</a>
+ */
+@API(API.Status.EXPERIMENTAL)
+public final class FDBIndexOutput extends IndexOutput {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBIndexOutput.class);
+    /**
+     * Current size keeps track of the number of bytes written overall.
+     */
+    private int currentSize = 0;
+    private ByteBuffer buffer;
+    private final String resourceDescription;
+    private final FDBDirectory fdbDirectory;
+    private final long blockSize;
+    private final CRC32 crc;
+    private final long id;
+    private static final ArrayBlockingQueue<ByteBuffer> BUFFERS;
+    private static final int POOL_SIZE = 100;
+
+    static {
+        BUFFERS = new ArrayBlockingQueue<>(POOL_SIZE);
+        for (int i = 0; i < POOL_SIZE; i++) {
+            BUFFERS.add(ByteBuffer.allocate(FDBDirectory.DEFAULT_BLOCK_SIZE));
+        }
+    }
+
+    /**
+     * Create an FDBIndexOutput given a name and FDBDirectory.
+     *
+     * @param name name of resource
+     * @param fdbDirectory existing FDBDirectory
+     */
+    public FDBIndexOutput(@Nonnull String name, @Nonnull FDBDirectory fdbDirectory) {
+        this(name, name, fdbDirectory);
+    }
+
+    /**
+     * Create an FDBIndexOutput given a resource description, name, and FDBDirectory.
+     *
+     * @param resourceDescription opaque description of file; used for logging
+     * @param name name of resource
+     * @param fdbDirectory existing FDBDirectory
+     */
+    public FDBIndexOutput(@Nonnull String resourceDescription, @Nonnull String name, @Nonnull FDBDirectory fdbDirectory) {
+        super(resourceDescription, name);
+        LOGGER.trace("init() -> resource={}, name={}", resourceDescription, name);
+        this.resourceDescription = resourceDescription;
+        this.fdbDirectory = fdbDirectory;
+        blockSize = fdbDirectory.getBlockSize();
+        buffer = BUFFERS.poll();
+        if (buffer == null) {
+            buffer = ByteBuffer.allocate((int)blockSize);
+        }
+        crc = new CRC32();
+        id = fdbDirectory.getIncrement();
+    }
+
+    /**
+     * Close the directory which writes the FileReference.
+     */
+    @Override
+    @SpotBugsSuppressWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification = "it is fine if it is not accepted")
+    public void close() {
+        LOGGER.trace("close() -> resource={}", resourceDescription);
+        flush();
+        fdbDirectory.writeFDBLuceneFileReference(resourceDescription, new FDBLuceneFileReference(id, currentSize, blockSize));
+        BUFFERS.offer(buffer);
+    }
+
+    @Override
+    public long getFilePointer() {
+        LOGGER.trace("getFilePointer() -> resource={}, pointer={}", resourceDescription, currentSize);
+        return currentSize;
+    }
+
+    @Override
+    public long getChecksum() {
+        LOGGER.trace("getChecksum() -> resource={}, checksum={}", resourceDescription, crc.getValue());
+        return crc.getValue();
+    }
+
+    @Override
+    public void writeByte(final byte b) {
+        LOGGER.trace("writeByte() -> resource={}", resourceDescription);
+        buffer.put(b);
+        crc.update(b);
+        currentSize++;
+        if (currentSize % blockSize == 0) {
+            flush();
+        }
+    }
+
+    @Override
+    public void copyBytes(@Nonnull final DataInput input, final long numBytes) throws IOException {
+        LOGGER.trace("copy bytes input={}, numbytes={}", input, numBytes);
+        super.copyBytes(input, numBytes);
+    }
+
+    /**
+     *
+     * This method will be called many times.
+     *
+     * @param bytes bytes to write
+     * @param offset offset
+     * @param length length
+     */
+    @Override
+    public void writeBytes(@Nonnull final byte[] bytes, final int offset, final int length) {
+        LOGGER.trace("writeBytes() -> resource={}, offset={}, length={}", resourceDescription, offset, length);
+        crc.update(bytes, offset, length);
+        int bytesWritten = 0;
+        while (bytesWritten < length) {
+            int toWrite = (int) (length - bytesWritten + (currentSize % blockSize) > blockSize ? blockSize - (currentSize % blockSize) : length - bytesWritten);
+            buffer.put(bytes, bytesWritten + offset, toWrite);
+            bytesWritten += toWrite;
+            currentSize += toWrite;
+            if (currentSize % blockSize == 0) {
+                flush();
+            }
+        }
+    }
+
+    private void flush() {
+        LOGGER.trace("flush() -> resource={}, id={}", resourceDescription, id);
+        if (buffer.position() > 0) {
+            buffer.flip();
+            byte[] arr = new byte[buffer.remaining()];
+            buffer.get(arr);
+            fdbDirectory.writeData(id, (int) ( (currentSize - 1) / blockSize), arr);
+            buffer.clear();
+        }
+    }
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
@@ -1,0 +1,67 @@
+/*
+ * FDBLuceneFileReference.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A File Reference record laying out the id, size, and block size.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class FDBLuceneFileReference {
+    private final long id;
+    private final long size;
+    private final long blockSize;
+
+    public FDBLuceneFileReference(@Nonnull Tuple tuple) {
+        this(tuple.getLong(0), tuple.getLong(1), tuple.getLong(2));
+    }
+
+    public FDBLuceneFileReference(long id, long size, long blockSize) {
+        this.id = id;
+        this.size = size;
+        this.blockSize = blockSize;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public long getBlockSize() {
+        return blockSize;
+    }
+
+    public Tuple getTuple() {
+        return Tuple.from(id, size, blockSize);
+    }
+
+    @Override
+    public String toString() {
+        return "Reference [ id=" + id + ", size=" + size + ", blockSize=" + blockSize + "]";
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common classes for lucene index queries.
+ */
+package com.apple.foundationdb.record.lucene.directory;

--- a/fdb-record-layer-lucene/src/main/javadoc/overview.html
+++ b/fdb-record-layer-lucene/src/main/javadoc/overview.html
@@ -1,0 +1,29 @@
+<!--
+  ~ overview.html
+  ~
+  ~ This source file is part of the FoundationDB open source project
+  ~
+  ~ Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<HTML>
+<BODY>
+
+Interface for Lucene Indexes
+
+<p>This lucene index implementation attempts to utilize FDB as a block file system to support the Lucene Directory Interface.</p>
+
+</BODY>
+</HTML>

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
@@ -1,0 +1,62 @@
+/*
+ * FDBDirectoryBaseTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
+import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
+import com.apple.foundationdb.subspace.Subspace;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.Random;
+
+/**
+ * Abstract class for testing FDBDirectory for Lucene.
+ *
+ */
+public abstract class FDBDirectoryBaseTest {
+    protected FDBDatabase fdb;
+    protected Subspace subspace;
+    protected FDBDirectory directory;
+    protected Random random = new Random();
+
+    @BeforeEach
+    public void setUp() {
+        if (fdb == null) {
+            fdb = FDBDatabaseFactory.instance().getDatabase();
+        }
+        if (subspace == null) {
+            subspace = fdb.run(context -> TestKeySpace.getKeyspacePath("record-test", "unit", "indexTest", "version").toSubspace(context));
+        }
+        fdb.run(context -> {
+            context.ensureActive().clear(subspace.range());
+            return null;
+        });
+        Transaction transaction = fdb.database().createTransaction();
+        directory = new FDBDirectory(subspace, transaction);
+    }
+
+    protected int randomInt(int minimum) {
+        return Math.abs(random.nextInt(10 * 1024)) + minimum;
+    }
+
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -1,0 +1,138 @@
+/*
+ * FDBDirectoryTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.Transaction;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.NoSuchFileException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test for FDBDirectory validating it can function as a backing store
+ * for Lucene.
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBDirectoryTest extends FDBDirectoryBaseTest {
+
+    @Test
+    public void testDirectoryCreate() {
+        assertNotNull(directory, "directory should not be null");
+        assertEquals(subspace, directory.getSubspace());
+    }
+
+    @Test
+    public void testGetIncrement() {
+        assertEquals(1, directory.getIncrement());
+        assertEquals(2, directory.getIncrement());
+        directory.getTxn().commit().join();
+        Transaction transaction = fdb.database().createTransaction();
+        directory = new FDBDirectory(subspace, transaction);
+        assertEquals(3, directory.getIncrement());
+    }
+
+    @Test
+    public void testWriteGetLuceneFileReference() throws Exception {
+        CompletableFuture<FDBLuceneFileReference> luceneFileReference = directory.getFDBLuceneFileReference("NonExist");
+        assertNull(luceneFileReference.get(5, TimeUnit.SECONDS));
+        String luceneReference1 = "luceneReference1";
+        FDBLuceneFileReference fileReference = new FDBLuceneFileReference(1, 10, 10);
+        directory.writeFDBLuceneFileReference(luceneReference1, fileReference);
+        luceneFileReference = directory.getFDBLuceneFileReference(luceneReference1);
+        FDBLuceneFileReference actual = luceneFileReference.get(5, TimeUnit.SECONDS);
+        assertNotNull(actual, "file reference should exist");
+        assertEquals(actual, fileReference);
+    }
+
+    @Test
+    public void testWriteLuceneFileReference() throws Exception {
+        // write already created file reference
+        FDBLuceneFileReference reference1 = new FDBLuceneFileReference(2, 1, 1);
+        directory.writeFDBLuceneFileReference("test1", reference1);
+        FDBLuceneFileReference reference2 = new FDBLuceneFileReference(3, 1, 1);
+        directory.writeFDBLuceneFileReference("test1", reference2);
+        CompletableFuture<FDBLuceneFileReference> luceneFileReference = directory.getFDBLuceneFileReference("test1");
+        assertNotNull(luceneFileReference.get(5, TimeUnit.SECONDS), "fileReference should exist");
+    }
+
+    @Test
+    public void testMissingSeek() {
+        assertThrows(NullPointerException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
+    }
+
+    @Test
+    public void testWriteSeekData() throws Exception {
+        directory.writeFDBLuceneFileReference("testReference1", new FDBLuceneFileReference(1, 1, 1));
+        assertNull(directory.readBlock("testReference1", directory.getFDBLuceneFileReference("testReference1"), 1).get());
+        directory.writeFDBLuceneFileReference("testReference2", new FDBLuceneFileReference(2, 1, 200));
+        byte[] data = "test string for write".getBytes();
+        directory.writeData(2, 1, data);
+        assertNotNull(directory.readBlock("testReference2",
+                directory.getFDBLuceneFileReference("testReference2"), 1).get(), "seek data should exist");
+    }
+
+    @Test
+    public void testListAll() {
+        assertEquals(directory.listAll().length, 0);
+        directory.writeFDBLuceneFileReference("test1", new FDBLuceneFileReference(1, 1, 1));
+        directory.writeFDBLuceneFileReference("test2", new FDBLuceneFileReference(2, 1, 1));
+        directory.writeFDBLuceneFileReference("test3", new FDBLuceneFileReference(3, 1, 1));
+        assertArrayEquals(new String[]{"test1", "test2", "test3"}, directory.listAll());
+        directory.getTxn().cancel();
+        Transaction transaction = fdb.database().createTransaction();
+        directory = new FDBDirectory(subspace, transaction);
+        assertArrayEquals(new String[0], directory.listAll());
+    }
+
+    @Test
+    public void testDeleteData() throws Exception {
+        assertThrows(NoSuchFileException.class, () -> directory.deleteFile("NonExist"));
+        FDBLuceneFileReference reference1 = new FDBLuceneFileReference(1, 1, 1);
+        directory.writeFDBLuceneFileReference("test1", reference1);
+        directory.deleteFile("test1");
+        assertEquals(directory.listAll().length, 0);
+    }
+
+    @Test
+    public void testFileLength() throws Exception {
+        assertThrows(NoSuchFileException.class, () -> directory.fileLength("nonExist"));
+        FDBLuceneFileReference reference1 = new FDBLuceneFileReference(1, 20, 1024);
+        directory.writeFDBLuceneFileReference("test1", reference1);
+        long fileSize = directory.fileLength("test1");
+        assertEquals(20, fileSize);
+    }
+
+    @Test
+    public void testRename() {
+        assertThrows(CompletionException.class, () -> directory.rename("NoExist", "newName"));
+    }
+
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInputTest.java
@@ -1,0 +1,68 @@
+/*
+ * FDBIndexInputTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * Test to FDBIndexInput functionality.
+ *
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBIndexInputTest extends FDBDirectoryBaseTest {
+    private static final String FILE_NAME = "y";
+
+    @Test
+    public void testWriteReadBytes() throws Exception {
+        FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
+        byte[] expected = new byte[randomInt(1)];
+        random.nextBytes(expected);
+        output.writeBytes(expected, expected.length);
+        output.close();
+        FDBIndexInput input = new FDBIndexInput(FILE_NAME, directory);
+        byte[] actual = new byte[expected.length];
+        input.readBytes(actual, 0, expected.length);
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testSeek() throws Exception {
+        FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
+        byte[] expected = new byte[randomInt(512)];
+        random.nextBytes(expected);
+        output.writeBytes(expected, expected.length);
+        output.close();
+        FDBIndexInput input = new FDBIndexInput(FILE_NAME, directory);
+        input.seek(256);
+        byte[] actual = new byte[expected.length - 256];
+        input.readBytes(actual, 0, expected.length - 256);
+        byte[] expectedAfterSeek = new byte[expected.length - 256];
+        ByteBuffer.wrap(expected, 256, expected.length - 256).get(expectedAfterSeek);
+        assertArrayEquals(expectedAfterSeek, actual);
+    }
+
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
@@ -1,0 +1,56 @@
+/*
+ * FDBIndexInputTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/**
+ * Test to FDBIndexOutput functionality.
+ *
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
+    private static final String FILE_NAME = "y";
+
+    @Test
+    public void testWriteBytes() throws Exception {
+        FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
+        byte[] data = new byte[randomInt(256)];
+        random.nextBytes(data);
+        output.writeBytes(data, data.length);
+        output.close();
+        assertEquals(data.length, directory.getFDBLuceneFileReference(FILE_NAME).get().getSize());
+    }
+    
+    @Test
+    public void testWriteByte() throws Exception {
+        FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
+        output.writeByte((byte) 0);
+        output.close();
+        assertEquals(1, directory.getFDBLuceneFileReference(FILE_NAME).get().getSize());
+    }
+
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
@@ -1,0 +1,163 @@
+/*
+ * FDBDirectoryTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.test.Tags;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for FDBDirectory validating it can function as a backing store
+ * for Lucene.
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
+    private FDBLuceneTestIndex luceneIndex;
+
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        luceneIndex = new FDBLuceneTestIndex(directory, new StandardAnalyzer());
+    }
+
+    @Test
+    public void givenSearchQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        luceneIndex.indexDocument("Hello world", "Some hello world ");
+        List<Document> documents = luceneIndex.searchIndex("body", "world");
+        assertEquals("Hello world", documents.get(0).get("title"));
+    }
+
+
+    @Test
+    public void givenTermQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        luceneIndex.indexDocument("activity", "running in track");
+        luceneIndex.indexDocument("activity", "Cars are running on road");
+        Term term = new Term("body", "running");
+        Query query = new TermQuery(term);
+        List<Document> documents = luceneIndex.searchIndex(query);
+        assertEquals(2, documents.size());
+    }
+
+    @Test
+    public void givenPrefixQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        luceneIndex.indexDocument("article", "Lucene introduction");
+        luceneIndex.indexDocument("article", "Introduction to Lucene");
+        Term term = new Term("body", "intro");
+        Query query = new PrefixQuery(term);
+        List<Document> documents = luceneIndex.searchIndex(query);
+        assertEquals(2, documents.size());
+    }
+
+    @Test
+    public void givenBooleanQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        luceneIndex.indexDocument("Destination", "Las Vegas singapore car");
+        luceneIndex.indexDocument("Commutes in singapore", "Bus Car Bikes");
+        Term term1 = new Term("body", "singapore");
+        Term term2 = new Term("body", "car");
+        TermQuery query1 = new TermQuery(term1);
+        TermQuery query2 = new TermQuery(term2);
+        BooleanQuery booleanQuery = new BooleanQuery.Builder().add(query1, BooleanClause.Occur.MUST)
+                .add(query2, BooleanClause.Occur.MUST).build();
+        List<Document> documents = luceneIndex.searchIndex(booleanQuery);
+        assertEquals(1, documents.size());
+    }
+
+    @Test
+    public void givenPhraseQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        luceneIndex.indexDocument("quotes", "A rose by any other name would smell as sweet.");
+        Query query = new PhraseQuery(1, "body", new BytesRef("smell"), new BytesRef("sweet"));
+        List<Document> documents = luceneIndex.searchIndex(query);
+        assertEquals(1, documents.size());
+    }
+
+    @Test
+    public void givenFuzzyQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        luceneIndex.indexDocument("article", "Halloween Festival");
+        luceneIndex.indexDocument("decoration", "Decorations for Halloween");
+        Term term = new Term("body", "hallowen");
+        Query query = new FuzzyQuery(term);
+        List<Document> documents = luceneIndex.searchIndex(query);
+        assertEquals(2, documents.size());
+    }
+
+    @Test
+    public void givenWildCardQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        luceneIndex.indexDocument("article", "Lucene introduction");
+        luceneIndex.indexDocument("article", "Introducing Lucene with Spring");
+        Term term = new Term("body", "intro*");
+        Query query = new WildcardQuery(term);
+        List<Document> documents = luceneIndex.searchIndex(query);
+        assertEquals(2, documents.size());
+    }
+
+    @Test
+    public void givenSortFieldWhenSortedThenCorrect() throws Exception {
+        luceneIndex.indexDocument("Ganges", "River in India");
+        luceneIndex.indexDocument("Mekong", "This river flows in south Asia");
+        luceneIndex.indexDocument("Amazon", "Rain forest river");
+        luceneIndex.indexDocument("Rhine", "Belongs to Europe");
+        luceneIndex.indexDocument("Nile", "Longest River");
+
+        Term term = new Term("body", "river");
+        Query query = new WildcardQuery(term);
+
+        SortField sortField = new SortField("title", SortField.Type.STRING_VAL, false);
+        Sort sortByTitle = new Sort(sortField);
+
+        List<Document> documents = luceneIndex.searchIndex(query, sortByTitle);
+        assertEquals(4, documents.size());
+        assertEquals("Amazon", documents.get(0).getField("title").stringValue());
+    }
+
+    @Test
+    public void whenDocumentDeletedThenCorrect() throws IOException {
+        luceneIndex.indexDocument("Ganges", "River in India");
+        luceneIndex.indexDocument("Mekong", "This river flows in south Asia");
+        Term term = new Term("title", "ganges");
+        luceneIndex.deleteDocument(term);
+        Query query = new TermQuery(term);
+        assertEquals(0, luceneIndex.searchIndex(query).size());
+        term = new Term("title", "mekong");
+        query = new TermQuery(term);
+        assertEquals(1, luceneIndex.searchIndex(query).size());
+    }
+
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
@@ -1,0 +1,135 @@
+/*
+ * FDBLuceneTestIndex.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for Encapsulating Test Functionality.
+ *
+ */
+public class FDBLuceneTestIndex {
+    private final Directory directory;
+    private final Analyzer analyzer;
+
+    public FDBLuceneTestIndex(Directory directory, Analyzer analyzer) {
+        this.directory = directory;
+        this.analyzer = analyzer;
+    }
+
+    /**
+     * Method to index a simple document.
+     *
+     * @param title title
+     * @param body body
+     */
+    public void indexDocument(String title, String body) throws IOException {
+        IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
+        try (IndexWriter writer = new IndexWriter(directory, indexWriterConfig)) {
+            Document document = new Document();
+            document.add(new TextField("title", title, Field.Store.YES));
+            document.add(new TextField("body", body, Field.Store.YES));
+            document.add(new SortedDocValuesField("title", new BytesRef(title)));
+            writer.addDocument(document);
+        }
+    }
+
+    /**
+     * Method to search an index on a field.
+     *
+     * @param inField field to query
+     * @param queryString query string in Lucene Query Syntax
+     * @return List of Documents
+     * @throws ParseException bad parse
+     * @throws IOException IOException from Directory layer
+     */
+    public List<Document> searchIndex(String inField, String queryString) throws ParseException, IOException {
+        Query query = new QueryParser(inField, analyzer).parse(queryString);
+        try (IndexReader indexReader = DirectoryReader.open(directory)) {
+            IndexSearcher searcher = new IndexSearcher(indexReader);
+            TopDocs topDocs = searcher.search(query, 10);
+            List<Document> documents = new ArrayList<>();
+            for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                documents.add(searcher.doc(scoreDoc.doc));
+            }
+            return documents;
+        }
+    }
+
+    public List<Document> searchIndex(Query query) throws IOException {
+        try (IndexReader indexReader = DirectoryReader.open(directory)) {
+            IndexSearcher searcher = new IndexSearcher(indexReader);
+            TopDocs topDocs = searcher.search(query, 10);
+            List<Document> documents = new ArrayList<>();
+            for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                documents.add(searcher.doc(scoreDoc.doc));
+            }
+            return documents;
+        }
+    }
+
+    public List<Document> searchIndex(Query query, Sort sort) throws IOException {
+        try (IndexReader indexReader = DirectoryReader.open(directory)) {
+            IndexSearcher searcher = new IndexSearcher(indexReader);
+            TopDocs topDocs = searcher.search(query, 10, sort);
+            List<Document> documents = new ArrayList<>();
+            for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                documents.add(searcher.doc(scoreDoc.doc));
+            }
+            return documents;
+        }
+    }
+
+    /**
+     * Delete a document with a Term.
+     *
+     * @param term Term
+     * @throws IOException exception
+     */
+    public void deleteDocument(Term term) throws IOException {
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer))) {
+            writer.deleteDocuments(term);
+        }
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,7 @@ include 'fdb-record-layer-core'
 include 'fdb-record-layer-core-shaded'
 include 'fdb-record-layer-icu'
 include 'fdb-record-layer-spatial'
+include 'fdb-record-layer-lucene'
 include 'examples'
 
 // It's confusing to have dozens of files called build.gradle scattered around the project


### PR DESCRIPTION
_Why are we doing this?_
There is a desire for RecordLayer to be able to support FullTextSearch as a core capability.  There have been several attempts to do this in the open source community.  

_What is this?_
The Directory implementation is the abstraction in Lucene above the FileSystem.  This initial commit to full text search only focuses and tests this abstraction.  Forthcoming PRs, will add an IndexMaintainer and other pieces required to handle query processing.

**Implementation:**

An FDBDirectory is created to implement Lucene's Directory interface.  Data is stored into FDB using the following layout.

**Sequence Space** 
_{Directory Bytes}{indexspace}{key=s value={atomic integer}_
This first section stores the atomic integer to make sure temporary files prior to renaming are unique.

**Metadata Space** 
_{Directory Bytes}{indexspace}{m}[{key=file123, value={id=1, size=2018, blockSize=1024}},{key=file12345, value={id=2, size=124, blockSize=1024}}]_
The metadata is keyed by filename and in the value it provides the total size, the block size, and an id to lookup the data.

**Data Space** 
_{Directory Bytes}{indexspace}{d}[{key=(1,1), value=byte[]},{key=(1,2), value=byte[]},{key=(2,1), value=byte[]}]_
The data section is keyed via the files id in the metadata directory coupled with a block number.