### PR TITLE
Resolves #1138: Planner's key from index should include primary keys

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Planner's key from index should include primary keys [(Issue #1138)](https://github.com/FoundationDB/fdb-record-layer/issues/1138)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
@@ -448,7 +448,7 @@ public class FDBAndQueryToIntersectionTest extends FDBRecordStoreQueryTestBase {
     @ParameterizedTest
     @BooleanSource
     public void testAndQuery7(boolean shouldDeferFetch) throws Exception {
-        RecordMetaDataHook hook = complexPrimaryKeyHook();
+        RecordMetaDataHook hook = complexPrimaryKeyHook(true);
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -66,7 +66,6 @@ import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTup
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScanType;
-import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.intersection;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.primaryKeyDistinct;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.queryPredicateDescendant;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scan;
@@ -318,12 +317,11 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
         RecordQueryPlan plan = planner.plan(query);
 
         if (planner instanceof RecordQueryPlanner) {
+            // Does not understand duplicate condition
             assertThat(plan,
                     filter(nestedComponent,
-                            intersection(
-                                    indexScan(allOf(indexName("composite"), bounds(hasTupleString("[[something, 1],[something, 1]]")))),
-                                    indexScan(allOf(indexName("duplicates"), bounds(hasTupleString("[[something, something],[something, something]]"))))
-                            )));
+                            indexScan(allOf(indexName("duplicates"), bounds(hasTupleString("[[something, something, 1],[something, something, 1]]"))))
+                            ));
         } else {
             assertThat(plan, primaryKeyDistinct(indexScan(allOf(indexName("complex"), bounds(hasTupleString("[[something, 1, 10, 20],[something, 1, 10, 20]]"))))));
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -731,7 +731,7 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      */
     @Test
     public void testOrQuery7() throws Exception {
-        RecordMetaDataHook hook = complexPrimaryKeyHook();
+        RecordMetaDataHook hook = complexPrimaryKeyHook(true);
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -308,13 +308,23 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         }
     }
 
+
     @Nonnull
     protected RecordMetaDataHook complexPrimaryKeyHook() {
+        return complexPrimaryKeyHook(false);
+    }
+
+    @Nonnull
+    protected RecordMetaDataHook complexPrimaryKeyHook(boolean skipNum3) {
         return metaData -> {
             RecordTypeBuilder recordType = metaData.getRecordType("MySimpleRecord");
             recordType.setPrimaryKey(concatenateFields("str_value_indexed", "num_value_unique"));
             metaData.addIndex(recordType, new Index("str_value_2_index",
                     "str_value_indexed", "num_value_2"));
+            if (skipNum3) {
+                // Same fields in different order as str_value_3_index.
+                metaData.removeIndex("MySimpleRecord$num_value_3_indexed");
+            }
             metaData.addIndex(recordType, new Index("str_value_3_index",
                     "str_value_indexed", "num_value_3_indexed"));
         };

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanHashTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanHashTest.java
@@ -386,14 +386,17 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_3_indexed").equalsValue(4)),
                 field("rec_no"));
 
-        assertEquals(575076824, plan1.planHash(PlanHashable.PlanHashKind.LEGACY));
-        assertEquals(575076888, plan2.planHash(PlanHashable.PlanHashKind.LEGACY));
+        // Index(MySimpleRecord$num_value_unique [[1],[1]]) ∩ Index(MySimpleRecord$num_value_3_indexed [[2],[2]])
+        // Index(MySimpleRecord$num_value_unique [[3],[3]]) ∩ Index(MySimpleRecord$num_value_3_indexed [[4],[4]])
 
-        assertEquals(-554014099, plan1.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-554014035, plan2.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(62126310, plan1.planHash(PlanHashable.PlanHashKind.LEGACY));
+        assertEquals(62126374, plan2.planHash(PlanHashable.PlanHashKind.LEGACY));
 
-        assertEquals(-2050705076, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-2050705076, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(380936464, plan1.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(440041808, plan2.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+
+        assertEquals(-1611765649, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-1611765649, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test


### PR DESCRIPTION
Fixes #5: Queries with order-preserving filter sorting by primary key will not use index for filter

It's possible that we should be more concerned about unanticipated effects of this change and should have some kind of control switch in the planner options to enable it. (It's never incorrect, but might expose previously hidden bugs.)