### PR TITLE
Resolve #1136: Implement Lucene IndexMaintainer and RecordCursor

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -157,6 +157,8 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     private boolean dirtyStoreState;
     private boolean dirtyMetaDataVersionStamp;
     private long trackOpenTimeNanos;
+    @Nonnull
+    private final Map<String, Object> session = new LinkedHashMap<>();
 
     protected FDBRecordContext(@Nonnull FDBDatabase fdb,
                                @Nonnull Transaction transaction,
@@ -1299,4 +1301,45 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
             }
         }
     }
+
+    /**
+     * Retrieve a value from the session in the FDBRecordContext.
+     *
+     * @param key key
+     * @param clazz class
+     * @param <T> Class
+     * @return value
+     */
+    @SuppressWarnings("unchecked")
+    @API(API.Status.EXPERIMENTAL)
+    public synchronized <T> T getInSession(@Nonnull String key, @Nonnull Class<T> clazz) {
+        return (T) session.get(key);
+    }
+
+    /**
+     * Put an object into the session of the FDBRecordContext.
+     *
+     * @param key key
+     * @param <T> the type of the value
+     * @param value value
+     */
+    @API(API.Status.EXPERIMENTAL)
+    public synchronized <T extends Object> void putInSessionIfAbsent(@Nonnull String key, @Nonnull T value) {
+        session.put(key, value);
+    }
+
+    /**
+     * Put an object into the session of the FDBRecordContext.
+     *
+     * @param key key
+     * @param clazz class
+     * @param <T> the type of the class
+     * @return value
+     */
+    @SuppressWarnings("unchecked")
+    @API(API.Status.EXPERIMENTAL)
+    public synchronized <T> T removeFromSession(@Nonnull String key, @Nonnull Class<T> clazz) {
+        return (T) session.remove(key);
+    }
+
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -63,6 +63,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -431,6 +432,17 @@ public class FDBRecordContextTest extends FDBTestBase {
             context.commit();
         }
     }
+
+    @Test
+    public void testSession() {
+        try (FDBRecordContext context = fdb.openContext(null, null, null, FDBTransactionPriority.DEFAULT, "logTransactionTwice")) {
+            context.putInSessionIfAbsent("Yo", "YOLO");
+            assertEquals("YOLO", context.getInSession("Yo", String.class));
+            assertEquals("YOLO", context.removeFromSession("Yo", String.class));
+            assertNull(context.getInSession("Yo", String.class));
+        }
+    }
+
 
     @Test
     public void logTransactionAfterGettingAReadVersion() {

--- a/fdb-record-layer-core/src/test/proto/test_records_text.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_text.proto
@@ -39,6 +39,7 @@ message ComplexDocument {
     optional string text = 3;
     repeated string tag = 4;
     optional int32 score = 5;
+    optional string text2 = 6;
 }
 
 message MapDocument {

--- a/fdb-record-layer-lucene/README.md
+++ b/fdb-record-layer-lucene/README.md
@@ -1,13 +1,18 @@
 # FoundationDB Record Layer Lucene Index
 
-The lucene index implementation on the record layer consists of two key components.  The first component is a Directory implementation backed by an FDB KeySpace.
+The lucene index implementation on the record layer consists of several components.  The first component is a Directory implementation backed by an FDB KeySpace.
 
 * **Directory Implementation** 
 
-A <a href="https://lucene.apache.org/core/7_6_0/core/org/apache/lucene/store/Directory.html">Directory</a> provides an abstraction layer for storing a list of files. A directory contains only files (no sub-folder hierarchy). Implementing classes must comply with the following:
+A <a href="https://lucene.apache.org/core/7_7_2/core/org/apache/lucene/store/Directory.html">Directory</a> provides an abstraction layer for storing a list of files. A directory contains only files (no sub-folder hierarchy). Implementing classes must comply with the following:
 A file in a directory can be created (createOutput(java.lang.String, org.apache.lucene.store.IOContext)), appended to, then closed.
 A file open for writing may not be available for read access until the corresponding IndexOutput is closed.
 Once a file is created it must only be opened for input (openInput(java.lang.String, org.apache.lucene.store.IOContext)), or deleted (deleteFile(java.lang.String)). Calling createOutput(java.lang.String, org.apache.lucene.store.IOContext) on an existing file must throw FileAlreadyExistsException.
+
+* **Lucene Index Maintenance and Scans**
+
+The LuceneIndexMaintainer provides core functionality for scanning Lucene Indexes backed by FoundationDB.
+The core scan interface is the existing <a href="https://lucene.apache.org/core/7_7_3/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description"> Lucene Query Parser syntax</a>.
 
 ## Documentation
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/DirectoryCommitCheckAsync.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/DirectoryCommitCheckAsync.java
@@ -1,0 +1,111 @@
+/*
+ * DirectoryCheck.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreStorageException;
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.subspace.Subspace;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Closes the directory before commit.
+ *
+ */
+@API(API.Status.EXPERIMENTAL)
+public class DirectoryCommitCheckAsync implements FDBRecordContext.CommitCheckAsync {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LuceneIndexMaintainer.class);
+    private final FDBDirectory directory;
+
+    /**
+     * Creates a lucene directory from a subspace (keyspace) and a transaction.
+     *
+     * @param subspace the index subspace that contains the Directory/Files/etc.
+     * @param context context
+     */
+    public DirectoryCommitCheckAsync(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context) {
+        this.directory = new FDBDirectory(subspace, context);
+    }
+
+    /**
+     * Close Lucene Directory.
+     *
+     * @return CompletableFuture
+     */
+    @Nonnull
+    @Override
+    public CompletableFuture<Void> checkAsync() {
+        LOGGER.trace("closing directory check");
+        return CompletableFuture.runAsync(() -> {
+            try {
+                IOUtils.close(directory);
+            } catch (IOException ioe) {
+                LOGGER.error("DirectoryCommitCheckAsync Failed", ioe);
+                throw new RecordCoreStorageException("DirectCommitCheckAsyncFailed for directory=" + directory.getSubspace(), ioe);
+            }
+        },
+        directory.getContext().getExecutor());
+    }
+
+    @Nonnull
+    public Directory getDirectory() {
+        return directory;
+    }
+
+    /**
+     * Attempts to get the commit check from the context and if it cannot find it, creates one and adds it to the context.
+     *
+     * @param state state
+     * @return DirectoryCommitCheckAsync
+     */
+    @Nonnull
+    protected static DirectoryCommitCheckAsync getOrCreateDirectoryCommitCheckAsync(@Nonnull final IndexMaintainerState state) {
+        synchronized (state.context) {
+            DirectoryCommitCheckAsync directoryCheck = state.context.getInSession(getDirectoryName(state), DirectoryCommitCheckAsync.class);
+            if (directoryCheck == null) {
+                directoryCheck = new DirectoryCommitCheckAsync(state.indexSubspace, state.context);
+                state.context.addCommitCheck(directoryCheck);
+                state.context.putInSessionIfAbsent(getDirectoryName(state), directoryCheck);
+            }
+            return directoryCheck;
+        }
+    }
+
+    /**
+     * The directory name in the context.
+     *
+     * @param state state
+     * @return String
+     */
+    private static String getDirectoryName(@Nonnull final IndexMaintainerState state) {
+        return "directory$" + state.index.getName();
+    }
+}
+

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/IndexWriterCommitCheckAsync.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/IndexWriterCommitCheckAsync.java
@@ -1,0 +1,134 @@
+/*
+ * IndexWriterCommitCheckAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreStorageException;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
+import org.apache.lucene.codecs.lucene70.Lucene70Codec;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.TieredMergePolicy;
+import org.apache.lucene.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static com.apple.foundationdb.record.lucene.DirectoryCommitCheckAsync.getOrCreateDirectoryCommitCheckAsync;
+
+/**
+ * This class closes the writer after commit.  The goal here is to only flush the results
+ * at the end of the commit.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class IndexWriterCommitCheckAsync implements FDBRecordContext.CommitCheckAsync {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LuceneIndexMaintainer.class);
+    protected final IndexWriter indexWriter;
+    protected final Executor executor;
+
+
+    /**
+     * Creates an index writer config with merge configurations that limit the amount of data in a segment.
+     *
+     * @param analyzer analyzer
+     * @param directoryCommitCheckAsync directoryCommitCheckAsync
+     * @param executor executor
+     * @throws IOException exception
+     */
+    public IndexWriterCommitCheckAsync(@Nonnull Analyzer analyzer, @Nonnull DirectoryCommitCheckAsync directoryCommitCheckAsync, Executor executor) throws IOException {
+        TieredMergePolicy tieredMergePolicy = new TieredMergePolicy();
+        tieredMergePolicy.setMaxMergedSegmentMB(5.00);
+        tieredMergePolicy.setMaxMergeAtOnceExplicit(2);
+        tieredMergePolicy.setNoCFSRatio(1.00);
+        IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
+        indexWriterConfig.setUseCompoundFile(true);
+        indexWriterConfig.setMergePolicy(tieredMergePolicy);
+        indexWriterConfig.setMergeScheduler(new ConcurrentMergeScheduler() {
+            @Override
+            protected void doMerge(final IndexWriter writer, final MergePolicy.OneMerge merge) throws IOException {
+                merge.segments.forEach( (segmentCommitInfo) -> LOGGER.trace("segmentInfo={}", segmentCommitInfo.info.name));
+                super.doMerge(writer, merge);
+            }
+        });
+        indexWriterConfig.setCodec(new Lucene70Codec(Lucene50StoredFieldsFormat.Mode.BEST_COMPRESSION));
+        this.indexWriter = new IndexWriter(directoryCommitCheckAsync.getDirectory(), indexWriterConfig);
+        this.executor = executor;
+    }
+
+    /**
+     * Close IndexWriter.
+     *
+     * @return CompletableFuture
+     */
+    @Nonnull
+    @Override
+    public CompletableFuture<Void> checkAsync() {
+        LOGGER.trace("closing writer check");
+        if (indexWriter.isOpen()) {
+            return CompletableFuture.runAsync(() -> {
+                try {
+                    IOUtils.close(indexWriter);
+                } catch (IOException ioe) {
+                    LOGGER.error("IndexWriterCommitCheckSync Failed", ioe);
+                    throw new RecordCoreStorageException("IndexWriterCommitCheckSync Failed", ioe);
+                }
+            },
+            executor);
+        } else {
+            return AsyncUtil.DONE;
+        }
+    }
+
+    @Nullable
+    protected static IndexWriterCommitCheckAsync getIndexWriterCommitCheckAsync(@Nonnull final IndexMaintainerState state) {
+        return state.context.getInSession(getWriterName(state), IndexWriterCommitCheckAsync.class);
+    }
+
+    @Nonnull
+    protected static IndexWriter getOrCreateIndexWriter(@Nonnull final IndexMaintainerState state, @Nonnull Analyzer analyzer, @Nonnull Executor executor) throws IOException {
+        synchronized (state.context) {
+            IndexWriterCommitCheckAsync writerCheck = getIndexWriterCommitCheckAsync(state);
+            if (writerCheck == null) {
+                writerCheck = new IndexWriterCommitCheckAsync(analyzer, getOrCreateDirectoryCommitCheckAsync(state), executor);
+                state.context.addCommitCheck(writerCheck);
+                state.context.putInSessionIfAbsent(getWriterName(state), writerCheck);
+            }
+            return writerCheck.indexWriter;
+        }
+    }
+
+    @Nonnull
+    private static String getWriterName(@Nonnull final IndexMaintainerState state) {
+        return "writer$" + state.index.getName();
+    }
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -1,0 +1,247 @@
+/*
+ * LuceneIndexMaintainer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
+import com.apple.foundationdb.record.metadata.IndexRecordFunction;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperation;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperationResult;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.InvalidIndexEntry;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.StandardIndexMaintainer;
+import com.apple.foundationdb.record.query.QueryToKeyMatcher;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.base.Verify;
+import com.google.protobuf.Message;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static com.apple.foundationdb.record.lucene.IndexWriterCommitCheckAsync.getOrCreateIndexWriter;
+
+/**
+ * Index maintainer for Lucene Indexes backed by FDB.  The insert, update, and delete functionality
+ * coupled with the scan functionality is implemented here.
+ *
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LuceneIndexMaintainer extends StandardIndexMaintainer {
+    private static final Logger LOG = LoggerFactory.getLogger(LuceneIndexMaintainer.class);
+    private final Analyzer analyzer;
+    protected static final String PRIMARY_KEY_FIELD_NAME = "p"; // TODO: Need to find reserved names..
+    private static final String PRIMARY_KEY_SEARCH_NAME = "s"; // TODO: Need to find reserved names..
+    private final List<String> fieldNames = new ArrayList<>(2);
+    private final Executor executor;
+
+    public LuceneIndexMaintainer(@Nonnull final IndexMaintainerState state, @Nonnull Executor executor, @Nonnull Analyzer analyzer) {
+        super(state);
+        this.analyzer = analyzer;
+        this.state.index.getRootExpression()
+                .normalizeKeyForPositions().forEach( (fke) -> this.fieldNames.add( ((FieldKeyExpression) fke).getFieldName()));
+        this.executor = executor;
+    }
+
+    /**
+     * The scan uses the low element in the range to execute the
+     * MultiFieldQueryParser.
+     *
+     * @param scanType the {@link IndexScanType type} of scan to perform
+     * @param range the range to scan
+     * @param continuation any continuation from a previous scan invocation
+     * @param scanProperties skip, limit and other properties of the scan
+     * @return RecordCursor
+     */
+    @Nonnull
+    @Override
+    public RecordCursor<IndexEntry> scan(@Nonnull IndexScanType scanType, @Nonnull TupleRange range,
+                                         @Nullable byte[] continuation,
+                                         @Nonnull ScanProperties scanProperties) {
+        LOG.trace("scan scanType={}", scanType);
+        Verify.verify(range.getLow() != null);
+        Verify.verify(scanType.equals(LuceneIndexScanTypes.BY_LUCENE_QUERY));
+        try {
+            final MultiFieldQueryParser parser = new MultiFieldQueryParser(fieldNames.toArray(new String[0]) , analyzer);
+            Query query = parser.parse(range.getLow().getString(0));
+            return new LuceneRecordCursor(executor, scanProperties, state, query, continuation, fieldNames);
+        } catch (Exception ioe) {
+            throw new RecordCoreArgumentException("Unable to parse range given for query", "range", range, ioe);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public <M extends Message> CompletableFuture<Void> update(@Nullable FDBIndexableRecord<M> oldRecord,
+                                                              @Nullable FDBIndexableRecord<M> newRecord) {
+        LOG.trace("update oldRecord={}, newRecord{}", oldRecord, newRecord);
+        return super.update(oldRecord, newRecord);
+    }
+
+    @Nonnull
+    @Override
+    protected <M extends Message> CompletableFuture<Void> updateIndexKeys(@Nonnull final FDBIndexableRecord<M> savedRecord,
+                                                                          final boolean remove,
+                                                                          @Nonnull final List<IndexEntry> indexEntries) {
+        LOG.trace("updateIndexKeys savedRecord={}, remove=={}, indexEntries={}", savedRecord, remove, indexEntries);
+        if (indexEntries.isEmpty()) {
+            return AsyncUtil.DONE;
+        }
+        try {
+            final IndexWriter writer = getOrCreateIndexWriter(state, analyzer, executor);
+            indexEntries.forEach( (entry ) -> {
+                try {
+                    if (remove) {
+                        Query query = SortedDocValuesField.newSlowExactQuery(PRIMARY_KEY_SEARCH_NAME, new BytesRef(savedRecord.getPrimaryKey().pack()));
+                        writer.deleteDocuments(query);
+                    } else {
+                        Document document = new Document();
+                        byte[] primaryKey = savedRecord.getPrimaryKey().pack();
+                        BytesRef ref = new BytesRef(primaryKey);
+                        document.add(new StoredField(PRIMARY_KEY_FIELD_NAME, ref));
+                        document.add(new SortedDocValuesField(PRIMARY_KEY_SEARCH_NAME, ref));
+                        for (int i = 0; i < fieldNames.size(); i++) {
+                            document.add(new TextField(fieldNames.get(i), entry.getKey().getString(i), Field.Store.NO));
+                        }
+                        writer.addDocument(document);
+                    }
+                } catch (IOException ioe) {
+                    throw new RecordCoreException("Issue updating index keys", "Key", entry, "IndexEntries", indexEntries,
+                            "savedRecord", savedRecord, ioe);
+                }
+            });
+        } catch (Exception e) {
+            throw new RecordCoreException(e);
+        }
+        return AsyncUtil.DONE;
+    }
+
+    @Nonnull
+    @Override
+    public RecordCursor<IndexEntry> scanUniquenessViolations(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
+        LOG.trace("scanUniquenessViolations");
+        return RecordCursor.empty();
+    }
+
+    @Nonnull
+    @Override
+    public RecordCursor<InvalidIndexEntry> validateEntries(@Nullable byte[] continuation, @Nullable ScanProperties scanProperties) {
+        LOG.trace("validateEntries");
+        return RecordCursor.empty();
+    }
+
+    @Override
+    public boolean canEvaluateRecordFunction(@Nonnull IndexRecordFunction<?> function) {
+        LOG.trace("canEvaluateRecordFunction() function={}", function);
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public <T, M extends Message> CompletableFuture<T> evaluateRecordFunction(@Nonnull EvaluationContext context,
+                                                                              @Nonnull IndexRecordFunction<T> function,
+                                                                              @Nonnull FDBRecord<M> record) {
+        LOG.warn("evaluateRecordFunction() function={}", function);
+        return unsupportedRecordFunction(function);
+    }
+
+    @Override
+    public boolean canEvaluateAggregateFunction(@Nonnull IndexAggregateFunction function) {
+        LOG.trace("canEvaluateAggregateFunction() function={}", function);
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Tuple> evaluateAggregateFunction(@Nonnull IndexAggregateFunction function,
+                                                              @Nonnull TupleRange range,
+                                                              @Nonnull IsolationLevel isolationLevel) {
+        LOG.warn("evaluateAggregateFunction() function={}", function);
+        return unsupportedAggregateFunction(function);
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        LOG.trace("isIdempotent()");
+        return true;
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Boolean> addedRangeWithKey(@Nonnull Tuple primaryKey) {
+        LOG.trace("addedRangeWithKey primaryKey={}", primaryKey);
+        return AsyncUtil.READY_FALSE;
+    }
+
+    @Override
+    public boolean canDeleteWhere(@Nonnull QueryToKeyMatcher matcher, @Nonnull Key.Evaluated evaluated) {
+        LOG.trace("canDeleteWhere matcher={}", matcher);
+        return false;
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<Void> deleteWhere(Transaction tr, @Nonnull Tuple prefix) {
+        LOG.trace("deleteWhere transaction={}, prefix={}", tr, prefix);
+        return AsyncUtil.DONE;
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<IndexOperationResult> performOperation(@Nonnull IndexOperation operation) {
+        LOG.trace("performOperation operation={}", operation);
+        return CompletableFuture.completedFuture(new IndexOperationResult() {
+        });
+    }
+
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
@@ -1,0 +1,69 @@
+/*
+ * LuceneIndexMaintainerFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.metadata.MetaDataValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.google.auto.service.AutoService;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Index Maintainer Factory for Lucene Indexes.  This adds the Lucene index to supported indexes.
+ *
+ */
+@AutoService(IndexMaintainerFactory.class)
+@API(API.Status.EXPERIMENTAL)
+public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
+
+    @Nonnull
+    private static final List<String> TYPES = Collections.singletonList(LuceneIndexTypes.LUCENE);
+
+    @Override
+    public Iterable<String> getIndexTypes() {
+        return TYPES;
+    }
+
+    @Nonnull
+    @Override
+    public IndexValidator getIndexValidator(@Nonnull Index index) {
+        return new IndexValidator(index) {
+            @Override
+            public void validate(@Nonnull MetaDataValidator metaDataValidator) {
+                // nothing to validate
+            }
+        };
+    }
+
+    @Override
+    @Nonnull
+    public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
+        return new LuceneIndexMaintainer(state, state.context.getExecutor(), new StandardAnalyzer());
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScanTypes.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScanTypes.java
@@ -1,0 +1,47 @@
+/*
+ * LuceneIndexScanTypes.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.IndexScanType;
+
+/**
+ * Scan Types for Lucene Scans.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LuceneIndexScanTypes {
+    /**
+     * Supports Lucene Query Syntax https://lucene.apache.org/core/2_9_4/queryparsersyntax.html
+     *
+     */
+    public static final IndexScanType BY_LUCENE_QUERY = new IndexScanType("BY_LUCENE_QUERY");
+    /**
+     * Return AUTO Complete for Field. (NOT IMPLEMENTED)
+     *
+     */
+    public static final IndexScanType LUCENE_AUTOCOMPLETE = new IndexScanType("LUCENE_AUTOCOMPLETE");
+    /**
+     * Return Lucene Query with positions for syntax highlighting. (NOT IMPLEMENTED)
+     *
+     */
+    public static final IndexScanType BY_LUCENE_QUERY_WITH_POSITIONS = new IndexScanType("BY_LUCENE_QUERY_WITH_POSITIONS");
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexTypes.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexTypes.java
@@ -1,0 +1,35 @@
+/*
+ * LuceneIndexTypes.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+
+/**
+ * An index on the tokens in a text field.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LuceneIndexTypes {
+
+    public static final String LUCENE = "lucene";
+
+    private LuceneIndexTypes() {
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -1,0 +1,237 @@
+/*
+ * LuceneRecordCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.ByteArrayContinuation;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.cursors.BaseCursor;
+import com.apple.foundationdb.record.cursors.CursorLimitManager;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.primitives.Ints;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static com.apple.foundationdb.record.lucene.DirectoryCommitCheckAsync.getOrCreateDirectoryCommitCheckAsync;
+import static com.apple.foundationdb.record.lucene.IndexWriterCommitCheckAsync.getIndexWriterCommitCheckAsync;
+
+/**
+ * This class is a Record Cursor implementation for Lucene queries.
+ *
+ */
+@API(API.Status.EXPERIMENTAL)
+class LuceneRecordCursor implements BaseCursor<IndexEntry> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LuceneRecordCursor.class);
+    @Nonnull
+    private final Executor executor;
+    @Nonnull
+    private final CursorLimitManager limitManager;
+    @Nullable
+    private CompletableFuture<Boolean> hasNextFuture;
+    @Nullable
+    private final FDBStoreTimer timer;
+    private int limitRemaining;
+    @Nullable
+    private RecordCursorResult<IndexEntry> nextResult;
+    final IndexMaintainerState state;
+    private IndexReader indexReader;
+    private final Query query;
+    private IndexSearcher searcher;
+    private TopDocs topDocs;
+    private int currentPosition;
+    private final List<String> fieldNames;
+
+    LuceneRecordCursor(@Nonnull Executor executor,
+                       @Nonnull ScanProperties scanProperties,
+                       @Nonnull final IndexMaintainerState state, Query query,
+                       byte[] continuation, List<String> fieldNames) {
+        this.state = state;
+        this.executor = executor;
+        this.limitManager = new CursorLimitManager(state.context, scanProperties);
+        this.limitRemaining = scanProperties.getExecuteProperties().getReturnedRowLimitOrMax();
+        this.timer = state.context.getTimer();
+        this.query = query;
+        this.currentPosition = continuation == null ? 0 : Ints.fromByteArray(continuation);
+        if (scanProperties.getExecuteProperties().getSkip() > 0) {
+            this.currentPosition += scanProperties.getExecuteProperties().getSkip();
+        }
+        this.fieldNames = fieldNames;
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<RecordCursorResult<IndexEntry>> onNext() {
+        if (nextResult != null && !nextResult.hasNext()) {
+            // Like the KeyValueCursor, it is necessary to memoize and return the first result where
+            // hasNext is false to avoid the NoNextReason changing.
+            return CompletableFuture.completedFuture(nextResult);
+        }
+        if (topDocs == null) {
+            try {
+                performScan();
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }
+        if (limitRemaining > 0 && currentPosition < topDocs.scoreDocs.length && limitManager.tryRecordScan()) {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    Document document = searcher.doc(topDocs.scoreDocs[currentPosition].doc);
+                    IndexableField primaryKey = document.getField(LuceneIndexMaintainer.PRIMARY_KEY_FIELD_NAME);
+                    BytesRef pk = primaryKey.binaryValue();
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace("document={}", document);
+                        LOGGER.trace("primary key read={}", Tuple.fromBytes(pk.bytes, pk.offset, pk.length));
+                    }
+                    if (timer != null) {
+                        timer.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
+                    }
+                    if (limitRemaining != Integer.MAX_VALUE) {
+                        limitRemaining--;
+                    }
+                    Tuple tuple = Tuple.fromList(fieldNames);
+                    nextResult = RecordCursorResult.withNextValue(new IndexEntry(state.index,
+                            tuple.addAll(Tuple.fromBytes(pk.bytes, pk.offset, pk.length)), null), continuationHelper());
+                    currentPosition++;
+                    return nextResult;
+                } catch (Exception e) {
+                    throw new RecordCoreException("Failed to get document", "currentPosition", currentPosition, e);
+                }
+            }, executor);
+        } else { // a limit was exceeded
+            if (limitRemaining <= 0) {
+                nextResult = RecordCursorResult.withoutNextValue(continuationHelper(), NoNextReason.RETURN_LIMIT_REACHED);
+            } else if (currentPosition >= topDocs.scoreDocs.length) {
+                nextResult = RecordCursorResult.withoutNextValue(continuationHelper(), NoNextReason.SOURCE_EXHAUSTED);
+            } else {
+                final Optional<NoNextReason> stoppedReason = limitManager.getStoppedReason();
+                if (!stoppedReason.isPresent()) {
+                    throw new RecordCoreException("limit manager stopped LuceneRecordCursor but did not report a reason");
+                } else {
+                    nextResult = RecordCursorResult.withoutNextValue(continuationHelper(), stoppedReason.get());
+                }
+            }
+            return CompletableFuture.completedFuture(nextResult);
+        }
+    }
+
+    @Nonnull
+    private RecordCursorContinuation continuationHelper() {
+        if (currentPosition >= topDocs.scoreDocs.length && limitRemaining > 0) {
+            return ByteArrayContinuation.fromNullable(null);
+        } else {
+            return ByteArrayContinuation.fromNullable(Ints.toByteArray(currentPosition));
+        }
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public CompletableFuture<Boolean> onHasNext() {
+        if (hasNextFuture == null) {
+            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
+        }
+        return hasNextFuture;
+    }
+
+    @Nullable
+    @Override
+    @Deprecated
+    public IndexEntry next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        hasNextFuture = null;
+        return nextResult.get();
+    }
+
+    @Nullable
+    @Override
+    @Deprecated
+    public byte[] getContinuation() {
+        return Ints.toByteArray(currentPosition);
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public NoNextReason getNoNextReason() {
+        return nextResult.getNoNextReason();
+    }
+
+    @Override
+    public void close() {
+        if (indexReader != null) {
+            IOUtils.closeWhileHandlingException(indexReader);
+        }
+        if (hasNextFuture != null) {
+            hasNextFuture.cancel(false);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public Executor getExecutor() {
+        return executor;
+    }
+
+    @Override
+    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+        visitor.visitEnter(this);
+        return visitor.visitLeave(this);
+    }
+
+    private synchronized IndexReader getIndexReader() throws IOException {
+        IndexWriterCommitCheckAsync writerCheck = getIndexWriterCommitCheckAsync(state);
+        return writerCheck == null ? DirectoryReader.open(getOrCreateDirectoryCommitCheckAsync(state).getDirectory()) : DirectoryReader.open(writerCheck.indexWriter);
+    }
+
+    private void performScan() throws IOException {
+        indexReader = getIndexReader();
+        searcher = new IndexSearcher(indexReader);
+        topDocs = searcher.search(query, limitRemaining);
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common classes for lucene storage and queries.
+ */
+package com.apple.foundationdb.record.lucene;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -1,0 +1,359 @@
+/*
+ * LuceneIndexTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecordsTextProto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.provider.common.text.AllSuffixesTextTokenizer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import javax.annotation.Nonnull;
+import java.util.Random;
+
+import static com.apple.foundationdb.record.lucene.LuceneIndexScanTypes.BY_LUCENE_QUERY;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.COMPLEX_DOC;
+import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.SIMPLE_DOC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@code LUCENE} type indexes.
+ */
+@Tag(Tags.RequiresFDB)
+public class LuceneIndexTest extends FDBRecordStoreTestBase {
+
+    private static final Index SIMPLE_TEXT_SUFFIXES = new Index("Simple$text_suffixes", field("text"), LuceneIndexTypes.LUCENE,
+            ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME));
+
+    private static final Index COMPLEX_MULTIPLE_TEXT_INDEXES = new Index("Complex$text_multipleIndexes", concatenateFields("text", "text2"), LuceneIndexTypes.LUCENE,
+            ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME));
+
+    private static final String DYLAN = "You're an idiot, babe\n" +
+                                        "It's a wonder that you still know how to breathe";
+
+    private static final String WAYLON = "There's always one more way to do things and that's your way, and you have a right to try it at least once.";
+
+    protected void openRecordStore(FDBRecordContext context, FDBRecordStoreTestBase.RecordMetaDataHook hook) {
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
+        metaDataBuilder.getRecordType(COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
+        hook.apply(metaDataBuilder);
+        recordStore = getStoreBuilder(context, metaDataBuilder.getRecordMetaData())
+                .setSerializer(TextIndexTestUtils.COMPRESSING_SERIALIZER)
+                .uncheckedOpen();
+        setupPlanner(null);
+    }
+
+    @Nonnull
+    protected FDBRecordStore.Builder getStoreBuilder(@Nonnull FDBRecordContext context, @Nonnull RecordMetaData metaData) {
+        return FDBRecordStore.newBuilder()
+                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION) // set to max to test newest features (unsafe for real deployments)
+                .setKeySpacePath(path)
+                .setContext(context)
+                .setMetaDataProvider(metaData);
+    }
+
+    private TestRecordsTextProto.SimpleDocument createSimpleDocument(long docId, String text, int group) {
+        return TestRecordsTextProto.SimpleDocument.newBuilder()
+                .setDocId(docId)
+                .setText(text)
+                .setGroup(group)
+                .build();
+    }
+
+    private TestRecordsTextProto.ComplexDocument createComplexDocument(long docId, String text, String text2, int group) {
+        return TestRecordsTextProto.ComplexDocument.newBuilder()
+                .setDocId(docId)
+                .setText(text)
+                .setText2(text2)
+                .setGroup(group)
+                .build();
+    }
+
+
+    @Test
+    public void simpleInsertAndSearch() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            recordStore.saveRecord(createSimpleDocument(1623L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
+            RecordCursor<IndexEntry> indexEntries = recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY, TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN);
+            assertEquals(1, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN)
+                    .getCount().join());
+            assertEquals(1, context.getTimer().getCounter(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
+        }
+    }
+
+    @Test
+    public void testContinuation() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            recordStore.saveRecord(createSimpleDocument(1623L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1624L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1625L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1626L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
+            assertEquals(2, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), Ints.toByteArray(2), ScanProperties.FORWARD_SCAN)
+                    .getCount().join());
+        }
+    }
+
+    @Test
+    public void testLimit() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            for (int i = 0; i < 200; i++) {
+                recordStore.saveRecord(createSimpleDocument(1623L + i, DYLAN, 2));
+            }
+            assertEquals(50, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null,
+                    ExecuteProperties.newBuilder().setReturnedRowLimit(50).build().asScanProperties(false))
+                    .getCount().join());
+        }
+    }
+
+    @Test
+    public void testSkip() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            for (int i = 0; i < 50; i++) {
+                recordStore.saveRecord(createSimpleDocument(1623L + i, DYLAN, 2));
+            }
+            assertEquals(40, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null,
+                    ExecuteProperties.newBuilder().setReturnedRowLimit(50).setSkip(10).build().asScanProperties(false))
+                    .getCount().join());
+        }
+    }
+
+    @Test
+    public void testSkipWithLimit() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            for (int i = 0; i < 50; i++) {
+                recordStore.saveRecord(createSimpleDocument(1623L + i, DYLAN, 2));
+            }
+            assertEquals(40, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null,
+                    ExecuteProperties.newBuilder().setReturnedRowLimit(50).setSkip(10).build().asScanProperties(false))
+                    .getCount().join());
+        }
+    }
+
+    @Test
+    public void testLimitWithContinuation() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            for (int i = 0; i < 200; i++) {
+                recordStore.saveRecord(createSimpleDocument(1623L + i, DYLAN, 2));
+            }
+            assertEquals(48, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), Ints.toByteArray(2),
+                    ExecuteProperties.newBuilder().setReturnedRowLimit(50).build().asScanProperties(false))
+                    .getCount().join());
+        }
+    }
+
+    @Test
+    public void testMultipleFieldSearch() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_MULTIPLE_TEXT_INDEXES);
+            });
+            recordStore.saveRecord(createComplexDocument(1623L, DYLAN, "john_leach@apple.com", 2));
+            recordStore.saveRecord(createComplexDocument(1547L, WAYLON, "hering@gmail.com", 2));
+            assertEquals(1, recordStore.scanIndex(COMPLEX_MULTIPLE_TEXT_INDEXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("text:\"idiot\" AND text2:\"john_leach@apple.com\"")),
+                    null, ScanProperties.FORWARD_SCAN).getCount().join());
+        }
+    }
+
+    @Test
+    public void testFuzzySearchWithDefaultEdit2() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_MULTIPLE_TEXT_INDEXES);
+            });
+            recordStore.saveRecord(createComplexDocument(1623L, DYLAN, "john_leach@apple.com", 2));
+            recordStore.saveRecord(createComplexDocument(1547L, WAYLON, "hering@gmail.com", 2));
+            assertEquals(1, recordStore.scanIndex(COMPLEX_MULTIPLE_TEXT_INDEXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("text:\"idiot\" AND text2:jonleach@apple.com\\~")),
+                    null, ScanProperties.FORWARD_SCAN).getCount().join());
+        }
+    }
+
+    @Test
+    public void simpleInsertDeleteAndSearch() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            recordStore.saveRecord(createSimpleDocument(1623L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1624L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 2));
+            assertEquals(2, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN).getCount().join());
+            assertTrue(recordStore.deleteRecord(Tuple.from(1624L)));
+            assertEquals(1, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN).getCount().join());
+        }
+    }
+
+    @Test
+    public void testCommit() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            recordStore.saveRecord(createSimpleDocument(1623L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
+            assertEquals(1, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN)
+                    .getCount().join());
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            assertEquals(1, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN)
+                    .getCount().join());
+        }
+    }
+
+    @Test
+    public void testRollback() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            recordStore.saveRecord(createSimpleDocument(1623L, DYLAN, 2));
+            recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
+            assertEquals(1, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN)
+                    .getCount().join());
+            context.ensureActive().cancel();
+        }
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
+            assertEquals(0, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN)
+                    .getCount().join());
+            recordStore.saveRecord(createSimpleDocument(1623L, DYLAN, 2));
+            assertEquals(1, recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, BY_LUCENE_QUERY,
+                    TupleRange.allOf(Tuple.from("idiot")), null, ScanProperties.FORWARD_SCAN)
+                    .getCount().join());
+
+        }
+    }
+
+    @Test
+    public void testDataLoad() {
+        FDBRecordContext context = openContext();
+        for (int i = 0; i < 2000; i++) {
+            openRecordStore(context, metaDataBuilder -> {
+                metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
+                metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
+            });
+            String[] randomWords = generateRandomWords(500);
+            final TestRecordsTextProto.SimpleDocument dylan = TestRecordsTextProto.SimpleDocument.newBuilder()
+                    .setDocId(i)
+                    .setText(randomWords[1])
+                    .setGroup(2)
+                    .build();
+            recordStore.saveRecord(dylan);
+            if (i % 50 == 0) {
+                commit(context);
+                context = openContext();
+            }
+        }
+        context.close();
+    }
+
+    public static String[] generateRandomWords(int numberOfWords) {
+        assert numberOfWords > 0 : "Number of words have to be greater than 0";
+        StringBuilder builder = new StringBuilder();
+        Random random = new Random();
+        char[] word = null;
+        for (int i = 0; i < numberOfWords; i++) {
+            word = new char[random.nextInt(8) + 3]; // words of length 3 through 10. (1 and 2 letter words are boring.)
+            for (int j = 0; j < word.length; j++) {
+                word[j] = (char)('a' + random.nextInt(26));
+            }
+            if (i != numberOfWords - 1) {
+                builder.append(word).append(" ");
+            }
+        }
+        String[] returnValue = new String[2];
+        returnValue[0] = new String(word);
+        returnValue[1] = builder.toString();
+        return returnValue;
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
@@ -20,9 +20,9 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
-import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
 import com.apple.foundationdb.subspace.Subspace;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,8 +51,8 @@ public abstract class FDBDirectoryBaseTest {
             context.ensureActive().clear(subspace.range());
             return null;
         });
-        Transaction transaction = fdb.database().createTransaction();
-        directory = new FDBDirectory(subspace, transaction);
+        FDBRecordContext context = fdb.openContext();
+        directory = new FDBDirectory(subspace, context);
     }
 
     protected int randomInt(int minimum) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -20,7 +20,7 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
-import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -53,9 +53,9 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     public void testGetIncrement() {
         assertEquals(1, directory.getIncrement());
         assertEquals(2, directory.getIncrement());
-        directory.getTxn().commit().join();
-        Transaction transaction = fdb.database().createTransaction();
-        directory = new FDBDirectory(subspace, transaction);
+        directory.getContext().ensureActive().commit().join();
+        FDBRecordContext context = fdb.openContext();
+        directory = new FDBDirectory(subspace, context);
         assertEquals(3, directory.getIncrement());
     }
 
@@ -106,9 +106,9 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         directory.writeFDBLuceneFileReference("test2", new FDBLuceneFileReference(2, 1, 1));
         directory.writeFDBLuceneFileReference("test3", new FDBLuceneFileReference(3, 1, 1));
         assertArrayEquals(new String[]{"test1", "test2", "test3"}, directory.listAll());
-        directory.getTxn().cancel();
-        Transaction transaction = fdb.database().createTransaction();
-        directory = new FDBDirectory(subspace, transaction);
+        directory.getContext().ensureActive().cancel();
+        FDBRecordContext context = fdb.openContext();
+        directory = new FDBDirectory(subspace, context);
         assertArrayEquals(new String[0], directory.listAll());
     }
 


### PR DESCRIPTION
Supports updates/deletes with cursor support (limit, skip, continuations).  

The LuceneIndexMaintainer provides core functionality for scanning Lucene Indexes backed by FoundationDB.
The core scan interface is the existing <a href="https://lucene.apache.org/core/7_7_3/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description"> Lucene Query Parser syntax</a>.
