### PR TITLE
fixes #1129: Address follow-up issues in Lucene Index implementation

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -78,6 +78,9 @@ public class FDBDirectory extends Directory {
     public static final int DEFAULT_MAXIMUM_SIZE = 1024;
     public static final int DEFAULT_CONCURRENCY_LEVEL = 16;
     public static final int DEFAULT_INITIAL_CAPACITY = 128;
+    private static final int SEQUENCE_SUBSPACE = 0;
+    private static final int META_SUBSPACE = 1;
+    private static final int DATA_SUBSPACE = 2;
     private final AtomicLong nextTempFileCounter = new AtomicLong();
     private final FDBRecordContext context;
     private final Subspace subspace;
@@ -104,10 +107,10 @@ public class FDBDirectory extends Directory {
         Verify.verify(lockFactory != null);
         this.context = context;
         this.subspace = subspace;
-        final Subspace sequenceSubspace = subspace.subspace(Tuple.from(0));
+        final Subspace sequenceSubspace = subspace.subspace(Tuple.from(SEQUENCE_SUBSPACE));
         this.sequenceSubspaceKey = sequenceSubspace.pack();
-        this.metaSubspace = subspace.subspace(Tuple.from(1));
-        this.dataSubspace = subspace.subspace(Tuple.from(2));
+        this.metaSubspace = subspace.subspace(Tuple.from(META_SUBSPACE));
+        this.dataSubspace = subspace.subspace(Tuple.from(DATA_SUBSPACE));
         this.lockFactory = lockFactory;
         this.blockSize = blockSize;
         this.fileReferenceCache = CacheBuilder.newBuilder()

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -220,7 +220,7 @@ public class FDBIndexInput extends IndexInput {
      * @throws IOException exception
      */
     @Override
-    public void readBytes(@Nonnull final byte[] bytes, final int offset, final int length) throws IOException {
+    public void readBytes(@Nonnull final byte[] bytes, final int offset, final int length) {
         LOGGER.trace("readBytes resource={}, offset={}, length={}", resourceDescription, offset, length);
         int bytesRead = 0;
         long blockSize = reference.join().getBlockSize();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
+import static com.google.common.base.Verify.verify;
+
 /**
  * Class that handles reading data cut into blocks (KeyValue) backed by an FDB keyspace.
  *
@@ -196,7 +198,7 @@ public class FDBIndexInput extends IndexInput {
         try {
             int probe = (int)(absolutePosition() % reference.join().getBlockSize());
             position++;
-            assert currentData.join() != null : "current Data is null: " + resourceDescription + " " + reference.join().getId();
+            verify(currentData.join() != null, "current Data is null: " + resourceDescription + " " + reference.join().getId());
             return currentData.join()[probe];
         } finally {
             if (absolutePosition() % reference.join().getBlockSize() == 0) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -217,7 +217,6 @@ public class FDBIndexInput extends IndexInput {
      * @param bytes bytes
      * @param offset offset
      * @param length length
-     * @throws IOException exception
      */
     @Override
     public void readBytes(@Nonnull final byte[] bytes, final int offset, final int length) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
+import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
@@ -85,7 +86,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
     @Test
     public void testMissingSeek() {
-        assertThrows(NullPointerException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
+        assertThrows(RecordCoreArgumentException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
     }
 
     @Test

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -86,7 +86,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
     @Test
     public void testMissingSeek() {
-        assertThrows(RecordCoreArgumentException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
+        assertThrows(IllegalArgumentException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
     }
 
     @Test

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -86,7 +86,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
     @Test
     public void testMissingSeek() {
-        assertThrows(IllegalArgumentException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
+        assertThrows(RecordCoreArgumentException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
     }
 
     @Test


### PR DESCRIPTION
- Transaction -> FDBRecordContext
- removing reads value from FDBDirectory 
- trivial fixes

Not addressed here: 
- Apply vs ApplyAsync
- tuple to Protobuf 