### PR TITLE
Fixes #1139: Covering check when chosen index has duplicate fields

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Covering check when chosen index has duplicate fields [(Issue #1139)](https://github.com/FoundationDB/fdb-record-layer/issues/1139)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/AvailableFields.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/AvailableFields.java
@@ -161,7 +161,9 @@ public class AvailableFields {
                     fieldKeyExpression.getFanType().equals(KeyExpression.FanType.FanOut)) {
                 return false;
             }
-            builder.addField(fieldKeyExpression.getFieldName(), fieldData.source, fieldData.index);
+            if (!builder.hasField(fieldKeyExpression.getFieldName())) {
+                builder.addField(fieldKeyExpression.getFieldName(), fieldData.source, fieldData.index);
+            }
             return true;
         } else {
             return false;


### PR DESCRIPTION
I'm not opposed to making these illegal at metadata validation time. But there were already tests that created such indexes, but they weren't ever candidates for covering queries.