### PR TITLE
Update Spotbugs Gradle plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,18 +34,17 @@ buildscript {
         classpath 'de.undercouch:gradle-download-task:4.1.1'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.15'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
-        //classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.9'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 
 plugins {
-    id 'com.github.spotbugs' version '1.6.9'
+    id 'com.github.spotbugs' version '4.6.1'
     id 'org.sonarqube' version '2.6'
 }
 
 ext {
-    SpotBugsTask = com.github.spotbugs.SpotBugsTask
+    SpotBugsTask = com.github.spotbugs.snom.SpotBugsTask
 }
 
 defaultTasks 'build'

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/IdentityBiMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/IdentityBiMap.java
@@ -45,6 +45,7 @@ import java.util.stream.Collector;
  * @param <K> key type
  * @param <V> value type
  */
+@SpotBugsSuppressWarnings("NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION")
 public class IdentityBiMap<K, V> implements BiMap<Wrapper<K>, Wrapper<V>> {
 
     private static final Equivalence<Object> identity = Equivalence.identity();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/MatchInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/MatchInfo.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.temp;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.google.common.base.Equivalence;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -120,6 +121,7 @@ public class MatchInfo {
         return accumulatedPredicateMapSupplier.get();
     }
 
+    @SpotBugsSuppressWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private void collectPredicateMappings(@Nonnull PredicateMap.Builder targetBuilder) {
         targetBuilder.putAll(predicateMap);
 

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -69,12 +69,13 @@ quickCheck.dependsOn checkstyleMandatory
 apply plugin: 'com.github.spotbugs'
 
 spotbugs {
-    toolVersion = '3.1.7'
+//  toolVersion = '4.2.1'
     ignoreFailures = false
     effort = 'max'
-    sourceSets = [sourceSets.main]
     excludeFilter = rootProject.file('gradle/codequality/spotbugs_exclude.xml')
 }
+
+spotbugsTest.enabled = false
 
 def spotbugsFailed = false
 
@@ -87,7 +88,6 @@ def printInstructionsOnRunningWithHtmlOutput = task('printInstructionsOnRunningW
 }
 
 tasks.withType(rootProject.SpotBugsTask) { task ->
-    task.exclude '**/protogen/**'
     if (project.hasProperty('spotbugsEnableHtmlReport')) {
         // SpotBugs task can only have one report type enabled at a time
         reports {
@@ -100,14 +100,6 @@ tasks.withType(rootProject.SpotBugsTask) { task ->
 
     task.doFirst {
         spotbugsFailed = true
-        def  ft = task.classes
-        if (task.classes == null) {
-            return
-        }
-        task.classes = files(ft.files).filter {
-          !(it.path.contains('Proto$')
-            || it.path.contains('Proto.class'))
-        }
     }
     task.doLast {
         spotbugsFailed = false

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -69,7 +69,7 @@ quickCheck.dependsOn checkstyleMandatory
 apply plugin: 'com.github.spotbugs'
 
 spotbugs {
-//  toolVersion = '4.2.1'
+//  toolVersion = '4.2.1' // (current default with plugin 4.6.1)
     ignoreFailures = false
     effort = 'max'
     excludeFilter = rootProject.file('gradle/codequality/spotbugs_exclude.xml')

--- a/gradle/codequality/spotbugs_exclude.xml
+++ b/gradle/codequality/spotbugs_exclude.xml
@@ -3,6 +3,6 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
     <Match>
-        <Class name="~.*Proto\$.*" />
+        <Source name="~.*/protogen/.*" />
     </Match>
 </FindBugsFilter>


### PR DESCRIPTION
This is less straightforward than the previous branch, due to some incompatible changes. Hence the separate PR.

* The package of the task has changed.
* `excludes` and `sourceSets` are gone.

It is simpler to disable running against the `test` configuration with `spotbugsTest.enabled = false`.

Previously, Protobuf generated files were excluded in three ways:
1. `task.exclude`, which doesn't exist any more.
2. A filter on `task.classes`, which isn't really needed.
3. An `excludeFilter` file, which does everything we need.

The Protobuf exclusions are still needed because:
* `SE_BAD_FIELD`: `Class x defines non-transient non-serializable instance field unknownFields`
* `MS_SHOULD_BE_FINAL`: `PARSER isn't final but should be`
* `UCF_USELESS_CONTROL_FLOW`: `Useless control flow in maybeForceBuilderInitialization()`

There are also two new warnings about nullity from `IdentityBiMap`, which are just ignored.