### PR TITLE
Resolves #1161: Prototype non-index sorting

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Prototype non-index sorting [(Issue #1161)](https://github.com/FoundationDB/fdb-record-layer/issues/1161)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/CipherPool.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/CipherPool.java
@@ -1,0 +1,50 @@
+/*
+ * CipherPool.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.common;
+
+import javax.annotation.Nonnull;
+import javax.crypto.Cipher;
+import java.security.GeneralSecurityException;
+
+/**
+ * Helper class for pooling {@link Cipher}.
+ */
+public class CipherPool {
+    // AES with 128 bits key
+    public static final String DEFAULT_CIPHER = "AES/CBC/PKCS5Padding";
+    public static final int IV_SIZE = 16;
+    public static final MappedPool<String, Cipher, GeneralSecurityException> MAPPED_POOL = new MappedPool<>(Cipher::getInstance);
+
+    private CipherPool() {
+    }
+
+    public static Cipher borrowCipher() throws GeneralSecurityException {
+        return borrowCipher(DEFAULT_CIPHER);
+    }
+
+    public static Cipher borrowCipher(@Nonnull String cipherName) throws GeneralSecurityException {
+        return MAPPED_POOL.poll(cipherName);
+    }
+
+    public static void returnCipher(@Nonnull Cipher cipher) {
+        MAPPED_POOL.offer(cipher.getAlgorithm(), cipher);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MappedPool.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MappedPool.java
@@ -33,8 +33,8 @@ import java.util.concurrent.ExecutionException;
 
 /**
  * MappedPool Class Attempts to reuse objects organized by keys.
- * This class can be used for objects that require thread safety but our expensive to create.
- * The number of keys in the ConcurrentHashMap are unbounded but the queue for each key is bounded to 64.
+ * This class can be used for objects that require thread safety but are expensive to create.
+ * The number of keys in the ConcurrentHashMap is unbounded but the queue for each key is bounded to 64.
  *
  *  Examples include Ciphers and Compressors
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -325,6 +325,11 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
         return new TransformedRecordSerializer<>(inner.widen(), compressWhenSerializing, compressionLevel, encryptWhenSerializing);
     }
 
+    @Nonnull
+    public RecordSerializer<M> untransformed() {
+        return inner;
+    }
+
     /**
      * Creates a new {@link Builder TransformedRecordSerializer.Builder} instance
      * that is backed by the default serializer for {@link Message}s, namely

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerJCE.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerJCE.java
@@ -39,11 +39,6 @@ import java.security.SecureRandom;
 @API(API.Status.UNSTABLE)
 public class TransformedRecordSerializerJCE<M extends Message> extends TransformedRecordSerializer<M> {
 
-    // AES with 128 bits key
-    protected static final String DEFAULT_CIPHER = "AES/CBC/PKCS5Padding";
-    protected static final int IV_SIZE = 16;
-    protected static final MappedPool<String, Cipher, GeneralSecurityException> MAPPED_POOL = new MappedPool<>(Cipher::getInstance);
-
     @Nullable
     protected final String cipherName;
     @Nullable
@@ -71,24 +66,27 @@ public class TransformedRecordSerializerJCE<M extends Message> extends Transform
         }
         long startTime = System.nanoTime();
 
-        byte[] ivData = new byte[IV_SIZE];
+        byte[] ivData = new byte[CipherPool.IV_SIZE];
         secureRandom.nextBytes(ivData);
         IvParameterSpec iv = new IvParameterSpec(ivData);
-        Cipher cipher = MAPPED_POOL.poll(cipherName);
-        cipher.init(Cipher.ENCRYPT_MODE, encryptionKey, iv);
+        Cipher cipher = CipherPool.borrowCipher(cipherName);
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, encryptionKey, iv);
 
-        byte[] plainText = state.getDataArray();
-        byte[] cipherText = cipher.doFinal(plainText);
+            byte[] plainText = state.getDataArray();
+            byte[] cipherText = cipher.doFinal(plainText);
 
-        int totalSize = IV_SIZE + cipherText.length;
-        byte[] serialized = new byte[totalSize];
-        System.arraycopy(iv.getIV(), 0, serialized, 0, IV_SIZE);
-        System.arraycopy(cipherText, 0, serialized, IV_SIZE, cipherText.length);
-        state.encrypted = true;
-        state.setDataArray(serialized);
-        MAPPED_POOL.offer(cipherName, cipher);
-        if (timer != null) {
-            timer.recordSinceNanoTime(Events.ENCRYPT_SERIALIZED_RECORD, startTime);
+            int totalSize = CipherPool.IV_SIZE + cipherText.length;
+            byte[] serialized = new byte[totalSize];
+            System.arraycopy(iv.getIV(), 0, serialized, 0, CipherPool.IV_SIZE);
+            System.arraycopy(cipherText, 0, serialized, CipherPool.IV_SIZE, cipherText.length);
+            state.encrypted = true;
+            state.setDataArray(serialized);
+        } finally {
+            CipherPool.returnCipher(cipher);
+            if (timer != null) {
+                timer.recordSinceNanoTime(Events.ENCRYPT_SERIALIZED_RECORD, startTime);
+            }
         }
     }
 
@@ -99,21 +97,23 @@ public class TransformedRecordSerializerJCE<M extends Message> extends Transform
         }
         long startTime = System.nanoTime();
 
-        byte[] ivData = new byte[IV_SIZE];
-        System.arraycopy(state.data, state.offset, ivData, 0, IV_SIZE);
+        byte[] ivData = new byte[CipherPool.IV_SIZE];
+        System.arraycopy(state.data, state.offset, ivData, 0, CipherPool.IV_SIZE);
         IvParameterSpec iv = new IvParameterSpec(ivData);
 
-        byte[] cipherText = new byte[state.length - IV_SIZE];
-        System.arraycopy(state.data, state.offset + IV_SIZE, cipherText, 0, cipherText.length);
-        Cipher cipher = MAPPED_POOL.poll(cipherName);
-        cipher.init(Cipher.DECRYPT_MODE, encryptionKey, iv);
+        byte[] cipherText = new byte[state.length - CipherPool.IV_SIZE];
+        System.arraycopy(state.data, state.offset + CipherPool.IV_SIZE, cipherText, 0, cipherText.length);
+        Cipher cipher = CipherPool.borrowCipher(cipherName);
+        try {
+            cipher.init(Cipher.DECRYPT_MODE, encryptionKey, iv);
 
-        byte[] plainText = cipher.doFinal(cipherText);
-        state.setDataArray(plainText);
-        MAPPED_POOL.offer(cipherName, cipher);
-
-        if (timer != null) {
-            timer.recordSinceNanoTime(Events.DECRYPT_SERIALIZED_RECORD, startTime);
+            byte[] plainText = cipher.doFinal(cipherText);
+            state.setDataArray(plainText);
+        } finally {
+            CipherPool.returnCipher(cipher);
+            if (timer != null) {
+                timer.recordSinceNanoTime(Events.DECRYPT_SERIALIZED_RECORD, startTime);
+            }
         }
     }
 
@@ -272,7 +272,7 @@ public class TransformedRecordSerializerJCE<M extends Message> extends Transform
             }
             if (encryptionKey != null) {
                 if (cipherName == null) {
-                    cipherName = DEFAULT_CIPHER;
+                    cipherName = CipherPool.DEFAULT_CIPHER;
                 }
                 if (secureRandom == null) {
                     secureRandom = new SecureRandom();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -553,6 +553,8 @@ public class FDBStoreTimer extends StoreTimer implements EventKeeper {
         PLAN_FETCH("number of fetch from partial record plans", false),
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan}. */
         PLAN_COMPOSED_BITMAP_INDEX("number of composed bitmap plans", false),
+        /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan}. */
+        PLAN_SORT("number of composed bitmap plans", false),
         /** The number of records given given to any filter within any plan. */
         QUERY_FILTER_GIVEN("number of records given to any filter within any plan", false),
         /** The number of records passed by any filter within any plan. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -554,7 +554,7 @@ public class FDBStoreTimer extends StoreTimer implements EventKeeper {
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan}. */
         PLAN_COMPOSED_BITMAP_INDEX("number of composed bitmap plans", false),
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan}. */
-        PLAN_SORT("number of composed bitmap plans", false),
+        PLAN_SORT("number of sort plans", false),
         /** The number of records given given to any filter within any plan. */
         QUERY_FILTER_GIVEN("number of records given to any filter within any plan", false),
         /** The number of records passed by any filter within any plan. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
@@ -1,0 +1,142 @@
+/*
+ * SortedRecordSerializer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordSortingProto;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.provider.common.RecordSerializer;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.ExtensionRegistryLite;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.Map;
+
+/**
+ * Serialize records during sorting, either in a continuation or in a file.
+ * @param <M> type used to represent stored records
+ */
+@API(API.Status.EXPERIMENTAL)
+public class SortedRecordSerializer<M extends Message> {
+    @Nonnull
+    private final RecordSerializer<M> serializer;
+    @Nonnull
+    private final RecordMetaData recordMetaData;
+    @Nullable
+    private final StoreTimer timer;
+    
+    public SortedRecordSerializer(@Nonnull final RecordSerializer<M> serializer, @Nonnull final RecordMetaData recordMetaData, @Nullable final StoreTimer timer) {
+        this.serializer = serializer;
+        this.recordMetaData = recordMetaData;
+        this.timer = timer;
+    }
+
+    static class Sorted<M extends Message> extends FDBQueriedRecord.Stored<M> {
+        Sorted(@Nonnull FDBStoredRecord<M> stored) {
+            super(stored);
+        }
+    }
+
+    public void write(@Nonnull FDBRecord<M> record, CodedOutputStream stream) throws IOException {
+        stream.writeMessageNoTag(toProto(record));
+    }
+
+    @Nonnull
+    public byte[] serialize(@Nonnull FDBRecord<M> record) {
+        return toProto(record).toByteArray();
+    }
+
+    @Nonnull
+    public RecordSortingProto.SortedRecord toProto(@Nonnull FDBRecord<M> record) {
+        final RecordSortingProto.SortedRecord.Builder builder = RecordSortingProto.SortedRecord.newBuilder();
+        builder.setPrimaryKey(ByteString.copyFrom(record.getPrimaryKey().pack()));
+        builder.setMessage(ByteString.copyFrom(serializer.serialize(recordMetaData, record.getRecordType(), record.getRecord(), timer)));
+        if (record.hasVersion()) {
+            builder.setVersion(ByteString.copyFrom(record.getVersion().toBytes()));
+        }
+        return builder.build();
+    }
+
+    @Nonnull
+    public FDBQueriedRecord<M> read(@Nonnull CodedInputStream stream) throws IOException {
+        final RecordSortingProto.SortedRecord.Builder builder =  RecordSortingProto.SortedRecord.newBuilder();
+        stream.readMessage(builder, ExtensionRegistryLite.getEmptyRegistry());
+        return deserialize(builder.build());
+    }
+
+    @Nonnull
+    public FDBQueriedRecord<M> deserialize(@Nonnull byte[] serialized) {
+        final RecordSortingProto.SortedRecord sortedRecord;
+        try {
+            sortedRecord = RecordSortingProto.SortedRecord.parseFrom(serialized);
+        } catch (InvalidProtocolBufferException ex) {
+            throw new RecordCoreException(ex);
+        }
+        return deserialize(sortedRecord);
+    }
+
+    @Nonnull
+    public FDBQueriedRecord<M> deserialize(@Nonnull RecordSortingProto.SortedRecord sortedRecord) {
+        final SplitHelper.SizeInfo size = new SplitHelper.SizeInfo();
+        final byte[] primaryKeyBytes = sortedRecord.getPrimaryKey().toByteArray();
+        final Tuple primaryKey = Tuple.fromBytes(primaryKeyBytes);
+        final byte[] recordBytes = sortedRecord.getMessage().toByteArray();
+        final M record = serializer.deserialize(recordMetaData, primaryKey, recordBytes, timer);
+        final RecordType recordType = recordMetaData.getRecordTypeForDescriptor(record.getDescriptorForType());
+        size.set(primaryKeyBytes, recordBytes);
+        final FDBRecordVersion version;
+        if (sortedRecord.hasVersion()) {
+            version = FDBRecordVersion.fromBytes(sortedRecord.getVersion().toByteArray());
+        } else {
+            version = null;
+        }
+        FDBStoredRecord<M> storedRecord = new FDBStoredRecord<>(primaryKey, recordType, record, size, version);
+        return new Sorted<>(storedRecord);
+    }
+
+    public void writeSortKeyAndRecord(@Nonnull Tuple sortKey, @Nonnull FDBRecord<M> record, @Nonnull CodedOutputStream stream) throws IOException {
+        stream.writeByteArrayNoTag(sortKey.pack());
+        write(record, stream);
+    }
+
+    @Nonnull
+    public Map.Entry<Tuple, FDBQueriedRecord<M>> readSortKeyAndRecord(@Nonnull CodedInputStream stream) throws IOException {
+        return new AbstractMap.SimpleEntry<>(Tuple.fromBytes(stream.readByteArray()), read(stream));
+    }
+
+    @Nonnull
+    public FDBQueriedRecord<M> skipSortKeyAndReadRecord(@Nonnull CodedInputStream stream) throws IOException {
+        stream.skipRawBytes(stream.readRawVarint32());
+        return read(stream);
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -76,7 +76,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
-import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortKey;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQueryPlannerSortConfiguration;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphProperty;
 import com.apple.foundationdb.record.query.plan.temp.properties.FieldWithComparisonCountProperty;
@@ -280,14 +280,15 @@ public class RecordQueryPlanner implements QueryPlanner {
             if (sort == null) {
                 throw new RecordCoreException("Unexpected failure to plan without sort");
             }
-            if (configuration.shouldAllowNonIndexSort()) {
+            final RecordQueryPlannerSortConfiguration sortConfiguration = configuration.getSortConfiguration();
+            if (sortConfiguration != null && sortConfiguration.shouldAllowNonIndexSort(query)) {
                 final PlanContext withoutSort = new PlanContext(query.toBuilder().setSort(null).build(),
                         planContext.indexes, planContext.commonPrimaryKey);
                 plan = plan(withoutSort, filter, null, false);
                 if (plan == null) {
                     throw new RecordCoreException("Unexpected failure to plan without sort");
                 }
-                plan = new RecordQuerySortPlan(plan, new RecordQuerySortKey(sort, sortReverse));
+                plan = new RecordQuerySortPlan(plan, sortConfiguration.getSortKey(sort, sortReverse));
             } else {
                 throw new RecordCoreException("Cannot sort without appropriate index: " + sort);
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -76,6 +76,8 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortKey;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphProperty;
 import com.apple.foundationdb.record.query.plan.temp.properties.FieldWithComparisonCountProperty;
 import com.apple.foundationdb.record.query.plan.visitor.FilterVisitor;
@@ -233,6 +235,23 @@ public class RecordQueryPlanner implements QueryPlanner {
 
     /**
      * Create a plan to get the results of the provided query.
+     * This method returns a {@link QueryPlanResult} that contains the same plan ass returned by {@link #plan(RecordQuery)}
+     * with additional information provided in the {@link QueryPlanInfo}
+     *
+     * @param query a query for records on this planner's metadata
+     * @param parameterRelationshipGraph a set of bindings the planner can use that may constrain requirements of the plan
+     *        but also lead to better plans
+     * @return a {@link QueryPlanResult} that contains the plan for the query with additional information
+     * @throws com.apple.foundationdb.record.RecordCoreException if the planner cannot plan the query
+     */
+    @Nonnull
+    @Override
+    public QueryPlanResult planQuery(@Nonnull final RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        return new QueryPlanResult(plan(query, parameterRelationshipGraph));
+    }
+
+    /**
+     * Create a plan to get the results of the provided query.
      *
      * @param query a query for records on this planner's metadata
      * @param parameterRelationshipGraph a set of bindings and their relationships that provide additional information
@@ -256,6 +275,46 @@ public class RecordQueryPlanner implements QueryPlanner {
         final KeyExpression sort = query.getSort();
         final boolean sortReverse = query.isSortReverse();
 
+        RecordQueryPlan plan = plan(planContext, filter, sort, sortReverse);
+        if (plan == null) {
+            if (sort == null) {
+                throw new RecordCoreException("Unexpected failure to plan without sort");
+            }
+            if (configuration.shouldAllowNonIndexSort()) {
+                final PlanContext withoutSort = new PlanContext(query.toBuilder().setSort(null).build(),
+                        planContext.indexes, planContext.commonPrimaryKey);
+                plan = plan(withoutSort, filter, null, false);
+                if (plan == null) {
+                    throw new RecordCoreException("Unexpected failure to plan without sort");
+                }
+                plan = new RecordQuerySortPlan(plan, new RecordQuerySortKey(sort, sortReverse));
+            } else {
+                throw new RecordCoreException("Cannot sort without appropriate index: " + sort);
+            }
+        }
+
+        if (query.getRequiredResults() != null) {
+            plan = tryToConvertToCoveringPlan(planContext, plan);
+        }
+
+        if (timer != null) {
+            plan.logPlanStructure(timer);
+        }
+
+        if (plan.getComplexity() > configuration.getComplexityThreshold()) {
+            throw new RecordQueryPlanComplexityException(plan);
+        }
+
+        if (logger.isTraceEnabled()) {
+            logger.trace(KeyValueLogMessage.of("explain of plan",
+                    "explain", PlannerGraphProperty.explain(plan)));
+        }
+
+        return plan;
+    }
+
+    @Nullable
+    private RecordQueryPlan plan(PlanContext planContext, QueryComponent filter, KeyExpression sort, boolean sortReverse) {
         RecordQueryPlan plan = null;
         if (filter == null) {
             plan = planNoFilter(planContext, sort, sortReverse);
@@ -272,21 +331,8 @@ public class RecordQueryPlanner implements QueryPlanner {
                     plan = new RecordQueryFilterPlan(plan, filter);
                 }
             } else {
-                throw new RecordCoreException("Cannot sort without appropriate index: " + sort);
+                return null;
             }
-        }
-
-        if (timer != null) {
-            plan.logPlanStructure(timer);
-        }
-
-        if (plan.getComplexity() > configuration.getComplexityThreshold()) {
-            throw new RecordQueryPlanComplexityException(plan);
-        }
-
-        if (logger.isTraceEnabled()) {
-            logger.trace(KeyValueLogMessage.of("explain of plan",
-                    "explain", PlannerGraphProperty.explain(plan)));
         }
         if (configuration.shouldDeferFetchAfterUnionAndIntersection()) {
             plan = RecordQueryPlannerSubstitutionVisitor.applyVisitors(plan, metaData, indexTypes, planContext.commonPrimaryKey);
@@ -294,28 +340,7 @@ public class RecordQueryPlanner implements QueryPlanner {
             // Always do filter pushdown
             plan = plan.accept(new FilterVisitor(metaData, indexTypes, planContext.commonPrimaryKey));
         }
-        if (query.getRequiredResults() != null) {
-            plan = tryToConvertToCoveringPlan(planContext, plan);
-        }
-
         return plan;
-    }
-
-    /**
-     * Create a plan to get the results of the provided query.
-     * This method returns a {@link QueryPlanResult} that contains the same plan ass returned by {@link #plan(RecordQuery)}
-     * with additional information provided in the {@link QueryPlanInfo}
-     *
-     * @param query a query for records on this planner's metadata
-     * @param parameterRelationshipGraph a set of bindings the planner can use that may constrain requirements of the plan
-     *        but also lead to better plans
-     * @return a {@link QueryPlanResult} that contains the plan for the query with additional information
-     * @throws com.apple.foundationdb.record.RecordCoreException if the planner cannot plan the query
-     */
-    @Nonnull
-    @Override
-    public QueryPlanResult planQuery(@Nonnull final RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
-        return new QueryPlanResult(plan(query, parameterRelationshipGraph));
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -42,6 +42,7 @@ public class RecordQueryPlannerConfiguration {
     private final int maxTotalTaskCount;
     private final boolean useFullKeyForValueIndex;
     private final int maxNumMatchesPerRuleCall;
+    private final boolean allowNonIndexSort;
 
     private RecordQueryPlannerConfiguration(@Nonnull QueryPlanner.IndexScanPreference indexScanPreference,
                                             boolean attemptFailedInJoinAsOr,
@@ -53,7 +54,8 @@ public class RecordQueryPlannerConfiguration {
                                             int maxTaskQueueSize,
                                             int maxTotalTaskCount,
                                             boolean useFullKeyForValueIndex,
-                                            int maxNumMatchesPerRuleCall) {
+                                            int maxNumMatchesPerRuleCall,
+                                            boolean allowNonIndexSort) {
         this.indexScanPreference = indexScanPreference;
         this.attemptFailedInJoinAsOr = attemptFailedInJoinAsOr;
         this.attemptFailedInJoinAsUnionMaxSize = attemptFailedInJoinAsUnionMaxSize;
@@ -65,6 +67,7 @@ public class RecordQueryPlannerConfiguration {
         this.maxTotalTaskCount = maxTotalTaskCount;
         this.useFullKeyForValueIndex = useFullKeyForValueIndex;
         this.maxNumMatchesPerRuleCall = maxNumMatchesPerRuleCall;
+        this.allowNonIndexSort = allowNonIndexSort;
     }
 
     /**
@@ -184,6 +187,14 @@ public class RecordQueryPlannerConfiguration {
         return maxNumMatchesPerRuleCall;
     }
 
+    /**
+     * Get whether the planner is allowed to use an in-memory sort plan.
+     * @return whether to allow non-index sorting
+     */
+    public boolean shouldAllowNonIndexSort() {
+        return allowNonIndexSort;
+    }
+
     @Nonnull
     public Builder asBuilder() {
         return new Builder(this);
@@ -210,6 +221,7 @@ public class RecordQueryPlannerConfiguration {
         private int maxTotalTaskCount = 0;
         private boolean useFullKeyForValueIndex = true;
         private int maxNumMatchesPerRuleCall = 0;
+        private boolean allowNonIndexSort = false;
 
         public Builder(@Nonnull RecordQueryPlannerConfiguration configuration) {
             this.indexScanPreference = configuration.indexScanPreference;
@@ -223,6 +235,7 @@ public class RecordQueryPlannerConfiguration {
             this.maxTotalTaskCount = configuration.maxTotalTaskCount;
             this.useFullKeyForValueIndex = configuration.useFullKeyForValueIndex;
             this.maxNumMatchesPerRuleCall = configuration.maxNumMatchesPerRuleCall;
+            this.allowNonIndexSort = configuration.allowNonIndexSort;
         }
 
         public Builder() {
@@ -308,8 +321,18 @@ public class RecordQueryPlannerConfiguration {
             return this;
         }
 
+        /**
+         * Set whether the planner is allowed to use an in-memory sort plan.
+         * @param allowNonIndexSort whether to allow non-index sorting
+         * @return this builder
+         */
+        public Builder setAllowNonIndexSort(final boolean allowNonIndexSort) {
+            this.allowNonIndexSort = allowNonIndexSort;
+            return this;
+        }
+
         public RecordQueryPlannerConfiguration build() {
-            return new RecordQueryPlannerConfiguration(indexScanPreference, attemptFailedInJoinAsOr, attemptFailedInJoinAsUnionMaxSize, complexityThreshold, checkForDuplicateConditions, deferFetchAfterUnionAndIntersection, optimizeForIndexFilters, maxTaskQueueSize, maxTotalTaskCount, useFullKeyForValueIndex, maxNumMatchesPerRuleCall);
+            return new RecordQueryPlannerConfiguration(indexScanPreference, attemptFailedInJoinAsOr, attemptFailedInJoinAsUnionMaxSize, complexityThreshold, checkForDuplicateConditions, deferFetchAfterUnionAndIntersection, optimizeForIndexFilters, maxTaskQueueSize, maxTotalTaskCount, useFullKeyForValueIndex, maxNumMatchesPerRuleCall, allowNonIndexSort);
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -22,8 +22,10 @@ package com.apple.foundationdb.record.query.plan;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQueryPlannerSortConfiguration;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * A set of configuration options for the {@link RecordQueryPlanner}.
@@ -42,7 +44,8 @@ public class RecordQueryPlannerConfiguration {
     private final int maxTotalTaskCount;
     private final boolean useFullKeyForValueIndex;
     private final int maxNumMatchesPerRuleCall;
-    private final boolean allowNonIndexSort;
+    @Nullable
+    private final RecordQueryPlannerSortConfiguration sortConfiguration;
 
     private RecordQueryPlannerConfiguration(@Nonnull QueryPlanner.IndexScanPreference indexScanPreference,
                                             boolean attemptFailedInJoinAsOr,
@@ -55,7 +58,7 @@ public class RecordQueryPlannerConfiguration {
                                             int maxTotalTaskCount,
                                             boolean useFullKeyForValueIndex,
                                             int maxNumMatchesPerRuleCall,
-                                            boolean allowNonIndexSort) {
+                                            @Nullable RecordQueryPlannerSortConfiguration sortConfiguration) {
         this.indexScanPreference = indexScanPreference;
         this.attemptFailedInJoinAsOr = attemptFailedInJoinAsOr;
         this.attemptFailedInJoinAsUnionMaxSize = attemptFailedInJoinAsUnionMaxSize;
@@ -67,7 +70,7 @@ public class RecordQueryPlannerConfiguration {
         this.maxTotalTaskCount = maxTotalTaskCount;
         this.useFullKeyForValueIndex = useFullKeyForValueIndex;
         this.maxNumMatchesPerRuleCall = maxNumMatchesPerRuleCall;
-        this.allowNonIndexSort = allowNonIndexSort;
+        this.sortConfiguration = sortConfiguration;
     }
 
     /**
@@ -188,11 +191,12 @@ public class RecordQueryPlannerConfiguration {
     }
 
     /**
-     * Get whether the planner is allowed to use an in-memory sort plan.
-     * @return whether to allow non-index sorting
+     * Get configuration for planning sorting, including whether the planner is allowed to use an in-memory sort plan.
+     * @return configuration to use for planning non-index sorting, or {@code null} to never allow it
      */
-    public boolean shouldAllowNonIndexSort() {
-        return allowNonIndexSort;
+    @Nullable
+    public RecordQueryPlannerSortConfiguration getSortConfiguration() {
+        return sortConfiguration;
     }
 
     @Nonnull
@@ -221,7 +225,8 @@ public class RecordQueryPlannerConfiguration {
         private int maxTotalTaskCount = 0;
         private boolean useFullKeyForValueIndex = true;
         private int maxNumMatchesPerRuleCall = 0;
-        private boolean allowNonIndexSort = false;
+        @Nullable
+        private RecordQueryPlannerSortConfiguration sortConfiguration;
 
         public Builder(@Nonnull RecordQueryPlannerConfiguration configuration) {
             this.indexScanPreference = configuration.indexScanPreference;
@@ -235,7 +240,7 @@ public class RecordQueryPlannerConfiguration {
             this.maxTotalTaskCount = configuration.maxTotalTaskCount;
             this.useFullKeyForValueIndex = configuration.useFullKeyForValueIndex;
             this.maxNumMatchesPerRuleCall = configuration.maxNumMatchesPerRuleCall;
-            this.allowNonIndexSort = configuration.allowNonIndexSort;
+            this.sortConfiguration = configuration.sortConfiguration;
         }
 
         public Builder() {
@@ -322,17 +327,27 @@ public class RecordQueryPlannerConfiguration {
         }
 
         /**
+         * Set configuration for planning sorting, including whether the planner is allowed to use an in-memory sort plan.
+         * @param sortConfiguration configuration to use for planning non-index sorting, or {@code null} to never allow it
+         * @return this builder
+         */
+        public Builder setSortConfiguration(final RecordQueryPlannerSortConfiguration sortConfiguration) {
+            this.sortConfiguration = sortConfiguration;
+            return this;
+        }
+
+        /**
          * Set whether the planner is allowed to use an in-memory sort plan.
          * @param allowNonIndexSort whether to allow non-index sorting
          * @return this builder
          */
         public Builder setAllowNonIndexSort(final boolean allowNonIndexSort) {
-            this.allowNonIndexSort = allowNonIndexSort;
+            setSortConfiguration(allowNonIndexSort ? RecordQueryPlannerSortConfiguration.getDefaultInstance() : null);
             return this;
         }
-
+ 
         public RecordQueryPlannerConfiguration build() {
-            return new RecordQueryPlannerConfiguration(indexScanPreference, attemptFailedInJoinAsOr, attemptFailedInJoinAsUnionMaxSize, complexityThreshold, checkForDuplicateConditions, deferFetchAfterUnionAndIntersection, optimizeForIndexFilters, maxTaskQueueSize, maxTotalTaskCount, useFullKeyForValueIndex, maxNumMatchesPerRuleCall, allowNonIndexSort);
+            return new RecordQueryPlannerConfiguration(indexScanPreference, attemptFailedInJoinAsOr, attemptFailedInJoinAsUnionMaxSize, complexityThreshold, checkForDuplicateConditions, deferFetchAfterUnionAndIntersection, optimizeForIndexFilters, maxTaskQueueSize, maxTotalTaskCount, useFullKeyForValueIndex, maxNumMatchesPerRuleCall, sortConfiguration);
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQueryPlannerSortConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQueryPlannerSortConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * RecordQueryPlannerSortConfiguration.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Configuration for planning of non-index sort queries.
+ *
+ * @see RecordQueryPlannerConfiguration#getSortConfiguration
+ */
+@API(API.Status.EXPERIMENTAL)
+public class RecordQueryPlannerSortConfiguration {
+    private static final RecordQueryPlannerSortConfiguration DEFAULT_INSTANCE = new RecordQueryPlannerSortConfiguration();
+
+    public static RecordQueryPlannerSortConfiguration getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    protected RecordQueryPlannerSortConfiguration() {
+    }
+
+    /**
+     * Get whether the planner is allowed to use an in-memory sort plan.
+     *
+     * This method returns {@code true}.
+     *
+     * A subclass can override this method to use more complex criteria to decide.
+     * @param query the query that cannot be planned without a sort
+     * @return whether to allow non-index sorting
+     */
+    public boolean shouldAllowNonIndexSort(@Nonnull RecordQuery query) {
+        return true;
+    }
+
+    /**
+     * Get the sort key for the given key expression and direction.
+     *
+     * A subclass can override this method to return a subclass of {@link RecordQuerySortKey} and thereby affect
+     * the {@link RecordQuerySortAdapter} used.
+     * @param key required sort key
+     * @param reverse whether to sort in reverse
+     * @return a new sort key instance
+     * @see RecordQuerySortKey#getAdapter
+     */
+    @Nonnull
+    public RecordQuerySortKey getSortKey(@Nonnull KeyExpression key, boolean reverse) {
+        return new RecordQuerySortKey(key, reverse);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
@@ -26,8 +26,8 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.provider.common.CipherPool;
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
 import com.apple.foundationdb.record.provider.common.TransformedRecordSerializer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.SortedRecordSerializer;
 import com.apple.foundationdb.record.sorting.FileSortAdapter;
 import com.apple.foundationdb.record.sorting.MemorySortAdapter;
@@ -53,7 +53,7 @@ import java.util.function.Supplier;
  * @param <M> type used to represent stored records
  */
 @API(API.Status.EXPERIMENTAL)
-public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapter<Tuple, FDBStoredRecord<M>> {
+public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapter<Tuple, FDBQueriedRecord<M>> {
     public static final int MAX_RECORD_COUNT_IN_MEMORY = 1000;
     public static final int MAX_FILE_COUNT = 10;
     public static final int RECORD_COUNT_PER_SECTION = 100;
@@ -96,7 +96,7 @@ public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapte
 
     @Nonnull
     @Override
-    public Tuple generateKey(@Nonnull FDBStoredRecord<M> value) {
+    public Tuple generateKey(@Nonnull FDBQueriedRecord<M> value) {
         return key.getKey().evaluateSingleton(value).toTuple();
     }
 
@@ -119,14 +119,14 @@ public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapte
 
     @Nonnull
     @Override
-    public byte[] serializeValue(final FDBStoredRecord<M> record) {
+    public byte[] serializeValue(final FDBQueriedRecord<M> record) {
         return serializer.serialize(record);
     }
 
     @Nonnull
     @Override
-    public FDBStoredRecord<M> deserializeValue(@Nonnull final byte[] bytes) {
-        return serializer.deserialize(bytes).getStoredRecord();
+    public FDBQueriedRecord<M> deserializeValue(@Nonnull final byte[] bytes) {
+        return serializer.deserialize(bytes);
     }
 
     @Override
@@ -152,13 +152,13 @@ public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapte
     }
 
     @Override
-    public void writeValue(@Nonnull final FDBStoredRecord<M> record, @Nonnull final CodedOutputStream stream) throws IOException {
+    public void writeValue(@Nonnull final FDBQueriedRecord<M> record, @Nonnull final CodedOutputStream stream) throws IOException {
         serializer.write(record, stream);
     }
 
     @Override
-    public FDBStoredRecord<M> readValue(@Nonnull final CodedInputStream stream) throws IOException {
-        return serializer.read(stream).getStoredRecord();
+    public FDBQueriedRecord<M> readValue(@Nonnull final CodedInputStream stream) throws IOException {
+        return serializer.read(stream);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
@@ -1,0 +1,193 @@
+/*
+ * SortQueryKey.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.provider.common.RecordSerializer;
+import com.apple.foundationdb.record.provider.common.TransformedRecordSerializer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.SortedRecordSerializer;
+import com.apple.foundationdb.record.sorting.FileSortAdapter;
+import com.apple.foundationdb.record.sorting.MemorySortAdapter;
+import com.apple.foundationdb.record.sorting.MemorySorter;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.base.Suppliers;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.crypto.KeyGenerator;
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.SecureRandom;
+import java.util.function.Supplier;
+
+/**
+ * A {@link MemorySortAdapter} / {@link FileSortAdapter} for use with {@link RecordQuerySortPlan}.
+ */
+@API(API.Status.EXPERIMENTAL)
+class RecordQuerySortAdapter<M extends Message> implements FileSortAdapter<Tuple, FDBStoredRecord<M>> {
+    public static final int MAX_MEMORY_SIZE = 1000;
+    public static final int MAX_FILES = 10;
+    public static final int RECORDS_PER_SECTION = 100;
+
+    private final int memoryLimit;
+    private final boolean memoryOnly;
+    @Nonnull
+    private final RecordQuerySortKey key;
+    @Nonnull
+    private final SortedRecordSerializer<M> serializer;
+
+    @Nullable
+    private Key encryptionKey;
+    private static final Supplier<SecureRandom> RANDOM = Suppliers.memoize(SecureRandom::new);
+
+    protected RecordQuerySortAdapter(int memoryLimit, boolean memoryOnly,
+                                     @Nonnull RecordQuerySortKey key, @Nonnull FDBRecordStoreBase<M> recordStore) {
+        this.memoryLimit = memoryLimit;
+        this.memoryOnly = memoryOnly;
+        this.key = key;
+        RecordSerializer<M> recordSerializer = recordStore.getSerializer();
+        if (recordSerializer instanceof TransformedRecordSerializer) {
+            // Nothing goes wrong without this, but it avoids double encryption / compression.
+            recordSerializer = ((TransformedRecordSerializer<M>)recordSerializer).untransformed();
+        }
+        serializer = new SortedRecordSerializer<>(recordSerializer, recordStore.getRecordMetaData(), recordStore.getTimer());
+    }
+
+    public boolean isMemoryOnly() {
+        return memoryOnly;
+    }
+
+    @Override
+    public int compare(@Nonnull Tuple o1, @Nonnull Tuple o2) {
+        return key.isReverse() ? o2.compareTo(o1) : o1.compareTo(o2);
+    }
+
+    @Nonnull
+    @Override
+    public Tuple generateKey(@Nonnull FDBStoredRecord<M> value) {
+        return key.getKey().evaluateSingleton(value).toTuple();
+    }
+
+    @Nonnull
+    @Override
+    public byte[] serializeKey(final Tuple key) {
+        return key.pack();
+    }
+
+    @Override
+    public boolean isSerializedOrderReversed() {
+        return key.isReverse();
+    }
+
+    @Nonnull
+    @Override
+    public Tuple deserializeKey(@Nonnull final byte[] key) {
+        return Tuple.fromBytes(key);
+    }
+
+    @Nonnull
+    @Override
+    public byte[] serializeValue(final FDBStoredRecord<M> record) {
+        return serializer.serialize(record);
+    }
+
+    @Nonnull
+    @Override
+    public FDBStoredRecord<M> deserializeValue(@Nonnull final byte[] bytes) {
+        return serializer.deserialize(bytes).getStoredRecord();
+    }
+
+    @Override
+    public int getMaxMapSize() {
+        return memoryOnly ? memoryLimit : MAX_MEMORY_SIZE;
+    }
+
+    @Nonnull
+    @Override
+    public MemorySorter.SizeLimitMode getSizeLimitMode() {
+        return memoryOnly ? MemorySorter.SizeLimitMode.DISCARD : MemorySorter.SizeLimitMode.STOP;
+    }
+
+    @Nonnull
+    @Override
+    public File generateFilename() throws IOException {
+        return File.createTempFile("fdb", ".bin");
+    }
+
+    @Override
+    public void writeValue(@Nonnull final FDBStoredRecord<M> record, @Nonnull final CodedOutputStream stream) throws IOException {
+        serializer.write(record, stream);
+    }
+
+    @Override
+    public FDBStoredRecord<M> readValue(@Nonnull final CodedInputStream stream) throws IOException {
+        return serializer.read(stream).getStoredRecord();
+    }
+
+    @Override
+    public int getMinFileSize() {
+        return MAX_MEMORY_SIZE;
+    }
+
+    @Override
+    public int getMaxNumFiles() {
+        return MAX_FILES;
+    }
+
+    @Override
+    public int getRecordsPerSection() {
+        return RECORDS_PER_SECTION;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public synchronized Key getEncryptionKey() {
+        if (encryptionKey == null) {
+            try {
+                final KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+                keyGen.init(128, RANDOM.get());
+                encryptionKey = keyGen.generateKey();
+            } catch (GeneralSecurityException ex) {
+                throw new RecordCoreException(ex);
+            }
+        }
+        return encryptionKey;
+    }
+
+    @Nullable
+    @Override
+    public SecureRandom getSecureRandom() {
+        return RANDOM.get();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
@@ -54,9 +54,10 @@ import java.util.function.Supplier;
  */
 @API(API.Status.EXPERIMENTAL)
 public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapter<Tuple, FDBQueriedRecord<M>> {
-    public static final int MAX_RECORD_COUNT_IN_MEMORY = 1000;
-    public static final int MAX_FILE_COUNT = 10;
-    public static final int RECORD_COUNT_PER_SECTION = 100;
+    // To use different values, override the associated methods.
+    public static final int DEFAULT_MAX_RECORD_COUNT_IN_MEMORY = 1000;
+    public static final int DEFAULT_MAX_FILE_COUNT = 10;
+    public static final int DEFAULT_RECORD_COUNT_PER_SECTION = 100;
 
     private final int memoryLimit;
     private final boolean memoryOnly;
@@ -131,7 +132,7 @@ public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapte
 
     @Override
     public int getMaxRecordCountInMemory() {
-        return memoryOnly ? memoryLimit : MAX_RECORD_COUNT_IN_MEMORY;
+        return memoryOnly ? memoryLimit : DEFAULT_MAX_RECORD_COUNT_IN_MEMORY;
     }
 
     @Nonnull
@@ -163,17 +164,17 @@ public class RecordQuerySortAdapter<M extends Message> implements FileSortAdapte
 
     @Override
     public int getMinFileRecordCount() {
-        return MAX_RECORD_COUNT_IN_MEMORY;
+        return DEFAULT_MAX_RECORD_COUNT_IN_MEMORY;
     }
 
     @Override
     public int getMaxFileCount() {
-        return MAX_FILE_COUNT;
+        return DEFAULT_MAX_FILE_COUNT;
     }
 
     @Override
     public int getRecordCountPerSection() {
-        return RECORD_COUNT_PER_SECTION;
+        return DEFAULT_RECORD_COUNT_PER_SECTION;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
@@ -51,9 +51,9 @@ import java.util.function.Supplier;
  */
 @API(API.Status.EXPERIMENTAL)
 class RecordQuerySortAdapter<M extends Message> implements FileSortAdapter<Tuple, FDBStoredRecord<M>> {
-    public static final int MAX_MEMORY_SIZE = 1000;
-    public static final int MAX_FILES = 10;
-    public static final int RECORDS_PER_SECTION = 100;
+    public static final int MAX_RECORD_COUNT_IN_MEMORY = 1000;
+    public static final int MAX_FILE_COUNT = 10;
+    public static final int RECORD_COUNT_PER_SECTION = 100;
 
     private final int memoryLimit;
     private final boolean memoryOnly;
@@ -124,14 +124,14 @@ class RecordQuerySortAdapter<M extends Message> implements FileSortAdapter<Tuple
     }
 
     @Override
-    public int getMaxMapSize() {
-        return memoryOnly ? memoryLimit : MAX_MEMORY_SIZE;
+    public int getMaxRecordCountInMemory() {
+        return memoryOnly ? memoryLimit : MAX_RECORD_COUNT_IN_MEMORY;
     }
 
     @Nonnull
     @Override
-    public MemorySorter.SizeLimitMode getSizeLimitMode() {
-        return memoryOnly ? MemorySorter.SizeLimitMode.DISCARD : MemorySorter.SizeLimitMode.STOP;
+    public MemorySorter.RecordCountInMemoryLimitMode getRecordCountInMemoryLimitMode() {
+        return memoryOnly ? MemorySorter.RecordCountInMemoryLimitMode.DISCARD : MemorySorter.RecordCountInMemoryLimitMode.STOP;
     }
 
     @Nonnull
@@ -151,18 +151,18 @@ class RecordQuerySortAdapter<M extends Message> implements FileSortAdapter<Tuple
     }
 
     @Override
-    public int getMinFileSize() {
-        return MAX_MEMORY_SIZE;
+    public int getMinFileRecordCount() {
+        return MAX_RECORD_COUNT_IN_MEMORY;
     }
 
     @Override
-    public int getMaxNumFiles() {
-        return MAX_FILES;
+    public int getMaxFileCount() {
+        return MAX_FILE_COUNT;
     }
 
     @Override
-    public int getRecordsPerSection() {
-        return RECORDS_PER_SECTION;
+    public int getRecordCountPerSection() {
+        return RECORD_COUNT_PER_SECTION;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
@@ -1,0 +1,107 @@
+/*
+ * SortQueryKey.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link KeyExpression} used as the sort key for {@link RecordQuerySortPlan}.
+ * Also acts as a factory for {@link RecordQuerySortAdapter}.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class RecordQuerySortKey implements PlanHashable {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Record-Query-Sort-Key");
+
+    @Nonnull
+    private final KeyExpression key;
+    private final boolean reverse;
+
+    public RecordQuerySortKey(@Nonnull final KeyExpression key, final boolean reverse) {
+        this.key = key;
+        this.reverse = reverse;
+    }
+
+    @Nonnull
+    public KeyExpression getKey() {
+        return key;
+    }
+
+    public boolean isReverse() {
+        return reverse;
+    }
+
+    /**
+     * Get a sort adapter used for a single invocation of a plan using this key.
+     * The adapter will have a unique encryption key.
+     * The limit on the number of records returned limits the size of the sort buffer that needs to be kept,
+     * and so may allow it to be in-memory only.
+     * @param recordStore the record store against which the plan is running
+     * @param skipPlusLimit the maximum number of records to read
+     * @return a new sort adapter
+     */
+    @Nonnull
+    public <M extends Message> RecordQuerySortAdapter<M> getAdapter(@Nonnull FDBRecordStoreBase<M> recordStore, int skipPlusLimit) {
+        final int memoryLimit = Math.min(skipPlusLimit, RecordQuerySortAdapter.MAX_MEMORY_SIZE);
+        final boolean memoryOnly = memoryLimit == skipPlusLimit;
+        return new RecordQuerySortAdapter<>(memoryLimit, memoryOnly, this, recordStore);
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, key, reverse);
+    }
+
+    @Override
+    public String toString() {
+        return reverse ? key + " DESC" : key.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final RecordQuerySortKey that = (RecordQuerySortKey)o;
+
+        if (reverse != that.reverse) {
+            return false;
+        }
+        return key.equals(that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key.hashCode();
+        result = 31 * result + (reverse ? 1 : 0);
+        return result;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
@@ -67,7 +67,7 @@ public class RecordQuerySortKey implements PlanHashable {
      */
     @Nonnull
     public <M extends Message> RecordQuerySortAdapter<M> getAdapter(@Nonnull FDBRecordStoreBase<M> recordStore, int maxRecordsToRead) {
-        final int memoryLimit = Math.min(maxRecordsToRead, RecordQuerySortAdapter.MAX_RECORD_COUNT_IN_MEMORY);
+        final int memoryLimit = Math.min(maxRecordsToRead, RecordQuerySortAdapter.DEFAULT_MAX_RECORD_COUNT_IN_MEMORY);
         final boolean memoryOnly = memoryLimit == maxRecordsToRead;
         return new RecordQuerySortAdapter<>(memoryLimit, memoryOnly, this, recordStore);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
@@ -60,13 +60,14 @@ public class RecordQuerySortKey implements PlanHashable {
      * The adapter will have a unique encryption key.
      * The limit on the number of records returned limits the size of the sort buffer that needs to be kept,
      * and so may allow it to be in-memory only.
+     * @param <M> type used to represent stored records
      * @param recordStore the record store against which the plan is running
      * @param skipPlusLimit the maximum number of records to read
      * @return a new sort adapter
      */
     @Nonnull
     public <M extends Message> RecordQuerySortAdapter<M> getAdapter(@Nonnull FDBRecordStoreBase<M> recordStore, int skipPlusLimit) {
-        final int memoryLimit = Math.min(skipPlusLimit, RecordQuerySortAdapter.MAX_MEMORY_SIZE);
+        final int memoryLimit = Math.min(skipPlusLimit, RecordQuerySortAdapter.MAX_RECORD_COUNT_IN_MEMORY);
         final boolean memoryOnly = memoryLimit == skipPlusLimit;
         return new RecordQuerySortAdapter<>(memoryLimit, memoryOnly, this, recordStore);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
@@ -1,5 +1,5 @@
 /*
- * SortQueryKey.java
+ * RecordQuerySortKey.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -30,7 +30,7 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 
 /**
- * A {@link KeyExpression} used as the sort key for {@link RecordQuerySortPlan}.
+ * Defines, logically, how {@link RecordQuerySortPlan} should sort the records.
  * Also acts as a factory for {@link RecordQuerySortAdapter}.
  */
 @API(API.Status.EXPERIMENTAL)
@@ -62,13 +62,13 @@ public class RecordQuerySortKey implements PlanHashable {
      * and so may allow it to be in-memory only.
      * @param <M> type used to represent stored records
      * @param recordStore the record store against which the plan is running
-     * @param skipPlusLimit the maximum number of records to read
+     * @param maxRecordsToRead the maximum number of records to read
      * @return a new sort adapter
      */
     @Nonnull
-    public <M extends Message> RecordQuerySortAdapter<M> getAdapter(@Nonnull FDBRecordStoreBase<M> recordStore, int skipPlusLimit) {
-        final int memoryLimit = Math.min(skipPlusLimit, RecordQuerySortAdapter.MAX_RECORD_COUNT_IN_MEMORY);
-        final boolean memoryOnly = memoryLimit == skipPlusLimit;
+    public <M extends Message> RecordQuerySortAdapter<M> getAdapter(@Nonnull FDBRecordStoreBase<M> recordStore, int maxRecordsToRead) {
+        final int memoryLimit = Math.min(maxRecordsToRead, RecordQuerySortAdapter.MAX_RECORD_COUNT_IN_MEMORY);
+        final boolean memoryOnly = memoryLimit == maxRecordsToRead;
         return new RecordQuerySortAdapter<>(memoryLimit, memoryOnly, this, recordStore);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
@@ -89,7 +89,8 @@ public class RecordQuerySortPlan implements RecordQueryPlanWithChild {
         // even just to get the top few.
         final ExecuteProperties executeInner = executeProperties.clearSkipAndLimit();
         final Function<byte[], RecordCursor<FDBStoredRecord<M>>> innerCursor =
-                innerContinuation -> getChild().execute(store, context, innerContinuation, executeInner).map(FDBQueriedRecord::getStoredRecord);
+                innerContinuation -> getChild().executePlan(store, context, innerContinuation, executeInner)
+                        .map(result -> result.<M>getQueriedRecord(0).getStoredRecord());
         final int skip = executeProperties.getSkip();
         final int limit = executeProperties.getReturnedRowLimitOrMax();
         final int maxRecordsToRead = limit == Integer.MAX_VALUE ? limit : skip + limit;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
@@ -1,5 +1,5 @@
 /*
- * SortQueryPlan.java
+ * RecordQuerySortPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -92,8 +92,8 @@ public class RecordQuerySortPlan implements RecordQueryPlanWithChild {
                 innerContinuation -> getChild().execute(store, context, innerContinuation, executeInner).map(FDBQueriedRecord::getStoredRecord);
         final int skip = executeProperties.getSkip();
         final int limit = executeProperties.getReturnedRowLimitOrMax();
-        final int skipPlusLimit = limit == Integer.MAX_VALUE ? limit : skip + limit;
-        final RecordQuerySortAdapter<M> adapter = key.getAdapter(store, skipPlusLimit);
+        final int maxRecordsToRead = limit == Integer.MAX_VALUE ? limit : skip + limit;
+        final RecordQuerySortAdapter<M> adapter = key.getAdapter(store, maxRecordsToRead);
         final FDBStoreTimer timer = store.getTimer();
         final RecordCursor<FDBStoredRecord<M>> sorted;
         if (adapter.isMemoryOnly()) {
@@ -205,7 +205,8 @@ public class RecordQuerySortPlan implements RecordQueryPlanWithChild {
 
     @Override
     public int getComplexity() {
-        return 100 + getChild().getComplexity();
+        // TODO: Does not introduce any additional complexity, so not currently a good measure of sort vs no-sort.
+        return getChild().getComplexity();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
@@ -1,0 +1,219 @@
+/*
+ * SortQueryPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithChild;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
+import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
+import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
+import com.apple.foundationdb.record.sorting.FileSortCursor;
+import com.apple.foundationdb.record.sorting.MemorySortCursor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * A query plan implementing sorting in-memory, possibly spilling to disk.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class RecordQuerySortPlan implements RecordQueryPlanWithChild {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Record-Query-Sort-Plan");
+
+    @Nonnull
+    private final Quantifier.Physical inner;
+    @Nonnull
+    private final RecordQuerySortKey key;
+
+    public RecordQuerySortPlan(@Nonnull RecordQueryPlan plan, @Nonnull RecordQuerySortKey key) {
+        this(Quantifier.physical(GroupExpressionRef.of(plan)), key);
+    }
+
+    private RecordQuerySortPlan(@Nonnull Quantifier.Physical inner, @Nonnull RecordQuerySortKey key) {
+        this.inner = inner;
+        this.key = key;
+    }
+
+    @Nonnull
+    @Override
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull FDBRecordStoreBase<M> store,
+                                                                     @Nonnull EvaluationContext context,
+                                                                     @Nullable byte[] continuation,
+                                                                     @Nonnull ExecuteProperties executeProperties) {
+        // Since we are sorting, we need to feed through everything from the inner plan,
+        // even just to get the top few.
+        final ExecuteProperties executeInner = executeProperties.clearSkipAndLimit();
+        final Function<byte[], RecordCursor<FDBStoredRecord<M>>> innerCursor =
+                innerContinuation -> getChild().execute(store, context, innerContinuation, executeInner).map(FDBQueriedRecord::getStoredRecord);
+        final int skip = executeProperties.getSkip();
+        final int limit = executeProperties.getReturnedRowLimitOrMax();
+        final int skipPlusLimit = limit == Integer.MAX_VALUE ? limit : skip + limit;
+        final RecordQuerySortAdapter<M> adapter = key.getAdapter(store, skipPlusLimit);
+        final FDBStoreTimer timer = store.getTimer();
+        final RecordCursor<FDBStoredRecord<M>> sorted;
+        if (adapter.isMemoryOnly()) {
+            sorted = MemorySortCursor.create(adapter, innerCursor, timer, continuation).skipThenLimit(skip, limit);
+        } else {
+            sorted = FileSortCursor.create(adapter, innerCursor, timer, continuation, skip, limit);
+        }
+        return sorted.map(FDBQueriedRecord::stored).map(QueryResult::of);
+    }
+
+    @Override
+    @Nonnull
+    public RecordQueryPlan getChild() {
+        return inner.getRangesOverPlan();
+    }
+
+    @Nonnull
+    public RecordQuerySortKey getKey() {
+        return key;
+    }
+
+    @Override
+    public boolean isReverse() {
+        return key.isReverse();
+    }
+
+    @Nonnull
+    @Override
+    @API(API.Status.EXPERIMENTAL)
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(inner);
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
+    }
+
+    @Nonnull
+    @Override
+    public AvailableFields getAvailableFields() {
+        return AvailableFields.ALL_FIELDS;
+    }
+
+    @Override
+    public String toString() {
+        return getChild() + " ORDER BY " + getKey();
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    public RecordQuerySortPlan rebaseWithRebasedQuantifiers(@Nonnull final AliasMap translationMap,
+                                                            @Nonnull final List<Quantifier> rebasedQuantifiers) {
+        return new RecordQuerySortPlan((Quantifier.Physical)Iterables.getOnlyElement(rebasedQuantifiers), key);
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQuerySortPlan(child, key);
+    }
+
+    @Override
+    public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
+                                         @Nonnull final AliasMap equivalencesMap) {
+        if (this == otherExpression) {
+            return true;
+        }
+        if (getClass() != otherExpression.getClass()) {
+            return false;
+        }
+        final RecordQuerySortPlan other = (RecordQuerySortPlan) otherExpression;
+        return key.equals(other.key);
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(final Object other) {
+        return structuralEquals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return structuralHashCode();
+    }
+
+    @Override
+    public int hashCodeWithoutChildren() {
+        return Objects.hash(key);
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, getChild(), getKey());
+    }
+
+    @Override
+    public void logPlanStructure(StoreTimer timer) {
+        timer.increment(FDBStoreTimer.Counts.PLAN_SORT);
+        getChild().logPlanStructure(timer);
+    }
+
+    @Override
+    public int getComplexity() {
+        return 100 + getChild().getComplexity();
+    }
+
+    @Nonnull
+    @Override
+    public PlannerGraph rewritePlannerGraph(@Nonnull final List<? extends PlannerGraph> childGraphs) {
+        return PlannerGraph.fromNodeAndChildGraphs(
+                new PlannerGraph.OperatorNodeWithInfo(this, NodeInfo.SORT_OPERATOR),
+                childGraphs);
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes relating to plan execution with in-memory / file sorting.
+ */
+package com.apple.foundationdb.record.query.plan.sorting;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
@@ -1,0 +1,107 @@
+/*
+ * FileSortAdapter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.security.Key;
+import java.security.SecureRandom;
+
+/**
+ * Provide various options for {@link FileSorter} and {@link FileSortCursor}.
+ * @param <K> type of key
+ * @param <V> type of value
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface FileSortAdapter<K, V> extends MemorySortAdapter<K, V> {
+    /**
+     * Get the name of a file to use for saving sorted records.
+     * @return a file into which to save sorted records
+     * @throws IOException if something fails creating the file
+     */
+    @Nonnull
+    File generateFilename() throws IOException;
+
+    /**
+     * Write the value to a Protobuf stream.
+     * @param value the sorted value
+     * @param stream the destination stream
+     * @throws IOException if something fails writing to a file
+     */
+    void writeValue(@Nonnull V value, @Nonnull CodedOutputStream stream) throws IOException;
+
+    /**
+     * Read the value from a Protobuf stream.
+     * @param stream the source stream
+     * @return the next value in the stream
+     * @throws IOException if something fails reading from the file
+     */
+    @Nonnull
+    V readValue(@Nonnull CodedInputStream stream) throws IOException;
+
+    /**
+     * Get the mimimum number of records needed to write a file.
+     * If loading finds fewer than this number of records, the results are kept in memory and returned from there.
+     * @return minimum number of records
+     */
+    int getMinFileSize();
+
+    /**
+     * Get the maximum number of files to keep before merging.
+     * @return the maximum number of files kept by a single cursor
+     */
+    int getMaxNumFiles();
+
+    /**
+     * Get the maximum number of files in a section.
+     * Sections allow skipping through the file faster.
+     * @return the number of records in each section
+     */
+    int getRecordsPerSection();
+
+    // TODO: Limit on number of records total?
+
+    /**
+     * Get whether files should be compressed.
+     * @return {@code true} if files are compressed
+     */
+    boolean isCompressed();
+
+    /**
+     * Get whether files should be encrypted.
+     * @return encryption key to use or {@code null} for unencrypted files
+     */
+    @Nullable
+    Key getEncryptionKey();
+
+    /**
+     * Get source of randomness for encryption.
+     * @return secure random source
+     */
+    @Nullable
+    SecureRandom getSecureRandom();
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
@@ -68,20 +68,20 @@ public interface FileSortAdapter<K, V> extends MemorySortAdapter<K, V> {
      * If loading finds fewer than this number of records, the results are kept in memory and returned from there.
      * @return minimum number of records
      */
-    int getMinFileSize();
+    int getMinFileRecordCount();
 
     /**
      * Get the maximum number of files to keep before merging.
      * @return the maximum number of files kept by a single cursor
      */
-    int getMaxNumFiles();
+    int getMaxFileCount();
 
     /**
      * Get the maximum number of files in a section.
      * Sections allow skipping through the file faster.
      * @return the number of records in each section
      */
-    int getRecordsPerSection();
+    int getRecordCountPerSection();
 
     // TODO: Limit on number of records total?
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.sorting;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 
@@ -45,6 +46,13 @@ public interface FileSortAdapter<K, V> extends MemorySortAdapter<K, V> {
      */
     @Nonnull
     File generateFilename() throws IOException;
+
+    /**
+     * Get the version of the meta-data used to save the file.
+     * @return the meta-data version
+     * @see RecordMetaData#getVersion
+     */
+    int getMetaDataVersion();
 
     /**
      * Write the value to a Protobuf stream.
@@ -80,6 +88,7 @@ public interface FileSortAdapter<K, V> extends MemorySortAdapter<K, V> {
      * Get the maximum number of files in a section.
      * Sections allow skipping through the file faster.
      * @return the number of records in each section
+     * @see FileSorter
      */
     int getRecordCountPerSection();
 
@@ -90,6 +99,13 @@ public interface FileSortAdapter<K, V> extends MemorySortAdapter<K, V> {
      * @return {@code true} if files are compressed
      */
     boolean isCompressed();
+
+    /**
+     * Get name of cipher to use for encrypting.
+     * @return cipher name to use or {@code null} for unencrypted files
+     */
+    @Nullable
+    String getEncryptionCipherName();
 
     /**
      * Get whether files should be encrypted.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursor.java
@@ -1,0 +1,191 @@
+/*
+ * FileSortCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+/**
+ * Sort records in memory and / or in files, then return them in order.
+ * @param <K> type of key
+ * @param <V> type of value
+ */
+@API(API.Status.EXPERIMENTAL)
+public class FileSortCursor<K, V> implements RecordCursor<V> {
+    @Nonnull
+    private final RecordCursor<V> inputCursor;
+    @Nonnull
+    private final FileSorter<K, V> sorter;
+    @Nonnull
+    private final FileSortAdapter<K, V> adapter;
+    @Nullable
+    private final StoreTimer timer;
+    private final int skip;
+    private final int limit;
+
+    private RecordCursorContinuation inputContinuation;
+    private Iterator<Map.Entry<K, V>> inMemoryIterator;
+    private int inMemoryPosition;
+    @Nullable
+    private K minimumKey;
+    private SortedFileReader<V> fileReader;
+
+    private FileSortCursor(@Nonnull FileSortAdapter<K, V> adapter, @Nonnull FileSorter<K, V> sorter,
+                           @Nonnull RecordCursor<V> inputCursor, @Nullable StoreTimer timer,
+                           int skip, int limit) {
+        this.inputCursor = inputCursor;
+        this.sorter = sorter;
+        this.adapter = adapter;
+        this.timer = timer;
+        this.skip = skip;
+        this.limit = limit;
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<RecordCursorResult<V>> onNext() {
+        if (inMemoryIterator != null) {
+            return CompletableFuture.completedFuture(nextFromIterator());
+        }
+        if (fileReader != null) {
+            return CompletableFuture.completedFuture(nextFromReader());
+        }
+        return sorter.load(inputCursor).thenApply(loadResult -> {
+            inputContinuation = loadResult.getSourceContinuation();
+            if (loadResult.getSourceNoNextReason().isOutOfBand()) {
+                // The input cursor did not complete; we must save the sorter state in the continuation so can pick up after.
+                Collection<V> inMemoryRecords = sorter.getMapSorter().getMap().values();
+                FileSortCursorContinuation<K, V> continuation = new FileSortCursorContinuation<>(adapter, false, true, inMemoryRecords, sorter.getFiles(), inputContinuation, 0, 0);
+                return RecordCursorResult.withoutNextValue(continuation, loadResult.getSourceNoNextReason());
+            }
+            // Loaded all the records into the sorter, start returning them.
+            if (loadResult.isInMemory()) {
+                inMemoryIterator = sorter.getMapSorter().getMap().entrySet().iterator();
+                for (int i = 0; i < skip; i++) {
+                    if (!inMemoryIterator.hasNext()) {
+                        break;
+                    }
+                    inMemoryIterator.next();
+                }
+                return nextFromIterator();
+            }
+            try {
+                fileReader = new SortedFileReader<>(sorter.getFiles().get(0), adapter, timer, skip, limit);
+            } catch (IOException | GeneralSecurityException ex) {
+                throw new RecordCoreException(ex);
+            }
+            return nextFromReader();
+        });
+    }
+
+    @Nonnull
+    private RecordCursorResult<V> nextFromIterator() {
+        if (inMemoryPosition >= limit) {
+            FileSortCursorContinuation<K, V> continuation = new FileSortCursorContinuation<>(adapter, true, false, Collections.emptyList(), Collections.emptyList(), inputContinuation, inMemoryPosition, 0);
+            return RecordCursorResult.withoutNextValue(continuation, NoNextReason.RETURN_LIMIT_REACHED);
+        }
+        if (inMemoryIterator.hasNext()) {
+            // Return a sorted record.
+            Map.Entry<K, V> next = inMemoryIterator.next();
+            minimumKey = next.getKey();
+            inMemoryPosition++;
+            Collection<V> remainingRecords = sorter.getMapSorter().getMap().tailMap(minimumKey, false).values();
+            FileSortCursorContinuation<K, V> continuation = new FileSortCursorContinuation<>(adapter, false, false, remainingRecords, sorter.getFiles(), inputContinuation, inMemoryPosition, 0);
+            return RecordCursorResult.withNextValue(next.getValue(), continuation);
+        }
+        FileSortCursorContinuation<K, V> continuation = new FileSortCursorContinuation<>(adapter, true, false, Collections.emptyList(), Collections.emptyList(), inputContinuation, inMemoryPosition, 0);
+        return RecordCursorResult.withoutNextValue(continuation, NoNextReason.SOURCE_EXHAUSTED);
+    }
+
+    @Nonnull
+    private RecordCursorResult<V> nextFromReader() {
+        @Nullable V record;
+        try {
+            record = fileReader.read();
+        } catch (IOException | GeneralSecurityException ex) {
+            throw new RecordCoreException(ex);
+        }
+        FileSortCursorContinuation<K, V> continuation = new FileSortCursorContinuation<>(adapter, record == null, false, Collections.emptyList(), sorter.getFiles(), inputContinuation, fileReader.getRecordPosition(), fileReader.getFilePosition());
+        if (record != null) {
+            return RecordCursorResult.withNextValue(record, continuation);
+        } else {
+            return RecordCursorResult.withoutNextValue(continuation, NoNextReason.SOURCE_EXHAUSTED);
+        }
+    }
+
+    @Override
+    public void close() {
+        inputCursor.close();
+        try {
+            sorter.deleteFiles();
+        } catch (IOException ex) {
+            throw new RecordCoreException(ex);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public Executor getExecutor() {
+        return inputCursor.getExecutor();
+    }
+
+    @Override
+    public boolean accept(@Nonnull final RecordCursorVisitor visitor) {
+        if (visitor.visitEnter(this)) {
+            inputCursor.accept(visitor);
+        }
+        return visitor.visitLeave(this);
+    }
+
+    public static <K, V> FileSortCursor<K, V> create(@Nonnull FileSortAdapter<K, V> adapter,
+                                                     @Nonnull Function<byte[], RecordCursor<V>> inputCursorFunction,
+                                                     @Nullable StoreTimer timer,
+                                                     @Nullable byte[] continuation, int skip, int limit) {
+        final FileSortCursorContinuation<K, V> parsedContinuation = FileSortCursorContinuation.from(continuation, adapter);
+        final RecordCursor<V> inputCursor = parsedContinuation.isLoading() ? inputCursorFunction.apply(parsedContinuation.getChild().toBytes()) : RecordCursor.empty();
+        final FileSorter<K, V> sorter = new FileSorter<>(adapter, timer, inputCursor.getExecutor());
+        for (V record : parsedContinuation.getInMemoryRecords()) {
+            sorter.getMapSorter().addValue(record);
+        }
+        for (File file : parsedContinuation.getFiles()) {
+            sorter.getFiles().add(file);
+        }
+        return new FileSortCursor<>(adapter, sorter, inputCursor, timer, skip, limit);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursor.java
@@ -105,6 +105,9 @@ public class FileSortCursor<K, V> implements RecordCursor<V> {
                 }
                 return nextFromIterator();
             }
+            if (sorter.getFiles().size() != 1) {
+                throw new RecordCoreException("sort loading did not produce exactly one file");
+            }
             try {
                 fileReader = new SortedFileReader<>(sorter.getFiles().get(0), adapter, timer, skip, limit);
             } catch (IOException | GeneralSecurityException ex) {
@@ -152,6 +155,8 @@ public class FileSortCursor<K, V> implements RecordCursor<V> {
     @Override
     public void close() {
         inputCursor.close();
+        // TODO: For now, delete the sort file.
+        //  In the future, it should be possible to save a query result to a file and open multiple cursors on that same file to page through the results.
         try {
             sorter.deleteFiles();
         } catch (IOException ex) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursorContinuation.java
@@ -1,0 +1,181 @@
+/*
+ * FileSortCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.ByteArrayContinuation;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.RecordSortingProto;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@API(API.Status.EXPERIMENTAL)
+class FileSortCursorContinuation<K, V> implements RecordCursorContinuation {
+    @Nonnull
+    private final FileSortAdapter<K, V> adapter;
+
+    private final boolean exhausted;
+    private final boolean loading;
+    @Nonnull
+    private final Collection<V> inMemoryRecords;
+    @Nonnull
+    private final List<File> files;
+    @Nonnull
+    private final RecordCursorContinuation childContinuation;
+    private final int recordPosition;
+    private final long filePosition;
+    
+    @Nullable
+    private RecordSortingProto.FileSortContinuation cachedProto;
+    @Nullable
+    private byte[] cachedBytes;
+
+    FileSortCursorContinuation(@Nonnull FileSortAdapter<K, V> adapter,
+                               boolean exhausted, boolean loading,
+                               @Nonnull Collection<V> inMemoryRecords,
+                               @Nonnull List<File> files, @Nonnull RecordCursorContinuation childContinuation,
+                               int recordPosition, long filePosition) {
+        this.exhausted = exhausted;
+        this.loading = loading;
+        this.adapter = adapter;
+        this.inMemoryRecords = inMemoryRecords;
+        this.files = files;
+        this.childContinuation = childContinuation;
+        this.recordPosition = recordPosition;
+        this.filePosition = filePosition;
+    }
+
+    @Nonnull
+    RecordSortingProto.FileSortContinuation toProto() {
+        if (cachedProto == null) {
+            RecordSortingProto.FileSortContinuation.Builder builder = RecordSortingProto.FileSortContinuation.newBuilder();
+            if (loading) {
+                builder.setLoading(true);
+            }
+            for (V record : inMemoryRecords) {
+                builder.addInMemoryRecords(ByteString.copyFrom(adapter.serializeValue(record)));
+            }
+            for (File file : files) {
+                builder.addFiles(file.getPath());
+            }
+            byte[] childBytes = childContinuation.toBytes();
+            if (childBytes != null) {
+                builder.setContinuation(ByteString.copyFrom(childBytes));
+            }
+            if (recordPosition > 0) {
+                builder.setRecordPosition(recordPosition);
+            }
+            if (filePosition > 0) {
+                builder.setFilePosition(filePosition);
+            }
+            cachedProto = builder.build();
+        }
+        return cachedProto;
+    }
+
+    @Override
+    @Nullable
+    public byte[] toBytes() {
+        if (isEnd()) {
+            return null;
+        }
+        if (cachedBytes == null) {
+            cachedBytes = toProto().toByteArray();
+        }
+        return cachedBytes;
+    }
+
+    @Nonnull
+    static <K, V> FileSortCursorContinuation<K, V> from(@Nonnull RecordSortingProto.FileSortContinuation parsed,
+                                                        @Nonnull FileSortAdapter<K, V> adapter) {
+        FileSortCursorContinuation<K, V> result = new FileSortCursorContinuation<>(
+                adapter, false, parsed.getLoading(),
+                parsed.getInMemoryRecordsList().stream().map(bs -> adapter.deserializeValue(bs.toByteArray())).collect(Collectors.toList()),
+                parsed.getFilesList().stream().map(File::new).collect(Collectors.toList()),
+                parsed.hasContinuation() ? ByteArrayContinuation.fromNullable(parsed.getContinuation().toByteArray()) : RecordCursorStartContinuation.START,
+                parsed.getRecordPosition(), parsed.getFilePosition()
+        );
+        result.cachedProto = parsed;
+        return result;
+    }
+
+    @Nonnull
+    static <K, V> FileSortCursorContinuation<K, V> from(@Nullable byte[] unparsed,
+                                                        @Nonnull FileSortAdapter<K, V> adapter) {
+        FileSortCursorContinuation<K, V> result;
+        if (unparsed == null) {
+            result = new FileSortCursorContinuation<K, V>(adapter, false, true, Collections.emptyList(), Collections.emptyList(), RecordCursorStartContinuation.START, 0, 0);
+        } else {
+            try {
+                result = from(RecordSortingProto.FileSortContinuation.parseFrom(unparsed), adapter);
+            } catch (InvalidProtocolBufferException ex) {
+                throw new RecordCoreException("invalid continuation", ex)
+                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(unparsed));
+            }
+            result.cachedBytes = unparsed;
+        }
+        return result;
+    }
+
+    public boolean isLoading() {
+        return loading;
+    }
+
+    @Nonnull
+    public Collection<V> getInMemoryRecords() {
+        return inMemoryRecords;
+    }
+
+    @Nonnull
+    public List<File> getFiles() {
+        return files;
+    }
+
+    @Nonnull
+    RecordCursorContinuation getChild() {
+        return childContinuation;
+    }
+
+    public int getRecordPosition() {
+        return recordPosition;
+    }
+
+    public long getFilePosition() {
+        return filePosition;
+    }
+
+    @Override
+    public boolean isEnd() {
+        return exhausted;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSorter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSorter.java
@@ -1,0 +1,601 @@
+/*
+ * FileSorter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordSortingProto;
+import com.apple.foundationdb.record.provider.common.CipherPool;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.ExtensionRegistryLite;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.spec.IvParameterSpec;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
+
+/**
+ * Write sorted keyed values into {@link File}s.
+ *
+ * Subsets of the input data are sorted in memory using a {@link MemorySorter}.
+ * Then these are saved to files.
+ * The files are then merged and values returned in order from there.
+ * In addition to a final merge at the end, files can be merged when there are too many pending files.
+ *
+ * The files are divided into sections with headers that allow skipping ahead sequentially
+ * somewhat faster than would be possible if every record had to be read,
+ * but without as much overhead as fully indexing record positions into file positions.
+ *
+ * Files can be optionally compressed and encrypted. This applies at the section level: the section
+ * headers are cleartext and the keys and records are not individually compressed / encrypted.
+ *
+ *
+ * If the input set is small enough, it can remain in memory in the tree map
+ * and can be returned directly from there.
+ * @param <K> type of key
+ * @param <V> type of value
+ */
+@API(API.Status.EXPERIMENTAL)
+public class FileSorter<K, V>  {
+    @Nonnull
+    private final MemorySorter<K, V> mapSorter;
+    @Nonnull
+    private final FileSortAdapter<K, V> adapter;
+    @Nullable
+    private final StoreTimer timer;
+    @Nonnull
+    private final Executor executor;
+    @Nonnull
+    private final List<File> files;
+
+    private LoadResult loadResult;
+
+    public FileSorter(@Nonnull FileSortAdapter<K, V> adapter, @Nullable StoreTimer timer,
+                      @Nonnull Executor executor) {
+        this.adapter = adapter;
+        this.timer = timer;
+        this.executor = executor;
+        mapSorter = new MemorySorter<>(adapter, timer);
+        files = new ArrayList<>();
+    }
+
+    @Nonnull
+    public MemorySorter<K, V> getMapSorter() {
+        return mapSorter;
+    }
+
+    @Nonnull
+    public List<File> getFiles() {
+        return files;
+    }
+
+    /** The result of {@link #load}. */
+    public static class LoadResult {
+        private final boolean loadComplete;
+        private final boolean inMemory;
+        @Nonnull
+        private final RecordCursorContinuation sourceContinuation;
+        @Nullable
+        private final RecordCursor.NoNextReason sourceNoNextReason;
+
+        public LoadResult(boolean loadComplete, boolean inMemory,
+                          @Nonnull RecordCursorContinuation sourceContinuation, @Nullable RecordCursor.NoNextReason sourceNoNextReason) {
+            this.loadComplete = loadComplete;
+            this.inMemory = inMemory;
+            this.sourceContinuation = sourceContinuation;
+            this.sourceNoNextReason = sourceNoNextReason;
+        }
+
+        public boolean isLoadComplete() {
+            return loadComplete;
+        }
+
+        public boolean isInMemory() {
+            return inMemory;
+        }
+
+        @Nonnull
+        public RecordCursorContinuation getSourceContinuation() {
+            return sourceContinuation;
+        }
+
+        @Nullable
+        public RecordCursor.NoNextReason getSourceNoNextReason() {
+            return sourceNoNextReason;
+        }
+    }
+
+    public CompletableFuture<LoadResult> load(@Nonnull RecordCursor<V> source) {
+        loadResult = null;
+        return AsyncUtil.whileTrue(() -> mapSorter.load(source, null).thenCompose(mapResult -> {
+            if (mapResult.isFull()) {
+                return CompletableFuture.runAsync(() -> saveToNextFile(adapter.getMaxNumFiles()), executor).thenApply(vignore -> true);
+            }
+            if (mapResult.getSourceNoNextReason().isOutOfBand()) {
+                loadResult = new LoadResult(false, false, mapResult.getSourceContinuation(), mapResult.getSourceNoNextReason());
+                return AsyncUtil.READY_FALSE;
+            } else if (files.isEmpty() && mapSorter.getMap().size() < adapter.getMinFileSize()) {
+                loadResult = new LoadResult(true, true, mapResult.getSourceContinuation(), mapResult.getSourceNoNextReason());
+                return AsyncUtil.READY_FALSE;
+            } else {
+                loadResult = new LoadResult(true, false, mapResult.getSourceContinuation(), mapResult.getSourceNoNextReason());
+                return CompletableFuture.runAsync(() -> saveToNextFile(1), executor).thenApply(vignore -> false);
+            }
+        })).thenApply(vignore -> loadResult);
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private void saveToNextFile(int maxNumFiles) {
+        final long startTime = System.nanoTime();
+        final boolean compress = adapter.isCompressed();
+        final java.security.Key encryptionKey = adapter.getEncryptionKey();
+        Cipher cipher = null;
+        if (!mapSorter.getMap().isEmpty()) {
+            File file;
+            try {
+                file = adapter.generateFilename();
+                try (FileOutputStream fileStream = new FileOutputStream(file)) {
+                    final FileChannel fileChannel = fileStream.getChannel();
+                    final CodedOutputStream headerStream = CodedOutputStream.newInstance(fileStream);
+                    // To stay the same size, field existence must not change.
+                    final RecordSortingProto.SortFileHeader.Builder fileHeader = RecordSortingProto.SortFileHeader.newBuilder()
+                            .setNumberOfRecords(0)
+                            .setNumberOfSections(0);
+                    headerStream.writeMessageNoTag(fileHeader.build());
+                    final RecordSortingProto.SortSectionHeader.Builder sectionHeader = RecordSortingProto.SortSectionHeader.newBuilder()
+                            .setNumberOfRecords(0)
+                            .setNumberOfBytes(0);
+                    if (encryptionKey != null) {
+                        cipher = CipherPool.borrowCipher();
+                        final byte[] iv = new byte[CipherPool.IV_SIZE];
+                        adapter.getSecureRandom().nextBytes(iv);
+                        cipher.init(Cipher.ENCRYPT_MODE, encryptionKey, new IvParameterSpec(iv));
+                        sectionHeader.setEncryptionIv(ByteString.copyFrom(iv));
+                    }
+                    headerStream.writeMessageNoTag(sectionHeader.build());
+                    final long headerEnd = headerStream.getTotalBytesWritten();
+                    final OutputStream outputStream;
+                    final CodedOutputStream entryStream;
+                    if (compress || cipher != null) {
+                        headerStream.flush();
+                        OutputStream stream = new NoCloseFilterStream(fileStream);
+                        if (cipher != null) {
+                            stream = new CipherOutputStream(stream, cipher);
+                        }
+                        if (compress) {
+                            stream = new DeflaterOutputStream(stream);
+                        }
+                        outputStream = stream;
+                        entryStream = CodedOutputStream.newInstance(outputStream);
+                    } else {
+                        outputStream = fileStream;
+                        entryStream = headerStream;
+                    }
+                    if (timer != null) {
+                        timer.recordSinceNanoTime(SortEvents.Events.FILE_SORT_OPEN_FILE, startTime);
+                    }
+                    int numberOfRecords = 0;
+                    for (Map.Entry<K, V> keyAndValue : mapSorter.getMap().entrySet()) {
+                        final long recordStartTime = System.nanoTime();
+                        entryStream.writeByteArrayNoTag(adapter.serializeKey(keyAndValue.getKey()));
+                        adapter.writeValue(keyAndValue.getValue(), entryStream);
+                        numberOfRecords++;
+                        if (timer != null) {
+                            timer.recordSinceNanoTime(SortEvents.Events.FILE_SORT_SAVE_RECORD, recordStartTime);
+                        }
+                    }
+                    entryStream.flush();
+                    if (outputStream != fileStream) {
+                        outputStream.close();
+                    }
+                    final long fileLength = fileChannel.position();
+                    fileChannel.position(0);
+                    fileHeader.setNumberOfSections(1).setNumberOfRecords(numberOfRecords);
+                    headerStream.writeMessageNoTag(fileHeader.build());
+                    sectionHeader.setNumberOfRecords(numberOfRecords).setNumberOfBytes(fileLength - headerEnd);
+                    headerStream.writeMessageNoTag(sectionHeader.build());
+                    headerStream.flush();
+                    if (fileChannel.position() != headerEnd) {
+                        throw new RecordCoreException("header size changed");
+                    }
+                    fileChannel.position(fileLength);
+                    if (timer != null) {
+                        timer.increment(SortEvents.Counts.FILE_SORT_FILE_BYTES, (int)fileLength);
+                    }
+                }
+            } catch (IOException | GeneralSecurityException ex) {
+                throw new RecordCoreException(ex);
+            } finally {
+                if (cipher != null) {
+                    CipherPool.returnCipher(cipher);
+                }
+            }
+            files.add(file);
+            mapSorter.getMap().clear();
+        }
+        if (files.size() > maxNumFiles) {
+            File file;
+            try {
+                file = adapter.generateFilename();
+                merge(files, file);
+            } catch (IOException | GeneralSecurityException ex) {
+                throw new RecordCoreException(ex);
+            }
+            files.clear();
+            files.add(file);
+        }
+    }
+
+    // Both DeflaterOutputStream and CipherOutputStream have the problem that close() does finish work that isn't otherwise
+    // available as a flush()-type operation. So close down those streams while keeping the actual FileOutputStream open.
+    // Since those streams are pretty thin wrappers around Deflater and Cipher, an alternative would be to implement better
+    // contracts from scratch, which might also benefit record serialization.
+    private static class NoCloseFilterStream extends FilterOutputStream {
+        public NoCloseFilterStream(@Nonnull OutputStream stream) {
+            super(stream);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class InputState implements Closeable {
+        @Nonnull
+        final File file;
+        @Nonnull
+        final FileInputStream fileStream;
+        @Nonnull
+        CodedInputStream headerStream;
+        @Nonnull
+        CodedInputStream entryStream;
+
+        final boolean compressed;
+        @Nullable
+        final java.security.Key encryptionKey;
+        @Nullable
+        final Cipher cipher;
+
+        @Nullable
+        byte[] key;
+        @Nullable
+        byte[] value;
+
+        long sectionFilePosition;
+        int sectionRecordEnd;
+        int fileRecordEnd;
+        int recordPosition;
+        
+        public InputState(@Nonnull File file, @Nonnull FileSortAdapter<?, ?> adapter) throws IOException, GeneralSecurityException {
+            this.file = file;
+            fileStream = new FileInputStream(file);
+            headerStream = CodedInputStream.newInstance(fileStream);
+            entryStream = headerStream;
+            compressed = adapter.isCompressed();
+            encryptionKey = adapter.getEncryptionKey();
+            if (encryptionKey != null) {
+                cipher = CipherPool.borrowCipher();
+            } else {
+                cipher = null;
+            }
+            final RecordSortingProto.SortFileHeader.Builder builder =  RecordSortingProto.SortFileHeader.newBuilder();
+            headerStream.readMessage(builder, ExtensionRegistryLite.getEmptyRegistry());
+            fileRecordEnd = builder.getNumberOfRecords();
+        }
+
+        public void next() throws IOException, GeneralSecurityException {
+            while (recordPosition >= sectionRecordEnd) {
+                if (recordPosition >= fileRecordEnd) {
+                    key = null;
+                    value = null;
+                    return;
+                }
+                final FileChannel fileChannel;
+                if (compressed || encryptionKey != null) {
+                    fileChannel = fileStream.getChannel();
+                    if (recordPosition > 0) {
+                        fileChannel.position(sectionFilePosition);
+                        headerStream = CodedInputStream.newInstance(fileStream);
+                    }
+                } else {
+                    fileChannel = null;
+                }
+                final RecordSortingProto.SortSectionHeader.Builder builder =  RecordSortingProto.SortSectionHeader.newBuilder();
+                headerStream.readMessage(builder, ExtensionRegistryLite.getEmptyRegistry());
+                sectionRecordEnd += builder.getNumberOfRecords();
+                if (fileChannel != null) {
+                    sectionFilePosition += headerStream.getTotalBytesRead();
+                    fileChannel.position(sectionFilePosition);
+                    sectionFilePosition += builder.getNumberOfBytes();
+                    if (cipher != null) {
+                        IvParameterSpec iv = new IvParameterSpec(builder.getEncryptionIv().toByteArray());
+                        cipher.init(Cipher.DECRYPT_MODE, encryptionKey, iv);
+                    }
+                    InputStream inputStream = fileStream;
+                    if (cipher != null) {
+                        inputStream = new CipherInputStream(inputStream, cipher);
+                    }
+                    if (compressed) {
+                        inputStream = new InflaterInputStream(inputStream);
+                    }
+                    entryStream = CodedInputStream.newInstance(inputStream);
+                }
+            }
+            key = entryStream.readByteArray();
+            value = entryStream.readByteArray();
+            recordPosition++;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (cipher != null) {
+                CipherPool.returnCipher(cipher);
+            }
+            fileStream.close();
+        }
+    }
+
+    private static class OutputState implements Closeable {
+        @Nonnull
+        final File file;
+        final int recordsPerSection;
+        @Nonnull
+        final FileOutputStream fileStream;
+        @Nonnull
+        final FileChannel fileChannel;
+        @Nonnull
+        CodedOutputStream headerStream;
+        @Nonnull
+        OutputStream outputStream;
+        @Nonnull
+        CodedOutputStream entryStream;
+
+        final boolean compress;
+        @Nullable
+        final java.security.Key encryptionKey;
+        @Nullable
+        final SecureRandom secureRandom;
+        @Nullable
+        final Cipher cipher;
+
+        @Nonnull
+        final RecordSortingProto.SortFileHeader.Builder fileHeader;
+        @Nonnull
+        final RecordSortingProto.SortSectionHeader.Builder sectionHeader;
+
+        long sectionHeaderPosition;
+        long sectionRecordsPosition;
+
+        public OutputState(@Nonnull File file, @Nonnull FileSortAdapter<?, ?> adapter) throws IOException, GeneralSecurityException {
+            this.file = file;
+            this.recordsPerSection = adapter.getRecordsPerSection();
+            fileStream = new FileOutputStream(file);
+            outputStream = fileStream;
+            fileChannel = fileStream.getChannel();
+            headerStream = CodedOutputStream.newInstance(fileStream);
+            entryStream = headerStream;
+            compress = adapter.isCompressed();
+            encryptionKey = adapter.getEncryptionKey();
+            if (encryptionKey != null) {
+                secureRandom = adapter.getSecureRandom();
+                cipher = CipherPool.borrowCipher();
+            } else {
+                secureRandom = null;
+                cipher = null;
+            }
+            fileHeader = RecordSortingProto.SortFileHeader.newBuilder()
+                    .setNumberOfSections(0)
+                    .setNumberOfRecords(0);
+            headerStream.writeMessageNoTag(fileHeader.build());
+            sectionHeader = RecordSortingProto.SortSectionHeader.newBuilder()
+                    .setSectionNumber(0)
+                    .setStartRecordNumber(0)
+                    .setNumberOfRecords(0)
+                    .setNumberOfBytes(0);
+            writeSectionHeader();
+        }
+
+        public void next(@Nonnull byte[] key, @Nonnull byte[] value) throws IOException, GeneralSecurityException {
+            entryStream.writeByteArrayNoTag(key);
+            entryStream.writeByteArrayNoTag(value);
+            fileHeader.setNumberOfRecords(fileHeader.getNumberOfRecords() + 1);
+            sectionHeader.setNumberOfRecords(sectionHeader.getNumberOfRecords() + 1);
+            if (sectionHeader.getNumberOfRecords() >= recordsPerSection) {
+                rewriteSectionHeader();
+                fileHeader.setNumberOfSections(fileHeader.getNumberOfSections() + 1);
+                sectionHeader.setSectionNumber(fileHeader.getNumberOfSections());
+                sectionHeader.setStartRecordNumber(fileHeader.getNumberOfRecords());
+                sectionHeader.setNumberOfRecords(0).setNumberOfBytes(0);
+                writeSectionHeader();
+            }
+        }
+
+        public void finish() throws IOException {
+            rewriteSectionHeader();
+            final long fileLength = fileChannel.position();
+            fileChannel.position(0);
+            headerStream.writeMessageNoTag(fileHeader.build());
+            headerStream.flush();
+            fileChannel.position(fileLength);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (cipher != null) {
+                CipherPool.returnCipher(cipher);
+            }
+            fileStream.close();
+        }
+
+        void writeSectionHeader() throws IOException, GeneralSecurityException {
+            headerStream.flush();
+            sectionHeaderPosition = fileChannel.position();
+            if (cipher != null) {
+                final byte[] iv = new byte[CipherPool.IV_SIZE];
+                secureRandom.nextBytes(iv);
+                cipher.init(Cipher.ENCRYPT_MODE, encryptionKey, new IvParameterSpec(iv));
+                sectionHeader.setEncryptionIv(ByteString.copyFrom(iv));
+            }
+            headerStream.writeMessageNoTag(sectionHeader.build());
+            headerStream.flush();
+            sectionRecordsPosition = fileChannel.position();
+            if (compress || cipher != null) {
+                headerStream.flush();
+                outputStream = new NoCloseFilterStream(fileStream);
+                if (cipher != null) {
+                    outputStream = new CipherOutputStream(outputStream, cipher);
+                }
+                if (compress) {
+                    outputStream = new DeflaterOutputStream(outputStream);
+                }
+                entryStream = CodedOutputStream.newInstance(outputStream);
+            }
+        }
+
+        @SuppressWarnings("PMD.CompareObjectsWithEquals")
+        void rewriteSectionHeader() throws IOException {
+            entryStream.flush();
+            if (outputStream != fileStream) {
+                outputStream.close();
+            }
+            final long fileLength = fileChannel.position();
+            fileChannel.position(sectionHeaderPosition);
+            headerStream.writeMessageNoTag(sectionHeader.setNumberOfBytes(fileLength - sectionRecordsPosition).build());
+            headerStream.flush();
+            if (fileChannel.position() != sectionRecordsPosition) {
+                throw new RecordCoreException("header size changed");
+            }
+            fileChannel.position(fileLength);
+        }
+    }
+
+    // TODO: If there were a limit on the total number of records saved, then each file could be limited to
+    // that number and merge could stop when it is reached.
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    private void merge(@Nonnull Collection<File> inputFiles, @Nonnull File outputFile) throws IOException, GeneralSecurityException {
+        final long startTime = System.nanoTime();
+        final List<InputState> inputs = new ArrayList<>(inputFiles.size());
+        OutputState output = null;
+        boolean success = false;
+        try {
+            for (File file : inputFiles) {
+                InputState input = new InputState(file, adapter);
+                inputs.add(input);
+                input.next();
+            }
+            output = new OutputState(outputFile, adapter);
+            while (true) {
+                InputState minState = null;
+                for (InputState input : inputs) {
+                    if (input.key != null) {
+                        if (minState == null) {
+                            minState = input;
+                        } else {
+                            int comp = adapter.isSerializedOrderReversed() ?
+                                       ByteArrayUtil.compareUnsigned(input.key, minState.key) :
+                                       ByteArrayUtil.compareUnsigned(minState.key, input.key);
+                            if (comp > 0) {
+                                minState = input;
+                            }
+                        }
+                    }
+                }
+                if (minState == null) {
+                    break;
+                }
+                output.next(minState.key, minState.value);
+                minState.next();
+            }
+            output.finish();
+            output.close();
+            success = true;
+        } finally {
+            if (output != null) {
+                try {
+                    output.close();
+                } catch (IOException ex) {
+                    // swallow cleanup error
+                }
+                if (!success) {
+                    try {
+                        deleteFile(outputFile);
+                    } catch (IOException ex) {
+                        // swallow cleanup error
+                    }
+                }
+            }
+            for (InputState input : inputs) {
+                try {
+                    input.close();
+                    if (success) {
+                        deleteFile(input.file);
+                    }
+                } catch (IOException ex) {
+                    // swallow cleanup error
+                }
+            }
+            if (timer != null) {
+                timer.recordSinceNanoTime(SortEvents.Events.FILE_SORT_MERGE_FILES, startTime);
+            }
+        }
+    }
+
+    public void deleteFiles() throws IOException {
+        for (File file : files) {
+            deleteFile(file);
+        }
+    }
+
+    private void deleteFile(@Nonnull File file) throws IOException {
+        // file.delete() doesn't have real error handling.
+        Files.delete(file.toPath());
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortAdapter.java
@@ -1,0 +1,96 @@
+/*
+ * MemorySortAdapter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+import java.util.Comparator;
+
+/**
+ * Provide various options for {@link MemorySorter} and {@link MemorySortCursor}.
+ * @param <K> type of key
+ * @param <V> type of value
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface MemorySortAdapter<K, V> extends Comparator<K> {
+    /**
+     * Generate a sorting key for the given value.
+     * @param value value to be sorted
+     * @return the key for {@code value}
+     */
+    @Nonnull
+    K generateKey(V value);
+
+    /**
+     * Convert key into a byte array.
+     * The desired sort order of keys must be congruent to unsigned byte order of the serialized form, up to
+     * {@link #isSerializedOrderReversed}.
+     * @param key the key
+     * @return a byte array encoding {@code key}
+     */
+    @Nonnull
+    byte[] serializeKey(K key);
+
+    /**
+     * Get whether the unsigned byte comparison order of values returned by {@link #serializeKey} is the same
+     * as {@link #compare}'s order or its reverse.
+     * @return {@code true} if the byte comparison order is the reverse of the key order
+     */
+    boolean isSerializedOrderReversed();
+
+    /**
+     * Convert serialized key back to key.
+     * @param key the serialized form of a key
+     * @return the original key
+     */
+    @Nonnull
+    K deserializeKey(@Nonnull byte[] key);
+
+    /**
+     * Convert value into a byte array.
+     * @param value the value
+     * @return a byte array encoding {@code value}
+     */
+    @Nonnull
+    byte[] serializeValue(V value);
+
+    /**
+     * Convert serialized value back into value.
+     * @param value the serialized form of a value
+     * @return the original value
+     */
+    @Nonnull
+    V deserializeValue(@Nonnull byte[] value);
+
+    /**
+     * Get the maximum allowed size of the in-memory map.
+     * @return the maximum size
+     */
+    int getMaxMapSize();
+
+    /**
+     * Get action to perform when in-memory map is full.
+     * @return size limit mode
+     */
+    @Nonnull
+    MemorySorter.SizeLimitMode getSizeLimitMode();
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortAdapter.java
@@ -85,12 +85,12 @@ public interface MemorySortAdapter<K, V> extends Comparator<K> {
      * Get the maximum allowed size of the in-memory map.
      * @return the maximum size
      */
-    int getMaxMapSize();
+    int getMaxRecordCountInMemory();
 
     /**
      * Get action to perform when in-memory map is full.
      * @return size limit mode
      */
     @Nonnull
-    MemorySorter.SizeLimitMode getSizeLimitMode();
+    MemorySorter.RecordCountInMemoryLimitMode getRecordCountInMemoryLimitMode();
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursor.java
@@ -1,0 +1,142 @@
+/*
+ * MemorySortCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+/**
+ * Sort records in memory up to a specified limit, then return them in order.
+ * @param <K> type of key
+ * @param <V> type of value
+ */
+@API(API.Status.EXPERIMENTAL)
+public class MemorySortCursor<K, V> implements RecordCursor<V> {
+    @Nonnull
+    private final RecordCursor<V> inputCursor;
+    @Nonnull
+    private final MemorySorter<K, V> sorter;
+    @Nonnull
+    private final MemorySortAdapter<K, V> adapter;
+    @Nullable
+    private final StoreTimer timer;
+    @Nullable
+    private K minimumKey;
+
+    private RecordCursorContinuation inputContinuation;
+    private Iterator<Map.Entry<K, V>> iterator;
+    
+    private MemorySortCursor(@Nonnull final MemorySortAdapter<K, V> adapter, @Nonnull MemorySorter<K, V> sorter,
+                             @Nonnull RecordCursor<V> inputCursor, @Nullable StoreTimer timer, @Nullable K minimumKey) {
+        this.inputCursor = inputCursor;
+        this.sorter = sorter;
+        this.adapter = adapter;
+        this.timer = timer;
+        this.minimumKey = minimumKey;
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<RecordCursorResult<V>> onNext() {
+        if (iterator != null) {
+            return CompletableFuture.completedFuture(nextFromIterator());
+        }
+        return sorter.load(inputCursor, minimumKey).thenApply(loadResult -> {
+            inputContinuation = loadResult.getSourceContinuation();
+            if (loadResult.getSourceNoNextReason().isOutOfBand()) {
+                // The input cursor did not complete; we must save the sorter state in the continuation so can pick up after.
+                MemorySortCursorContinuation<K, V> continuation = new MemorySortCursorContinuation<>(adapter, false, sorter.getMap().values(), minimumKey, inputContinuation);
+                return RecordCursorResult.withoutNextValue(continuation, loadResult.getSourceNoNextReason());
+            }
+            // Loaded all the records into the sorter, start returning them.
+            iterator = sorter.getMap().entrySet().iterator();
+            return nextFromIterator();
+        });
+    }
+
+    @Nonnull
+    private RecordCursorResult<V> nextFromIterator() {
+        final long startTime = System.nanoTime();
+        if (iterator.hasNext()) {
+            // Return a sorted record.
+            Map.Entry<K, V> next = iterator.next();
+            minimumKey = next.getKey();
+            Collection<V> remainingRecords = sorter.getMap().tailMap(minimumKey, false).values();
+            MemorySortCursorContinuation<K, V> continuation = new MemorySortCursorContinuation<>(adapter, false, remainingRecords, minimumKey, inputContinuation);
+            RecordCursorResult<V> result = RecordCursorResult.withNextValue(next.getValue(), continuation);
+            if (timer != null) {
+                timer.recordSinceNanoTime(SortEvents.Events.MEMORY_SORT_LOAD_RECORD, startTime);
+            }
+            return result;
+        }
+        // If filling the sorter didn't reach the limit, none were discarded and all the records in it must be all the records period.
+        boolean exhausted = sorter.getMap().size() < adapter.getMaxMapSize();
+        MemorySortCursorContinuation<K, V> continuation = new MemorySortCursorContinuation<>(adapter, exhausted, Collections.emptyList(), minimumKey, inputContinuation);
+        return RecordCursorResult.withoutNextValue(continuation, exhausted ? NoNextReason.SOURCE_EXHAUSTED : NoNextReason.RETURN_LIMIT_REACHED);
+    }
+
+    @Override
+    public void close() {
+        inputCursor.close();
+    }
+
+    @Nonnull
+    @Override
+    public Executor getExecutor() {
+        return inputCursor.getExecutor();
+    }
+
+    @Override
+    public boolean accept(@Nonnull final RecordCursorVisitor visitor) {
+        if (visitor.visitEnter(this)) {
+            inputCursor.accept(visitor);
+        }
+        return visitor.visitLeave(this);
+    }
+
+    public static <K, V> MemorySortCursor<K, V> create(@Nonnull MemorySortAdapter<K, V> adapter,
+                                                       @Nonnull Function<byte[], RecordCursor<V>> inputCursorFunction,
+                                                       @Nullable StoreTimer timer,
+                                                       @Nullable byte[] continuation) {
+        final MemorySortCursorContinuation<K, V> parsedContinuation = MemorySortCursorContinuation.from(continuation, adapter);
+        final RecordCursor<V> inputCursor = inputCursorFunction.apply(parsedContinuation.getChild().toBytes());
+        final MemorySorter<K, V> sorter = new MemorySorter<>(adapter, timer);
+        for (V record : parsedContinuation.getRecords()) {
+            sorter.addValue(record);
+        }
+        final K minimumKey = parsedContinuation.getMinimumKey();
+        return new MemorySortCursor<>(adapter, sorter, inputCursor, timer, minimumKey);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursor.java
@@ -102,7 +102,7 @@ public class MemorySortCursor<K, V> implements RecordCursor<V> {
             return result;
         }
         // If filling the sorter didn't reach the limit, none were discarded and all the records in it must be all the records period.
-        boolean exhausted = sorter.getMap().size() < adapter.getMaxMapSize();
+        boolean exhausted = sorter.getMap().size() < adapter.getMaxRecordCountInMemory();
         MemorySortCursorContinuation<K, V> continuation = new MemorySortCursorContinuation<>(adapter, exhausted, Collections.emptyList(), minimumKey, inputContinuation);
         return RecordCursorResult.withoutNextValue(continuation, exhausted ? NoNextReason.SOURCE_EXHAUSTED : NoNextReason.RETURN_LIMIT_REACHED);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursorContinuation.java
@@ -1,0 +1,144 @@
+/*
+ * MemorySortCursorContinuation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.ByteArrayContinuation;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.RecordSortingProto;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+@API(API.Status.EXPERIMENTAL)
+class MemorySortCursorContinuation<K, V> implements RecordCursorContinuation {
+    @Nonnull
+    private final MemorySortAdapter<K, V> adapter;
+    private final boolean exhausted;
+    @Nonnull
+    private final Collection<V> records;
+    @Nullable
+    private final K minimumKey;
+    @Nonnull
+    private final RecordCursorContinuation childContinuation;
+
+    @Nullable
+    private RecordSortingProto.MemorySortContinuation cachedProto;
+    @Nullable
+    private byte[] cachedBytes;
+
+    MemorySortCursorContinuation(@Nonnull MemorySortAdapter<K, V> adapter, boolean exhausted, @Nonnull Collection<V> records,
+                                 @Nullable K minimumKey, @Nonnull RecordCursorContinuation childContinuation) {
+        this.adapter = adapter;
+        this.exhausted = exhausted;
+        this.records = records;
+        this.minimumKey = minimumKey;
+        this.childContinuation = childContinuation;
+    }
+
+    @Nonnull
+    RecordSortingProto.MemorySortContinuation toProto() {
+        if (cachedProto == null) {
+            RecordSortingProto.MemorySortContinuation.Builder builder = RecordSortingProto.MemorySortContinuation.newBuilder();
+            for (V record : records) {
+                builder.addRecords(ByteString.copyFrom(adapter.serializeValue(record)));
+            }
+            if (minimumKey != null) {
+                builder.setMinimumKey(ByteString.copyFrom(adapter.serializeKey(minimumKey)));
+            }
+            byte[] childBytes = childContinuation.toBytes();
+            if (childBytes != null) {
+                builder.setContinuation(ByteString.copyFrom(childBytes));
+            }
+            cachedProto = builder.build();
+        }
+        return cachedProto;
+    }
+
+    @Override
+    @Nullable
+    public byte[] toBytes() {
+        if (cachedBytes == null) {
+            cachedBytes = toProto().toByteArray();
+        }
+        return cachedBytes;
+    }
+
+    @Nonnull
+    static <K, V> MemorySortCursorContinuation<K, V> from(@Nonnull RecordSortingProto.MemorySortContinuation parsed,
+                                                          @Nonnull MemorySortAdapter<K, V> adapter) {
+        MemorySortCursorContinuation<K, V> result = new MemorySortCursorContinuation<>(
+                adapter, false,
+                parsed.getRecordsList().stream().map(bs -> adapter.deserializeValue(bs.toByteArray())).collect(Collectors.toList()),
+                parsed.hasMinimumKey() ? adapter.deserializeKey(parsed.getMinimumKey().toByteArray()) : null,
+                parsed.hasContinuation() ? ByteArrayContinuation.fromNullable(parsed.getContinuation().toByteArray()) : RecordCursorStartContinuation.START
+        );
+        result.cachedProto = parsed;
+        return result;
+    }
+
+    @Nonnull
+    static <K, V> MemorySortCursorContinuation<K, V> from(@Nullable byte[] unparsed,
+                                                          @Nonnull MemorySortAdapter<K, V> adapter) {
+        MemorySortCursorContinuation<K, V> result;
+        if (unparsed == null) {
+            result = new MemorySortCursorContinuation<>(adapter, false, Collections.emptyList(), null, RecordCursorStartContinuation.START);
+        } else {
+            try {
+                result = MemorySortCursorContinuation.from(RecordSortingProto.MemorySortContinuation.parseFrom(unparsed), adapter);
+            } catch (InvalidProtocolBufferException ex) {
+                throw new RecordCoreException("invalid continuation", ex)
+                        .addLogInfo(LogMessageKeys.RAW_BYTES, ByteArrayUtil2.loggable(unparsed));
+            }
+            result.cachedBytes = unparsed;
+        }
+        return result;
+    }
+
+    @Nonnull
+    public Collection<V> getRecords() {
+        return records;
+    }
+
+    @Nullable
+    public K getMinimumKey() {
+        return minimumKey;
+    }
+
+    @Nonnull
+    RecordCursorContinuation getChild() {
+        return childContinuation;
+    }
+
+    @Override
+    public boolean isEnd() {
+        return exhausted;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
@@ -1,0 +1,160 @@
+/*
+ * TreeMapSorter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Collect keyed values into a {@link TreeMap} so that they end up sorted.
+ * @param <K> type of key
+ * @param <V> type of value
+ */
+@API(API.Status.EXPERIMENTAL)
+public class MemorySorter<K, V> {
+    @Nonnull
+    private final NavigableMap<K, V> map;
+    @Nonnull
+    private final MemorySortAdapter<K, V> adapter;
+    @Nullable
+    private final StoreTimer timer;
+
+    private LoadResult loadResult;
+
+    public MemorySorter(@Nonnull MemorySortAdapter<K, V> adapter, @Nullable StoreTimer timer) {
+        this.adapter = adapter;
+        this.map = new TreeMap<>(adapter);
+        this.timer = timer;
+    }
+
+    @Nonnull
+    public NavigableMap<K, V> getMap() {
+        return map;
+    }
+
+    @Nonnull
+    public MemorySortAdapter<K, V> getAdapter() {
+        return adapter;
+    }
+
+    public void addKeyValue(K key, V value) {
+        map.put(key, value);
+    }
+
+    public void addValue(V value) {
+        addKeyValue(adapter.generateKey(value), value);
+    }
+
+    /** How the {@code sizeLimit} is interpreted for {@link #load}. */
+    public enum SizeLimitMode { 
+        /** Map retains top {@code sizeLimit} values and discards additional values. */
+        DISCARD,
+        /** Map retains {@code sizeLimit} values and then stops. */
+        STOP
+    }
+
+    /** The result of {@link #load}. */
+    public static class LoadResult {
+        private final boolean full;
+        @Nonnull
+        private final RecordCursorContinuation sourceContinuation;
+        @Nullable
+        private final RecordCursor.NoNextReason sourceNoNextReason;
+
+        public LoadResult(final boolean full, @Nonnull RecordCursorContinuation sourceContinuation, @Nullable RecordCursor.NoNextReason sourceNoNextReason) {
+            this.full = full;
+            this.sourceContinuation = sourceContinuation;
+            this.sourceNoNextReason = sourceNoNextReason;
+        }
+
+        public boolean isFull() {
+            return full;
+        }
+
+        @Nonnull
+        public RecordCursorContinuation getSourceContinuation() {
+            return sourceContinuation;
+        }
+
+        @Nullable
+        public RecordCursor.NoNextReason getSourceNoNextReason() {
+            return sourceNoNextReason;
+        }
+    }
+
+    /**
+     * Load and sort records from a cursor.
+     * @param source source cursor
+     * @param minimumKey ignore cursor entries that are not greater than this key
+     * @return the reason the load stopped
+     */
+    public CompletableFuture<LoadResult> load(@Nonnull RecordCursor<V> source, @Nullable K minimumKey) {
+        loadResult = null;
+        return AsyncUtil.whileTrue(() -> source.onNext().thenApply(sourceResult -> {
+            if (!sourceResult.hasNext()) {
+                loadResult = new LoadResult(false, sourceResult.getContinuation(), sourceResult.getNoNextReason());
+                return false;
+            }
+            final long startTime = System.nanoTime();
+            try {
+                if (minimumKey == null) {
+                    addValue(sourceResult.get());
+                } else {
+                    V value = sourceResult.get();
+                    K key = adapter.generateKey(value);
+                    if (adapter.compare(key, minimumKey) > 0) {
+                        addKeyValue(key, value);
+                    } else {
+                        return true;
+                    }
+                }
+                if (map.size() <= adapter.getMaxMapSize()) {
+                    return true;
+                }
+                switch (adapter.getSizeLimitMode()) {
+                    case DISCARD:
+                        map.pollLastEntry();
+                        return true;
+                    case STOP:
+                        // TODO: Need some more NoNextReason's
+                        loadResult = new LoadResult(true, sourceResult.getContinuation(), RecordCursor.NoNextReason.SCAN_LIMIT_REACHED);
+                        return false;
+                    default:
+                        throw new RecordCoreArgumentException("Unknown size limit mode: " + adapter.getSizeLimitMode());
+                }
+            } finally {
+                if (timer != null) {
+                    timer.recordSinceNanoTime(SortEvents.Events.MEMORY_SORT_STORE_RECORD, startTime);
+                }
+            }
+        })).thenApply(vignore -> loadResult);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
@@ -1,5 +1,5 @@
 /*
- * TreeMapSorter.java
+ * MemorySorter.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
@@ -73,11 +73,11 @@ public class MemorySorter<K, V> {
         addKeyValue(adapter.generateKey(value), value);
     }
 
-    /** How the {@code sizeLimit} is interpreted for {@link #load}. */
-    public enum SizeLimitMode { 
-        /** Map retains top {@code sizeLimit} values and discards additional values. */
+    /** How the {@code getMaxRecordCountInMemory} is interpreted for {@link #load}. */
+    public enum RecordCountInMemoryLimitMode {
+        /** Map retains top {@code getMaxRecordCountInMemory} values and discards additional values. */
         DISCARD,
-        /** Map retains {@code sizeLimit} values and then stops. */
+        /** Map retains {@code getMaxRecordCountInMemory} values and then stops. */
         STOP
     }
 
@@ -86,10 +86,10 @@ public class MemorySorter<K, V> {
         private final boolean full;
         @Nonnull
         private final RecordCursorContinuation sourceContinuation;
-        @Nullable
+        @Nonnull
         private final RecordCursor.NoNextReason sourceNoNextReason;
 
-        public LoadResult(final boolean full, @Nonnull RecordCursorContinuation sourceContinuation, @Nullable RecordCursor.NoNextReason sourceNoNextReason) {
+        public LoadResult(final boolean full, @Nonnull RecordCursorContinuation sourceContinuation, @Nonnull RecordCursor.NoNextReason sourceNoNextReason) {
             this.full = full;
             this.sourceContinuation = sourceContinuation;
             this.sourceNoNextReason = sourceNoNextReason;
@@ -104,7 +104,7 @@ public class MemorySorter<K, V> {
             return sourceContinuation;
         }
 
-        @Nullable
+        @Nonnull
         public RecordCursor.NoNextReason getSourceNoNextReason() {
             return sourceNoNextReason;
         }
@@ -136,10 +136,10 @@ public class MemorySorter<K, V> {
                         return true;
                     }
                 }
-                if (map.size() <= adapter.getMaxMapSize()) {
+                if (map.size() <= adapter.getMaxRecordCountInMemory()) {
                     return true;
                 }
-                switch (adapter.getSizeLimitMode()) {
+                switch (adapter.getRecordCountInMemoryLimitMode()) {
                     case DISCARD:
                         map.pollLastEntry();
                         return true;
@@ -148,7 +148,7 @@ public class MemorySorter<K, V> {
                         loadResult = new LoadResult(true, sourceResult.getContinuation(), RecordCursor.NoNextReason.SCAN_LIMIT_REACHED);
                         return false;
                     default:
-                        throw new RecordCoreArgumentException("Unknown size limit mode: " + adapter.getSizeLimitMode());
+                        throw new RecordCoreArgumentException("Unknown size limit mode: " + adapter.getRecordCountInMemoryLimitMode());
                 }
             } finally {
                 if (timer != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortEvents.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortEvents.java
@@ -1,0 +1,109 @@
+/*
+ * SortEvents.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+
+import javax.annotation.Nonnull;
+
+/**
+ * {@link StoreTimer} events related to sorting.
+ */
+@API(API.Status.EXPERIMENTAL)
+@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass")
+public class SortEvents {
+    private SortEvents() {
+    }
+
+    public enum Events implements StoreTimer.Event {
+        MEMORY_SORT_STORE_RECORD("memory sort store record"),
+        MEMORY_SORT_LOAD_RECORD("memory sort load record"),
+        FILE_SORT_OPEN_FILE("file sort open file"),
+        FILE_SORT_SAVE_RECORD("file sort save record"),
+        FILE_SORT_MERGE_FILES("file sort merge files"),
+        FILE_SORT_SKIP_SECTION("file sort skip section"),
+        FILE_SORT_SKIP_RECORD("file sort skip record"),
+        FILE_SORT_LOAD_RECORD("file sort load record");
+
+        private final String title;
+        private final String logKey;
+
+        Events(String title, String logKey) {
+            this.title = title;
+            this.logKey = (logKey != null) ? logKey : StoreTimer.Event.super.logKey();
+        }
+
+        Events(String title) {
+            this(title, null);
+        }
+
+        @Override
+        public String title() {
+            return title;
+        }
+
+        @Override
+        @Nonnull
+        public String logKey() {
+            return this.logKey;
+        }
+    }
+
+    public enum Counts implements StoreTimer.Count {
+        FILE_SORT_FILE_BYTES("file sort file bytes", true);
+
+        private final String title;
+        private final String logKey;
+        private final boolean isSize;
+
+        Counts(String title, String logKey, boolean isSize) {
+            this.title = title;
+            this.logKey = (logKey != null) ? logKey : StoreTimer.Count.super.logKey();
+            this.isSize = false;
+        }
+
+        Counts(String title, boolean isSize) {
+            this(title, null, isSize);
+        }
+
+        Counts(String title) {
+            this(title, null, false);
+        }
+
+        @Override
+        public String title() {
+            return title;
+        }
+
+        @Override
+        @Nonnull
+        public String logKey() {
+            return this.logKey;
+        }
+
+        @Override
+        public boolean isSize() {
+            return isSize;
+        }
+    }
+    
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortedFileReader.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortedFileReader.java
@@ -1,0 +1,228 @@
+/*
+ * SortedFileReader.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.sorting;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordSortingProto;
+import com.apple.foundationdb.record.provider.common.CipherPool;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.ExtensionRegistryLite;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.spec.IvParameterSpec;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.security.GeneralSecurityException;
+import java.util.zip.InflaterInputStream;
+
+/**
+ * Read values from files written by {@link FileSorter}. Keys are skipped.
+ * @param <V> type of value
+ */
+@API(API.Status.EXPERIMENTAL)
+public class SortedFileReader<V> implements AutoCloseable {
+    @Nonnull
+    private final FileInputStream fileStream;
+    @Nonnull
+    private final FileSortAdapter<?, V> adapter;
+
+    private final boolean compressed;
+    @Nullable
+    private final java.security.Key encryptionKey;
+    @Nullable
+    private final Cipher cipher;
+    @Nullable
+    private final StoreTimer timer;
+
+    private int sectionRecordStart;
+    private int sectionRecordEnd;
+    private int fileRecordEnd;
+    private int recordPosition;
+    private int recordSectionPosition;
+    private long sectionFileStart;
+    private long sectionFileEnd;
+
+    @Nonnull
+    private CodedInputStream headerStream;
+    @Nonnull
+    private CodedInputStream entryStream;
+
+    public SortedFileReader(@Nonnull File file, @Nonnull FileSortAdapter<?, V> adapter, @Nullable StoreTimer timer,
+                            int skip, int limit) throws IOException, GeneralSecurityException {
+        fileStream = new FileInputStream(file);
+        this.adapter = adapter;
+        headerStream = CodedInputStream.newInstance(fileStream);
+        entryStream = headerStream;
+        compressed = adapter.isCompressed();
+        encryptionKey = adapter.getEncryptionKey();
+        if (encryptionKey != null) {
+            cipher = CipherPool.borrowCipher();
+        } else {
+            cipher = null;
+        }
+        this.timer = timer;
+        skipLimit(skip, limit);
+    }
+
+    private void skipLimit(int skip, int limit) throws IOException, GeneralSecurityException {
+        final RecordSortingProto.SortFileHeader.Builder fileHeader = RecordSortingProto.SortFileHeader.newBuilder();
+        headerStream.readMessage(fileHeader, ExtensionRegistryLite.getEmptyRegistry());
+        sectionFileStart = headerStream.getTotalBytesRead();
+        headerStream.resetSizeCounter();
+        sectionFileEnd = sectionFileStart;  // As though end of previous one.
+        if (skip > 0) {
+            final FileChannel fileChannel = fileStream.getChannel();
+            if (skip >= fileHeader.getNumberOfRecords()) {
+                // We don't need to try to skip when there aren't enough records.
+                fileChannel.position(fileChannel.size());
+                recordPosition = fileRecordEnd = fileHeader.getNumberOfRecords();
+                return;
+            }
+            while (true) {
+                // Skip whole sections until skip position within one.
+                final long startTime = System.nanoTime();
+                final RecordSortingProto.SortSectionHeader.Builder sectionHeader = RecordSortingProto.SortSectionHeader.newBuilder();
+                headerStream.readMessage(sectionHeader, ExtensionRegistryLite.getEmptyRegistry());
+                sectionRecordStart = sectionHeader.getStartRecordNumber();
+                sectionRecordEnd = sectionRecordStart + sectionHeader.getNumberOfRecords();
+                long sectionRecordsPosition = sectionFileStart + headerStream.getTotalBytesRead();
+                sectionFileEnd = sectionRecordsPosition + sectionHeader.getNumberOfBytes();
+                if (sectionRecordEnd > skip) {
+                    recordPosition = sectionHeader.getStartRecordNumber();
+                    recordSectionPosition = 0;
+                    if (compressed || encryptionKey != null) {
+                        if (cipher != null) {
+                            IvParameterSpec iv = new IvParameterSpec(sectionHeader.getEncryptionIv().toByteArray());
+                            cipher.init(Cipher.DECRYPT_MODE, encryptionKey, iv);
+                        }
+                        fileChannel.position(sectionFileStart + headerStream.getTotalBytesRead());
+                        InputStream inputStream = fileStream;
+                        if (cipher != null) {
+                            inputStream = new CipherInputStream(inputStream, cipher);
+                        }
+                        if (compressed) {
+                            inputStream = new InflaterInputStream(inputStream);
+                        }
+                        entryStream = CodedInputStream.newInstance(inputStream);
+                    } else {
+                        entryStream = headerStream;
+                    }
+                    break;
+                }
+                sectionFileStart = sectionFileEnd;
+                fileChannel.position(sectionFileStart);
+                // We can't reuse coded streams as we skip around as they have a buffer.
+                // Moreover there isn't a public way to make their 4K buffer smaller.
+                headerStream = CodedInputStream.newInstance(fileStream);
+                if (timer != null) {
+                    timer.recordSinceNanoTime(SortEvents.Events.FILE_SORT_SKIP_SECTION, startTime);
+                }
+            }
+            while (recordPosition < skip) {
+                // Skip initial keys and values in this section.
+                final long startTime = System.nanoTime();
+                entryStream.skipRawBytes(entryStream.readRawVarint32());
+                entryStream.skipRawBytes(entryStream.readRawVarint32());
+                recordPosition++;
+                recordSectionPosition++;
+                if (timer != null) {
+                    timer.recordSinceNanoTime(SortEvents.Events.FILE_SORT_SKIP_RECORD, startTime);
+                }
+            }
+            limit += skip;
+        }
+        fileRecordEnd = Math.min(limit, fileHeader.getNumberOfRecords());
+    }
+
+    @Nullable
+    public V read() throws IOException, GeneralSecurityException {
+        if (recordPosition >= fileRecordEnd) {
+            return null;
+        }
+        final long startTime = System.nanoTime();
+        while (recordPosition >= sectionRecordEnd) {
+            sectionFileStart = sectionFileEnd;
+            final FileChannel fileChannel;
+            if (compressed || encryptionKey != null) {
+                fileChannel = fileStream.getChannel();
+                fileChannel.position(sectionFileStart);
+                headerStream = CodedInputStream.newInstance(fileStream);
+            } else {
+                fileChannel = null;
+            }
+            final RecordSortingProto.SortSectionHeader.Builder sectionHeader =  RecordSortingProto.SortSectionHeader.newBuilder();
+            headerStream.readMessage(sectionHeader, ExtensionRegistryLite.getEmptyRegistry());
+            sectionRecordStart = sectionHeader.getStartRecordNumber();
+            sectionRecordEnd = sectionRecordStart + sectionHeader.getNumberOfRecords();
+            long sectionRecordsPosition = sectionFileStart + headerStream.getTotalBytesRead();
+            sectionFileEnd = sectionRecordsPosition + sectionHeader.getNumberOfBytes();
+            recordPosition = sectionHeader.getStartRecordNumber();
+            recordSectionPosition = 0;
+            if (fileChannel != null) {
+                if (cipher != null) {
+                    IvParameterSpec iv = new IvParameterSpec(sectionHeader.getEncryptionIv().toByteArray());
+                    cipher.init(Cipher.DECRYPT_MODE, encryptionKey, iv);
+                }
+                fileChannel.position(sectionRecordsPosition);
+                InputStream inputStream = fileStream;
+                if (cipher != null) {
+                    inputStream = new CipherInputStream(inputStream, cipher);
+                }
+                if (compressed) {
+                    inputStream = new InflaterInputStream(inputStream);
+                }
+                entryStream = CodedInputStream.newInstance(inputStream);
+            }
+        }
+        entryStream.skipRawBytes(entryStream.readRawVarint32());
+        final V record = adapter.readValue(entryStream);
+        recordPosition++;
+        recordSectionPosition++;
+        if (timer != null) {
+            timer.recordSinceNanoTime(SortEvents.Events.FILE_SORT_LOAD_RECORD, startTime);
+        }
+        return record;
+    }
+
+    public int getRecordPosition() {
+        return recordPosition;
+    }
+
+    public long getFilePosition() {
+        return sectionFileStart;
+    }
+
+    public int getRecordSectionPosition() {
+        return recordSectionPosition;
+    }
+
+    @Override
+    public void close() throws IOException {
+        fileStream.close();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortedFileReader.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortedFileReader.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.sorting;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordSortingProto;
 import com.apple.foundationdb.record.provider.common.CipherPool;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
@@ -92,6 +93,9 @@ public class SortedFileReader<V> implements AutoCloseable {
     private void skipLimit(int skip, int limit) throws IOException, GeneralSecurityException {
         final RecordSortingProto.SortFileHeader.Builder fileHeader = RecordSortingProto.SortFileHeader.newBuilder();
         headerStream.readMessage(fileHeader, ExtensionRegistryLite.getEmptyRegistry());
+        if (fileHeader.getVersion() != FileSorter.SORT_FILE_VERSION) {
+            throw new RecordCoreException("file header version mismatch");
+        }
         sectionFileStart = headerStream.getTotalBytesRead();
         headerStream.resetSizeCounter();
         sectionFileEnd = sectionFileStart;  // As though end of previous one.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Implement sorting for {@link com.apple.foundationdb.record.RecordCursor} for use in queries without a sorting index.
+ *
+ * <ul>
+ * <li>{@code MemorySortCursor}: Save a limited number of records in memory and then return them.</li>
+ *
+ * <li>{@code FileSortCursor}: Use a memory table to sort batches of records, then write them to disk in files,
+ *     then merge sort those files, then return results by reading the resultant file.</li>
+ * </ul>
+ */
+package com.apple.foundationdb.record.sorting;

--- a/fdb-record-layer-core/src/main/proto/record_sorting.proto
+++ b/fdb-record-layer-core/src/main/proto/record_sorting.proto
@@ -1,0 +1,59 @@
+/*
+ * record_sorting.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record;
+import "google/protobuf/descriptor.proto";
+
+option java_outer_classname = "RecordSortingProto";
+
+message SortedRecord {
+    optional bytes primary_key = 1;
+    optional bytes message = 2;
+    optional bytes version = 3;
+}
+
+message MemorySortContinuation {
+    repeated bytes records = 1;
+    optional bytes minimum_key = 2;
+    optional bytes continuation = 3;
+}
+
+message FileSortContinuation {
+    optional bool loading = 1;
+    repeated bytes in_memory_records = 2;
+    repeated string files = 3;
+    optional bytes continuation = 4;
+    optional int32 record_position = 5;
+    optional int64 file_position = 6;
+}
+
+message SortFileHeader {
+    optional fixed32 number_of_sections = 1;
+    optional fixed32 number_of_records = 2;
+}
+
+message SortSectionHeader {
+    optional fixed32 section_number = 1;
+    optional fixed32 start_record_number = 2;
+    optional fixed32 number_of_records = 3;
+    optional fixed64 number_of_bytes = 4;
+    optional bytes encryption_iv = 5;
+}

--- a/fdb-record-layer-core/src/main/proto/record_sorting.proto
+++ b/fdb-record-layer-core/src/main/proto/record_sorting.proto
@@ -47,8 +47,9 @@ message FileSortContinuation {
 
 message SortFileHeader {
     optional int32 version = 1;
-    optional fixed32 number_of_sections = 2;
-    optional fixed32 number_of_records = 3;
+    optional int32 meta_data_version = 2;
+    optional fixed32 number_of_sections = 3;
+    optional fixed32 number_of_records = 4;
 }
 
 message SortSectionHeader {

--- a/fdb-record-layer-core/src/main/proto/record_sorting.proto
+++ b/fdb-record-layer-core/src/main/proto/record_sorting.proto
@@ -46,8 +46,9 @@ message FileSortContinuation {
 }
 
 message SortFileHeader {
-    optional fixed32 number_of_sections = 1;
-    optional fixed32 number_of_records = 2;
+    optional int32 version = 1;
+    optional fixed32 number_of_sections = 2;
+    optional fixed32 number_of_records = 3;
 }
 
 message SortSectionHeader {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
@@ -1,0 +1,398 @@
+/*
+ * SortCursorTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.cursors;
+
+import com.apple.foundationdb.record.EndpointType;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.common.DynamicMessageRecordSerializer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.SortedRecordSerializer;
+import com.apple.foundationdb.record.sorting.FileSortAdapter;
+import com.apple.foundationdb.record.sorting.FileSortCursor;
+import com.apple.foundationdb.record.sorting.MemorySortAdapter;
+import com.apple.foundationdb.record.sorting.MemorySortCursor;
+import com.apple.foundationdb.record.sorting.MemorySorter;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.io.File;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link MemorySortCursor} and {@link FileSortCursor}.
+ */
+@Tag(Tags.RequiresFDB)
+public class SortCursorTests extends FDBRecordStoreTestBase {
+    final KeyExpression num2Field = Key.Expressions.field("num_value_2");
+
+    private SortedRecordSerializer<Message> serializer;
+
+    private List<Integer> sortedNums;
+
+    @BeforeEach
+    public void setupRecords() throws Exception {
+        sortedNums = new ArrayList<>(100);
+        Random random = new Random(3456);
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+
+            serializer = new SortedRecordSerializer<>(DynamicMessageRecordSerializer.instance(), recordStore.getRecordMetaData(), recordStore.getTimer());
+
+            for (int i = 0; i < 100; i++) {
+                int num = random.nextInt();
+                sortedNums.add(num);
+
+                TestRecords1Proto.MySimpleRecord.Builder record = TestRecords1Proto.MySimpleRecord.newBuilder();
+                record.setRecNo(i);
+                record.setNumValue2(num);
+                recordStore.saveRecord(record.build());
+            }
+            commit(context);
+        }
+        Collections.sort(sortedNums);
+    }
+
+    abstract class MemoryAdapterBase implements MemorySortAdapter<Tuple, FDBStoredRecord<Message>> {
+        @Override
+        public int compare(Tuple o1, Tuple o2) {
+            return o1.compareTo(o2);
+        }
+
+        @Nonnull
+        @Override
+        public Tuple generateKey(FDBStoredRecord<Message> record) {
+            return num2Field.evaluateSingleton(record).toTuple();
+        }
+
+        @Nonnull
+        @Override
+        public byte[] serializeKey(final Tuple key) {
+            return key.pack();
+        }
+
+        @Override
+        public boolean isSerializedOrderReversed() {
+            return false;
+        }
+
+        @Nonnull
+        @Override
+        public Tuple deserializeKey(@Nonnull final byte[] key) {
+            return Tuple.fromBytes(key);
+        }
+
+        @Nonnull
+        @Override
+        public byte[] serializeValue(final FDBStoredRecord<Message> record) {
+            return serializer.serialize(record);
+        }
+
+        @Nonnull
+        @Override
+        public FDBStoredRecord<Message> deserializeValue(@Nonnull final byte[] bytes) {
+            return serializer.deserialize(bytes).getStoredRecord();
+        }
+
+        @Nonnull
+        @Override
+        public MemorySorter.SizeLimitMode getSizeLimitMode() {
+            return MemorySorter.SizeLimitMode.DISCARD;
+        }
+    }
+
+    @Test
+    public void memorySort() throws Exception {
+        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> scanRecords =
+                continuation -> recordStore.scanRecords(null, null, EndpointType.TREE_START, EndpointType.TREE_END, continuation, ScanProperties.FORWARD_SCAN);
+        final MemoryAdapterBase adapter = new MemoryAdapterBase() {
+            @Override
+            public int getMaxMapSize() {
+                return 20;
+            }
+        };
+
+        List<Integer> resultNums;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            try (RecordCursor<FDBStoredRecord<Message>> cursor = MemorySortCursor.create(adapter, scanRecords, timer, null)) {
+                resultNums = cursor.map(r -> TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(r.getRecord()).getNumValue2()).asList().get();
+            }
+        }
+        assertEquals(sortedNums.subList(0, 20), resultNums);
+    }
+
+    @Test
+    public void memorySortContinuations() throws Exception {
+        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> scanRecords =
+                continuation -> {
+                    final ExecuteProperties executeProperties = ExecuteProperties.newBuilder().setScannedRecordsLimit(20).build();
+                    return recordStore.scanRecords(null, null, EndpointType.TREE_START, EndpointType.TREE_END, continuation, new ScanProperties(executeProperties));
+                };
+        final MemoryAdapterBase adapter = new MemoryAdapterBase() {
+            @Override
+            public int getMaxMapSize() {
+                return 10;
+            }
+        };
+
+        List<Integer> resultNums = new ArrayList<>();
+        byte[] continuation = null;
+        int transactionCount = 0;
+        
+        do {
+            try (FDBRecordContext context = openContext()) {
+                openSimpleRecordStore(context);
+                try (RecordCursor<FDBStoredRecord<Message>> cursor = MemorySortCursor.create(adapter, scanRecords, timer, continuation)) {
+                    while (true) {
+                        RecordCursorResult<FDBStoredRecord<Message>> result = cursor.getNext();
+                        if (result.hasNext()) {
+                            int num2 = TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(result.get().getRecord()).getNumValue2();
+                            resultNums.add(num2);
+                        } else {
+                            continuation = result.getContinuation().toBytes();
+                            break;
+                        }
+                    }
+                }
+                transactionCount++;
+            }
+        } while (continuation != null);
+        assertEquals(110, transactionCount);
+        assertEquals(sortedNums, resultNums);
+    }
+
+    abstract class FileSortAdapterBase extends MemoryAdapterBase implements FileSortAdapter<Tuple, FDBStoredRecord<Message>> {
+        @Nonnull
+        @Override
+        public MemorySorter.SizeLimitMode getSizeLimitMode() {
+            return MemorySorter.SizeLimitMode.STOP;
+        }
+
+        @Nonnull
+        @Override
+        public File generateFilename() throws IOException {
+            return File.createTempFile("fdb", ".bin");
+        }
+
+        @Override
+        public void writeValue(@Nonnull final FDBStoredRecord<Message> record, @Nonnull final CodedOutputStream stream) throws IOException {
+            serializer.write(record, stream);
+        }
+
+        @Override
+        public FDBStoredRecord<Message> readValue(@Nonnull final CodedInputStream stream) throws IOException {
+            return serializer.read(stream).getStoredRecord();
+        }
+
+        @Override
+        public boolean isCompressed() {
+            return false;
+        }
+
+        @Nullable
+        @Override
+        public java.security.Key getEncryptionKey() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public SecureRandom getSecureRandom() {
+            return null;
+        }
+    }
+
+    private FileSortAdapterBase fileSortMemoryAdapter() {
+        return new FileSortAdapterBase() {
+            @Override
+            public int getMinFileSize() {
+                return 200;
+            }
+
+            @Override
+            public int getMaxNumFiles() {
+                return 5;
+            }
+
+            @Override
+            public int getRecordsPerSection() {
+                return 200;
+            }
+
+            @Override
+            public int getMaxMapSize() {
+                return 250;
+            }
+        };
+    }
+
+    private FileSortAdapterBase fileSortFilesAdapter() {
+        return new FileSortAdapterBase() {
+            @Override
+            public int getMinFileSize() {
+                return 10;
+            }
+
+            @Override
+            public int getMaxNumFiles() {
+                return 5;
+            }
+
+            @Override
+            public int getRecordsPerSection() {
+                return 10;
+            }
+
+            @Override
+            public int getMaxMapSize() {
+                return 10;
+            }
+        };
+    }
+
+    private FileSortAdapterBase fileSortEncryptedAdapter() throws Exception {
+        final SecureRandom secureRandom = new SecureRandom();
+        final KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(128, secureRandom);
+        final SecretKey secretKey = keyGen.generateKey();
+        return new FileSortAdapterBase() {
+            @Override
+            public int getMinFileSize() {
+                return 10;
+            }
+
+            @Override
+            public int getMaxNumFiles() {
+                return 5;
+            }
+
+            @Override
+            public int getRecordsPerSection() {
+                return 10;
+            }
+
+            @Override
+            public int getMaxMapSize() {
+                return 10;
+            }
+
+            @Override
+            public boolean isCompressed() {
+                return true;
+            }
+
+            @Nullable
+            @Override
+            public java.security.Key getEncryptionKey() {
+                return secretKey;
+            }
+
+            @Nullable
+            @Override
+            public SecureRandom getSecureRandom() {
+                return secureRandom;
+            }
+        };
+    }
+
+    @Test
+    public void fileSortMemory() throws Exception {
+        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> scanRecords =
+                continuation -> recordStore.scanRecords(null, null, EndpointType.TREE_START, EndpointType.TREE_END, continuation, ScanProperties.FORWARD_SCAN);
+        List<Integer> resultNums;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            try (RecordCursor<FDBStoredRecord<Message>> cursor = FileSortCursor.create(fileSortMemoryAdapter(), scanRecords, timer, null, 0, Integer.MAX_VALUE)) {
+                resultNums = cursor.map(r -> TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(r.getRecord()).getNumValue2()).asList().get();
+            }
+        }
+        assertEquals(sortedNums, resultNums);
+    }
+
+    @Test
+    public void fileSortFiles() throws Exception {
+        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> scanRecords =
+                continuation -> recordStore.scanRecords(null, null, EndpointType.TREE_START, EndpointType.TREE_END, continuation, ScanProperties.FORWARD_SCAN);
+        List<Integer> resultNums;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            try (RecordCursor<FDBStoredRecord<Message>> cursor = FileSortCursor.create(fileSortFilesAdapter(), scanRecords, timer, null, 0, Integer.MAX_VALUE)) {
+                resultNums = cursor.map(r -> TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(r.getRecord()).getNumValue2()).asList().get();
+            }
+        }
+        assertEquals(sortedNums, resultNums);
+    }
+
+    @Test
+    public void fileSortSkip() throws Exception {
+        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> scanRecords =
+                continuation -> recordStore.scanRecords(null, null, EndpointType.TREE_START, EndpointType.TREE_END, continuation, ScanProperties.FORWARD_SCAN);
+        List<Integer> resultNums;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            try (RecordCursor<FDBStoredRecord<Message>> cursor = FileSortCursor.create(fileSortFilesAdapter(), scanRecords, timer, null, 13, 8)) {
+                resultNums = cursor.map(r -> TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(r.getRecord()).getNumValue2()).asList().get();
+            }
+        }
+        assertEquals(sortedNums.subList(13, 21), resultNums);
+    }
+
+    @Test
+    public void fileSortEncrypted() throws Exception {
+        final Function<byte[], RecordCursor<FDBStoredRecord<Message>>> scanRecords =
+                continuation -> recordStore.scanRecords(null, null, EndpointType.TREE_START, EndpointType.TREE_END, continuation, ScanProperties.FORWARD_SCAN);
+        List<Integer> resultNums;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            try (RecordCursor<FDBStoredRecord<Message>> cursor = FileSortCursor.create(fileSortEncryptedAdapter(), scanRecords, timer, null, 0, Integer.MAX_VALUE)) {
+                resultNums = cursor.map(r -> TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(r.getRecord()).getNumValue2()).asList().get();
+            }
+        }
+        assertEquals(sortedNums, resultNums);
+    }
+
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.common.CipherPool;
 import com.apple.foundationdb.record.provider.common.DynamicMessageRecordSerializer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
@@ -219,6 +220,11 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
         }
 
         @Override
+        public int getMetaDataVersion() {
+            return recordStore.getRecordMetaData().getVersion();
+        }
+
+        @Override
         public void writeValue(@Nonnull final FDBStoredRecord<Message> record, @Nonnull final CodedOutputStream stream) throws IOException {
             serializer.write(record, stream);
         }
@@ -231,6 +237,12 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
         @Override
         public boolean isCompressed() {
             return false;
+        }
+
+        @Nullable
+        @Override
+        public String getEncryptionCipherName() {
+            return null;
         }
 
         @Nullable
@@ -323,6 +335,12 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
             @Override
             public boolean isCompressed() {
                 return true;
+            }
+
+            @Nullable
+            @Override
+            public String getEncryptionCipherName() {
+                return CipherPool.DEFAULT_CIPHER;
             }
 
             @Nullable

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
@@ -139,8 +139,8 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
 
         @Nonnull
         @Override
-        public MemorySorter.SizeLimitMode getSizeLimitMode() {
-            return MemorySorter.SizeLimitMode.DISCARD;
+        public MemorySorter.RecordCountInMemoryLimitMode getRecordCountInMemoryLimitMode() {
+            return MemorySorter.RecordCountInMemoryLimitMode.DISCARD;
         }
     }
 
@@ -150,7 +150,7 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
                 continuation -> recordStore.scanRecords(null, null, EndpointType.TREE_START, EndpointType.TREE_END, continuation, ScanProperties.FORWARD_SCAN);
         final MemoryAdapterBase adapter = new MemoryAdapterBase() {
             @Override
-            public int getMaxMapSize() {
+            public int getMaxRecordCountInMemory() {
                 return 20;
             }
         };
@@ -174,7 +174,7 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
                 };
         final MemoryAdapterBase adapter = new MemoryAdapterBase() {
             @Override
-            public int getMaxMapSize() {
+            public int getMaxRecordCountInMemory() {
                 return 10;
             }
         };
@@ -208,8 +208,8 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
     abstract class FileSortAdapterBase extends MemoryAdapterBase implements FileSortAdapter<Tuple, FDBStoredRecord<Message>> {
         @Nonnull
         @Override
-        public MemorySorter.SizeLimitMode getSizeLimitMode() {
-            return MemorySorter.SizeLimitMode.STOP;
+        public MemorySorter.RecordCountInMemoryLimitMode getRecordCountInMemoryLimitMode() {
+            return MemorySorter.RecordCountInMemoryLimitMode.STOP;
         }
 
         @Nonnull
@@ -249,22 +249,22 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
     private FileSortAdapterBase fileSortMemoryAdapter() {
         return new FileSortAdapterBase() {
             @Override
-            public int getMinFileSize() {
+            public int getMinFileRecordCount() {
                 return 200;
             }
 
             @Override
-            public int getMaxNumFiles() {
+            public int getMaxFileCount() {
                 return 5;
             }
 
             @Override
-            public int getRecordsPerSection() {
+            public int getRecordCountPerSection() {
                 return 200;
             }
 
             @Override
-            public int getMaxMapSize() {
+            public int getMaxRecordCountInMemory() {
                 return 250;
             }
         };
@@ -273,22 +273,22 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
     private FileSortAdapterBase fileSortFilesAdapter() {
         return new FileSortAdapterBase() {
             @Override
-            public int getMinFileSize() {
+            public int getMinFileRecordCount() {
                 return 10;
             }
 
             @Override
-            public int getMaxNumFiles() {
+            public int getMaxFileCount() {
                 return 5;
             }
 
             @Override
-            public int getRecordsPerSection() {
+            public int getRecordCountPerSection() {
                 return 10;
             }
 
             @Override
-            public int getMaxMapSize() {
+            public int getMaxRecordCountInMemory() {
                 return 10;
             }
         };
@@ -301,22 +301,22 @@ public class SortCursorTests extends FDBRecordStoreTestBase {
         final SecretKey secretKey = keyGen.generateKey();
         return new FileSortAdapterBase() {
             @Override
-            public int getMinFileSize() {
+            public int getMinFileRecordCount() {
                 return 10;
             }
 
             @Override
-            public int getMaxNumFiles() {
+            public int getMaxFileCount() {
                 return 5;
             }
 
             @Override
-            public int getRecordsPerSection() {
+            public int getRecordCountPerSection() {
                 return 10;
             }
 
             @Override
-            public int getMaxMapSize() {
+            public int getMaxRecordCountInMemory() {
                 return 10;
             }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
@@ -24,7 +24,9 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorIterator;
+import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestHelpers;
@@ -46,6 +48,7 @@ import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.PlannableIndexTypes;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.sorting.SortEvents;
 import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.auto.service.AutoService;
@@ -56,6 +59,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
@@ -80,6 +84,7 @@ import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTup
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.sort;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.typeFilter;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.unbounded;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -88,6 +93,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -928,6 +934,92 @@ class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase {
             }
             assertEquals(100, i);
             assertDiscardedNone(context);
+        }
+    }
+
+    /**
+     * Verify that sort that cannot be done with any index can be enabled for in-memory sort.
+     */
+    public enum SortWithoutIndexMode {
+        DISALLOWED, MEMORY, FILE
+    }
+
+    @EnumSource(SortWithoutIndexMode.class)
+    @ParameterizedTest(name = "sortWithoutIndex [mode = {0}]")
+    public void sortWithoutIndex(SortWithoutIndexMode mode) throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+
+            for (int i = 0; i < 2000; i++) {
+                TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
+                recBuilder.setRecNo((2244 * i + 1649) % 2357); // Slightly larger prime.
+                recBuilder.setNumValue2(i);
+                recBuilder.setNumValue3Indexed(i % 5);
+                recordStore.saveRecord(recBuilder.build());
+            }
+            commit(context);
+        }
+
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.field("num_value_3_indexed").greaterThanOrEquals(2))
+                .setSort(field("num_value_2"), true)
+                .build();
+
+        if (mode == SortWithoutIndexMode.DISALLOWED) {
+            assertThrows(RecordCoreException.class, () -> {
+                planner.plan(query);
+            });
+            return;
+        }
+
+        ((RecordQueryPlanner)planner).setConfiguration(((RecordQueryPlanner)planner).getConfiguration().asBuilder().setAllowNonIndexSort(true).build());
+
+        // Index(MySimpleRecord$num_value_3_indexed [[2],>) ORDER BY num_value_2 DESC
+        RecordQueryPlan plan = planner.plan(query);
+        assertThat(plan, sort(allOf(hasProperty("reverse", equalTo(true))),
+                indexScan(allOf(indexName("MySimpleRecord$num_value_3_indexed"), bounds(hasTupleString("[[2],>"))))));
+        assertEquals(256365917, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
+        assertEquals(172993081, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(748321565, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+
+        ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder().setReturnedRowLimit(5);
+        if (mode == SortWithoutIndexMode.FILE) {
+            executeProperties.setSkip(1001);    // Skip + limit is enough to overflow memory buffer. Skips into middle of section.
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            timer.reset();
+            int i = mode == SortWithoutIndexMode.MEMORY ? 2000 : 333;
+            try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan, null, executeProperties.build())) {
+                while (true) {
+                    RecordCursorResult<FDBQueriedRecord<Message>> next = cursor.getNext();
+                    if (!next.hasNext()) {
+                        break;
+                    }
+                    FDBQueriedRecord<Message> rec = next.get();
+                    TestRecords1Proto.MySimpleRecord.Builder myrec = TestRecords1Proto.MySimpleRecord.newBuilder();
+                    myrec.mergeFrom(rec.getRecord());
+                    i--;
+                    if (i % 5 == 1) { i -= 2; }
+                    assertEquals(i, myrec.getNumValue2());
+                }
+            }
+            assertEquals(mode == SortWithoutIndexMode.MEMORY ? 1993 : 324, i);
+            assertDiscardedNone(context);
+            if (mode == SortWithoutIndexMode.MEMORY) {
+                assertEquals(0, timer.getCount(SortEvents.Events.FILE_SORT_OPEN_FILE));
+                assertEquals(1200, timer.getCount(SortEvents.Events.MEMORY_SORT_STORE_RECORD));
+                assertEquals(5, timer.getCount(SortEvents.Events.MEMORY_SORT_LOAD_RECORD));
+            } else {
+                assertEquals(2, timer.getCount(SortEvents.Events.FILE_SORT_OPEN_FILE));
+                assertEquals(1, timer.getCount(SortEvents.Events.FILE_SORT_MERGE_FILES));
+                assertEquals(1200, timer.getCount(SortEvents.Events.FILE_SORT_SAVE_RECORD));
+                assertEquals(5, timer.getCount(SortEvents.Events.FILE_SORT_LOAD_RECORD));
+                assertEquals(10, timer.getCount(SortEvents.Events.FILE_SORT_SKIP_SECTION));
+                assertEquals(1, timer.getCount(SortEvents.Events.FILE_SORT_SKIP_RECORD));
+                assertThat(timer.getCount(SortEvents.Counts.FILE_SORT_FILE_BYTES), allOf(greaterThan(1000), lessThan(100000)));
+            }
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
@@ -1021,13 +1021,13 @@ class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase {
                 assertEquals(countBeforeSorting, timer.getCount(SortEvents.Events.MEMORY_SORT_STORE_RECORD));
                 assertEquals(numberOfResultsToReturn, timer.getCount(SortEvents.Events.MEMORY_SORT_LOAD_RECORD));
             } else {
-                int nfiles = numberOfRecordsToSave / RecordQuerySortAdapter.MAX_RECORD_COUNT_IN_MEMORY;
+                int nfiles = numberOfRecordsToSave / RecordQuerySortAdapter.DEFAULT_MAX_RECORD_COUNT_IN_MEMORY;
                 assertEquals(nfiles, timer.getCount(SortEvents.Events.FILE_SORT_OPEN_FILE));
                 assertEquals(nfiles - 1, timer.getCount(SortEvents.Events.FILE_SORT_MERGE_FILES));
                 assertEquals(countBeforeSorting, timer.getCount(SortEvents.Events.FILE_SORT_SAVE_RECORD));
                 assertEquals(numberOfResultsToReturn, timer.getCount(SortEvents.Events.FILE_SORT_LOAD_RECORD));
-                assertEquals(skip / RecordQuerySortAdapter.RECORD_COUNT_PER_SECTION, timer.getCount(SortEvents.Events.FILE_SORT_SKIP_SECTION));
-                assertEquals(skip % RecordQuerySortAdapter.RECORD_COUNT_PER_SECTION, timer.getCount(SortEvents.Events.FILE_SORT_SKIP_RECORD));
+                assertEquals(skip / RecordQuerySortAdapter.DEFAULT_RECORD_COUNT_PER_SECTION, timer.getCount(SortEvents.Events.FILE_SORT_SKIP_SECTION));
+                assertEquals(skip % RecordQuerySortAdapter.DEFAULT_RECORD_COUNT_PER_SECTION, timer.getCount(SortEvents.Events.FILE_SORT_SKIP_RECORD));
                 assertThat(timer.getCount(SortEvents.Counts.FILE_SORT_FILE_BYTES), allOf(greaterThan(1000), lessThan(100000)));
             }
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortKey;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 import org.hamcrest.Matcher;
 
@@ -234,5 +235,10 @@ public class PlanMatchers {
     public static Matcher<RecordQueryPlan> compositeBitmap(@Nonnull Matcher<ComposedBitmapIndexQueryPlan.ComposerBase> composerMatcher,
                                                            @Nonnull List<Matcher<RecordQueryPlan>> childMatchers) {
         return new ComposedBitmapIndexMatcher(composerMatcher, childMatchers);
+    }
+
+    public static Matcher<RecordQueryPlan> sort(@Nonnull Matcher<RecordQuerySortKey> keyMatcher,
+                                                @Nonnull Matcher<RecordQueryPlan> childMatcher) {
+        return new SortMatcher(keyMatcher, childMatcher);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/SortMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/SortMatcher.java
@@ -1,0 +1,63 @@
+/*
+ * FilterMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.match;
+
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortKey;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Plan matcher for a sort applied to a child plan matcher.
+ */
+public class SortMatcher extends PlanMatcherWithChild {
+    @Nonnull
+    private final Matcher<RecordQuerySortKey> keyMatcher;
+
+    public SortMatcher(@Nonnull Matcher<RecordQuerySortKey> keyMatcher, @Nonnull Matcher<RecordQueryPlan> childMatcher) {
+        super(childMatcher);
+        this.keyMatcher = keyMatcher;
+    }
+
+    @Override
+    public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
+        final RecordQuerySortKey key;
+        if (plan instanceof RecordQuerySortPlan) {
+            key = ((RecordQuerySortPlan)plan).getKey();
+        } else {
+            return false;
+        }
+        return keyMatcher.matches(key) && super.matchesSafely(plan);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Sort(");
+        keyMatcher.describeTo(description);
+        description.appendText("; ");
+        super.describeTo(description);
+        description.appendText(")");
+    }
+
+}


### PR DESCRIPTION
Adds RecordCursor implementations that sort inputs and output in order: either just a few records in memory or spilling out to disk using files.