### PR TITLE
Resolves #1191: Remove non-controversial deprecated methods

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,7 +30,7 @@ This verison of the Record Layer removes some legacy elements of the API that we
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** The iterator style `RecordCursor` API is removed [(Issue #1136)](https://github.com/FoundationDB/fdb-record-layer/issues/1136)
-* **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Remove non-controversial deprecated methods [(Issue #1191)](https://github.com/FoundationDB/fdb-record-layer/issues/1191)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteState.java
@@ -41,14 +41,6 @@ public class ExecuteState {
      */
     public static final ExecuteState NO_LIMITS = new ExecuteState(RecordScanLimiterFactory.untracked(), ByteScanLimiterFactory.untracked());
 
-    /**
-     * An empty execute state with no scan limits.
-     * @deprecated in favor of NO_LIMITS when the byte scan limit was added
-     */
-    @API(API.Status.DEPRECATED)
-    @Deprecated
-    public static final ExecuteState NO_SCANNED_RECORDS_LIMIT = NO_LIMITS;
-
     @Nonnull
     private final RecordScanLimiter recordScanLimiter;
     @Nonnull
@@ -64,17 +56,6 @@ public class ExecuteState {
     public ExecuteState(@Nullable RecordScanLimiter recordScanLimiter, @Nullable ByteScanLimiter byteScanLimiter) {
         this.recordScanLimiter = recordScanLimiter == null ? RecordScanLimiterFactory.tracking() : recordScanLimiter;
         this.byteScanLimiter = byteScanLimiter == null ? ByteScanLimiterFactory.tracking() : byteScanLimiter;
-    }
-
-    /**
-     * A deprecated constructor that takes only a {@code RecordScanLimiter} and not a {@code ByteScanLimiter}.
-     * @param recordScanLimiter a {@code RecordScanLimiter} to use in this state
-     * @deprecated in favor of the constructor that takes multiple limiters
-     */
-    @API(API.Status.DEPRECATED)
-    @Deprecated
-    public ExecuteState(@Nullable RecordScanLimiter recordScanLimiter) {
-        this(recordScanLimiter, null);
     }
 
     public ExecuteState() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/MutableRecordStoreState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/MutableRecordStoreState.java
@@ -51,11 +51,6 @@ public class MutableRecordStoreState extends RecordStoreState {
         this(recordStoreState.getStoreHeader(), recordStoreState.getIndexStates());
     }
 
-    @Deprecated
-    public MutableRecordStoreState(@Nullable Map<String, IndexState> indexStateMap) {
-        super(indexStateMap);
-    }
-
     private static long readIncrement(long u) {
         return ((((u >> 32) + 1) << 32) & READ_MASK) | (u & WRITE_MASK);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaDataBuilder.java
@@ -142,100 +142,6 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
         syntheticRecordTypes = new HashMap<>();
     }
 
-    /**
-     * Creates a new builder from the provided record types protobuf.
-     * @param fileDescriptor a file descriptor containing all the record types in the metadata
-     * @deprecated use {@link RecordMetaData#newBuilder()} instead
-     */
-    @Deprecated
-    public RecordMetaDataBuilder(@Nonnull Descriptors.FileDescriptor fileDescriptor) {
-        this(fileDescriptor, true);
-    }
-
-    /**
-     * Creates a new builder from the provided record types protobuf.
-     * @param fileDescriptor a file descriptor containing all the record types in the metadata
-     * @param processExtensionOptions whether to add primary keys and indexes based on extensions in the protobuf
-     * @deprecated use {@link RecordMetaData#newBuilder()} instead
-     */
-    @Deprecated
-    public RecordMetaDataBuilder(@Nonnull Descriptors.FileDescriptor fileDescriptor,
-                                 boolean processExtensionOptions) {
-        this();
-        loadFromFileDescriptor(fileDescriptor, processExtensionOptions);
-    }
-
-    /**
-     * Creates a new builder from the provided meta-data protobuf.
-     *
-     * This constructor assumes that {@code metaDataProto} is not the result of {@link RecordMetaData#toProto} and will not already
-     * include all the indexes defined by any original extension options, so that they still need to be processed.
-     * If {@code metaDataProto} is the result of {@code toProto} and indexes also appear in extension options, a duplicate index
-     * error will result. In that case, {@link #RecordMetaDataBuilder(RecordMetaDataProto.MetaData, boolean)} will be needed instead.
-     *
-     * @param metaDataProto the protobuf form of the meta-data
-     * @deprecated use {@link RecordMetaData#newBuilder()} instead
-     */
-    @Deprecated
-    public RecordMetaDataBuilder(@Nonnull RecordMetaDataProto.MetaData metaDataProto) {
-        this(metaDataProto, true);
-    }
-
-    /**
-     * Creates a new builder from the provided meta-data protobuf.
-     *
-     * If {@code metaDataProto} is the result of {@link RecordMetaData#toProto}, it will already
-     * include all the indexes defined by any original extension options, so {@code processExtensionOptions}
-     * should be {@code false}.
-     *
-     * @param metaDataProto the protobuf form of the meta-data
-     * @param processExtensionOptions whether to add primary keys and indexes based on extensions in the protobuf
-     * @deprecated use {@link RecordMetaData#newBuilder()} instead
-     */
-    @Deprecated
-    public RecordMetaDataBuilder(@Nonnull RecordMetaDataProto.MetaData metaDataProto,
-                                 boolean processExtensionOptions) {
-        this(metaDataProto, new Descriptors.FileDescriptor[] { RecordMetaDataOptionsProto.getDescriptor() }, processExtensionOptions);
-    }
-
-    /**
-     * Creates a new builder from the provided meta-data protobuf.
-     *
-     * This constructor assumes that {@code metaDataProto} is not the result of {@link RecordMetaData#toProto} and will not already
-     * include all the indexes defined by any original extension options, so that they still need to be processed.
-     * If {@code metaDataProto} is the result of {@code toProto} and indexes also appear in extension options, a duplicate index
-     * error will result. In that case, {@link #RecordMetaDataBuilder(RecordMetaDataProto.MetaData, Descriptors.FileDescriptor[], boolean)} will be needed instead.
-     *
-     * @param metaDataProto the protobuf form of the meta-data
-     * @param dependencies other files imported by the record types protobuf
-     * @deprecated use {@link RecordMetaData#newBuilder()} instead
-     */
-    @Deprecated
-    public RecordMetaDataBuilder(@Nonnull RecordMetaDataProto.MetaData metaDataProto,
-                                 @Nonnull Descriptors.FileDescriptor[] dependencies) {
-        this(metaDataProto, dependencies, true);
-    }
-
-    /**
-     * Creates a new builder from the provided meta-data protobuf.
-     *
-     * If {@code metaDataProto} is the result of {@link RecordMetaData#toProto}, it will already
-     * include all the indexes defined by any original extension options, so {@code processExtensionOptions}
-     * should be {@code false}.
-     *
-     * @param metaDataProto the protobuf form of the meta-data
-     * @param dependencies other files imported by the record types protobuf
-     * @param processExtensionOptions whether to add primary keys and indexes based on extensions in the protobuf
-     * @deprecated use {@link RecordMetaData#newBuilder()} instead
-     */
-    @Deprecated
-    public RecordMetaDataBuilder(@Nonnull RecordMetaDataProto.MetaData metaDataProto,
-                                 @Nonnull Descriptors.FileDescriptor[] dependencies,
-                                 boolean processExtensionOptions) {
-        this();
-        loadFromProto(metaDataProto, dependencies, processExtensionOptions);
-    }
-
     private void processSchemaOptions(boolean processExtensionOptions) {
         if (processExtensionOptions) {
             RecordMetaDataOptionsProto.SchemaOptions schemaOptions = recordsDescriptor.getOptions()
@@ -1250,6 +1156,7 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
     @Nullable
     @Deprecated
     @API(API.Status.DEPRECATED)
+    // Deprecated for new usage, but this can't really be removed because old meta-data might include it.
     public KeyExpression getRecordCountKey() {
         return recordCountKey;
     }
@@ -1261,6 +1168,7 @@ public class RecordMetaDataBuilder implements RecordMetaDataProvider {
      */
     @Deprecated
     @API(API.Status.DEPRECATED)
+    // Deprecated for new usage, but this can't really be removed because old meta-data might include it.
     public void setRecordCountKey(KeyExpression recordCountKey) {
         if (recordsDescriptor == null) {
             throw new MetaDataException("No records added yet");

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordStoreState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordStoreState.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
@@ -59,23 +58,6 @@ import java.util.stream.Collectors;
  */
 @API(API.Status.MAINTAINED)
 public class RecordStoreState {
-    /**
-     * Empty <code>RecordStoreState</code>. This is the state of an empty record store that has not yet been
-     * used. Calling the argument-less constructor of this class will produce a logically-equivalent object,
-     * but having this code around avoids having to instantiate this class unnecessarily.
-     *
-     * <p>
-     * When this object was initially introduced, the only information included in the record store state
-     * was index readability information. This was the common case, and therefore sharing the same object
-     * for most record stores was desirable. However, the store header information is not likely to be
-     * the same for multiple record stores, so using this record store state is usually not recommended.
-     * </p>
-     *
-     * @deprecated as this object usually has the wrong store header
-     */
-    @Deprecated
-    @Nonnull
-    public static final RecordStoreState EMPTY = new RecordStoreState();
 
     @Nonnull
     protected final AtomicReference<RecordMetaDataProto.DataStoreInfo> storeHeader;
@@ -99,35 +81,6 @@ public class RecordStoreState {
         }
         this.storeHeader = new AtomicReference<>(storeHeader == null ? RecordMetaDataProto.DataStoreInfo.getDefaultInstance() : storeHeader);
         this.indexStateMap = new AtomicReference<>(copy);
-    }
-
-    /**
-     * Creates a <code>RecordStoreState</code> with the given index states.
-     * Only indexes that are not in the default state ({@link IndexState#READABLE IndexState.READABLE})
-     * need to be included in the map. This initializes the record store state with a default store header, which
-     * is not the expected state for most record stores. As a result, this constructor has been deprecated in favor
-     * of the constructor where a store header must be provided.
-     *
-     * @param indexStateMap mapping from index name to index state
-     * @deprecated as the default store header is incorrect for most record stores
-     */
-    @Deprecated
-    public RecordStoreState(@Nullable Map<String, IndexState> indexStateMap) {
-        this(null, indexStateMap);
-    }
-
-    /**
-     * Creates an empty <code>RecordStoreState</code> instance. This is the state that an empty {@link FDBRecordStoreBase}
-     * would be expected to be in. All indexes are assumed to be readable with this constructor. This also
-     * initializes the record store state with the default store header, which is not the expected state for
-     * most record stores. As a result, this constructor has been deprecated in favor of the constructor where
-     * a store header must be provided.
-     *
-     * @deprecated as the default store header is incorrect for most record stores
-     */
-    @Deprecated
-    public RecordStoreState() {
-        this(null);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/FormerIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/FormerIndex.java
@@ -92,16 +92,6 @@ public class FormerIndex {
     }
 
     /**
-     * Synonym for {@link #getRemovedVersion}.
-     * @return the removed version
-     * @deprecated use {@link #getRemovedVersion}
-     */
-    @Deprecated
-    public int getVersion() {
-        return addedVersion;
-    }
-
-    /**
      * Get the version at which the index was first added.
      * @return the added version
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Index.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Index.java
@@ -387,7 +387,7 @@ public class Index {
      * <p>
      * This method should generally not be called by users outside of the Record Layer.
      * For the most part, it should be sufficient for index maintainers to call
-     * {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase#indexEntryPrimaryKey(Index, Tuple) FDBRecordStoreBase.indexEntryPrimaryKey()}
+     * {@link #getEntryPrimaryKey(Tuple)}
      * to determine the primary key of a record from an index entry and
      * {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase#indexEntryKey(Index, Tuple, Tuple) FDBRecordStoreBase.indexEntryKey()}
      * to determine the index entry given a record's primary key.
@@ -490,26 +490,6 @@ public class Index {
             }
         }
         return Tuple.fromList(primaryKeys);
-    }
-
-    /**
-     * Synonynm for {@link #getLastModifiedVersion}.
-     * @return the last modified version
-     * @deprecated use {@link #getLastModifiedVersion}.
-     */
-    @Deprecated
-    public int getVersion() {
-        return lastModifiedVersion;
-    }
-
-    /**
-     * Synonynm for {@link #setLastModifiedVersion}.
-     * @param version the last modified version
-     * @deprecated use {@link #setLastModifiedVersion}.
-     */
-    @Deprecated
-    public void setVersion(int version) {
-        this.lastModifiedVersion = version;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexTypes.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexTypes.java
@@ -69,6 +69,7 @@ public class IndexTypes {
      * @deprecated use {@link #MIN_EVER_LONG} for compatibility with existing data or {@link #MIN_EVER_TUPLE} for more flexibility
      */
     @Deprecated
+    // Deprecated for new usage, but this can't really be removed because old meta-data might include it.
     public static final String MIN_EVER = FunctionNames.MIN_EVER;
 
     /**
@@ -76,6 +77,7 @@ public class IndexTypes {
      * @deprecated use {@link #MAX_EVER_LONG} for compatibility with existing data or {@link #MAX_EVER_TUPLE} for more flexibility
      */
     @Deprecated
+    // Deprecated for new usage, but this can't really be removed because old meta-data might include it.
     public static final String MAX_EVER = FunctionNames.MAX_EVER;
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.util.MapUtils;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -323,21 +322,6 @@ public class StoreTimer {
          * @param storeTimer the time from which to draw the values that are necessary to compute this aggregate
          * @param events the events that are to be aggregated into the resulting {@code Counteer}
          * @return the computed result or null if none of the value that comprise this aggregate were available
-         * @deprecated use {@link #compute(StoreTimer, Set)} instead
-         */
-        @Nullable
-        @Deprecated
-        @API(API.Status.DEPRECATED)
-        default Counter compute(@Nonnull StoreTimer storeTimer, @Nonnull Event...events) {
-            return compute(storeTimer, ImmutableSet.copyOf(events));
-        }
-
-        /**
-         * Compute the value for this aggregate.
-         *
-         * @param storeTimer the time from which to draw the values that are necessary to compute this aggregate
-         * @param events the events that are to be aggregated into the resulting {@code Counteer}
-         * @return the computed result or null if none of the value that comprise this aggregate were available
          */
         @Nullable
         default Counter compute(@Nonnull StoreTimer storeTimer, @Nonnull Set<? extends Event> events) {
@@ -531,19 +515,6 @@ public class StoreTimer {
      */
     public void record(Event event, long timeDifferenceNanos) {
         getCounter(event, true).record(timeDifferenceNanos);
-    }
-
-    /**
-     * Deprecated. Record that an event occurred once. Users should use
-     * {@link #increment(Count)} instead.
-     *
-     * @param event the event being recorded
-     *
-     * @deprecated replaced with {@link #increment(Count)}
-     */
-    @Deprecated
-    public void record(@Nonnull Count event) {
-        increment(event);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -604,20 +604,6 @@ public class FDBDatabase {
         return resolverStateCache.orElseGet(resolver, loader);
     }
 
-    /**
-     * Get the read version (GRV) for the given context.
-     * An explicit get read version is no more expensive than the implicit one that every operation will entail.
-     * Measuring it explicitly gives an indication of the cluster's GRV latency, which is driven by its rate keeping.
-     * @param context transaction to use to access the database
-     * @return a future that will be completed with the read version of the current transaction
-     * @deprecated use {@link FDBRecordContext#getReadVersionAsync()} instead
-     */
-    @Deprecated
-    @Nonnull
-    public CompletableFuture<Long> getReadVersion(@Nonnull FDBRecordContext context) {
-        return context.getReadVersionAsync();
-    }
-
     // Update lastSeenFDBVersion if readVersion is newer
     @API(API.Status.INTERNAL)
     public void updateLastSeenFDBVersion(long startTime, long readVersion) {
@@ -743,26 +729,6 @@ public class FDBDatabase {
 
     protected Executor newContextExecutor(@Nullable Map<String, String> mdcContext) {
         return factory.newContextExecutor(mdcContext);
-    }
-
-    /**
-     * Creates a new transaction against the database.
-     *
-     * @param executor the executor to be used for asynchronous operations
-     * @param mdcContext if not [@code null} and tracing is enabled, information in the context will be included
-     *      in tracing log messages
-     * @param transactionIsTraced unused
-     * @return newly created transaction
-     * @deprecated use {@link #openContext()} instead
-     */
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    public Transaction createTransaction(Executor executor, @Nullable Map<String, String> mdcContext, boolean transactionIsTraced) {
-        return createTransaction(
-                FDBRecordContextConfig.newBuilder()
-                        .setMdcContext(mdcContext)
-                        .build(),
-                executor);
     }
 
     /**
@@ -1303,11 +1269,6 @@ public class FDBDatabase {
 
         // Whether the transaction should be set with a causal read risky flag.
         private boolean isCausalReadRisky;
-
-        @Deprecated
-        public WeakReadSemantics(long minVersion, long stalenessBoundMillis) {
-            this(minVersion, stalenessBoundMillis, false);
-        }
 
         public WeakReadSemantics(long minVersion, long stalenessBoundMillis, boolean isCausalReadRisky) {
             this.minVersion = minVersion;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRecord.java
@@ -47,21 +47,6 @@ public class FDBIndexedRecord<M extends Message> implements FDBRecord<M>, FDBSto
     private final FDBStoredRecord<M> storedRecord;
 
     /**
-     * Wrap a stored record with an index entry that pointed to it.
-     *
-     * @param index the index that this record originated from
-     * @param indexEntry the index entry that produced this record
-     * @param storedRecord the {@link FDBStoredRecord} containing the record's data
-     * @deprecated use {@link FDBIndexedRecord#FDBIndexedRecord(IndexEntry, FDBStoredRecord)} instead
-     */
-    @API(API.Status.DEPRECATED)
-    @Deprecated
-    public FDBIndexedRecord(@Nonnull Index index, @Nonnull IndexEntry indexEntry, @Nullable FDBStoredRecord<M> storedRecord) {
-        this(indexEntry, storedRecord);
-        indexEntry.validateInIndex(index);
-    }
-
-    /**
      * Wrap a stored record with an index entry that pointed to it. This method is internal, and it generally
      * should not be called be external clients.
      *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -900,23 +900,6 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Run all of the after commit hooks.
-     *
-     * @deprecated this method probably should never have been public
-     */
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    public void runAfterCommits() {
-        synchronized (postCommits) {
-            @Nullable
-            AfterCommitPostCommit adapter = (AfterCommitPostCommit) postCommits.get(AFTER_COMMIT_HOOK_NAME);
-            if (adapter != null) {
-                adapter.run();
-            }
-        }
-    }
-
-    /**
      * Return the eight byte version assigned to this context at commit time. This version is
      * used internally by the database to determine which transactions should be visible
      * by which reads. (In other words, only transactions assigned a read version greater than
@@ -1180,24 +1163,6 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @Nonnull
     Optional<Integer> getLocalVersion(@Nonnull byte[] recordVersionKey) {
         return Optional.ofNullable(localVersionCache.get(recordVersionKey));
-    }
-
-    /**
-     * Add a {@link MutationType#SET_VERSIONSTAMPED_KEY SET_VERSIONSTAMPED_KEY}
-     * mutation to be run at commit time. This method is deprecated in favor of
-     * {@link #addVersionMutation(MutationType, byte[], byte[])} which
-     * behaves like this method except that the choice of <code>SET_VERSIONSTAMPED_KEY</code>
-     * as the mutation type must be made explicitly.
-     *
-     * @param key key bytes for the mutation
-     * @param value parameter bytes for the mutation
-     * @return the previous value set for the given key or <code>null</code> if unset
-     * @deprecated use #addVersionMutation(MutationType, byte[], byte[]) instead
-     */
-    @Deprecated
-    @Nullable
-    public byte[] addVersionMutation(@Nonnull byte[] key, @Nonnull byte[] value) {
-        return addVersionMutation(MutationType.SET_VERSIONSTAMPED_KEY, key, value);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -68,7 +68,6 @@ import com.apple.foundationdb.record.metadata.IndexRecordFunction;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.RecordTypeOrBuilder;
 import com.apple.foundationdb.record.metadata.StoreRecordFunction;
@@ -3677,16 +3676,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 return true;
             }
         }
-    }
-
-    /**
-     * Validate the current meta-data for this store.
-     * @deprecated validation is done by {@link com.apple.foundationdb.record.RecordMetaDataBuilder}
-     */
-    @Deprecated
-    public void validateMetaData() {
-        final MetaDataValidator validator = new MetaDataValidator(metaDataProvider, indexMaintainerRegistry);
-        validator.validate();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreBase.java
@@ -138,17 +138,6 @@ public abstract class FDBStoreBase {
     }
 
     /**
-     * Deprecated. Users should use {@link #increment(StoreTimer.Count)} instead.
-     *
-     * @param count the event being recorded
-     * @deprecated use {@link #increment(StoreTimer.Count)} instead
-     */
-    @Deprecated
-    public void record(@Nonnull StoreTimer.Count count) {
-        context.record(count);
-    }
-
-    /**
      * Record the amount of time an event took to run.
      *
      * @param event the event being recorded

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -116,12 +116,6 @@ public class FDBStoreTimer extends StoreTimer {
          * This time includes fetching from the database and deserialization.
          */
         LOAD_RECORD("load record"),
-        /**
-         * The amount of time taken loading record versions.
-         * @deprecated this is no longer published
-         */
-        @Deprecated
-        LOAD_RECORD_VERSION("load record version"),
         /** The amount of time taken scanning records directly without any index. */
         SCAN_RECORDS("scan records"),
         /**
@@ -175,12 +169,6 @@ public class FDBStoreTimer extends StoreTimer {
         INTERNING_LAYER_CREATE("create the value in the interning layer"),
         /** The amount of time spent loading boundary keys. */
         LOAD_BOUNDARY_KEYS("load boundary keys"),
-        /**
-         * The amount of time spent computing boundary keys.
-         * @deprecated this is no longer used
-         */
-        @Deprecated
-        COMPUTE_BOUNDARY_KEYS("compute boundary keys"),
         /** The amount of time spent reading a sample key to measure read latency. */
         READ_SAMPLE_KEY("read sample key"),
         /** The amount of time spent planning a query. */
@@ -311,7 +299,7 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_ERROR_CHECK("check for error completion"),
         /** Wait for performing a no-op operation.*/
         WAIT_PERFORM_NO_OP("wait for performing a no-op"),
-        /** Wait for explicit call to {@link FDBDatabase#getReadVersion}. */
+        /** Wait for explicit call to {@link FDBRecordContext#getReadVersionAsync}. */
         WAIT_GET_READ_VERSION("get_read_version"),
         /** Wait for a transaction to commit. */
         WAIT_COMMIT("wait for commit"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
@@ -116,19 +116,6 @@ public class FDBTransactionContext {
     }
 
     /**
-     * Deprecated. Users should use {@link #increment(StoreTimer.Count)} instead.
-     *
-     * @param count the count to record an occurrence of
-     * @deprecated use {@link #increment(StoreTimer.Count)} instead
-     */
-    @Deprecated
-    public void record(@Nonnull StoreTimer.Count count) {
-        if (timer != null) {
-            timer.record(count);
-        }
-    }
-
-    /**
      * Record the amount of time an event took to run.
      *
      * @param event the event being recorded

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -656,22 +656,6 @@ public class OnlineIndexer implements AutoCloseable {
     }
 
     /**
-     * Wait for an index build to complete. This method has been deprecated in favor
-     * of {@link #asyncToSync(StoreTimer.Wait, CompletableFuture)} which gives the user more
-     * control over which {@link StoreTimer.Wait} to instrument.
-     *
-     * @param buildIndexFuture a task to build an index
-     * @param <T> the return type of the asynchronous task
-     * @return the result of {@code buildIndexFuture} when it completes
-     * @deprecated in favor of {@link #asyncToSync(StoreTimer.Wait, CompletableFuture)}
-     */
-    @API(API.Status.DEPRECATED)
-    @Deprecated
-    public <T> T asyncToSync(@Nonnull CompletableFuture<T> buildIndexFuture) {
-        return asyncToSync(FDBStoreTimer.Waits.WAIT_ONLINE_BUILD_INDEX, buildIndexFuture);
-    }
-
-    /**
      * Wait for an asynchronous task to complete. This returns the result from the future or propagates
      * the error if the future completes exceptionally.
      *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/InvalidIndexEntry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/InvalidIndexEntry.java
@@ -43,19 +43,6 @@ public class InvalidIndexEntry {
     @Nullable
     private FDBStoredRecord<Message> record;
 
-    /**
-     * Construct an invalid index entry including the entry and the reason why it is invalid.
-     * @param entry the invalid index entry
-     * @param reason the reason why this entry is invalid
-     * @deprecated in favor of {@link #newOrphan(IndexEntry)} or {@link #newMissing(IndexEntry, FDBStoredRecord)}
-     */
-    @API(API.Status.DEPRECATED)
-    @Deprecated
-    public InvalidIndexEntry(@Nonnull IndexEntry entry, @Nonnull Reason reason) {
-        this.entry = entry;
-        this.reason = reason;
-    }
-
     private InvalidIndexEntry(@Nonnull IndexEntry entry, @Nonnull Reason reason, @Nullable FDBStoredRecord<Message> record) {
         this.entry = entry;
         this.reason = reason;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayer.java
@@ -68,21 +68,6 @@ public class ExtendedDirectoryLayer extends LocatableResolver {
     /**
      * Create an extended directory layer.
      *
-     * @param context the context that will be used to resolve the provided path into the subspace at which
-     *   the directory layer will be created. This context is only used during the construction of the
-     *   this class is not subsequently used
-     * @param path the path at which the directory layer should store its mappings.
-     * @deprecated use {@link #ExtendedDirectoryLayer(FDBDatabase, ResolvedKeySpacePath)} instead
-     */
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    public ExtendedDirectoryLayer(@Nonnull FDBRecordContext context, @Nonnull KeySpacePath path) {
-        this(context.getDatabase(), path, path.toResolvedPathAsync(context));
-    }
-
-    /**
-     * Create an extended directory layer.
-     *
      * @param database database that will be used when resolving values
      * @param path the path at which the directory layer should store its mappings.
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -664,21 +664,6 @@ public abstract class LocatableResolver {
     protected abstract CompletableFuture<Subspace> getStateSubspaceAsync();
 
     /**
-     * The {@link Subspace} where this resolver stores the mappings from <code>key</code> {@link String}s to
-     * <code>value</code> {@link Long}. Direct access to this subspace is not needed by general users and extreme care
-     * should be taken when interacting with it.
-     * @deprecated blocks until the mapping subspace is fetched from the database, instead use
-     * {@link #getMappingSubspaceAsync()}
-     * @return the mapping subspace
-     */
-    @Nonnull
-    @API(API.Status.DEPRECATED)
-    @Deprecated
-    public Subspace getMappingSubspace() {
-        return database.join(getMappingSubspaceAsync());
-    }
-
-    /**
      * Get a {@link CompletableFuture} that will contain the {@link Subspace} where this resolver stores
      * the mappings from <code>key</code> {@link String}s to <code>value</code> {@link Long}. Direct access
      * to this subspace is not needed by general users and extreme care should be taken when interacting with it.
@@ -686,22 +671,6 @@ public abstract class LocatableResolver {
      */
     @Nonnull
     public abstract CompletableFuture<Subspace> getMappingSubspaceAsync();
-
-    /**
-     * Get the {@link Subspace} that this resolver is rooted at (e.g. the global resolver
-     * {@link ExtendedDirectoryLayer#global(FDBDatabase)} has a base subspace at the root of the FDB keyspace.
-     * Note that this is not the subspace where the resolver maintains its allocation keys
-     * (see {@link #getMappingSubspaceAsync()}).
-     * @deprecated blocks until the mapping subspace is fetched from the database, instead use
-     * {@link #getBaseSubspaceAsync()}
-     * @return the base subspace
-     */
-    @Nonnull
-    @API(API.Status.DEPRECATED)
-    @Deprecated
-    public Subspace getBaseSubspace() {
-        return database.join(getBaseSubspaceAsync());
-    }
 
     /**
      * Get a {@link CompletableFuture} that will contain the {@link Subspace} this resolver is rooted

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryToKeyMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryToKeyMatcher.java
@@ -208,20 +208,6 @@ public class QueryToKeyMatcher {
         return matches(rootQuery, expression, MatchingMode.SATISFY_QUERY, filterMask);
     }
 
-    /**
-     * Attempt to match the expression to this matcher's root query and satisfy every filter.
-     * This has been deprecated in favor of {@link #matchesSatisfyingQuery(KeyExpression)}.
-     *
-     * @param expression the key expression to match the root query to
-     * @return a match if the entire expression is satisfied by this expression
-     * @deprecated use {@link #matchesSatisfyingQuery(KeyExpression)} instead
-     */
-    @Nonnull
-    @Deprecated
-    public Match matches(@Nonnull KeyExpression expression) {
-        return matchesSatisfyingQuery(expression);
-    }
-
     @Nonnull
     private Match matches(@Nonnull AndComponent query, @Nonnull KeyExpression key, @Nonnull MatchingMode matchingMode,
                           @Nullable FilterSatisfiedMask filterMask) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -84,40 +84,6 @@ public class RecordQueryIntersectionPlan implements RecordQueryPlanWithChildren,
 
     private final boolean reverse;
 
-    /**
-     * Construct a new intersection of two compatibly-ordered plans. This constructor has been deprecated in favor
-     * of the static initializer {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression)}.
-     *
-     * @param left the first plan to intersect
-     * @param right the second plan to intersect
-     * @param comparisonKey a key expression by which the results of both plans are ordered
-     * @param reverse whether both plans return results in reverse (i.e., descending) order by the comparison key
-     * @deprecated in favor of {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression)}
-     */
-    @Deprecated
-    public RecordQueryIntersectionPlan(@Nonnull RecordQueryPlan left, @Nonnull RecordQueryPlan right,
-                                       @Nonnull KeyExpression comparisonKey, boolean reverse) {
-        this(Quantifiers.fromPlans(ImmutableList.of(GroupExpressionRef.of(left), GroupExpressionRef.of(right))),
-                comparisonKey,
-                reverse,
-                false);
-    }
-
-    /**
-     * Construct a new intersection of two or more compatibly-ordered plans. This constructor has been deprecated in favor
-     * of the static initializer {@link #from(List, KeyExpression)}.
-     *
-     * @param plans the list of plans to take the intersection of
-     * @param comparisonKey a key expression by which the results of both plans are ordered
-     * @param reverse whether all plans return results in reverse (i.e., descending) order by the comparison key
-     * @deprecated in favor of {@link #from(List, KeyExpression)}
-     */
-    @Deprecated
-    public RecordQueryIntersectionPlan(@Nonnull List<RecordQueryPlan> plans,
-                                       @Nonnull KeyExpression comparisonKey, boolean reverse) {
-        this(Quantifiers.fromPlans(plans.stream().map(GroupExpressionRef::of).collect(Collectors.toList())), comparisonKey, reverse, false);
-    }
-
     @SuppressWarnings("PMD.UnusedFormalParameter")
     private RecordQueryIntersectionPlan(@Nonnull List<Quantifier.Physical> quantifiers,
                                         @Nonnull KeyExpression comparisonKey,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * A query plan that executes by taking the union of records from two or more compatibly-sorted child plans.
@@ -69,48 +68,6 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase implements Re
     @Nonnull
     private final KeyExpression comparisonKey;
     private final boolean showComparisonKey;
-
-    /**
-     * Construct a new union of two compatibly-ordered plans. This constructor has been deprecated in favor
-     * of the static initializer {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression, boolean)}.
-     *
-     * @param left the first plan to union
-     * @param right the second plan to union
-     * @param comparisonKey a key expression by which the results of both plans are ordered
-     * @param reverse whether both plans return results in reverse (i.e., descending) order by the comparison key
-     * @param showComparisonKey whether the comparison key should be included in string representations of the plan
-     * @deprecated in favor of {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression, boolean)}
-     */
-    @Deprecated
-    public RecordQueryUnionPlan(@Nonnull final RecordQueryPlan left,
-                                @Nonnull final RecordQueryPlan right,
-                                @Nonnull final KeyExpression comparisonKey,
-                                final boolean reverse,
-                                final boolean showComparisonKey) {
-        this(ImmutableList.of(left, right), comparisonKey, reverse, showComparisonKey);
-    }
-
-    /**
-     * Construct a union of two or more compatibly-ordered plans. This constructor has been deprecated in favor
-     * of the static initializer {@link #from(List, KeyExpression, boolean)}.
-     *
-     * @param children the list of compatibly-ordered plans to take the union of
-     * @param comparisonKey a key expression by which the results of all plans are ordered
-     * @param reverse whether all plans return results in reverse (i.e., descending) order by the comparison key
-     * @param showComparisonKey whether the comparison key should be included in string representations of the plan
-     * @deprecated in favor of {@link #from(RecordQueryPlan, RecordQueryPlan, KeyExpression, boolean)}
-     */
-    @Deprecated
-    public RecordQueryUnionPlan(@Nonnull final List<RecordQueryPlan> children,
-                                @Nonnull final KeyExpression comparisonKey,
-                                final boolean reverse,
-                                final boolean showComparisonKey) {
-        this(Quantifiers.fromPlans(children.stream().map(GroupExpressionRef::of).collect(Collectors.toList())),
-                comparisonKey,
-                reverse,
-                showComparisonKey,
-                false);
-    }
 
     @SuppressWarnings("PMD.UnusedFormalParameter")
     private RecordQueryUnionPlan(@Nonnull final List<Quantifier.Physical> quantifiers,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataProtoTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataProtoTest.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TestRecords2Proto;
-import com.apple.foundationdb.record.TestRecords3Proto;
 import com.apple.foundationdb.record.TestRecords4Proto;
 import com.apple.foundationdb.record.TestRecords5Proto;
 import com.apple.foundationdb.record.TestRecords6Proto;
@@ -236,53 +235,6 @@ public class MetaDataProtoTest {
             RecordMetaData metaDataRedone = builder.setRecords(metaData.toProto()).getRecordMetaData();
             verifyEquals(metaData, metaDataRedone);
         }
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    public void metadataProtoComplex() throws KeyExpression.DeserializationException, KeyExpression.SerializationException {
-        RecordMetaDataBuilder metaDataBuilder = new RecordMetaDataBuilder(TestRecords3Proto.getDescriptor());
-        metaDataBuilder.getOnlyRecordType().setPrimaryKey(Key.Expressions.concatenateFields("parent_path", "child_name"));
-        metaDataBuilder.addIndex("MyHierarchicalRecord", new Index("MHR$child$parentpath", Key.Expressions.concatenateFields("child_name", "parent_path"), IndexTypes.VALUE));
-        RecordMetaData metaData = metaDataBuilder.getRecordMetaData();
-        RecordMetaData metaDataRedone = RecordMetaData.newBuilder()
-                .addDependencies(BASE_DEPENDENCIES)
-                .setRecords(metaData.toProto())
-                .getRecordMetaData();
-        verifyEquals(metaData, metaDataRedone);
-
-        metaDataBuilder = new RecordMetaDataBuilder(TestRecords4Proto.getDescriptor());
-        metaDataBuilder.addIndex("RestaurantRecord", new Index("RR$ratings", Key.Expressions.field("reviews", KeyExpression.FanType.FanOut).nest("rating").ungrouped(), IndexTypes.RANK));
-        metaDataBuilder.removeIndex("RestaurantReviewer$name");
-        metaData = metaDataBuilder.getRecordMetaData();
-        metaDataRedone = RecordMetaData.newBuilder().addDependencies(BASE_DEPENDENCIES).setRecords(metaData.toProto()).getRecordMetaData();
-        assertEquals(1, metaData.getFormerIndexes().size());
-        assertFalse(metaData.isSplitLongRecords());
-        assertFalse(metaData.isStoreRecordVersions());
-        verifyEquals(metaData, metaDataRedone);
-
-        metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsMultiProto.getDescriptor());
-        metaDataBuilder.addMultiTypeIndex(Arrays.asList(
-                    metaDataBuilder.getRecordType("MultiRecordOne"),
-                    metaDataBuilder.getRecordType("MultiRecordTwo"),
-                    metaDataBuilder.getRecordType("MultiRecordThree")),
-                new Index("all$elements", Key.Expressions.field("element", KeyExpression.FanType.Concatenate),
-                        Index.EMPTY_VALUE, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
-        metaDataBuilder.addMultiTypeIndex(Arrays.asList(
-                    metaDataBuilder.getRecordType("MultiRecordTwo"),
-                    metaDataBuilder.getRecordType("MultiRecordThree")),
-                new Index("two&three$ego", Key.Expressions.field("ego"), Index.EMPTY_VALUE, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
-        metaDataBuilder.addIndex("MultiRecordOne", new Index("one$name", Key.Expressions.field("name"), IndexTypes.VALUE));
-        metaDataBuilder.setRecordCountKey(Key.Expressions.field("blah"));
-        metaDataBuilder.removeIndex("one$name");
-        metaDataBuilder.setStoreRecordVersions(true);
-        metaData = metaDataBuilder.getRecordMetaData();
-        assertEquals(2, metaData.getAllIndexes().size());
-        assertEquals(1, metaData.getFormerIndexes().size());
-        assertTrue(metaData.isSplitLongRecords());
-        assertTrue(metaData.isStoreRecordVersions());
-        metaDataRedone = RecordMetaData.newBuilder().addDependencies(BASE_DEPENDENCIES).setRecords(metaData.toProto()).getRecordMetaData();
-        verifyEquals(metaData, metaDataRedone);
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -27,13 +27,11 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.CloseableAsyncIterator;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
-import com.apple.foundationdb.record.ExecuteState;
 import com.apple.foundationdb.record.FunctionNames;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.IsolationLevel;
-import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
@@ -108,7 +106,6 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenate
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.indexEntryKey;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -2483,40 +2480,6 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             // The number of scans is about the number of index entries (orphan validation) plus the number of records
             // (missing validation).
             assertThat(generatorCount.get(), greaterThanOrEqualTo((5 + 10) / 4));
-        }
-    }
-
-    @SuppressWarnings("deprecation") // testing deprecated method
-    @Test
-    public void loadEntryFromWrongIndex() throws Exception {
-        try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
-            Index strValueIndex = recordStore.getRecordMetaData().getIndex("MySimpleRecord$str_value_indexed");
-            IndexEntry entry = new IndexEntry(strValueIndex, Tuple.from("bar", 1066L), TupleHelpers.EMPTY);
-            Index numValue3Index = recordStore.getRecordMetaData().getIndex("MySimpleRecord$num_value_3_indexed");
-            RecordCoreArgumentException e = assertThrows(RecordCoreArgumentException.class, () ->
-                    context.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_RECORD, recordStore.loadIndexEntryRecord(numValue3Index, entry, IndexOrphanBehavior.SKIP))
-            );
-            assertThat(e.getMessage(), containsString("index entry's index MySimpleRecord$str_value_indexed differs from specified index MySimpleRecord$num_value_3_indexed"));
-            e = assertThrows(RecordCoreArgumentException.class, () ->
-                    context.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_RECORD, recordStore.loadIndexEntryRecord(numValue3Index, entry, IndexOrphanBehavior.SKIP, ExecuteState.NO_LIMITS))
-            );
-            assertThat(e.getMessage(), containsString("index entry's index MySimpleRecord$str_value_indexed differs from specified index MySimpleRecord$num_value_3_indexed"));
-        }
-    }
-
-    @SuppressWarnings("deprecation") // testing deprecated method
-    @Test
-    public void hasEntryFromWrongIndex() throws Exception {
-        try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context);
-            Index strValueIndex = recordStore.getRecordMetaData().getIndex("MySimpleRecord$str_value_indexed");
-            IndexEntry entry = new IndexEntry(strValueIndex, Tuple.from("bar", 1066L), TupleHelpers.EMPTY);
-            Index numValue3Index = recordStore.getRecordMetaData().getIndex("MySimpleRecord$num_value_3_indexed");
-            RecordCoreArgumentException e = assertThrows(RecordCoreArgumentException.class, () ->
-                    context.asyncToSync(FDBStoreTimer.Waits.WAIT_RECORD_EXISTS, recordStore.hasIndexEntryRecord(numValue3Index, entry, IsolationLevel.SERIALIZABLE))
-            );
-            assertThat(e.getMessage(), containsString("index entry's index MySimpleRecord$str_value_indexed differs from specified index MySimpleRecord$num_value_3_indexed"));
         }
     }
 


### PR DESCRIPTION
What remains:
* `RecordCursor`, `OrElseCursor` methods (#1189)
* `KeySpace`, `KeySpacePath`, `KeySpacePathImpl`, `KeySpacePathWrapper`, `ScopedDirectoryLayer`, `ScopedInterningLayer`, all around resolved / unresolved paths, which all present challenges in straightforward conversion.
* Override of `@Deprecated` methods from dependencies.
* Some meta-data items, that are deprecated in new code, but may still be present in serialized form and so need to be supported.