### PR TITLE
Resolves #1183: Rank by grouped map-like values

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ In this realase, the various implementations of the `RecordQueryPlan` interface 
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Rank by grouped map-like values [(Issue #1183)](https://github.com/FoundationDB/fdb-record-layer/issues/1183)
 * **Feature** `VersionstampSaveBehavior.IF_PRESENT` allows the user to specify that a record should be saved with a version only if one is explicitly provided [(Issue #958)](https://github.com/FoundationDB/fdb-record-layer/issues/958)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunction.java
@@ -25,13 +25,17 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordFunction;
+import com.apple.foundationdb.record.metadata.IndexRecordFunction;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.IndexFunctionHelper;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -44,13 +48,50 @@ public class QueryRecordFunction<T> implements PlanHashable {
 
     @Nonnull
     private final RecordFunction<T> function;
+    @Nullable
+    private final QueryComponent additionalCondition;
+    @Nullable
+    private RecordFunction<T> evalFunction;
+
+    public QueryRecordFunction(@Nonnull RecordFunction<T> function, @Nullable final QueryComponent additionalCondition) {
+        this.function = function;
+        this.additionalCondition = additionalCondition;
+    }
 
     public QueryRecordFunction(@Nonnull RecordFunction<T> function) {
-        this.function = function;
+        this(function, null);
     }
 
     public RecordFunction<T> getFunction() {
         return function;
+    }
+
+    @Nonnull
+    public QueryRecordFunction<T> withFunction(@Nonnull RecordFunction<T> function) {
+        return new QueryRecordFunction<>(function, additionalCondition);
+    }
+
+    @Nullable
+    public QueryComponent getAdditionalCondition() {
+        return additionalCondition;
+    }
+
+    @Nonnull
+    public QueryRecordFunction<T> withAdditionalCondition(@Nonnull QueryComponent additionalCondition) {
+        return new QueryRecordFunction<>(function, and(additionalCondition));
+    }
+
+    @Nonnull
+    private  QueryComponent and(@Nonnull QueryComponent condition) {
+        if (additionalCondition == null) {
+            return condition;
+        } else if (additionalCondition instanceof AndComponent) {
+            List<QueryComponent> children = new ArrayList<>(((AndComponent)additionalCondition).getChildren());
+            children.add(condition);
+            return Query.and(children);
+        } else {
+            return Query.and(additionalCondition, condition);
+        }
     }
 
     // TODO: Perhaps these Object comparands should really be T. Right now everything is <Long>.
@@ -133,24 +174,36 @@ public class QueryRecordFunction<T> implements PlanHashable {
      */
     @Nonnull
     public QueryComponent in(@Nonnull String param) {
-        return new QueryRecordFunctionWithComparison(this.function, new Comparisons.ParameterComparison(Comparisons.Type.IN, param));
+        return withParameterComparison(Comparisons.Type.IN, param);
+    }
+
+    @Nonnull
+    public QueryComponent withComparison(@Nonnull Comparisons.Comparison comparison) {
+        return and(new QueryRecordFunctionWithComparison(function, comparison));
     }
 
     @Nonnull
     public QueryComponent withComparison(@Nonnull Comparisons.Type type, @Nonnull Object comparand) {
-        return new QueryRecordFunctionWithComparison(function, new Comparisons.SimpleComparison(type, comparand));
+        return withComparison(new Comparisons.SimpleComparison(type, comparand));
     }
 
     @Nonnull
     public QueryComponent withParameterComparison(@Nonnull Comparisons.Type type, String parameter) {
-        return new QueryRecordFunctionWithComparison(function, new Comparisons.ParameterComparison(type, parameter));
+        return withComparison(new Comparisons.ParameterComparison(type, parameter));
     }
 
     public <M extends Message> CompletableFuture<T> eval(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context, @Nullable FDBStoredRecord<M> record) {
         if (record == null) {
             return CompletableFuture.completedFuture(null);
         }
-        return store.evaluateRecordFunction(context, function, record);
+        if (additionalCondition == null) {
+            return store.evaluateRecordFunction(context, function, record);
+        }
+        // Cache the bound version of the record function.
+        if (evalFunction == null) {
+            evalFunction = IndexFunctionHelper.recordFunctionWithSubrecordCondition(store.getUntypedRecordStore(), (IndexRecordFunction<T>) function, record, additionalCondition);
+        }
+        return store.evaluateRecordFunction(context, evalFunction, record);
     }
 
     @Override
@@ -164,7 +217,7 @@ public class QueryRecordFunction<T> implements PlanHashable {
 
         QueryRecordFunction<?> that = (QueryRecordFunction)obj;
 
-        return this.function.equals(that.function);
+        return this.function.equals(that.function) && Objects.equals(this.additionalCondition, that.additionalCondition);
     }
 
     @Override
@@ -179,7 +232,11 @@ public class QueryRecordFunction<T> implements PlanHashable {
                 return function.planHash(hashKind);
             case FOR_CONTINUATION:
             case STRUCTURAL_WITHOUT_LITERALS:
-                return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, function);
+                if (additionalCondition == null) {
+                    return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, function);
+                } else {
+                    return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, function, additionalCondition);
+                }
             default:
                 throw new UnsupportedOperationException("Hash kind " + hashKind.name() + " is not supported");
         }
@@ -187,7 +244,11 @@ public class QueryRecordFunction<T> implements PlanHashable {
 
     @Override
     public String toString() {
-        return function.toString();
+        if (additionalCondition == null) {
+            return function.toString();
+        } else {
+            return function + " | " + additionalCondition;
+        }
     }
 
 }


### PR DESCRIPTION
Since `RANK` as a function is a record operation today (as opposed to some kind of join), need a variant of the function that captures the selection of the nested map entry. This is done in two stages.

1. Allow `QueryRecordFunction` (what `Query.rank` produces) to have an additional `QueryComponent` constraint.
2. When that is asked to `eval` itself, match the component against one of the group keys in the function and turn the condition into values to select from among the (multiple) index entry tuples.
3. Use that selected tuple in place of `evaluateSingleton` (the normal non-repeated case).