### PR TITLE
Remove deprecated RecordCursor apis

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/AutoContinuingCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/AutoContinuingCursor.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
@@ -84,12 +83,7 @@ public class AutoContinuingCursor<T> implements RecordCursor<T> {
     private FDBRecordContext currentContext;
 
     @Nullable
-    private CompletableFuture<Boolean> nextFuture;
-    @Nullable
     private RecordCursorResult<T> lastResult;
-
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
 
     /**
      * Creates a new {@link AutoContinuingCursor}.
@@ -139,50 +133,8 @@ public class AutoContinuingCursor<T> implements RecordCursor<T> {
         currentCursor = nextCursorGenerator.apply(currentContext, continuation);
     }
 
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (nextFuture == null) {
-            mayGetContinuation = false;
-            nextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return nextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-
-        nextFuture = null;
-        mayGetContinuation = true;
-        return lastResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return lastResult.getContinuation().toBytes();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return lastResult.getNoNextReason();
-    }
-
     @Override
     public void close() {
-        if (nextFuture != null) {
-            nextFuture.cancel(true);
-        }
         if (currentContext != null) {
             currentContext.close();
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -105,8 +104,6 @@ public class ChainedCursor<T> implements BaseCursor<T> {
     private final Function<T, byte[]> continuationEncoder;
     @Nonnull
     private final Executor executor;
-    @Nullable
-    private CompletableFuture<Boolean> nextFuture;
     @Nonnull
     private Optional<T> lastValue;
     @Nullable
@@ -116,9 +113,6 @@ public class ChainedCursor<T> implements BaseCursor<T> {
     private final CursorLimitManager limitManager;
     private final long maxReturnedRows;
     private long returnedRowCount;
-
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
 
     /**
      * Creates a new <code>ChainedCursor</code>.  When created in this fashion any resource limits that may be
@@ -232,56 +226,14 @@ public class ChainedCursor<T> implements BaseCursor<T> {
             } else {
                 lastValue = nextValue;
                 lastResult = RecordCursorResult.exhausted();
-                mayGetContinuation = true;
             }
             return lastResult;
         });
     }
 
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (nextFuture == null) {
-            mayGetContinuation = false;
-            nextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return nextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-
-        nextFuture = null;
-        mayGetContinuation = true;
-        return lastResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return lastResult.getContinuation().toBytes();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return lastResult.getNoNextReason();
-    }
-
     @Override
     public void close() {
-        if (nextFuture != null) {
-            nextFuture.cancel(true);
-        }
+
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/EmptyCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/EmptyCursor.java
@@ -26,8 +26,6 @@ import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -54,34 +52,6 @@ public class EmptyCursor<T> implements RecordCursor<T> {
     @Override
     public RecordCursorResult<T> getNext() {
         return RecordCursorResult.exhausted();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        return CompletableFuture.completedFuture(Boolean.FALSE);
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public T next() {
-        throw new NoSuchElementException();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        return null;
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return NoNextReason.SOURCE_EXHAUSTED;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
@@ -36,7 +36,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -71,16 +70,11 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
     @Nonnull
     private final Queue<PipelineQueueEntry> pipeline;
     @Nullable
-    private CompletableFuture<Boolean> nextFuture;
-    @Nullable
     private CompletableFuture<RecordCursorResult<T>> outerNextFuture;
     private boolean outerExhausted = false;
 
     @Nullable
     private RecordCursorResult<V> lastResult;
-
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
 
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP2")
     public FlatMapPipelinedCursor(@Nonnull RecordCursor<T> outerCursor,
@@ -113,51 +107,14 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         if (lastResult != null && !lastResult.hasNext()) {
             return CompletableFuture.completedFuture(lastResult);
         }
-        mayGetContinuation = false;
         return AsyncUtil.whileTrue(this::tryToFillPipeline, getExecutor()).thenApply(vignore -> {
             lastResult = pipeline.peek().nextResult();
-            mayGetContinuation = !lastResult.hasNext();
             return lastResult;
         });
     }
 
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (nextFuture == null) {
-            mayGetContinuation = false;
-            nextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return nextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public V next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        nextFuture = null;
-        mayGetContinuation = true;
-        return lastResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return lastResult.getContinuation().toBytes();
-    }
-
     @Override
     public void close() {
-        if (nextFuture != null) {
-            nextFuture.cancel(false);
-            nextFuture = null;
-        }
         while (!pipeline.isEmpty()) {
             pipeline.remove().close();
         }
@@ -166,13 +123,6 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
             outerNextFuture = null;
         }
         outerCursor.close();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return lastResult.getNoNextReason();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IteratorCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/IteratorCursorBase.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.cursors;
 
-import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.RecordCursor;
@@ -30,8 +29,6 @@ import com.apple.foundationdb.record.RecordCursorVisitor;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
@@ -47,12 +44,7 @@ abstract class IteratorCursorBase<T, C extends Iterator<T>> implements RecordCur
     protected int valuesSeen;
 
     @Nullable
-    protected CompletableFuture<Boolean> hasNextFuture;
-    @Nullable
     protected RecordCursorResult<T> nextResult;
-
-    // for detecting incorrect cursor usage
-    protected boolean mayGetContinuation = false;
 
     protected IteratorCursorBase(@Nonnull Executor executor, @Nonnull C iterator) {
         this.executor = executor;
@@ -61,7 +53,6 @@ abstract class IteratorCursorBase<T, C extends Iterator<T>> implements RecordCur
     }
 
     protected RecordCursorResult<T> computeNextResult(boolean hasNext) {
-        mayGetContinuation = !hasNext;
         if (hasNext) {
             valuesSeen++;
             nextResult = RecordCursorResult.withNextValue(iterator.next(), ByteArrayContinuation.fromInt(valuesSeen));
@@ -71,54 +62,9 @@ abstract class IteratorCursorBase<T, C extends Iterator<T>> implements RecordCur
         return nextResult;
     }
 
-    @Nonnull
-    @Override
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    public CompletableFuture<Boolean> onHasNext() {
-        if (hasNextFuture == null) {
-            mayGetContinuation = false;
-            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return hasNextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        mayGetContinuation = true;
-        hasNextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
-    }
-
     @Override
     public void close() {
         MoreAsyncUtil.closeIterator(iterator);
-        if (hasNextFuture != null) {
-            hasNextFuture.cancel(false);
-        }
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ListCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ListCursor.java
@@ -30,7 +30,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
@@ -49,8 +48,6 @@ public class ListCursor<T> implements RecordCursor<T> {
 
     @Nullable
     private RecordCursorResult<T> nextResult;
-    @Nullable
-    private CompletableFuture<Boolean> hasNextFuture;
 
     public ListCursor(@Nonnull List<T> list, byte []continuation) {
         this(ForkJoinPool.commonPool(), list, continuation != null ? ByteBuffer.wrap(continuation).getInt() : 0);
@@ -80,46 +77,9 @@ public class ListCursor<T> implements RecordCursor<T> {
         return nextResult;
     }
 
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (hasNextFuture == null) {
-            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return hasNextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        hasNextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
-    }
-
     @Override
     public void close() {
-        if (hasNextFuture != null) {
-            hasNextFuture.cancel(false);
-        }
+
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapWhileCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapWhileCursor.java
@@ -30,7 +30,6 @@ import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -44,7 +43,7 @@ import java.util.function.Function;
 @API(API.Status.MAINTAINED)
 public class MapWhileCursor<T, V> implements RecordCursor<V> {
     /**
-     * What to return for {@link #getContinuation()} after stopping.
+     * What to return for {@code onNext.getContinuation()} after stopping.
      */
     public enum StopContinuation {
         /**
@@ -118,42 +117,6 @@ public class MapWhileCursor<T, V> implements RecordCursor<V> {
                 return nextResult;
             });
         }
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (nextFuture == null) {
-            nextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return nextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public V next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        nextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
-    @Deprecated
-    public byte[] getContinuation() {
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/OrElseCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/OrElseCursor.java
@@ -33,7 +33,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
@@ -55,12 +54,7 @@ public class OrElseCursor<T> implements RecordCursor<T> {
     private RecordCursor<T> other;
 
     @Nullable
-    private CompletableFuture<Boolean> hasNextFuture;
-    @Nullable
     private RecordCursorResult<T> nextResult;
-
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
 
     /**
      * Deprecated constructor that does not support continuations.
@@ -156,47 +150,8 @@ public class OrElseCursor<T> implements RecordCursor<T> {
     // shim to support old continuation style
     @Nonnull
     private RecordCursorResult<T> postProcess(RecordCursorResult<T> result) {
-        mayGetContinuation = !result.hasNext();
         nextResult = result;
         return result;
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (hasNextFuture == null) {
-            mayGetContinuation = false;
-            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return hasNextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        mayGetContinuation = true;
-        hasNextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
     }
 
     @Override
@@ -205,9 +160,6 @@ public class OrElseCursor<T> implements RecordCursor<T> {
             other.close();
         }
         inner.close();
-        if (hasNextFuture != null) {
-            hasNextFuture.cancel(false);
-        }
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/SkipCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/SkipCursor.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.record.RecordCursorVisitor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -47,9 +46,6 @@ public class SkipCursor<T> implements RecordCursor<T> {
     @Nullable
     private RecordCursorResult<T> nextResult;
 
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
-
     public SkipCursor(@Nonnull RecordCursor<T> inner, int skip) {
         this.inner = inner;
         this.skipRemaining = skip;
@@ -63,7 +59,6 @@ public class SkipCursor<T> implements RecordCursor<T> {
         }
         if (skipRemaining <= 0) {
             return inner.onNext().thenApply(result -> {
-                mayGetContinuation = !result.hasNext();
                 nextResult = result;
                 return result;
             });
@@ -76,48 +71,8 @@ public class SkipCursor<T> implements RecordCursor<T> {
             }
             return false; // Exhausted while skipping or found the result
         }), getExecutor()).thenApply(vignore -> {
-            mayGetContinuation = !nextResult.hasNext();
             return nextResult;
         });
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (nextFuture == null) {
-            mayGetContinuation = false;
-            nextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return nextFuture;
-    }
-
-
-    @Nullable
-    @Override
-    @Deprecated
-    public T next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        mayGetContinuation = true;
-        nextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -841,41 +840,6 @@ public class StoreTimer {
                     nextResult = result;
                     return nextResult;
                 });
-            }
-
-            @Override
-            @Nonnull
-            @Deprecated
-            public CompletableFuture<Boolean> onHasNext() {
-                if (nextFuture == null) {
-                    nextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-                }
-                return nextFuture;
-            }
-
-            @Override
-            @Nullable
-            @Deprecated
-            public T next() {
-                if (!hasNext()) {
-                    throw new NoSuchElementException();
-                }
-                nextFuture = null;
-                return nextResult.get();
-            }
-
-            @Override
-            @Nullable
-            @Deprecated
-            public byte[] getContinuation() {
-                return nextResult.getContinuation().toBytes();
-            }
-
-            @Nonnull
-            @Override
-            @Deprecated
-            public NoNextReason getNoNextReason() {
-                return nextResult.getNoNextReason();
             }
 
             @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -89,7 +89,6 @@ public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements Bas
             return CompletableFuture.completedFuture(nextResult);
         } else if (limitManager.tryRecordScan()) {
             return iterator.onHasNext().thenApply(hasNext -> {
-                mayGetContinuation = !hasNext;
                 if (hasNext) {
                     KeyValue kv = iterator.next();
                     if (context != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.record.cursors.EmptyCursor;
-import com.apple.foundationdb.record.cursors.IllegalContinuationAccessChecker;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
@@ -40,7 +39,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -74,12 +72,7 @@ public abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implement
     @Nonnull
     private final Executor executor;
     @Nullable
-    private CompletableFuture<Boolean> hasNextFuture;
-    @Nullable
     private RecordCursorResult<U> nextResult;
-
-    // for detecting incorrect cursor usage
-    private boolean mayGetContinuation = false;
 
     protected MergeCursor(@Nonnull List<S> cursorStates, @Nullable FDBStoreTimer timer) {
         this.cursorStates = cursorStates;
@@ -292,10 +285,8 @@ public abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implement
         if (nextResult != null && !nextResult.hasNext()) {
             return CompletableFuture.completedFuture(nextResult);
         }
-        mayGetContinuation = false;
         return computeNextResultStates().thenApply(resultStates -> {
             boolean hasNext = !resultStates.isEmpty();
-            mayGetContinuation = !hasNext;
             if (!hasNext) {
                 nextResult = RecordCursorResult.withoutNextValue(getContinuationObject(), mergeNoNextReasons());
             } else {
@@ -307,44 +298,6 @@ public abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implement
         });
     }
 
-    @Override
-    @Nonnull
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (hasNextFuture == null) {
-            mayGetContinuation = false;
-            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return hasNextFuture;
-    }
-
-    @Override
-    @Nullable
-    @Deprecated
-    public U next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        mayGetContinuation = true;
-        hasNextFuture = null;
-        return nextResult.get();
-    }
-
-    @Override
-    @Nullable
-    @Deprecated
-    public byte[] getContinuation() {
-        IllegalContinuationAccessChecker.check(mayGetContinuation);
-        return nextResult.getContinuation().toBytes();
-    }
-
-    @Override
-    @Nonnull
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
-    }
-
     @Nonnull
     protected List<RecordCursorContinuation> getChildContinuations() {
         return cursorStates.stream().map(S::getContinuation).collect(Collectors.toList());
@@ -353,9 +306,6 @@ public abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implement
     @Override
     public void close() {
         cursorStates.forEach(S::close);
-        if (hasNextFuture != null) {
-            hasNextFuture.cancel(false);
-        }
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SizeStatisticsCollectorCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SizeStatisticsCollectorCursor.java
@@ -75,8 +75,6 @@ public class SizeStatisticsCollectorCursor implements RecordCursor<SizeStatistic
     @Nonnull
     private final ScanProperties scanProperties;
     @Nullable
-    private CompletableFuture<Boolean> hasNextFuture;
-    @Nullable
     private RecordCursorResult<SizeStatisticsResults> nextStatsResult;
     private boolean finalResultsEmitted;
     @Nullable
@@ -148,6 +146,11 @@ public class SizeStatisticsCollectorCursor implements RecordCursor<SizeStatistic
         });
     }
 
+    @Override
+    public void close() {
+
+    }
+
     @Nonnull
     @Override
     public Executor getExecutor() {
@@ -158,41 +161,6 @@ public class SizeStatisticsCollectorCursor implements RecordCursor<SizeStatistic
     public boolean accept(@Nonnull RecordCursorVisitor visitor) {
         visitor.visitEnter(this);
         return visitor.visitLeave(this);
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public SizeStatisticsResults next() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public RecordCursor.NoNextReason getNoNextReason() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void close() {
-        if (hasNextFuture != null) {
-            hasNextFuture.cancel(false);
-        }
     }
 
     //form a continuation that allows us to restart statistics aggregation from where we left off

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -50,7 +50,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -165,41 +164,6 @@ class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         } else {
             return ByteArrayContinuation.fromNullable(Ints.toByteArray(currentPosition));
         }
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public CompletableFuture<Boolean> onHasNext() {
-        if (hasNextFuture == null) {
-            hasNextFuture = onNext().thenApply(RecordCursorResult::hasNext);
-        }
-        return hasNextFuture;
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public IndexEntry next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        hasNextFuture = null;
-        return nextResult.get();
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public byte[] getContinuation() {
-        return Ints.toByteArray(currentPosition);
-    }
-
-    @Nonnull
-    @Override
-    @Deprecated
-    public NoNextReason getNoNextReason() {
-        return nextResult.getNoNextReason();
     }
 
     @Override


### PR DESCRIPTION
I am explicitly not optimizing any implementations now that they
don't need to implement the old api, just removing the api, and
fields that became unused.