### PR TITLE
Resolves #1130: Adjust costing for primary scans

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -552,7 +552,7 @@ public class RecordQueryPlanner implements QueryPlanner {
                 if (index == null) {
                     // if we scan without an index all filters become index filters as we don't need a fetch
                     // to evaluate these filters
-                    p = p.withFilters(Collections.emptyList(), p.combineNonSargables());
+                    p = p.withFilters(p.combineNonSargables(), Collections.emptyList());
                 } else {
                     p = computeIndexFilters(planContext, p);
                 }


### PR DESCRIPTION
This restores the behavior prior to #1039. Plans with predicates over primary scans are again treated in a way that they again compete with plans with residual predicates over index scans. The configuration parameter

```
num IndexScanPreference {
        /**
         * Prefer a full scan over an index scan.
         * A full scan does not have to separately fetch the record, but may return records of types that just
         * need to be skipped.
         */
        PREFER_SCAN,
        /**
         * Prefer index scan over full scan.
         * An index scan always fetches the record separately but is less vulnerable to the addition of records
         * of unrelated record types.
         */
        PREFER_INDEX,
        /**
         * Prefer a scan using an index for <em>exactly</em> the primary key.
         */
        PREFER_PRIMARY_KEY_INDEX
    }
```

should be used as tie-breaker between these plans.