### PR TITLE
Resolves #1155: Need a way to tell whether the result of planning a query is only sorted by the requested keys.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Bug fix** Planner's key from index should include primary keys [(Issue #1138)](https://github.com/FoundationDB/fdb-record-layer/issues/1138)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** RecordQueryPlanner.getKeyForMerge can build redundant merge keys [(Issue #1154)](https://github.com/FoundationDB/fdb-record-layer/issues/1154)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Planner's key from index should include primary keys [(Issue #1138)](https://github.com/FoundationDB/fdb-record-layer/issues/1138)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Need a way to tell whether the result of planning a query is only sorted by the requested keys [(Issue #1155)](https://github.com/FoundationDB/fdb-record-layer/issues/1155)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -1299,21 +1299,13 @@ public class RecordQueryPlanner implements QueryPlanner {
             } else {
                 possibleTypes = metaData.getRecordTypes().keySet();
             }
-            plan = new RecordQueryScanPlan(possibleTypes, scanComparisons, candidateScan.reverse);
-            if (strictlySorted) {
-                // TODO: Make this a plan property, when that exists.
-                ((RecordQueryScanPlan)plan).setStrictlySorted(true);
-            }
+            plan = new RecordQueryScanPlan(possibleTypes, scanComparisons, candidateScan.reverse, strictlySorted);
         } else {
             if (scanType == null) {
                 scanType = IndexScanType.BY_VALUE;
             }
-            plan = new RecordQueryIndexPlan(candidateScan.index.getName(), scanType, scanComparisons, candidateScan.reverse);
+            plan = new RecordQueryIndexPlan(candidateScan.index.getName(), scanType, scanComparisons, candidateScan.reverse, strictlySorted);
             possibleTypes = getPossibleTypes(candidateScan.index);
-            if (strictlySorted) {
-                // TODO: Make this a plan property, when that exists.
-                ((RecordQueryIndexPlan)plan).setStrictlySorted(true);
-            }
         }
         // Add a type filter if the query plan might return records of more types than the query specified
         plan = addTypeFilterIfNeeded(candidateScan, plan, possibleTypes);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
@@ -153,6 +153,14 @@ public interface QueryPlan<T> extends PlanHashable, RelationalExpression {
     }
 
     /**
+     * Return a copy of this plan that has the {@link #isStrictlySorted} property.
+     * @return a copy of this plan
+     */
+    default QueryPlan<T> strictlySorted() {
+        return this;
+    }
+
+    /**
      * Adds one to an appropriate {@link StoreTimer} counter for each plan and subplan of this plan, allowing tracking
      * of which plans are being chosen (e.g. index scan vs. full scan).
      * @param timer the counters to increment

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
@@ -148,7 +148,7 @@ public interface QueryPlan<T> extends PlanHashable, RelationalExpression {
      * That is, each new record will have a different value for that sort key.
      * @return {@code true} if this plan is fully sorted according to the query definition
      */
-    default boolean isFullySorted() {
+    default boolean isStrictlySorted() {
         return false;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryPlan.java
@@ -144,6 +144,15 @@ public interface QueryPlan<T> extends PlanHashable, RelationalExpression {
     }
 
     /**
+     * Indicates whether the ordering of records from this plan is fully accounted for by its requested sort.
+     * That is, each new record will have a different value for that sort key.
+     * @return {@code true} if this plan is fully sorted according to the query definition
+     */
+    default boolean isFullySorted() {
+        return false;
+    }
+
+    /**
      * Adds one to an appropriate {@link StoreTimer} counter for each plan and subplan of this plan, allowing tracking
      * of which plans are being chosen (e.g. index scan vs. full scan).
      * @param timer the counters to increment

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -151,6 +151,11 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
         return indexPlan.maxCardinality(metaData);
     }
 
+    @Override
+    public boolean isFullySorted() {
+        return indexPlan.isFullySorted();
+    }
+
     @Nonnull
     @Override
     public AvailableFields getAvailableFields() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -156,6 +156,11 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
         return indexPlan.isStrictlySorted();
     }
 
+    @Override
+    public RecordQueryCoveringIndexPlan strictlySorted() {
+        return new RecordQueryCoveringIndexPlan((RecordQueryPlanWithIndex)indexPlan.strictlySorted(), recordTypeName, availableFields, toRecord);
+    }
+
     @Nonnull
     @Override
     public AvailableFields getAvailableFields() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -152,8 +152,8 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
     }
 
     @Override
-    public boolean isFullySorted() {
-        return indexPlan.isFullySorted();
+    public boolean isStrictlySorted() {
+        return indexPlan.isStrictlySorted();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
@@ -130,6 +130,12 @@ public class RecordQueryFetchFromPartialRecordPlan implements RecordQueryPlanWit
         return new RecordQueryFetchFromPartialRecordPlan(Iterables.getOnlyElement(rebasedQuantifiers).narrow(Quantifier.Physical.class));
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryFetchFromPartialRecordPlan(child);
+    }
+
     @Override
     public boolean equalsWithoutChildren(@Nonnull final RelationalExpression otherExpression, @Nonnull final AliasMap equivalences) {
         if (this == otherExpression) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
@@ -127,6 +127,12 @@ public class RecordQueryFilterPlan extends RecordQueryFilterPlanBase {
                 getFilters());
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryFilterPlan(child, getFilters());
+    }
+
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInParameterJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInParameterJoinPlan.java
@@ -118,6 +118,12 @@ public class RecordQueryInParameterJoinPlan extends RecordQueryInJoinPlan {
                 sortReverse);
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryInParameterJoinPlan(child, bindingName, externalBinding, sortValuesNeeded, sortReverse);
+    }
+
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInValuesJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInValuesJoinPlan.java
@@ -114,6 +114,12 @@ public class RecordQueryInValuesJoinPlan extends RecordQueryInJoinPlan {
                 sortReverse);
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryInValuesJoinPlan(child, bindingName, values, sortValuesNeeded, sortReverse);
+    }
+
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -71,18 +71,13 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
     protected final ScanComparisons comparisons;
     protected final boolean reverse;
 
-    protected final boolean fullySorted;
+    protected boolean strictlySorted = false;
 
-    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse, final boolean fullySorted) {
+    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse) {
         this.indexName = indexName;
         this.scanType = scanType;
         this.comparisons = comparisons;
         this.reverse = reverse;
-        this.fullySorted = fullySorted;
-    }
-
-    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse) {
-        this(indexName, scanType, comparisons, reverse, false);
     }
 
     @Nonnull
@@ -149,8 +144,12 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
     }
 
     @Override
-    public boolean isFullySorted() {
-        return fullySorted;
+    public boolean isStrictlySorted() {
+        return strictlySorted;
+    }
+
+    public void setStrictlySorted(boolean strictlySorted) {
+        this.strictlySorted = strictlySorted;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -71,11 +71,18 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
     protected final ScanComparisons comparisons;
     protected final boolean reverse;
 
-    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse) {
+    protected final boolean fullySorted;
+
+    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse, final boolean fullySorted) {
         this.indexName = indexName;
         this.scanType = scanType;
         this.comparisons = comparisons;
         this.reverse = reverse;
+        this.fullySorted = fullySorted;
+    }
+
+    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse) {
+        this(indexName, scanType, comparisons, reverse, false);
     }
 
     @Nonnull
@@ -139,6 +146,11 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
         } else {
             return UNKNOWN_MAX_CARDINALITY;
         }
+    }
+
+    @Override
+    public boolean isFullySorted() {
+        return fullySorted;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -70,14 +70,18 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
     @Nonnull
     protected final ScanComparisons comparisons;
     protected final boolean reverse;
+    protected final boolean strictlySorted;
 
-    protected boolean strictlySorted = false;
-
-    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse) {
+    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse, final boolean strictlySorted) {
         this.indexName = indexName;
         this.scanType = scanType;
         this.comparisons = comparisons;
         this.reverse = reverse;
+        this.strictlySorted = strictlySorted;
+    }
+
+    public RecordQueryIndexPlan(@Nonnull final String indexName, @Nonnull IndexScanType scanType, @Nonnull final ScanComparisons comparisons, final boolean reverse) {
+        this(indexName, scanType, comparisons, reverse, false);
     }
 
     @Nonnull
@@ -148,8 +152,9 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
         return strictlySorted;
     }
 
-    public void setStrictlySorted(boolean strictlySorted) {
-        this.strictlySorted = strictlySorted;
+    @Override
+    public RecordQueryIndexPlan strictlySorted() {
+        return new RecordQueryIndexPlan(indexName, scanType, comparisons, reverse, true);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -275,6 +275,11 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren,
         return getChildStream().map(p -> p.maxCardinality(metaData)).min(Integer::compare).orElse(UNKNOWN_MAX_CARDINALITY);
     }
 
+    @Override
+    public boolean isFullySorted() {
+        return getChildren().stream().allMatch(RecordQueryPlan::isFullySorted);
+    }
+
     /**
      * Construct a new union of two compatibly-ordered plans. The resulting plan will return all results that are
      * returned by both the {@code left} or {@code right} child plans. Each plan should return results in the same

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -280,6 +280,11 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren,
         return getChildren().stream().allMatch(RecordQueryPlan::isStrictlySorted);
     }
 
+    @Override
+    public RecordQueryIntersectionPlan strictlySorted() {
+        return new RecordQueryIntersectionPlan(Quantifiers.fromPlans(getChildren().stream().map(p -> GroupExpressionRef.of((RecordQueryPlan)p.strictlySorted())).collect(Collectors.toList())), comparisonKey, reverse, true);
+    }
+
     /**
      * Construct a new union of two compatibly-ordered plans. The resulting plan will return all results that are
      * returned by both the {@code left} or {@code right} child plans. Each plan should return results in the same

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -276,8 +276,8 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren,
     }
 
     @Override
-    public boolean isFullySorted() {
-        return getChildren().stream().allMatch(RecordQueryPlan::isFullySorted);
+    public boolean isStrictlySorted() {
+        return getChildren().stream().allMatch(RecordQueryPlan::isStrictlySorted);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
@@ -79,6 +79,11 @@ public interface RecordQueryPlanWithChild extends RecordQueryPlanWithChildren {
     }
 
     @Override
+    default RecordQueryPlanWithChild strictlySorted() {
+        return withChild((RecordQueryPlan)getChild().strictlySorted());
+    }
+
+    @Override
     default boolean hasLoadBykeys() {
         return getChild().hasLoadBykeys();
     }
@@ -88,4 +93,7 @@ public interface RecordQueryPlanWithChild extends RecordQueryPlanWithChildren {
     default AvailableFields getAvailableFields() {
         return getChild().getAvailableFields();
     }
+
+    @Nonnull
+    RecordQueryPlanWithChild withChild(@Nonnull RecordQueryPlan child);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
@@ -74,8 +74,8 @@ public interface RecordQueryPlanWithChild extends RecordQueryPlanWithChildren {
     }
 
     @Override
-    default boolean isFullySorted() {
-        return getChild().isFullySorted();
+    default boolean isStrictlySorted() {
+        return getChild().isStrictlySorted();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
@@ -74,6 +74,11 @@ public interface RecordQueryPlanWithChild extends RecordQueryPlanWithChildren {
     }
 
     @Override
+    default boolean isFullySorted() {
+        return getChild().isFullySorted();
+    }
+
+    @Override
     default boolean hasLoadBykeys() {
         return getChild().hasLoadBykeys();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicateFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicateFilterPlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
@@ -111,6 +112,12 @@ public class RecordQueryPredicateFilterPlan extends RecordQueryFilterPlanBase im
         return new RecordQueryPredicateFilterPlan(
                 Iterables.getOnlyElement(rebasedQuantifiers).narrow(Quantifier.Physical.class),
                 getPredicate().rebase(translationMap));
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryPredicateFilterPlan(Quantifier.physical(GroupExpressionRef.of(child)), getPredicate());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -67,18 +67,17 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     @Nonnull
     private final ScanComparisons comparisons;
     private final boolean reverse;
-
-    private boolean strictlySorted = false;
+    private final boolean strictlySorted;
 
     /**
      * Overloaded constructor.
-     * Use the overloaded constructor {@link #RecordQueryScanPlan(Set, ScanComparisons, boolean)}
+     * Use the overloaded constructor {@link #RecordQueryScanPlan(Set, ScanComparisons, boolean, boolean)}
      * to also pass in a set of record types.
      * @param comparisons comparisons to be applied by the operator
      * @param reverse indicator whether this scan is reverse
      */
     public RecordQueryScanPlan(@Nonnull ScanComparisons comparisons, boolean reverse) {
-        this(null, comparisons, reverse);
+        this(null, comparisons, reverse, false);
     }
 
     /**
@@ -88,9 +87,21 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
      * @param reverse indicator whether this scan is reverse
      */
     public RecordQueryScanPlan(@Nullable Set<String> recordTypes, @Nonnull ScanComparisons comparisons, boolean reverse) {
+        this(recordTypes, comparisons, reverse, false);
+    }
+
+    /**
+     * Overloaded constructor.
+     * @param recordTypes a super set of record types of the records that this scan operator can produce
+     * @param comparisons comparisons to be applied by the operator
+     * @param reverse indicator whether this scan is reverse
+     * @param strictlySorted whether scan is stricted sorted for original query
+     */
+    public RecordQueryScanPlan(@Nullable Set<String> recordTypes, @Nonnull ScanComparisons comparisons, boolean reverse, boolean strictlySorted) {
         this.recordTypes = recordTypes == null ? null : ImmutableSet.copyOf(recordTypes);
         this.comparisons = comparisons;
         this.reverse = reverse;
+        this.strictlySorted = strictlySorted;
     }
 
     @Nonnull
@@ -159,9 +170,9 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
         return strictlySorted;
     }
 
-    public RecordQueryScanPlan setStrictlySorted(final boolean strictlySorted) {
-        this.strictlySorted = strictlySorted;
-        return this;
+    @Override
+    public RecordQueryScanPlan strictlySorted() {
+        return new RecordQueryScanPlan(recordTypes, comparisons, reverse, true);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -68,15 +68,17 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     private final ScanComparisons comparisons;
     private final boolean reverse;
 
+    private final boolean fullySorted;
+
     /**
      * Overloaded constructor.
-     * Use the overloaded constructor {@link #RecordQueryScanPlan(Set, ScanComparisons, boolean)}
+     * Use the overloaded constructor {@link #RecordQueryScanPlan(Set, ScanComparisons, boolean, boolean)}
      * to also pass in a set of record types.
      * @param comparisons comparisons to be applied by the operator
      * @param reverse indicator whether this scan is reverse
      */
     public RecordQueryScanPlan(@Nonnull ScanComparisons comparisons, boolean reverse) {
-        this(null, comparisons, reverse);
+        this(null, comparisons, reverse, false);
     }
 
     /**
@@ -86,9 +88,21 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
      * @param reverse indicator whether this scan is reverse
      */
     public RecordQueryScanPlan(@Nullable Set<String> recordTypes, @Nonnull ScanComparisons comparisons, boolean reverse) {
+        this(recordTypes, comparisons, reverse, false);
+    }
+
+    /**
+     * Overloaded constructor.
+     * @param recordTypes a super set of record types of the records that this scan operator can produce
+     * @param comparisons comparisons to be applied by the operator
+     * @param reverse indicator whether this scan is reverse
+     * @param fullySorted indicator whether this scan is only ordered by query's requested sort
+     */
+    public RecordQueryScanPlan(@Nullable Set<String> recordTypes, @Nonnull ScanComparisons comparisons, boolean reverse, boolean fullySorted) {
         this.recordTypes = recordTypes == null ? null : ImmutableSet.copyOf(recordTypes);
         this.comparisons = comparisons;
         this.reverse = reverse;
+        this.fullySorted = fullySorted;
     }
 
     @Nonnull
@@ -150,6 +164,11 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
         } else {
             return UNKNOWN_MAX_CARDINALITY;
         }
+    }
+
+    @Override
+    public boolean isFullySorted() {
+        return fullySorted;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -68,17 +68,17 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     private final ScanComparisons comparisons;
     private final boolean reverse;
 
-    private final boolean fullySorted;
+    private boolean strictlySorted = false;
 
     /**
      * Overloaded constructor.
-     * Use the overloaded constructor {@link #RecordQueryScanPlan(Set, ScanComparisons, boolean, boolean)}
+     * Use the overloaded constructor {@link #RecordQueryScanPlan(Set, ScanComparisons, boolean)}
      * to also pass in a set of record types.
      * @param comparisons comparisons to be applied by the operator
      * @param reverse indicator whether this scan is reverse
      */
     public RecordQueryScanPlan(@Nonnull ScanComparisons comparisons, boolean reverse) {
-        this(null, comparisons, reverse, false);
+        this(null, comparisons, reverse);
     }
 
     /**
@@ -88,21 +88,9 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
      * @param reverse indicator whether this scan is reverse
      */
     public RecordQueryScanPlan(@Nullable Set<String> recordTypes, @Nonnull ScanComparisons comparisons, boolean reverse) {
-        this(recordTypes, comparisons, reverse, false);
-    }
-
-    /**
-     * Overloaded constructor.
-     * @param recordTypes a super set of record types of the records that this scan operator can produce
-     * @param comparisons comparisons to be applied by the operator
-     * @param reverse indicator whether this scan is reverse
-     * @param fullySorted indicator whether this scan is only ordered by query's requested sort
-     */
-    public RecordQueryScanPlan(@Nullable Set<String> recordTypes, @Nonnull ScanComparisons comparisons, boolean reverse, boolean fullySorted) {
         this.recordTypes = recordTypes == null ? null : ImmutableSet.copyOf(recordTypes);
         this.comparisons = comparisons;
         this.reverse = reverse;
-        this.fullySorted = fullySorted;
     }
 
     @Nonnull
@@ -167,8 +155,13 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     }
 
     @Override
-    public boolean isFullySorted() {
-        return fullySorted;
+    public boolean isStrictlySorted() {
+        return strictlySorted;
+    }
+
+    public RecordQueryScanPlan setStrictlySorted(final boolean strictlySorted) {
+        this.strictlySorted = strictlySorted;
+        return this;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -172,6 +172,12 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
                 getRanks());
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryScoreForRankPlan(child, getRanks());
+    }
+
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
@@ -130,6 +130,12 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
                 getRecordTypes());
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryTypeFilterPlan(child, getRecordTypes());
+    }
+
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     @Override
     public boolean equals(final Object other) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -215,6 +215,11 @@ public abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChi
         return quantifiers.size();
     }
 
+    @Override
+    public boolean isFullySorted() {
+        return getChildren().stream().allMatch(RecordQueryPlan::isFullySorted);
+    }
+
     @Nonnull
     public abstract RecordQueryUnionPlanBase withChildren(@Nonnull List<RecordQueryPlan> newChildren);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -220,6 +220,11 @@ public abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChi
         return getChildren().stream().allMatch(RecordQueryPlan::isStrictlySorted);
     }
 
+    @Override
+    public QueryPlan<FDBQueriedRecord<Message>> strictlySorted() {
+        return withChildren(getChildren().stream().map(p -> (RecordQueryPlan)p.strictlySorted()).collect(Collectors.toList()));
+    }
+
     @Nonnull
     public abstract RecordQueryUnionPlanBase withChildren(@Nonnull List<RecordQueryPlan> newChildren);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -216,8 +216,8 @@ public abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChi
     }
 
     @Override
-    public boolean isFullySorted() {
-        return getChildren().stream().allMatch(RecordQueryPlan::isFullySorted);
+    public boolean isStrictlySorted() {
+        return getChildren().stream().allMatch(RecordQueryPlan::isStrictlySorted);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
@@ -147,6 +147,12 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
                 getComparisonKey());
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryUnorderedDistinctPlan(child, getComparisonKey());
+    }
+
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -133,6 +133,12 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
         return new RecordQueryUnorderedPrimaryKeyDistinctPlan(Iterables.getOnlyElement(rebasedQuantifiers).narrow(Quantifier.Physical.class));
     }
 
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new RecordQueryUnorderedPrimaryKeyDistinctPlan(child);
+    }
+
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/OrderingProperty.java
@@ -330,29 +330,16 @@ public class OrderingProperty implements PlannerProperty<Optional<OrderingProper
             return orderingKeyParts;
         }
 
-        // TODO: Make this a plan property, when that exists.
-        public void setStrictlyOrdred(boolean strictlyOrdred) {
-            if (orderedPlan instanceof RecordQueryIndexPlan) {
-                ((RecordQueryIndexPlan)orderedPlan).setStrictlySorted(strictlyOrdred);
-            } else if (orderedPlan instanceof RecordQueryScanPlan) {
-                ((RecordQueryScanPlan)orderedPlan).setStrictlySorted(strictlyOrdred);
-            }
-            if (children != null) {
-                for (OrderingInfo child : children) {
-                    child.setStrictlyOrdred(strictlyOrdred);
-                }
-            }
-        }
-
         // TODO: This suggests that ordering and distinct should be tracked together.
-        public void strictlyOrderedIfUnique(Function<String,Index> getIndex, int nkeys) {
+        public boolean strictlyOrderedIfUnique(Function<String,Index> getIndex, int nkeys) {
             if (orderedPlan instanceof RecordQueryIndexPlan) {
                 RecordQueryIndexPlan indexPlan = (RecordQueryIndexPlan)orderedPlan;
                 Index index = getIndex.apply(indexPlan.getIndexName());
                 if (index.isUnique() && nkeys >= index.getColumnSize()) {
-                    indexPlan.setStrictlySorted(true);
+                    return true;
                 }
             }
+            return false;
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveSortRule.java
@@ -70,6 +70,7 @@ public class RemoveSortRule extends PlannerRule<LogicalSortExpression> {
 
         final OrderingInfo orderingInfo = orderingInfoOptional.get();
         final Set<KeyExpression> equalityBoundKeys = orderingInfo.getEqualityBoundKeys();
+        int equalityBoundUnsorted = equalityBoundKeys.size();
         final List<KeyPart> orderingKeys = orderingInfo.getOrderingKeyParts();
         final Iterator<KeyPart> orderingKeysIterator = orderingKeys.iterator();
 
@@ -84,6 +85,7 @@ public class RemoveSortRule extends PlannerRule<LogicalSortExpression> {
             }
 
             if (equalityBoundKeys.contains(normalizedSortExpression)) {
+                equalityBoundUnsorted--;
                 continue;
             }
             if (!orderingKeysIterator.hasNext()) {
@@ -95,6 +97,13 @@ public class RemoveSortRule extends PlannerRule<LogicalSortExpression> {
             if (!normalizedSortExpression.equals(currentOrderingKeyPart.getNormalizedKeyExpression())) {
                 return;
             }
+        }
+
+        if (!orderingKeysIterator.hasNext()) {
+            // If we have exhausted the ordering info's keys, too, then its constituents are strictly ordered.
+            orderingInfo.setStrictlyOrdred(true);
+        } else {
+            orderingInfo.strictlyOrderedIfUnique(call.getContext()::getIndexByName, normalizedSortExpressions.size() + equalityBoundUnsorted);
         }
 
         call.yield(call.ref(innerPlan));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
@@ -448,7 +448,7 @@ public class FDBAndQueryToIntersectionTest extends FDBRecordStoreQueryTestBase {
     @ParameterizedTest
     @BooleanSource
     public void testAndQuery7(boolean shouldDeferFetch) throws Exception {
-        RecordMetaDataHook hook = complexPrimaryKeyHook();
+        RecordMetaDataHook hook = complexPrimaryKeyHook(true);
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -66,7 +66,6 @@ import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTup
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScanType;
-import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.intersection;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.primaryKeyDistinct;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.queryPredicateDescendant;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scan;
@@ -318,12 +317,11 @@ public class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
         RecordQueryPlan plan = planner.plan(query);
 
         if (planner instanceof RecordQueryPlanner) {
+            // Does not understand duplicate condition
             assertThat(plan,
                     filter(nestedComponent,
-                            intersection(
-                                    indexScan(allOf(indexName("composite"), bounds(hasTupleString("[[something, 1],[something, 1]]")))),
-                                    indexScan(allOf(indexName("duplicates"), bounds(hasTupleString("[[something, something],[something, something]]"))))
-                            )));
+                            indexScan(allOf(indexName("duplicates"), bounds(hasTupleString("[[something, something, 1],[something, something, 1]]"))))
+                            ));
         } else {
             assertThat(plan, primaryKeyDistinct(indexScan(allOf(indexName("complex"), bounds(hasTupleString("[[something, 1, 10, 20],[something, 1, 10, 20]]"))))));
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -817,6 +817,11 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             assertEquals(20 + 20, i);
             assertDiscardedNone(context);
         }
+
+        query = query.toBuilder()
+                .setSort(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")))
+                .build();
+        assertEquals(plan, planner.plan(query));
     }
 
     @ParameterizedTest

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -731,7 +731,7 @@ public class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      */
     @Test
     public void testOrQuery7() throws Exception {
-        RecordMetaDataHook hook = complexPrimaryKeyHook();
+        RecordMetaDataHook hook = complexPrimaryKeyHook(true);
         complexQuerySetup(hook);
         RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -308,13 +308,23 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         }
     }
 
+
     @Nonnull
     protected RecordMetaDataHook complexPrimaryKeyHook() {
+        return complexPrimaryKeyHook(false);
+    }
+
+    @Nonnull
+    protected RecordMetaDataHook complexPrimaryKeyHook(boolean skipNum3) {
         return metaData -> {
             RecordTypeBuilder recordType = metaData.getRecordType("MySimpleRecord");
             recordType.setPrimaryKey(concatenateFields("str_value_indexed", "num_value_unique"));
             metaData.addIndex(recordType, new Index("str_value_2_index",
                     "str_value_indexed", "num_value_2"));
+            if (skipNum3) {
+                // Same fields in different order as str_value_3_index.
+                metaData.removeIndex("MySimpleRecord$num_value_3_indexed");
+            }
             metaData.addIndex(recordType, new Index("str_value_3_index",
                     "str_value_indexed", "num_value_3_indexed"));
         };

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
@@ -1,0 +1,192 @@
+/*
+ * QueryPlanFullySortedTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.query;
+
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.RecordStoreState;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.QueryPlanner;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link com.apple.foundationdb.record.query.plan.plans.QueryPlan#isFullySorted}.
+ */
+@Tag(Tags.RequiresFDB)
+public class QueryPlanFullySortedTest extends FDBRecordStoreQueryTestBase {
+
+    RecordMetaData metaData;
+    QueryPlanner planner;
+
+    protected void setup(@Nullable RecordMetaDataHook hook) {
+        RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
+        if (hook != null) {
+            hook.apply(builder);
+        }
+        metaData = builder.getRecordMetaData();
+        planner = new RecordQueryPlanner(metaData, new RecordStoreState(null, null));
+    }
+
+    @Test
+    public void unsorted() {
+        setup(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.field("str_value_indexed").equalsValue("a"))
+                .build();
+        assertFalse(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void singleSort() {
+        setup(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setSort(Key.Expressions.field("str_value_indexed"))
+                .build();
+        assertFalse(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void primaryKey() {
+        setup(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setSort(Key.Expressions.field("rec_no"))
+                .build();
+        assertTrue(planner.plan(query).isFullySorted());
+    }
+
+    private static void compoundPrimaryKey(@Nonnull RecordMetaDataBuilder metaData) {
+        metaData.getRecordType("MySimpleRecord").setPrimaryKey(Key.Expressions.concatenateFields("num_value_2", "rec_no"));
+        metaData.addIndex("MySimpleRecord", "multi", Key.Expressions.concatenateFields("num_value_2", "num_value_3_indexed"));
+    }
+
+    @Test
+    public void primaryKeyPartial() {
+        setup(QueryPlanFullySortedTest::compoundPrimaryKey);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.field("num_value_2").equalsValue(1))
+                .setSort(Key.Expressions.field("num_value_3_indexed"))
+                .build();
+        assertFalse(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void primaryKeyFull() {
+        setup(QueryPlanFullySortedTest::compoundPrimaryKey);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.field("num_value_2").equalsValue(1))
+                .setSort(Key.Expressions.concatenateFields("num_value_3_indexed", "rec_no"))
+                .build();
+        assertTrue(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void intersection() {
+        setup(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(Query.field("num_value_3_indexed").equalsValue(1), Query.field("str_value_indexed").equalsValue("a")))
+                .setSort(Key.Expressions.field("rec_no"))
+                .build();
+        assertTrue(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void union() {
+        setup(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.or(Query.field("num_value_3_indexed").equalsValue(1), Query.field("str_value_indexed").equalsValue("a")))
+                .setSort(Key.Expressions.field("rec_no"))
+                .build();
+        assertTrue(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void sortingUnion() {
+        setup(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.or(Query.field("num_value_3_indexed").equalsValue(1), Query.field("num_value_3_indexed").equalsValue(3)))
+                .setSort(Key.Expressions.field("num_value_3_indexed"))
+                .build();
+        assertFalse(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void sortingUnionFull() {
+        setup(null);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.or(Query.field("num_value_3_indexed").equalsValue(1), Query.field("num_value_3_indexed").equalsValue(3)))
+                .setSort(Key.Expressions.concatenateFields("num_value_3_indexed", "rec_no"))
+                .build();
+        assertTrue(planner.plan(query).isFullySorted());
+    }
+
+    private static void compoundUnique(@Nonnull RecordMetaDataBuilder metaData) {
+        metaData.addIndex("MySimpleRecord", new Index("multi_unique",
+                Key.Expressions.concatenateFields("num_value_2", "num_value_unique"),
+                IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+    }
+
+    @Test
+    public void sortingUniquePrefix() {
+        setup(QueryPlanFullySortedTest::compoundUnique);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setSort(Key.Expressions.field("num_value_2"))
+                .build();
+        assertFalse(planner.plan(query).isFullySorted());
+    }
+
+    @Test
+    public void sortingUnique() {
+        setup(QueryPlanFullySortedTest::compoundUnique);
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(Query.field("num_value_2").equalsValue(1), Query.field("num_value_unique").lessThan(10)))
+                .setSort(Key.Expressions.field("num_value_unique"))
+                .build();
+        assertTrue(planner.plan(query).isFullySorted());
+    }
+
+
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanHashTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanHashTest.java
@@ -386,14 +386,17 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_3_indexed").equalsValue(4)),
                 field("rec_no"));
 
-        assertEquals(575076824, plan1.planHash(PlanHashable.PlanHashKind.LEGACY));
-        assertEquals(575076888, plan2.planHash(PlanHashable.PlanHashKind.LEGACY));
+        // Index(MySimpleRecord$num_value_unique [[1],[1]]) ∩ Index(MySimpleRecord$num_value_3_indexed [[2],[2]])
+        // Index(MySimpleRecord$num_value_unique [[3],[3]]) ∩ Index(MySimpleRecord$num_value_3_indexed [[4],[4]])
 
-        assertEquals(-554014099, plan1.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-554014035, plan2.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(62126310, plan1.planHash(PlanHashable.PlanHashKind.LEGACY));
+        assertEquals(62126374, plan2.planHash(PlanHashable.PlanHashKind.LEGACY));
 
-        assertEquals(-2050705076, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-2050705076, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(380936464, plan1.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(440041808, plan2.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+
+        assertEquals(-1611765649, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-1611765649, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanMaxCardinalityTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanMaxCardinalityTest.java
@@ -1,5 +1,5 @@
 /*
- * QueryPlanIsUniqueTest.java
+ * QueryPlanMaxCardinalityTest.java
  *
  * This source file is part of the FoundationDB open source project
  *


### PR DESCRIPTION
Includes #1169 and thereby #1168, since if the planner doesn't use the full key it doesn't have a complete picture of how the index entries are ordered, so it may be simpler to only look at the third (last) commit.

It's possible that there is a more general / forward-looking way of exposing the determination than just as another field in the plan.