### PR TITLE
Resolves #1214 and #1212: TreeLike for Values and QueryPredicates as …

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/EmptyKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/EmptyKeyExpression.java
@@ -26,8 +26,6 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
@@ -83,7 +81,7 @@ public class EmptyKeyExpression extends BaseKeyExpression implements KeyExpressi
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -29,8 +29,6 @@ import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.query.plan.temp.Quantifier;
@@ -211,7 +209,7 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
@@ -28,8 +28,6 @@ import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
@@ -250,7 +248,7 @@ public abstract class FunctionKeyExpression extends BaseKeyExpression implements
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupingKeyExpression.java
@@ -26,8 +26,6 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
@@ -118,7 +116,7 @@ public class GroupingKeyExpression extends BaseKeyExpression implements KeyExpre
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -213,7 +213,8 @@ public interface KeyExpression extends PlanHashable, QueryHashable {
      * ({@link com.apple.foundationdb.record.query.plan.temp.RelationalExpression}s). Note that implementors should
      * defer to the visitation methods in the supplied visitor rather than encoding actual logic in an overriding
      * method.
-     * @param <S> a type that reflects the state that {@code visitor} uses
+     * @param <S> a type that represents the state that {@code visitor} uses
+     * @param <R> a type that represents the result the {@code visitor} returns
      * @param visitor a {@link ExpansionVisitor} that is created by the caller from a data structure that reflects the
      *        specific semantics of the key expression. Normally this visitor is directly created based on an index.
      * @return a new {@link GraphExpansion} representing the query graph equivalent of this key expression using the
@@ -222,7 +223,7 @@ public interface KeyExpression extends PlanHashable, QueryHashable {
      */
     @API(API.Status.EXPERIMENTAL)
     @Nonnull
-    <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull ExpansionVisitor<S> visitor);
+    <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull KeyExpressionVisitor<S, R> visitor);
 
     /**
      * Return the key fields for an expression.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpressionWithValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpressionWithValue.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.record.metadata.expressions;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.query.predicates.Value;
 
@@ -45,7 +43,7 @@ public interface KeyExpressionWithValue extends KeyExpression {
 
     @Nonnull
     @Override
-    default <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    default <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
@@ -26,8 +26,6 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
@@ -145,7 +143,7 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ListKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ListKeyExpression.java
@@ -26,10 +26,8 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.util.HashUtils;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
+import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
@@ -157,7 +155,7 @@ public class ListKeyExpression extends BaseKeyExpression implements KeyExpressio
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
@@ -26,10 +26,8 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.util.HashUtils;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
+import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
@@ -125,7 +123,7 @@ public class NestingKeyExpression extends BaseKeyExpression implements KeyExpres
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SplitKeyExpression.java
@@ -27,8 +27,6 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
@@ -128,7 +126,7 @@ public class SplitKeyExpression extends BaseKeyExpression implements AtomKeyExpr
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final  ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
@@ -27,10 +27,8 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
-import com.apple.foundationdb.record.util.HashUtils;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
+import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
@@ -189,7 +187,7 @@ public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressio
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/EmptyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/EmptyComparison.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.predicates.FieldValue;
+import com.apple.foundationdb.record.query.predicates.QuantifiedColumnValue;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -87,7 +88,7 @@ public class EmptyComparison extends BaseRepeatedField implements ComponentWithN
                 .addAll(fieldNamePrefix)
                 .add(getFieldName())
                 .build();
-        return GraphExpansion.ofPredicate(new FieldValue(baseAlias, fieldNames).withComparison(Comparisons.LIST_EMPTY));
+        return GraphExpansion.ofPredicate(new FieldValue(QuantifiedColumnValue.of(baseAlias, 0), fieldNames).withComparison(Comparisons.LIST_EMPTY));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/FieldWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/FieldWithComparison.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.predicates.FieldValue;
+import com.apple.foundationdb.record.query.predicates.QuantifiedColumnValue;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -101,7 +102,7 @@ public class FieldWithComparison extends BaseField implements ComponentWithCompa
                 .addAll(fieldNamePrefix)
                 .add(getFieldName())
                 .build();
-        return GraphExpansion.ofPredicate(new FieldValue(baseAlias, fieldNames).withComparison(comparison));
+        return GraphExpansion.ofPredicate(new FieldValue(QuantifiedColumnValue.of(baseAlias, 0), fieldNames).withComparison(comparison));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/AvailableFields.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/AvailableFields.java
@@ -209,6 +209,15 @@ public class AvailableFields {
         }
 
         @Nonnull
+        public IndexKeyValueToPartialRecord.TupleSource getSource() {
+            return source;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        @Nonnull
         public static FieldData of(@Nonnull IndexKeyValueToPartialRecord.TupleSource source, int index) {
             return new FieldData(source, index);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -1362,7 +1362,7 @@ public class RecordQueryPlanner implements QueryPlanner {
         if (allHaveSameBasePlan) {
             final RecordQueryPlan combinedOrFilter = new RecordQueryFilterPlan(commonFilteredBasePlan,
                     new OrComponent(subplans.stream()
-                            .map(subplan -> ((RecordQueryFilterPlan)subplan.plan).getFilter())
+                            .map(subplan -> ((RecordQueryFilterPlan)subplan.plan).getConjunctedFilter())
                             .collect(Collectors.toList())));
             ScoredPlan firstSubPlan = subplans.get(0);
             return new ScoredPlan(combinedOrFilter, Collections.emptyList(), Collections.emptyList(), firstSubPlan.score,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
@@ -40,7 +40,10 @@ import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -185,6 +188,12 @@ public class ComposedBitmapIndexQueryPlan implements RecordQueryPlanWithNoChildr
         return new ComposedBitmapIndexQueryPlan(indexPlans.stream().map(i -> i.rebase(translationMap)).collect(Collectors.toList()), composer);
     }
 
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
+    }
+    
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression other, @Nonnull AliasMap equivalences) {
         if (this == other) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -43,6 +43,8 @@ import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.IndexedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -174,6 +176,12 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
 
     @Nonnull
     @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new IndexedValue());
+    }
+
+    @Nonnull
+    @Override
     public String toString() {
         return "Covering(" + indexPlan + " -> " + toRecord + ")";
     }
@@ -190,7 +198,6 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
         return new RecordQueryCoveringIndexPlan(indexPlan, recordTypeName, availableFields, toRecord);
     }
 
-    @Nonnull
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
@@ -31,14 +31,17 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexOrphanBehavior;
+import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
-import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.DerivedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -48,6 +51,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A query plan that transforms a stream of partial records (derived from index entries, as in the {@link RecordQueryCoveringIndexPlan})
@@ -59,6 +63,8 @@ public class RecordQueryFetchFromPartialRecordPlan implements RecordQueryPlanWit
 
     @Nonnull
     private final Quantifier.Physical inner;
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
 
     public RecordQueryFetchFromPartialRecordPlan(@Nonnull RecordQueryPlan inner) {
         this(Quantifier.physical(GroupExpressionRef.of(inner)));
@@ -66,6 +72,7 @@ public class RecordQueryFetchFromPartialRecordPlan implements RecordQueryPlanWit
 
     private RecordQueryFetchFromPartialRecordPlan(@Nonnull final Quantifier.Physical inner) {
         this.inner = inner;
+        this.resultValuesSupplier = Suppliers.memoize(() -> ImmutableList.of(new DerivedValue(inner.getFlowedValues())));
     }
 
     @Nonnull
@@ -76,13 +83,13 @@ public class RecordQueryFetchFromPartialRecordPlan implements RecordQueryPlanWit
                                                                          @Nonnull final ExecuteProperties executeProperties) {
         // Plan return exactly one (full) record for each (partial) record from inner, so we can preserve all limits.
         return store.fetchIndexRecords(getChild().execute(store, context, continuation, executeProperties)
-                        .map(FDBQueriedRecord::getIndexEntry), IndexOrphanBehavior.ERROR, executeProperties.getState())
+                .map(FDBQueriedRecord::getIndexEntry), IndexOrphanBehavior.ERROR, executeProperties.getState())
                 .map(store::queriedRecord);
     }
 
     @Nonnull
-    public RecordQueryPlan getInner() {
-        return inner.getRangesOverPlan();
+    public Quantifier.Physical getInner() {
+        return inner;
     }
 
     @Nonnull
@@ -134,6 +141,12 @@ public class RecordQueryFetchFromPartialRecordPlan implements RecordQueryPlanWit
     @Override
     public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
         return new RecordQueryFetchFromPartialRecordPlan(child);
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -43,6 +43,8 @@ import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -181,6 +183,12 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
     @Override
     public AvailableFields getAvailableFields() {
         return AvailableFields.ALL_FIELDS;
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -40,6 +40,8 @@ import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -159,6 +161,12 @@ public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren 
     @Override
     public RecordQueryLoadByKeysPlan rebase(@Nonnull final AliasMap translationMap) {
         return this;
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
@@ -1,5 +1,5 @@
 /*
- * RecordQueryPredicateFilterPlan.java
+ * RecordQueryPredicatesFilterPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -32,14 +32,19 @@ import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicates;
 import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.predicates.Value;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -48,21 +53,34 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 /**
  * A query plan that filters out records from a child plan that do not satisfy a {@link QueryPredicate}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class RecordQueryPredicateFilterPlan extends RecordQueryFilterPlanBase implements RelationalExpressionWithPredicate {
+public class RecordQueryPredicatesFilterPlan extends RecordQueryFilterPlanBase implements RelationalExpressionWithPredicates {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Record-Query-Predicate-Filter-Plan");
 
     @Nonnull
-    private final QueryPredicate filter;
+    private final List<QueryPredicate> predicates;
+    @Nonnull
+    private final QueryPredicate conjunctedPredicate;
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
 
-    public RecordQueryPredicateFilterPlan(@Nonnull Quantifier.Physical inner,
-                                          @Nonnull QueryPredicate filter) {
+    public RecordQueryPredicatesFilterPlan(@Nonnull Quantifier.Physical inner,
+                                           @Nonnull Iterable<? extends QueryPredicate> predicates) {
         super(inner);
-        this.filter = filter;
+        this.predicates = ImmutableList.copyOf(predicates);
+        this.conjunctedPredicate = AndPredicate.and(this.predicates);
+        this.resultValuesSupplier = Suppliers.memoize(inner::getFlowedValues);
+    }
+
+    @Nonnull
+    @Override
+    public List<QueryPredicate> getPredicates() {
+        return predicates;
     }
 
     @Override
@@ -78,19 +96,13 @@ public class RecordQueryPredicateFilterPlan extends RecordQueryFilterPlanBase im
         }
 
         final EvaluationContext nestedContext = context.withBinding(getInner().getAlias(), record.getRecord());
-        return filter.eval(store, nestedContext, record, record.getRecord());
+        return conjunctedPredicate.eval(store, nestedContext, record, record.getRecord());
     }
 
     @Nullable
     @Override
     protected <M extends Message> CompletableFuture<Boolean> evalFilterAsync(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context, @Nullable FDBRecord<M> record) {
         throw new UnsupportedOperationException();
-    }
-
-    @Nonnull
-    @Override
-    public QueryPredicate getPredicate() {
-        return filter;
     }
 
     @Nonnull
@@ -102,24 +114,33 @@ public class RecordQueryPredicateFilterPlan extends RecordQueryFilterPlanBase im
     @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
-        return filter.getCorrelatedTo();
+        return predicates.stream()
+                .flatMap(queryPredicate -> queryPredicate.getCorrelatedTo().stream())
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     @Nonnull
     @Override
-    public RecordQueryPredicateFilterPlan rebaseWithRebasedQuantifiers(@Nonnull final AliasMap translationMap,
-                                                                       @Nonnull final List<Quantifier> rebasedQuantifiers) {
-        return new RecordQueryPredicateFilterPlan(
+    public RecordQueryPredicatesFilterPlan rebaseWithRebasedQuantifiers(@Nonnull final AliasMap translationMap,
+                                                                        @Nonnull final List<Quantifier> rebasedQuantifiers) {
+        return new RecordQueryPredicatesFilterPlan(
                 Iterables.getOnlyElement(rebasedQuantifiers).narrow(Quantifier.Physical.class),
-                getPredicate().rebase(translationMap));
+                predicates.stream().map(queryPredicate -> queryPredicate.rebase(translationMap)).collect(ImmutableList.toImmutableList()));
     }
 
     @Nonnull
     @Override
     public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
-        return new RecordQueryPredicateFilterPlan(Quantifier.physical(GroupExpressionRef.of(child)), getPredicate());
+        return new RecordQueryPredicatesFilterPlan(Quantifier.physical(GroupExpressionRef.of(child)), getPredicates());
     }
 
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {
@@ -129,15 +150,21 @@ public class RecordQueryPredicateFilterPlan extends RecordQueryFilterPlanBase im
         if (getClass() != otherExpression.getClass()) {
             return false;
         }
-        final RecordQueryPredicateFilterPlan otherPlan = (RecordQueryPredicateFilterPlan)otherExpression;
-        return getInnerPlan().equals(otherPlan.getInnerPlan()) &&
-               filter.semanticEquals(otherPlan.getPredicate(), equivalencesMap);
+        final RecordQueryPredicatesFilterPlan otherPlan = (RecordQueryPredicatesFilterPlan)otherExpression;
+        final List<QueryPredicate> otherPredicates = otherPlan.getPredicates();
+        if (predicates.size() != otherPredicates.size()) {
+            return false;
+        }
+        return Streams.zip(this.predicates.stream(),
+                otherPredicates.stream(),
+                (queryPredicate, otherQueryPredicate) -> queryPredicate.semanticEquals(otherQueryPredicate, equivalencesMap))
+                .allMatch(isSame -> isSame);
     }
 
     @Nonnull
     @Override
     public String toString() {
-        return getInnerPlan() + " | " + getPredicate();
+        return getInnerPlan() + " | " + conjunctedPredicate;
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
@@ -153,18 +180,18 @@ public class RecordQueryPredicateFilterPlan extends RecordQueryFilterPlanBase im
 
     @Override
     public int hashCodeWithoutChildren() {
-        return Objects.hash(getPredicate());
+        return Objects.hash(conjunctedPredicate);
     }
 
     @Override
     public int planHash(@Nonnull final PlanHashKind hashKind) {
         switch (hashKind) {
             case LEGACY:
-                return getInnerPlan().planHash(hashKind) + getPredicate().planHash(hashKind);
+                return getInnerPlan().planHash(hashKind) + conjunctedPredicate.planHash(hashKind);
             case FOR_CONTINUATION:
             case STRUCTURAL_WITHOUT_LITERALS:
                 // Not using baseSource, since it uses Object.hashCode()
-                return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, getInnerPlan(), getPredicate());
+                return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, getInnerPlan(), conjunctedPredicate);
             default:
                 throw new UnsupportedOperationException("Hash kind " + hashKind.name() + " is not supported");
         }
@@ -177,7 +204,7 @@ public class RecordQueryPredicateFilterPlan extends RecordQueryFilterPlanBase im
                 new PlannerGraph.OperatorNodeWithInfo(this,
                         NodeInfo.PREDICATE_FILTER_OPERATOR,
                         ImmutableList.of("WHERE {{pred}}"),
-                        ImmutableMap.of("pred", Attribute.gml(getPredicate().toString()))),
+                        ImmutableMap.of("pred", Attribute.gml(conjunctedPredicate.toString()))),
                 childGraphs);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -41,6 +41,8 @@ import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -204,6 +206,12 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     @Override
     public RecordQueryScanPlan rebase(@Nonnull final AliasMap translationMap) {
         return new RecordQueryScanPlan(getRecordTypes(), getComparisons(), isReverse());
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -45,6 +45,8 @@ import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -140,6 +142,12 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
     @API(API.Status.EXPERIMENTAL)
     public List<? extends Quantifier> getQuantifiers() {
         return ImmutableList.of(inner);
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySetPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySetPlan.java
@@ -1,0 +1,69 @@
+/*
+ * RecordQuerySetPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.temp.ScalarTranslationVisitor;
+import com.apple.foundationdb.record.query.predicates.Value;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Interface for query plans that represent set-based operators such as union or intersection.
+ */
+public interface RecordQuerySetPlan extends RecordQueryPlan {
+    @Nonnull
+    Set<KeyExpression> getRequiredFields();
+
+    /**
+     * Method that returns a list of values that are required to be evaluable by this set-based plan operator. These
+     * values are evaluated by the plan operator during execution time and are usually comprised of values that e.g.
+     * establish equality between records. This method is declarative in nature and is called by the planner in order
+     * to evaluate optimized plan alternatives.
+     *
+     * @param baseAlias the base alias to use for all external references. This is the alias of the data stream
+     *        the values can be evaluated over.
+     * @return a list of values where each value is required to be evaluable by the set base operation
+     */
+    @Nonnull
+    default List<? extends Value> getRequiredValues(@Nonnull final CorrelationIdentifier baseAlias) {
+        return getRequiredFields()
+                .stream()
+                .map(keyExpression -> new ScalarTranslationVisitor(keyExpression).toResultValue(baseAlias))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Method to create a new set-based plan operator that mirrors the attributes of {@code this} except its children
+     * which are replaced with new children. It is the responsibility of the caller to ensure that the newly created plan
+     * operator is consistent with the new children. For instance, it is not advised to recreate this plan with a
+     * list of children of different size.
+     *
+     * @param newChildren a list of new children
+     * @return a new set-based plan
+     */
+    @Nonnull
+    RecordQuerySetPlan withChildren(@Nonnull final List<? extends RecordQueryPlan> newChildren);
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
@@ -39,6 +39,8 @@ import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -155,6 +157,12 @@ public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex, Recor
     @Override
     public RecordQueryTextIndexPlan rebase(@Nonnull final AliasMap translationMap) {
         return new RecordQueryTextIndexPlan(getIndexName(), getTextScan(), isReverse());
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
@@ -38,6 +38,8 @@ import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
+import com.apple.foundationdb.record.query.predicates.Value;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -52,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A query plan that filters out records from a child plan that are not of the designated record type(s).
@@ -66,6 +69,8 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
     private final Quantifier.Physical inner;
     @Nonnull
     private final Collection<String> recordTypes;
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
     @Nonnull
     private static final Set<StoreTimer.Count> inCounts = ImmutableSet.of(FDBStoreTimer.Counts.QUERY_FILTER_GIVEN, FDBStoreTimer.Counts.QUERY_TYPE_FILTER_PLAN_GIVEN);
     @Nonnull
@@ -82,6 +87,7 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
     public RecordQueryTypeFilterPlan(@Nonnull Quantifier.Physical inner, @Nonnull Collection<String> recordTypes) {
         this.inner = inner;
         this.recordTypes = recordTypes;
+        this.resultValuesSupplier = Suppliers.memoize(inner::getFlowedValues);
     }
 
     @Nonnull
@@ -134,6 +140,12 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
     @Override
     public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
         return new RecordQueryTypeFilterPlan(child, getRecordTypes());
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
  */
 @API(API.Status.INTERNAL)
 @SuppressWarnings({"squid:S1206", "squid:S2160", "PMD.OverrideBothEqualsAndHashcode"})
-public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase implements RecordQueryPlanWithRequiredFields {
+public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Record-Query-Union-Plan");
 
     public static final Logger LOGGER = LoggerFactory.getLogger(RecordQueryUnionPlan.class);
@@ -242,7 +242,7 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase implements Re
      * @return a new plan that will return the union of all results from all child plans
      */
     @Nonnull
-    public static RecordQueryUnionPlan from(@Nonnull List<RecordQueryPlan> children, @Nonnull KeyExpression comparisonKey,
+    public static RecordQueryUnionPlan from(@Nonnull List<? extends RecordQueryPlan> children, @Nonnull KeyExpression comparisonKey,
                                             boolean showComparisonKey) {
         if (children.size() < 2) {
             throw new RecordCoreArgumentException("fewer than two children given to union plan");
@@ -264,7 +264,7 @@ public class RecordQueryUnionPlan extends RecordQueryUnionPlanBase implements Re
 
     @Nonnull
     @Override
-    public RecordQueryUnionPlan withChildren(@Nonnull final List<RecordQueryPlan> newChildren) {
+    public RecordQueryUnionPlan withChildren(@Nonnull final List<? extends RecordQueryPlan> newChildren) {
         return RecordQueryUnionPlan.from(newChildren, comparisonKey, showComparisonKey);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
@@ -40,6 +40,8 @@ import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.Value;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -55,6 +57,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A query plan that removes duplicates by means of a hash table of previously seen values.
@@ -67,6 +70,8 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
 
     @Nonnull
     private final Quantifier.Physical inner;
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
     @Nonnull
     private final KeyExpression comparisonKey;
     @Nonnull
@@ -86,6 +91,7 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
                                              @Nonnull KeyExpression comparisonKey) {
         this.inner = inner;
         this.comparisonKey = comparisonKey;
+        this.resultValuesSupplier = Suppliers.memoize(inner::getFlowedValues);
     }
 
     @Nonnull
@@ -151,6 +157,12 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
     @Override
     public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
         return new RecordQueryUnorderedDistinctPlan(child, getComparisonKey());
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -37,7 +37,9 @@ import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -52,6 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A query plan that removes duplicates by means of a hash table of primary keys already seen.
@@ -64,6 +67,8 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
 
     @Nonnull
     private final Quantifier.Physical inner;
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
     @Nonnull
     private static final Set<StoreTimer.Event> duringEvents = Collections.singleton(FDBStoreTimer.Events.QUERY_PK_DISTINCT);
     @Nonnull
@@ -78,6 +83,7 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
 
     public RecordQueryUnorderedPrimaryKeyDistinctPlan(@Nonnull Quantifier.Physical inner) {
         this.inner = inner;
+        this.resultValuesSupplier = Suppliers.memoize(inner::getFlowedValues);
     }
 
     @Nonnull
@@ -137,6 +143,12 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
     @Override
     public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
         return new RecordQueryUnorderedPrimaryKeyDistinctPlan(child);
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedUnionPlan.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
@@ -89,7 +90,7 @@ public class RecordQueryUnorderedUnionPlan extends RecordQueryUnionPlanBase {
     }
 
     @Nonnull
-    public static RecordQueryUnorderedUnionPlan from(@Nonnull List<RecordQueryPlan> children) {
+    public static RecordQueryUnorderedUnionPlan from(@Nonnull List<? extends RecordQueryPlan> children) {
         final boolean reverse = children.get(0).isReverse();
         ImmutableList.Builder<ExpressionRef<RecordQueryPlan>> builder = ImmutableList.builder();
         for (RecordQueryPlan child : children) {
@@ -120,8 +121,14 @@ public class RecordQueryUnorderedUnionPlan extends RecordQueryUnionPlanBase {
 
     @Nonnull
     @Override
-    public RecordQueryUnorderedUnionPlan withChildren(@Nonnull final List<RecordQueryPlan> newChildren) {
+    public RecordQueryUnorderedUnionPlan withChildren(@Nonnull final List<? extends RecordQueryPlan> newChildren) {
         return from(newChildren);
+    }
+
+    @Nonnull
+    @Override
+    public Set<KeyExpression> getRequiredFields() {
+        return ImmutableSet.of();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Compensation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Compensation.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.record.query.plan.temp;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalFilterExpression;
 import com.apple.foundationdb.record.query.plan.temp.rules.DataAccessRule;
-import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -440,7 +439,7 @@ public interface Compensation extends Function<ExpressionRef<RelationalExpressio
          */
         @Override
         public RelationalExpression apply(ExpressionRef<RelationalExpression> reference) {
-            // apply the child is needed
+            // apply the child as needed
             if (childCompensation.isNeeded()) {
                 reference = GroupExpressionRef.of(childCompensation.apply(reference));
             }
@@ -455,7 +454,7 @@ public interface Compensation extends Function<ExpressionRef<RelationalExpressio
                         return queryPredicate.rebase(translationMap);
                     })
                     .collect(ImmutableList.toImmutableList());
-            return new LogicalFilterExpression(AndPredicate.and(rebasedPredicates), quantifier);
+            return new LogicalFilterExpression(rebasedPredicates, quantifier);
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/MatchCandidate.java
@@ -138,11 +138,12 @@ public interface MatchCandidate {
 
     /**
      * Creates a logical expression that represents a scan over the materialized candidate data.
-     * @param matchInfo the match info to be used
+     * @param partialMatch the match to be used
      * @return a new {@link RelationalExpression}
      */
     @SuppressWarnings("java:S135")
-    default RelationalExpression toScanExpression(@Nonnull final MatchInfo matchInfo) {
+    default RelationalExpression toEquivalentExpression(@Nonnull final PartialMatch partialMatch) {
+        final MatchInfo matchInfo = partialMatch.getMatchInfo();
         final Map<CorrelationIdentifier, ComparisonRange> prefixMap = computeBoundParameterPrefixMap(matchInfo);
 
         final ImmutableList.Builder<ComparisonRange> comparisonRangesForScanBuilder =
@@ -160,19 +161,20 @@ public interface MatchCandidate {
             comparisonRangesForScanBuilder.add(prefixMap.get(parameterAlias));
         }
 
-        return toScanExpression(comparisonRangesForScanBuilder.build(), matchInfo.isReverse());
+        return toEquivalentExpression(partialMatch, comparisonRangesForScanBuilder.build(), matchInfo.isReverse());
     }
 
     /**
      * Creates a logical expression that represents a scan over the materialized candidate data. This method is expected
      * to be implemented by specific implementations of {@link MatchCandidate}.
+     * @param partialMatch the {@link PartialMatch} that matched th query and the candidate
      * @param comparisonRanges a {@link List} of {@link ComparisonRange}s to be applied
      * @param isReverse an indicator whether this expression should conceptually flow data in an ascending (forward) or
      *        descending (backward or reverse) order
      * @return a new {@link RelationalExpression}
      */
     @Nonnull
-    RelationalExpression toScanExpression(@Nonnull final List<ComparisonRange> comparisonRanges, final boolean isReverse);
+    RelationalExpression toEquivalentExpression(@Nonnull PartialMatch partialMatch, @Nonnull final List<ComparisonRange> comparisonRanges, final boolean isReverse);
 
     @Nonnull
     default SetMultimap<ExpressionRef<? extends RelationalExpression>, RelationalExpression> findReferencingExpressions(@Nonnull final ImmutableList<? extends ExpressionRef<? extends RelationalExpression>> references) {
@@ -212,7 +214,7 @@ public interface MatchCandidate {
 
         if (type.equals(IndexTypes.VALUE)) {
             final Quantifier.ForEach baseQuantifier = createBaseQuantifier(availableRecordTypes, recordTypeNamesForIndex);
-            final ValueIndexExpansionVisitor expansionVisitor = new ValueIndexExpansionVisitor(index);
+            final ValueIndexExpansionVisitor expansionVisitor = new ValueIndexExpansionVisitor(index, recordTypesForIndex);
             return Optional.of(expansionVisitor.expand(baseQuantifier, commonPrimaryKeyForIndex, isReverse));
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PrimaryScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/PrimaryScanMatchCandidate.java
@@ -109,7 +109,9 @@ public class PrimaryScanMatchCandidate implements MatchCandidate {
 
     @Nonnull
     @Override
-    public RelationalExpression toScanExpression(@Nonnull final List<ComparisonRange> comparisonRanges, final boolean isReverse) {
+    public RelationalExpression toEquivalentExpression(@Nonnull PartialMatch partialMatch,
+                                                       @Nonnull final List<ComparisonRange> comparisonRanges,
+                                                       final boolean isReverse) {
         return new LogicalTypeFilterExpression(getQueriedRecordTypes(),
                 new PrimaryScanExpression(getAvailableRecordTypes(),
                         comparisonRanges,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RelationalExpressionWithPredicates.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/RelationalExpressionWithPredicates.java
@@ -1,5 +1,5 @@
 /*
- * RelationalExpressionWithPredicate.java
+ * RelationalExpressionWithPredicates.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -28,10 +28,7 @@ import java.util.List;
 /**
  * A (relational) expression that has a predicate on it.
  */
-public interface RelationalExpressionWithPredicate extends RelationalExpression {
+public interface RelationalExpressionWithPredicates extends RelationalExpression {
     @Nonnull
-    QueryPredicate getPredicate();
-
-    @Nonnull
-    RelationalExpression rebaseWithRebasedQuantifiers(@Nonnull final AliasMap translationMap, @Nonnull final List<Quantifier> rebasedQuantifiers);
+    List<QueryPredicate> getPredicates();
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ScalarTranslationVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ScalarTranslationVisitor.java
@@ -1,0 +1,229 @@
+/*
+ * ScalarTranslationVisitor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpressionWithValue;
+import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
+import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
+import com.apple.foundationdb.record.query.predicates.EmptyValue;
+import com.apple.foundationdb.record.query.predicates.FieldValue;
+import com.apple.foundationdb.record.query.predicates.QuantifiedColumnValue;
+import com.apple.foundationdb.record.query.predicates.Value;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Visitor that translates a {@link KeyExpression} into a {@link Value}.
+ */
+@SuppressWarnings("java:S5993")
+public class ScalarTranslationVisitor implements KeyExpressionVisitor<ScalarTranslationVisitor.ScalarVisitorState, Value> {
+
+    @Nonnull
+    private final KeyExpression keyExpression;
+
+    /**
+     * We maintain a conceptual stack for the states. States pass information down the visited structure while
+     * {@link GraphExpansion}s pass the resulting query graph expansion back up. We use a {@link Deque} here
+     * (via {@link ArrayDeque}) as {@link java.util.Stack} is synchronized upon access.
+     */
+    private final Deque<ScalarVisitorState> states;
+
+    public ScalarTranslationVisitor(@Nonnull final KeyExpression keyExpression) {
+        this.keyExpression = keyExpression;
+        this.states = new ArrayDeque<>();
+    }
+
+    @Override
+    public ScalarVisitorState getCurrentState() {
+        return states.peek();
+    }
+
+    public ScalarTranslationVisitor push(final ScalarVisitorState newState) {
+        states.push(newState);
+        return this;
+    }
+
+    /**
+     * Method to pop and return the top of the states stack.
+     * @return the currentState
+     */
+    public ScalarVisitorState pop() {
+        return states.pop();
+    }
+
+    /**
+     * Functional pop to facilitate a more fluent way of interacting with the states.
+     * @param <T> a type parameter
+     * @param t some value of type {@code T}
+     * @return {@code t}
+     */
+    public <T> T pop(final T t) {
+        pop();
+        return t;
+    }
+
+    /**
+     * Specific implementation of the fall-back visitation method. Sub classes of this class do not tolerate visits
+     * from unknown sub classes of {@link KeyExpression}. Implementors of new sub classes of {@link KeyExpression}
+     * should also add a new visitation method in {@link KeyExpressionVisitor}.
+     * @param keyExpression key expression to visit
+     * @return does not return a result but throws an exception of type {@link UnsupportedOperationException}
+     */
+    @Nonnull
+    @Override
+    public final Value visitExpression(@Nonnull final KeyExpression keyExpression) {
+        throw new UnsupportedOperationException("visitor method for this key expression is not implemented");
+    }
+
+
+    @Nonnull
+    @Override
+    public Value visitExpression(@Nonnull final EmptyKeyExpression emptyKeyExpression) {
+        return new EmptyValue();
+    }
+
+    @Nonnull
+    @Override
+    public Value visitExpression(@Nonnull FieldKeyExpression fieldKeyExpression) {
+        final KeyExpression.FanType fanType = fieldKeyExpression.getFanType();
+        if (fanType != KeyExpression.FanType.None) {
+            throw new RecordCoreException("cannot expand fan outs in scalar expansion");
+        }
+
+        final ScalarVisitorState state = getCurrentState();
+        final String fieldName = fieldKeyExpression.getFieldName();
+        final List<String> fieldNamePrefix = state.getFieldNamePrefix();
+        final CorrelationIdentifier baseAlias = state.getBaseAlias();
+        final List<String> fieldNames = ImmutableList.<String>builder()
+                .addAll(fieldNamePrefix)
+                .add(fieldName)
+                .build();
+        return new FieldValue(QuantifiedColumnValue.of(baseAlias, 0), fieldNames);
+    }
+
+    @Nonnull
+    @Override
+    public Value visitExpression(@Nonnull final KeyExpressionWithValue keyExpressionWithValue) {
+        final ScalarVisitorState state = getCurrentState();
+        return keyExpressionWithValue.toValue(state.getBaseAlias(), state.getFieldNamePrefix());
+    }
+    
+    @Nonnull
+    @Override
+    public Value visitExpression(@Nonnull final KeyWithValueExpression keyWithValueExpression) {
+        throw new RecordCoreException("cannot expand this expression in scalar expansion");
+    }
+
+    @Nonnull
+    @Override
+    public Value visitExpression(@Nonnull final NestingKeyExpression nestingKeyExpression) {
+        final FieldKeyExpression parent = nestingKeyExpression.getParent();
+        final KeyExpression.FanType fanType = parent.getFanType();
+        if (fanType != KeyExpression.FanType.None) {
+            throw new RecordCoreException("cannot expand fan outs in scalar expansion");
+        }
+
+        final ScalarVisitorState state = getCurrentState();
+        final List<String> fieldNamePrefix = state.getFieldNamePrefix();
+        final KeyExpression child = nestingKeyExpression.getChild();
+        final List<String> newPrefix = ImmutableList.<String>builder()
+                .addAll(fieldNamePrefix)
+                .add(parent.getFieldName())
+                .build();
+        return pop(child.expand(push(state.withFieldNamePrefix(newPrefix))));
+    }
+
+    @Nonnull
+    @Override
+    public Value visitExpression(@Nonnull final ThenKeyExpression thenKeyExpression) {
+        if (thenKeyExpression.getColumnSize() > 1) {
+            throw new RecordCoreException("cannot expand ThenKeyExpression in scalar expansion");
+        }
+
+        final ScalarVisitorState state = getCurrentState();
+        final KeyExpression child = Iterables.getOnlyElement(thenKeyExpression.getChildren());
+
+        return pop(child.expand(push(state)));
+    }
+
+    @Nonnull
+    public Value toResultValue(@Nonnull final CorrelationIdentifier alias) {
+        return pop(keyExpression.expand(push(ScalarVisitorState.of(alias, ImmutableList.of()))));
+    }
+
+    /**
+     * State class.
+     */
+    public static class ScalarVisitorState implements KeyExpressionVisitor.State {
+        /**
+         * Correlated input to operators using the current state. This alias usually refers to the global record type
+         * input or an exploded field (an iteration) defining this state.
+         */
+        @Nonnull
+        private final CorrelationIdentifier baseAlias;
+
+        /**
+         * List of field names that form a nesting chain of non-repeated fields.
+         */
+        @Nonnull
+        private final List<String> fieldNamePrefix;
+
+        private ScalarVisitorState(@Nonnull final CorrelationIdentifier baseAlias,
+                                   @Nonnull final List<String> fieldNamePrefix) {
+            this.baseAlias = baseAlias;
+            this.fieldNamePrefix = fieldNamePrefix;
+        }
+
+        @Nonnull
+        public CorrelationIdentifier getBaseAlias() {
+            return baseAlias;
+        }
+
+        @Nonnull
+        public List<String> getFieldNamePrefix() {
+            return fieldNamePrefix;
+        }
+
+        public ScalarVisitorState withBaseAlias(@Nonnull final CorrelationIdentifier baseAlias) {
+            return of(baseAlias, this.fieldNamePrefix);
+        }
+
+        public ScalarVisitorState withFieldNamePrefix(@Nonnull final List<String> fieldNamePrefix) {
+            return of(this.baseAlias, fieldNamePrefix);
+        }
+
+        public static ScalarVisitorState of(@Nonnull final CorrelationIdentifier baseAlias,
+                                            @Nonnull final List<String> fieldNamePrefix) {
+            return new ScalarVisitorState(baseAlias,
+                    fieldNamePrefix);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/TreeLike.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/TreeLike.java
@@ -113,7 +113,7 @@ public interface TreeLike<T extends TreeLike<T>> {
      * Note that this variant of fold does not permit {@code null} values to be produced and consumed by the map and
      * fold functions passed in. In return this method guarantees that the result of the folding the tree rooted at
      * {@code this} is well-defined and not {@code null}.
-     * @param mapFunction a mapping {@link Function} that computes a scalar value from a node of type {@code M}.
+     * @param mapFunction a mapping {@link Function} that computes a scalar value of type {@code M} from a node of type {@code T}.
      * @param foldFunction a folding {@link Function} that computes the result of the fold of a node {@code n} given
      *        an instance of type {@code M} (which is the result of applying {@code mapFunction})
      *        and an iterable of instances of type {@code F} that are the result of folding the children of that node.
@@ -146,7 +146,7 @@ public interface TreeLike<T extends TreeLike<T>> {
      * of the absence of a well-defined fold for the respective sub tree that is being considered at the time.
      * However, this method does not enforce this view meaning that callers can react to and pass on {@code null}s as
      * they see fit (by means of the provided lambdas for map and fold functions).
-     * @param mapFunction a mapping {@link Function} that computes a scalar value from a node of type {@code M}.
+     * @param mapFunction a mapping {@link Function} that computes a scalar value of type {@code M} from a node of type {@code T}.
      * @param foldFunction a folding {@link Function} that computes the result of the fold of a node {@code n} given
      *        an instance of type {@code M} (which is the result of applying {@code mapFunction})
      *        and an iterable of instances of type {@code F} that are the result of folding the children of that node.
@@ -191,12 +191,12 @@ public interface TreeLike<T extends TreeLike<T>> {
      * tree-like rooted at {@code this}.
      * @param replaceOperator an operator that translates a tree-like of {@code T} into another tree-like of type
      *        {@code T}.
-     * @return an {@link Optional} of a new tree-like object that is result of the tree-map operation if the fold of the
+     * @return an {@link Optional} of a tree-like object that is result of the tree-map operation if the fold of the
      *         tree rooted at {@code this} exists, {@code Optional.empty()} otherwise
      */
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
     @Nonnull
-    default Optional<T> mapLeavesMaybe(@Nonnull final UnaryOperator<T> replaceOperator) {
+    default Optional<T> replaceLeavesMaybe(@Nonnull final UnaryOperator<T> replaceOperator) {
         return mapMaybe((t, foldedChildren) -> {
             if (Iterables.isEmpty(foldedChildren)) {
                 return replaceOperator.apply(t);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/TreeLike.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/TreeLike.java
@@ -1,0 +1,266 @@
+/*
+ * TreeLike.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp;
+
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * Interface for tree-like structures and helpers for folds and traversals on these tree-like structures of node type
+ * {@link T}.
+ * @param <T> type parameter of the node
+ */
+public interface TreeLike<T extends TreeLike<T>> {
+
+    /**
+     * Method to get a {@code T}-typed {@code this}. This is the equivalent of Scala's typed self. Java's type inference
+     * of code referring to {@code this} in this interface infers {@code TreeLike<T extends TreeLike<T>>}. By convention
+     * any implementor should implement {@code class Tree implements TreeLike<Tree> ...} meaning that the implementor is
+     * {@code T} for those cases. Providing a narrowing method to get {@code this} from the implementor avoids an
+     * unchecked cast.
+     * @return {@code this} of type {@code T}.
+     */
+    @Nonnull
+    T getThis();
+
+    /**
+     * Method to retrieve a list of children values.
+     * @return a list of children
+     */
+    @Nonnull
+    Iterable<? extends T> getChildren();
+
+    /**
+     * Recreate the current treelike object with a new list of children.
+     * @param newChildren new children
+     * @return a copy of {@code this} using the new children passed in
+     */
+    @Nonnull
+    T withChildren(final Iterable<? extends T> newChildren);
+
+    /**
+     * Method that returns an {@link Iterable} of nodes as encountered in pre-order traversal of this tree-like.
+     * @return an {@link Iterable} of nodes
+     */
+    @Nonnull
+    default Iterable<? extends T> inPreOrder() {
+        final ImmutableList.Builder<Iterable<? extends T>> iterablesBuilder = ImmutableList.builder();
+        iterablesBuilder.add(ImmutableList.of(getThis()));
+        for (final T child : getChildren()) {
+            iterablesBuilder.add(child.inPreOrder());
+        }
+        return Iterables.concat(iterablesBuilder.build());
+    }
+
+    /**
+     * Method that returns an {@link Iterable} of nodes as encountered in post-order traversal of this tree-like.
+     * @return an {@link Iterable} of nodes
+     */
+    @Nonnull
+    default Iterable<? extends T> inPostOrder() {
+        final ImmutableList.Builder<Iterable<? extends T>> iterablesBuilder = ImmutableList.builder();
+        for (final T child : getChildren()) {
+            iterablesBuilder.add(child.inPostOrder());
+        }
+        iterablesBuilder.add(ImmutableList.of(getThis()));
+        return Iterables.concat(iterablesBuilder.build());
+    }
+
+    /**
+     * Method that returns an {@link Iterable} of nodes as encountered in pre-order traversal of this tree-like that
+     * are filtered by a {@link Predicate} that filters out every node for which {@code predicate} returns {@code false}.
+     * @param predicate a {@link Predicate} that is evaluated per encountered node during pre-order traversal of
+     *        the tree-like rooted at {@code this}
+     * @return an {@link Iterable} of nodes satisfying the predicate passed in
+     */
+    @Nonnull
+    default Iterable<? extends T> filter(@Nonnull final Predicate<T> predicate) {
+        return Iterables.filter(inPreOrder(), predicate::test);
+    }
+
+    /**
+     * Method that performs a tree fold over the tree-like rooted at {@code this} using the given map and fold functions.
+     * Note that this variant of fold does not permit {@code null} values to be produced and consumed by the map and
+     * fold functions passed in. In return this method guarantees that the result of the folding the tree rooted at
+     * {@code this} is well-defined and not {@code null}.
+     * @param mapFunction a mapping {@link Function} that computes a scalar value from a node of type {@code M}.
+     * @param foldFunction a folding {@link Function} that computes the result of the fold of a node {@code n} given
+     *        an instance of type {@code M} (which is the result of applying {@code mapFunction})
+     *        and an iterable of instances of type {@code F} that are the result of folding the children of that node.
+     *        The result of the folding function is also of type {@code F}.
+     *        Note that in this variant, the fold function is guaranteed to not be called with {@code null} for
+     *        the mapped {@code this}. Also, the {@link Iterable} over the children's folds does not produce
+     *        {@code null}s. In response to that the fold function itself is not allowed to return a {@code null}.
+     * @param <M> the type parameter of the result of the mapping function
+     * @param <F> the type parameter of the result of the folding function
+     * @return the fold of the tree rooted at {@code this}
+     */
+    @Nonnull
+    default <M, F> F fold(@Nonnull final NonnullFunction<T, M> mapFunction,
+                          @Nonnull final NonnullBiFunction<M, Iterable<? extends F>, F> foldFunction) {
+        final M mappedThis = mapFunction.apply(getThis());
+        final ImmutableList.Builder<F> foldedChildrenBuilder = ImmutableList.builder();
+
+        for (final T child : getChildren()) {
+            foldedChildrenBuilder.add(child.fold(mapFunction, foldFunction));
+        }
+
+        return foldFunction.apply(mappedThis, foldedChildrenBuilder.build());
+    }
+
+    /**
+     * Method that performs a tree fold over the tree-like rooted at {@code this} using the given map and fold functions.
+     * Note that this variant of fold does permit {@code null} values to be produced and consumed by the map and
+     * fold functions passed in. This method does not guarantee the existence of a well-defined tree-fold. A {@code null}
+     * that is returned by either the map function or the fold function is normally considered to be a result indicative
+     * of the absence of a well-defined fold for the respective sub tree that is being considered at the time.
+     * However, this method does not enforce this view meaning that callers can react to and pass on {@code null}s as
+     * they see fit (by means of the provided lambdas for map and fold functions).
+     * @param mapFunction a mapping {@link Function} that computes a scalar value from a node of type {@code M}.
+     * @param foldFunction a folding {@link Function} that computes the result of the fold of a node {@code n} given
+     *        an instance of type {@code M} (which is the result of applying {@code mapFunction})
+     *        and an iterable of instances of type {@code F} that are the result of folding the children of that node.
+     *        The result of the folding function is also of type {@code F}.
+     * @param <M> the type parameter of the result of the mapping function
+     * @param <F> the type parameter of the result of the folding function
+     * @return an {@link Optional} containing the fold of the tree rooted at {@code this} if it exists,
+     *         {@code Optional.empty()} otherwise.
+     */
+    @Nullable
+    default <M, F> F foldNullable(@Nonnull final Function<T, M> mapFunction,
+                                  @Nonnull final BiFunction<M, Iterable<? extends F>, F> foldFunction) {
+        final M mappedThis = mapFunction.apply(getThis());
+        final List<F> foldedChildren = Lists.newArrayList();
+
+        for (final T child : getChildren()) {
+            foldedChildren.add(child.foldNullable(mapFunction, foldFunction));
+        }
+
+        return foldFunction.apply(mappedThis, foldedChildren);
+    }
+
+    /**
+     * Method that maps the tree-like rooted at {@code this} to another tree-like using a fold operation that folds into
+     * a {@code TreeLike<V>} if the fold exists.
+     * This method is normally used when an immutable tree-like structure needs to be <em>modified</em> in a
+     * persistent (copy-on-write) way meaning that parts or even all of the original tree rooted at {@code this}
+     * needs to be recreated using the {@link #withChildren(Iterable)} method.
+     * @param foldFunction a fold function that returns tree-like structures
+     * @param <V> type parameter constraint to {@code TreeLike<V>}
+     * @return an {@link Optional} of a new tree-like object that is result of the tree-map operation if the fold of the
+     *         tree rooted at {@code this} exists, {@code Optional.empty()} otherwise
+     */
+    @Nonnull
+    default <V extends TreeLike<V>> Optional<V> mapMaybe(@Nonnull final BiFunction<T, Iterable<? extends V>, V> foldFunction) {
+        return Optional.ofNullable(foldNullable(Function.identity(), foldFunction));
+    }
+
+    /**
+     * Method that maps the tree-like rooted at {@code this} to another tree-like of the same type. Unlike the other
+     * methods providing generic tree folds and maps, this method provides an easy way to mutate the leaves of the
+     * tree-like rooted at {@code this}.
+     * @param replaceOperator an operator that translates a tree-like of {@code T} into another tree-like of type
+     *        {@code T}.
+     * @return an {@link Optional} of a new tree-like object that is result of the tree-map operation if the fold of the
+     *         tree rooted at {@code this} exists, {@code Optional.empty()} otherwise
+     */
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    @Nonnull
+    default Optional<T> mapLeavesMaybe(@Nonnull final UnaryOperator<T> replaceOperator) {
+        return mapMaybe((t, foldedChildren) -> {
+            if (Iterables.isEmpty(foldedChildren)) {
+                return replaceOperator.apply(t);
+            }
+
+            final Iterator<? extends T> foldedChildrenIterator = foldedChildren.iterator();
+            boolean isDifferent = false;
+            for (T child : t.getChildren()) {
+                Verify.verify(foldedChildrenIterator.hasNext());
+
+                final T nextFoldedChild = foldedChildrenIterator.next();
+                if (nextFoldedChild == null) {
+                    return null;
+                }
+                // note object identity comparison is desired here as this will tell us if descendant "modified"
+                // the tree
+                if (child != nextFoldedChild) {
+                    isDifferent = true;
+                    break;
+                }
+            }
+
+            if (isDifferent) {
+                return t.withChildren(foldedChildren);
+            }
+            return t;
+        });
+    }
+
+    /**
+     * Functional interface for a function whose result is not nullable.
+     * @param <T> argument type
+     * @param <R> result type
+     */
+    @FunctionalInterface
+    interface NonnullFunction<T, R> {
+
+        /**
+         * Applies this function to the given argument.
+         *
+         * @param t the function argument
+         * @return the function result
+         */
+        @Nonnull
+        R apply(@Nonnull T t);
+    }
+
+    /**
+     * Functional interface for a bi-function whose result is not nullable.
+     * @param <T> argument type of the first argument to the function
+     * @param <U> argument type of the second argument to the function
+     * @param <R> result type
+     */
+    @FunctionalInterface
+    interface NonnullBiFunction<T, U, R> {
+
+        /**
+         * Applies this function to the given arguments.
+         *
+         * @param t the first function argument
+         * @param u the second function argument
+         * @return the function result
+         */
+        @Nonnull
+        R apply(@Nonnull T t, @Nonnull U u);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ValueIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/ValueIndexExpansionVisitor.java
@@ -22,9 +22,13 @@ package com.apple.foundationdb.record.query.plan.temp;
 
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.query.plan.temp.debug.Debugger;
 import com.apple.foundationdb.record.query.plan.temp.expressions.MatchableSortExpression;
+import com.apple.foundationdb.record.query.predicates.QuantifiedColumnValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.apple.foundationdb.record.query.predicates.ValueComparisonRangePredicate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -33,6 +37,7 @@ import com.google.common.collect.Lists;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
@@ -42,11 +47,15 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
  * class {@link ValueIndexLikeExpansionVisitor}, this class merely provides a specific {@link #expand} method.
  */
 public class ValueIndexExpansionVisitor extends ValueIndexLikeExpansionVisitor {
+    @Nonnull
     private final Index index;
+    @Nonnull
+    private final List<RecordType> recordTypes;
 
-    public ValueIndexExpansionVisitor(@Nonnull Index index) {
+    public ValueIndexExpansionVisitor(@Nonnull Index index, @Nonnull Collection<RecordType> recordTypes) {
         Preconditions.checkArgument(index.getType().equals(IndexTypes.VALUE));
         this.index = index;
+        this.recordTypes = ImmutableList.copyOf(recordTypes);
     }
 
     @Nonnull
@@ -57,9 +66,35 @@ public class ValueIndexExpansionVisitor extends ValueIndexLikeExpansionVisitor {
         Debugger.updateIndex(ValueComparisonRangePredicate.Placeholder.class, old -> 0);
         final ImmutableList.Builder<GraphExpansion> allExpansionsBuilder = ImmutableList.builder();
 
-        push(VisitorState.of(baseQuantifier.getAlias(), ImmutableList.of(), -1, 0));
-        allExpansionsBuilder.add(index.getRootExpression().expand(this));
-        pop();
+        // add the value for the flow of records
+        final QuantifiedColumnValue recordValue = QuantifiedColumnValue.of(baseQuantifier.getAlias(), 0);
+        allExpansionsBuilder.add(GraphExpansion.ofResultValueAndQuantifier(recordValue, baseQuantifier));
+
+        KeyExpression rootExpression = index.getRootExpression();
+
+        final ImmutableList.Builder<Value> indexKeyValuesBuilder = ImmutableList.builder();
+        final ImmutableList.Builder<Value> indexValueValuesBuilder = ImmutableList.builder();
+
+        final int keyValueSplitPoint;
+        if (rootExpression instanceof KeyWithValueExpression) {
+            final KeyWithValueExpression keyWithValueExpression = (KeyWithValueExpression)rootExpression;
+            keyValueSplitPoint = keyWithValueExpression.getSplitPoint();
+            rootExpression = keyWithValueExpression.getInnerKey();
+        } else {
+            keyValueSplitPoint = -1;
+        }
+
+        final GraphExpansion keyValueExpansion =
+                pop(rootExpression.expand(push(VisitorState.of(baseQuantifier.getAlias(), ImmutableList.of(), keyValueSplitPoint, 0))));
+
+        final List<Value> regularExpansionResultValues = keyValueExpansion.getResultValues();
+        if (keyValueSplitPoint == -1) {
+            indexKeyValuesBuilder.addAll(regularExpansionResultValues);
+        } else {
+            indexKeyValuesBuilder.addAll(regularExpansionResultValues.subList(0, keyValueSplitPoint));
+            indexValueValuesBuilder.addAll(regularExpansionResultValues.subList(keyValueSplitPoint, regularExpansionResultValues.size()));
+        }
+        allExpansionsBuilder.add(keyValueExpansion);
 
         if (primaryKey != null) {
             // unfortunately we must copy as the returned list is not guaranteed to be mutable which is needed for the
@@ -69,40 +104,28 @@ public class ValueIndexExpansionVisitor extends ValueIndexLikeExpansionVisitor {
 
             trimmedPrimaryKeys
                     .forEach(primaryKeyPart -> {
-                        push(VisitorState.of(baseQuantifier.getAlias(), ImmutableList.of(), -1, 0));
-                        allExpansionsBuilder.add(primaryKeyPart.expand(this));
-                        pop();
+                        final GraphExpansion primaryKeyPartExpansion =
+                                pop(primaryKeyPart.expand(push(VisitorState.of(baseQuantifier.getAlias(),
+                                        ImmutableList.of(),
+                                        -1,
+                                        0))));
+                        indexKeyValuesBuilder.addAll(primaryKeyPartExpansion.getResultValues());
+                        allExpansionsBuilder
+                                .add(primaryKeyPartExpansion);
                     });
         }
 
         final GraphExpansion completeExpansion = GraphExpansion.ofOthers(allExpansionsBuilder.build());
         final List<CorrelationIdentifier> parameters = completeExpansion.getPlaceholderAliases();
-        final MatchableSortExpression matchableSortExpression = new MatchableSortExpression(parameters, isReverse, completeExpansion.buildSelectWithBase(baseQuantifier));
-        return new ValueIndexScanMatchCandidate(index.getName(),
+        final MatchableSortExpression matchableSortExpression = new MatchableSortExpression(parameters, isReverse, completeExpansion.buildSelect());
+        return new ValueIndexScanMatchCandidate(index,
+                recordTypes,
                 ExpressionRefTraversal.withRoot(GroupExpressionRef.of(matchableSortExpression)),
                 parameters,
-                fullKey(primaryKey));
-    }
-
-    /**
-     * Compute the full key of an index (given that the index is a value index).
-     *
-     * @param primaryKey primary key of the records the index ranges over. The primary key is used to determine
-     *        parts in the index definition that already contain parts of the primary key. All primary key components
-     *        that are not already part of the index key are appended to the index key.
-     * @return a {@link KeyExpression} describing the <em>full</em> index key as stored
-     */
-    @Nonnull
-    private KeyExpression fullKey(@Nullable final KeyExpression primaryKey) {
-        if (primaryKey == null) {
-            return index.getRootExpression();
-        }
-        final ArrayList<KeyExpression> trimmedPrimaryKeyComponents = new ArrayList<>(primaryKey.normalizeKeyForPositions());
-        index.trimPrimaryKey(trimmedPrimaryKeyComponents);
-        final ImmutableList.Builder<KeyExpression> fullKeyListBuilder = ImmutableList.builder();
-        fullKeyListBuilder.add(index.getRootExpression());
-        fullKeyListBuilder.addAll(trimmedPrimaryKeyComponents);
-        return concat(fullKeyListBuilder.build());
+                recordValue,
+                indexKeyValuesBuilder.build(),
+                indexValueValuesBuilder.build(),
+                fullKey(index, primaryKey));
     }
 
     /**
@@ -116,6 +139,14 @@ public class ValueIndexExpansionVisitor extends ValueIndexLikeExpansionVisitor {
      */
     @Nonnull
     public static KeyExpression fullKey(@Nonnull Index index, @Nullable final KeyExpression primaryKey) {
-        return new ValueIndexExpansionVisitor(index).fullKey(primaryKey);
+        if (primaryKey == null) {
+            return index.getRootExpression();
+        }
+        final ArrayList<KeyExpression> trimmedPrimaryKeyComponents = new ArrayList<>(primaryKey.normalizeKeyForPositions());
+        index.trimPrimaryKey(trimmedPrimaryKeyComponents);
+        final ImmutableList.Builder<KeyExpression> fullKeyListBuilder = ImmutableList.builder();
+        fullKeyListBuilder.add(index.getRootExpression());
+        fullKeyListBuilder.addAll(trimmedPrimaryKeyComponents);
+        return concat(fullKeyListBuilder.build());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/FullUnorderedScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/FullUnorderedScanExpression.java
@@ -34,7 +34,7 @@ import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
-import com.apple.foundationdb.record.query.predicates.BaseValue;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
 import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -45,7 +45,6 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -76,8 +75,8 @@ public class FullUnorderedScanExpression implements RelationalExpression, Planne
 
     @Nonnull
     @Override
-    public Optional<List<? extends Value>> getResultValues() {
-        return Optional.of(ImmutableList.of(new BaseValue()));
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/IndexScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/IndexScanExpression.java
@@ -31,6 +31,8 @@ import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -120,6 +122,12 @@ public class IndexScanExpression implements RelationalExpression, PlannerGraphRe
     @Override
     public IndexScanExpression rebase(@Nonnull final AliasMap translationMap) {
         return this;
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalFilterExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalFilterExpression.java
@@ -23,24 +23,29 @@ package com.apple.foundationdb.record.query.plan.temp.expressions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
-import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.Quantifier;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicates;
 import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
+import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A relational planner expression that represents an unimplemented filter on the records produced by its inner
@@ -48,21 +53,19 @@ import java.util.Set;
  * @see com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan for the fallback implementation
  */
 @API(API.Status.EXPERIMENTAL)
-public class LogicalFilterExpression implements RelationalExpressionWithChildren, RelationalExpressionWithPredicate, PlannerGraphRewritable {
+public class LogicalFilterExpression implements RelationalExpressionWithChildren, RelationalExpressionWithPredicates, PlannerGraphRewritable {
     @Nonnull
-    private final QueryPredicate filter;
+    private final List<QueryPredicate> queryPredicates;
     @Nonnull
     private final Quantifier inner;
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
 
-    public LogicalFilterExpression(@Nonnull QueryPredicate filter,
-                                   @Nonnull ExpressionRef<RelationalExpression> inner) {
-        this(filter, Quantifier.forEach(inner));
-    }
-
-    public LogicalFilterExpression(@Nonnull QueryPredicate filter,
+    public LogicalFilterExpression(@Nonnull Iterable<? extends QueryPredicate> queryPredicates,
                                    @Nonnull Quantifier inner) {
-        this.filter = filter;
+        this.queryPredicates = ImmutableList.copyOf(queryPredicates);
         this.inner = inner;
+        this.resultValuesSupplier = Suppliers.memoize(inner::getFlowedValues);
     }
 
     @Nonnull
@@ -78,8 +81,8 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
 
     @Nonnull
     @Override
-    public QueryPredicate getPredicate() {
-        return filter;
+    public List<QueryPredicate> getPredicates() {
+        return queryPredicates;
     }
 
     @Nonnull
@@ -91,7 +94,9 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
     @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
-        return filter.getCorrelatedTo();
+        return queryPredicates.stream()
+                .flatMap(queryPredicate -> queryPredicate.getCorrelatedTo().stream())
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     @Nonnull
@@ -105,10 +110,22 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
     @Override
     public LogicalFilterExpression rebaseWithRebasedQuantifiers(@Nonnull final AliasMap translationMap,
                                                                 @Nonnull final List<Quantifier> rebasedQuantifiers) {
-        return new LogicalFilterExpression(getPredicate().rebase(translationMap),
+        final ImmutableList<QueryPredicate> rebasedQueryPredicates =
+                queryPredicates.stream()
+                        .map(queryPredicate -> queryPredicate.rebase(translationMap))
+                        .collect(ImmutableList.toImmutableList());
+
+        return new LogicalFilterExpression(rebasedQueryPredicates,
                 Iterables.getOnlyElement(rebasedQuantifiers));
     }
 
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
     @Override
     public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
                                          @Nonnull final AliasMap equivalencesMap) {
@@ -118,7 +135,14 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
         if (getClass() != otherExpression.getClass()) {
             return false;
         }
-        return filter.semanticEquals(((LogicalFilterExpression)otherExpression).getPredicate(), equivalencesMap);
+        final LogicalFilterExpression otherLogicalFilterExpression = (LogicalFilterExpression)otherExpression;
+        final List<QueryPredicate> otherQueryPredicates = otherLogicalFilterExpression.getPredicates();
+        if (queryPredicates.size() != otherQueryPredicates.size()) {
+            return false;
+        }
+        return Streams.zip(queryPredicates.stream(), otherQueryPredicates.stream(),
+                (queryPredicate, otherQueryPredicate) -> queryPredicate.semanticEquals(otherQueryPredicate, equivalencesMap))
+                .allMatch(isSame -> isSame);
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
@@ -134,7 +158,7 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
 
     @Override
     public int hashCodeWithoutChildren() {
-        return Objects.hash(getPredicate());
+        return Objects.hash(getPredicates());
     }
 
     @Override
@@ -145,7 +169,7 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
                         this,
                         NodeInfo.PREDICATE_FILTER_OPERATOR,
                         ImmutableList.of("WHERE {{pred}}"),
-                        ImmutableMap.of("pred", Attribute.gml(getPredicate().toString()))),
+                        ImmutableMap.of("pred", Attribute.gml(AndPredicate.and(getPredicates()).toString()))),
                 childGraphs);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalSortExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/LogicalSortExpression.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.InternalPlannerGraphRewritable;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -40,6 +41,7 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A relational planner expression that represents an unimplemented sort on the records produced by its inner
@@ -55,6 +57,9 @@ public class LogicalSortExpression implements RelationalExpressionWithChildren, 
     @Nonnull
     private final Quantifier inner;
 
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
+
     public LogicalSortExpression(@Nonnull final KeyExpression sort,
                                  final boolean reverse,
                                  @Nonnull final RelationalExpression inner) {
@@ -67,6 +72,7 @@ public class LogicalSortExpression implements RelationalExpressionWithChildren, 
         this.sort = sort;
         this.reverse = reverse;
         this.inner = inner;
+        this.resultValuesSupplier = inner::getFlowedValues;
     }
 
     @Nonnull
@@ -114,6 +120,12 @@ public class LogicalSortExpression implements RelationalExpressionWithChildren, 
         return new LogicalSortExpression(getSort(),
                 isReverse(),
                 Iterables.getOnlyElement(rebasedQuantifiers));
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/MatchableSortExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/MatchableSortExpression.java
@@ -42,6 +42,7 @@ import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.rules.AdjustMatchRule;
 import com.apple.foundationdb.record.query.plan.temp.rules.RemoveSortRule;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.apple.foundationdb.record.query.predicates.ValueComparisonRangePredicate.Placeholder;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -56,6 +57,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A relational planner expression that represents an unimplemented sort on the records produced by its inner
@@ -149,6 +151,9 @@ public class MatchableSortExpression implements RelationalExpressionWithChildren
     @Nonnull
     private final Quantifier inner;
 
+    @Nonnull
+    private final Supplier<List<? extends Value>> resultValuesSupplier;
+
     /**
      * Overloaded constructor. Creates a new {@link MatchableSortExpression}
      * @param sortParameterIds a list of parameter ids defining the order
@@ -175,6 +180,7 @@ public class MatchableSortExpression implements RelationalExpressionWithChildren
         this.sortParameterIds = ImmutableList.copyOf(sortParameterIds);
         this.isReverse = isReverse;
         this.inner = inner;
+        this.resultValuesSupplier = inner::getFlowedValues;
     }
 
     @Nonnull
@@ -299,6 +305,12 @@ public class MatchableSortExpression implements RelationalExpressionWithChildren
         }
 
         return builder.build();
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return resultValuesSupplier.get();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/PrimaryScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/PrimaryScanExpression.java
@@ -31,6 +31,8 @@ import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraphRewritable;
 import com.apple.foundationdb.record.query.plan.temp.rules.ImplementPhysicalScanRule;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -102,6 +104,12 @@ public class PrimaryScanExpression implements RelationalExpression, PlannerGraph
     @Override
     public PrimaryScanExpression rebase(@Nonnull final AliasMap translationMap) {
         return this;
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/TypeWithPredicateMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/matchers/TypeWithPredicateMatcher.java
@@ -21,8 +21,9 @@
 package com.apple.foundationdb.record.query.plan.temp.matchers;
 
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicates;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
+import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 import com.google.common.collect.ImmutableList;
 
@@ -31,11 +32,11 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Matches a subclass of {@link RelationalExpressionWithPredicate} with a given predicate (as determined by
- * {@link RelationalExpressionWithPredicate#getPredicate()} and a given matcher against the children.
- * @param <T> the type of {@link RelationalExpressionWithPredicate} to match against
+ * Matches a subclass of {@link RelationalExpressionWithPredicates} with a given predicate (as determined by
+ * {@link RelationalExpressionWithPredicates#getPredicates()} and a given matcher against the children.
+ * @param <T> the type of {@link RelationalExpressionWithPredicates} to match against
  */
-public class TypeWithPredicateMatcher<T extends RelationalExpressionWithPredicate> extends TypeMatcher<T> {
+public class TypeWithPredicateMatcher<T extends RelationalExpressionWithPredicates> extends TypeMatcher<T> {
     @Nonnull
     private final ExpressionMatcher<? extends QueryPredicate> predicateMatcher;
 
@@ -49,23 +50,23 @@ public class TypeWithPredicateMatcher<T extends RelationalExpressionWithPredicat
     @Nonnull
     @Override
     public Stream<PlannerBindings> matchWith(@Nonnull final PlannerBindings outerBindings, @Nonnull final RelationalExpression expression, @Nonnull final List<? extends Bindable> children) {
-        if (!(expression instanceof RelationalExpressionWithPredicate)) {
+        if (!(expression instanceof RelationalExpressionWithPredicates)) {
             return Stream.empty();
         }
         Stream<PlannerBindings> superBindings = super.matchWith(outerBindings, expression, children);
-        QueryPredicate predicate = ((RelationalExpressionWithPredicate)expression).getPredicate();
+        QueryPredicate predicate = AndPredicate.and(((RelationalExpressionWithPredicates)expression).getPredicates());
         return superBindings.flatMap(bindings -> predicate.bindTo(outerBindings, predicateMatcher).map(bindings::mergedWith));
     }
 
-    public static <U extends RelationalExpressionWithPredicate> TypeWithPredicateMatcher<U> ofPredicate(@Nonnull Class<? extends U> expressionClass,
-                                                                                                        @Nonnull ExpressionMatcher<? extends QueryPredicate> predicateMatcher) {
+    public static <U extends RelationalExpressionWithPredicates> TypeWithPredicateMatcher<U> ofPredicate(@Nonnull Class<? extends U> expressionClass,
+                                                                                                         @Nonnull ExpressionMatcher<? extends QueryPredicate> predicateMatcher) {
         return ofPredicate(expressionClass, predicateMatcher, AnyChildrenMatcher.ANY);
     }
 
     @SafeVarargs
-    public static <U extends RelationalExpressionWithPredicate> TypeWithPredicateMatcher<U> ofPredicate(@Nonnull Class<? extends U> expressionClass,
-                                                                                                        @Nonnull ExpressionMatcher<? extends QueryPredicate> predicateMatcher,
-                                                                                                        @Nonnull ExpressionMatcher<? extends Bindable>... children) {
+    public static <U extends RelationalExpressionWithPredicates> TypeWithPredicateMatcher<U> ofPredicate(@Nonnull Class<? extends U> expressionClass,
+                                                                                                         @Nonnull ExpressionMatcher<? extends QueryPredicate> predicateMatcher,
+                                                                                                         @Nonnull ExpressionMatcher<? extends Bindable>... children) {
         ImmutableList.Builder<ExpressionMatcher<? extends Bindable>> builder = ImmutableList.builder();
         for (ExpressionMatcher<? extends Bindable> child : children) {
             builder.add(child);
@@ -73,9 +74,9 @@ public class TypeWithPredicateMatcher<T extends RelationalExpressionWithPredicat
         return ofPredicate(expressionClass, predicateMatcher, ListChildrenMatcher.of(builder.build()));
     }
 
-    public static <U extends RelationalExpressionWithPredicate> TypeWithPredicateMatcher<U> ofPredicate(@Nonnull Class<? extends U> expressionClass,
-                                                                                                        @Nonnull ExpressionMatcher<? extends QueryPredicate> predicateMatcher,
-                                                                                                        @Nonnull ExpressionChildrenMatcher childrenMatcher) {
+    public static <U extends RelationalExpressionWithPredicates> TypeWithPredicateMatcher<U> ofPredicate(@Nonnull Class<? extends U> expressionClass,
+                                                                                                         @Nonnull ExpressionMatcher<? extends QueryPredicate> predicateMatcher,
+                                                                                                         @Nonnull ExpressionChildrenMatcher childrenMatcher) {
         return new TypeWithPredicateMatcher<>(expressionClass, predicateMatcher, childrenMatcher);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/CreatesDuplicatesProperty.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.temp.properties;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
@@ -32,7 +33,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
-import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnionExpression;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -60,6 +61,8 @@ public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
             indexName = ((RecordQueryPlanWithIndex)expression).getIndexName();
         } else if (expression instanceof IndexScanExpression) {
             indexName = ((IndexScanExpression)expression).getIndexName();
+        } else if (expression instanceof RecordQueryCoveringIndexPlan) {
+            indexName = ((RecordQueryCoveringIndexPlan)expression).getIndexName();
         }
         if (indexName != null) {
             return context.getIndexByName(indexName).getRootExpression().createsDuplicates();
@@ -71,7 +74,7 @@ public class CreatesDuplicatesProperty implements PlannerProperty<Boolean> {
             // These expressions filter out duplicates, so they therefore will not return duplicates even if their
             // children will.
             return Boolean.FALSE;
-        } else if (expression instanceof RecordQueryUnorderedUnionPlan || expression instanceof LogicalUnorderedUnionExpression) {
+        } else if (expression instanceof RecordQueryUnorderedUnionPlan || expression instanceof LogicalUnionExpression) {
             // These expressions can create duplicates even if the underlying children do not.
             return Boolean.TRUE;
         } else {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/FieldWithComparisonCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/FieldWithComparisonCountProperty.java
@@ -48,7 +48,7 @@ public class FieldWithComparisonCountProperty implements PlannerProperty<Integer
     public Integer evaluateAtExpression(@Nonnull RelationalExpression expression, @Nonnull List<Integer> childResults) {
         int total = 0;
         if (expression instanceof RecordQueryFilterPlan) {
-            QueryComponent filter = ((RecordQueryFilterPlan)expression).getFilter();
+            QueryComponent filter = ((RecordQueryFilterPlan)expression).getConjunctedFilter();
             total = getFieldWithComparisonCount(filter);
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/PredicateCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/PredicateCountProperty.java
@@ -24,8 +24,9 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.temp.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.temp.PlannerProperty;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicate;
+import com.apple.foundationdb.record.query.plan.temp.RelationalExpressionWithPredicates;
 import com.apple.foundationdb.record.query.predicates.AndOrPredicate;
+import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.ExistsPredicate;
 import com.apple.foundationdb.record.query.predicates.NotPredicate;
 import com.apple.foundationdb.record.query.predicates.PredicateWithValue;
@@ -48,8 +49,8 @@ public class PredicateCountProperty implements PlannerProperty<Integer> {
     @Override
     public Integer evaluateAtExpression(@Nonnull RelationalExpression expression, @Nonnull List<Integer> childResults) {
         int total = 0;
-        if (expression instanceof RelationalExpressionWithPredicate) {
-            total = getValuePredicateCount(((RelationalExpressionWithPredicate)expression).getPredicate());
+        if (expression instanceof RelationalExpressionWithPredicates) {
+            total = getValuePredicateCount(AndPredicate.and(((RelationalExpressionWithPredicates)expression).getPredicates())); // TODO shouldn't that just be getPredicates()?
         }
         for (Integer childCount : childResults) {
             if (childCount != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/RecordTypesProperty.java
@@ -38,7 +38,7 @@ import com.apple.foundationdb.record.query.plan.temp.Quantifiers.AliasResolver;
 import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.FullUnorderedScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.IndexScanExpression;
-import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnionExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.PrimaryScanExpression;
 import com.apple.foundationdb.record.query.plan.temp.expressions.TypeFilterExpression;
 import com.google.common.collect.Sets;
@@ -125,7 +125,7 @@ public class RecordTypesProperty implements PlannerProperty<Set<String>> {
                 if (expression instanceof RecordQueryUnionPlan ||
                         expression instanceof RecordQueryUnorderedUnionPlan ||
                         expression instanceof RecordQueryIntersectionPlan ||
-                        expression instanceof LogicalUnorderedUnionExpression) {
+                        expression instanceof LogicalUnionExpression) {
                     final Set<String> union = new HashSet<>();
                     for (Set<String> childResulSet : childResults) {
                         union.addAll(childResulSet);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRule.java
@@ -34,7 +34,6 @@ import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ReferenceMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.TypeWithPredicateMatcher;
-import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 import com.google.common.collect.ImmutableList;
 
@@ -108,9 +107,8 @@ public class CombineFilterRule extends PlannerRule<LogicalFilterExpression> {
                 Quantifier.forEach(inner, upperQun.getAlias());
                         
         final QueryPredicate newLowerPred = lowerPred.rebase(Quantifiers.translate(lowerQun, newUpperQun));
-        final QueryPredicate combinedPred = new AndPredicate(ImmutableList.of(upperPred, newLowerPred));
         call.yield(call.ref(
-                new LogicalFilterExpression(combinedPred,
+                new LogicalFilterExpression(ImmutableList.of(upperPred, newLowerPred),
                         newUpperQun)));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/DataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/DataAccessRule.java
@@ -81,7 +81,7 @@ import java.util.stream.StreamSupport;
  * </ul>
  *
  * The logic that this rules delegates to to actually create the expressions can be found in
- * {@link MatchCandidate#toScanExpression(MatchInfo)}.
+ * {@link MatchCandidate#toEquivalentExpression(PartialMatch)}.
  */
 @API(API.Status.EXPERIMENTAL)
 public class DataAccessRule extends PlannerRule<MatchPartition> {
@@ -180,7 +180,7 @@ public class DataAccessRule extends PlannerRule<MatchPartition> {
                         Function.identity(),
                         partialMatch -> {
                             final MatchCandidate matchCandidate = partialMatch.getMatchCandidate();
-                            return matchCandidate.toScanExpression(partialMatch.getMatchInfo());
+                            return matchCandidate.toEquivalentExpression(partialMatch);
                         }));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FlattenNestedAndPredicateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/FlattenNestedAndPredicateRule.java
@@ -83,7 +83,7 @@ public class FlattenNestedAndPredicateRule extends PlannerRule<LogicalFilterExpr
         final Quantifier.ForEach innerQuantifier = call.get(innerQuantifierMatcher);
         List<QueryPredicate> allConjuncts = new ArrayList<>(innerAndChildren);
         allConjuncts.addAll(otherOuterAndChildren);
-        call.yield(call.ref(new LogicalFilterExpression(new AndPredicate(allConjuncts),
+        call.yield(call.ref(new LogicalFilterExpression(allConjuncts,
                 innerQuantifier)));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementDistinctUnionRule.java
@@ -30,7 +30,7 @@ import com.apple.foundationdb.record.query.plan.temp.PlanContext;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalDistinctExpression;
-import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnionExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.MultiChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
@@ -49,7 +49,7 @@ import java.util.Set;
 
 /**
  * A rule that implements a distinct union of its (already implemented) children. This will extract the
- * {@link RecordQueryPlan} from each child of a {@link LogicalUnorderedUnionExpression} and create a
+ * {@link RecordQueryPlan} from each child of a {@link LogicalUnionExpression} and create a
  * {@link RecordQueryUnionPlan} with those plans as children.
  */
 @API(API.Status.EXPERIMENTAL)
@@ -57,8 +57,8 @@ public class ImplementDistinctUnionRule extends PlannerRule<LogicalDistinctExpre
     @Nonnull
     private static final ExpressionMatcher<RecordQueryPlan> unionLegExpressionMatcher = TypeMatcher.of(RecordQueryPlan.class, MultiChildrenMatcher.allMatching(ReferenceMatcher.anyRef()));
     @Nonnull
-    private static final ExpressionMatcher<LogicalUnorderedUnionExpression> unionExpressionMatcher =
-            TypeMatcher.of(LogicalUnorderedUnionExpression.class,
+    private static final ExpressionMatcher<LogicalUnionExpression> unionExpressionMatcher =
+            TypeMatcher.of(LogicalUnionExpression.class,
                     MultiChildrenMatcher.allMatching(QuantifierMatcher.forEach(unionLegExpressionMatcher)));
 
     @Nonnull
@@ -75,8 +75,8 @@ public class ImplementDistinctUnionRule extends PlannerRule<LogicalDistinctExpre
         final PlanContext context = call.getContext();
         final PlannerBindings bindings = call.getBindings();
         final List<RecordQueryPlan> unionLegExpressions = bindings.getAll(unionLegExpressionMatcher);
-        final LogicalUnorderedUnionExpression logicalUnorderedUnionExpression = bindings.get(unionExpressionMatcher);
-        final Optional<OrderingInfo> orderingInfoOptional = OrderingProperty.evaluate(logicalUnorderedUnionExpression, context);
+        final LogicalUnionExpression logicalUnionExpression = bindings.get(unionExpressionMatcher);
+        final Optional<OrderingInfo> orderingInfoOptional = OrderingProperty.evaluate(logicalUnionExpression, context);
         if (!orderingInfoOptional.isPresent()) {
             return;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementTypeFilterRule.java
@@ -44,10 +44,10 @@ import java.util.Set;
  */
 @API(API.Status.EXPERIMENTAL)
 public class ImplementTypeFilterRule extends PlannerRule<LogicalTypeFilterExpression> {
-    private static ExpressionMatcher<RecordQueryPlan> innerMatcher = TypeMatcher.of(RecordQueryPlan.class,
+    private static final ExpressionMatcher<RecordQueryPlan> innerMatcher = TypeMatcher.of(RecordQueryPlan.class,
             AnyChildrenMatcher.ANY);
     private static final ExpressionMatcher<Quantifier.ForEach> innerQuantifierMatcher = QuantifierMatcher.forEach(innerMatcher);
-    private static ExpressionMatcher<LogicalTypeFilterExpression> root =
+    private static final ExpressionMatcher<LogicalTypeFilterExpression> root =
             TypeMatcher.of(LogicalTypeFilterExpression.class, innerQuantifierMatcher);
 
     public ImplementTypeFilterRule() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/ImplementUnorderedUnionRule.java
@@ -25,7 +25,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRule;
 import com.apple.foundationdb.record.query.plan.temp.PlannerRuleCall;
-import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnorderedUnionExpression;
+import com.apple.foundationdb.record.query.plan.temp.expressions.LogicalUnionExpression;
 import com.apple.foundationdb.record.query.plan.temp.matchers.MultiChildrenMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.QuantifierMatcher;
@@ -37,16 +37,16 @@ import java.util.List;
 
 /**
  * A rule that implements an unordered union of its (already implemented) children. This will extract the
- * {@link RecordQueryPlan} from each child of a {@link LogicalUnorderedUnionExpression} and create a
+ * {@link RecordQueryPlan} from each child of a {@link LogicalUnionExpression} and create a
  * {@link RecordQueryUnorderedUnionPlan} with those plans as children.
  */
 @API(API.Status.EXPERIMENTAL)
-public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnorderedUnionExpression> {
+public class ImplementUnorderedUnionRule extends PlannerRule<LogicalUnionExpression> {
     @Nonnull
     private static final ExpressionMatcher<RecordQueryPlan> childMatcher = TypeMatcher.of(RecordQueryPlan.class, MultiChildrenMatcher.allMatching(ReferenceMatcher.anyRef()));
     @Nonnull
-    private static final ExpressionMatcher<LogicalUnorderedUnionExpression> root =
-            TypeMatcher.of(LogicalUnorderedUnionExpression.class,
+    private static final ExpressionMatcher<LogicalUnionExpression> root =
+            TypeMatcher.of(LogicalUnionExpression.class,
                     MultiChildrenMatcher.allMatching(QuantifierMatcher.forEach(childMatcher)));
 
     public ImplementUnorderedUnionRule() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/IntersectionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/IntersectionVisitor.java
@@ -69,7 +69,7 @@ public class IntersectionVisitor extends RecordQueryPlannerSubstitutionVisitor {
     public RecordQueryPlan postVisit(@Nonnull final RecordQueryPlan recordQueryPlan) {
         if (recordQueryPlan instanceof RecordQueryIntersectionPlan) {
             RecordQueryIntersectionPlan intersectionPlan = (RecordQueryIntersectionPlan) recordQueryPlan;
-            Set<KeyExpression> requiredFields = ((RecordQueryIntersectionPlan)recordQueryPlan).getRequiredFields();
+            Set<KeyExpression> requiredFields = intersectionPlan.getRequiredFields();
 
             List<RecordQueryPlan> newChildren = new ArrayList<>(intersectionPlan.getChildren().size());
             for (RecordQueryPlan plan : intersectionPlan.getChildren()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/UnionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/UnionVisitor.java
@@ -28,13 +28,11 @@ import com.apple.foundationdb.record.query.plan.PlannableIndexTypes;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithRequiredFields;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlanBase;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -72,13 +70,7 @@ public class UnionVisitor extends RecordQueryPlannerSubstitutionVisitor {
         if (recordQueryPlan instanceof RecordQueryUnionPlanBase) {
             RecordQueryUnionPlanBase unionPlan = (RecordQueryUnionPlanBase) recordQueryPlan;
 
-            Set<KeyExpression> requiredFields;
-            if (unionPlan instanceof RecordQueryPlanWithRequiredFields) {
-                requiredFields = ((RecordQueryPlanWithRequiredFields)unionPlan).getRequiredFields();
-            } else {
-                requiredFields = Collections.emptySet();
-            }
-
+            final Set<KeyExpression> requiredFields = unionPlan.getRequiredFields();
             boolean shouldPullOutFilter = false;
             QueryComponent filter = null;
             if (unionPlan.getChildren().stream().allMatch(child -> child instanceof RecordQueryFilterPlan)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/UnionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/UnionVisitor.java
@@ -74,9 +74,9 @@ public class UnionVisitor extends RecordQueryPlannerSubstitutionVisitor {
             boolean shouldPullOutFilter = false;
             QueryComponent filter = null;
             if (unionPlan.getChildren().stream().allMatch(child -> child instanceof RecordQueryFilterPlan)) {
-                filter = ((RecordQueryFilterPlan) unionPlan.getChildren().get(0)).getFilter();
+                filter = ((RecordQueryFilterPlan) unionPlan.getChildren().get(0)).getConjunctedFilter();
                 final QueryComponent finalFilter = filter; // needed for lambda expression
-                shouldPullOutFilter = unionPlan.getChildren().stream().allMatch(plan -> ((RecordQueryFilterPlan) plan).getFilter().equals(finalFilter));
+                shouldPullOutFilter = unionPlan.getChildren().stream().allMatch(plan -> ((RecordQueryFilterPlan) plan).getConjunctedFilter().equals(finalFilter));
             }
 
             List<RecordQueryPlan> newChildren = new ArrayList<>(unionPlan.getChildren().size());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AndOrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AndOrPredicate.java
@@ -25,19 +25,13 @@ import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
-import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Streams;
-import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -57,7 +51,8 @@ public abstract class AndOrPredicate implements QueryPredicate {
     }
 
     @Nonnull
-    public List<QueryPredicate> getChildren() {
+    @Override
+    public List<? extends QueryPredicate> getChildren() {
         return children;
     }
 
@@ -67,33 +62,11 @@ public abstract class AndOrPredicate implements QueryPredicate {
         return matcher.matchWith(outerBindings, this, getChildren());
     }
 
-    @Nonnull
-    @Override
-    public Set<CorrelationIdentifier> getCorrelatedTo() {
-        final ImmutableSet.Builder<CorrelationIdentifier> builder = ImmutableSet.builder();
-        for (final QueryPredicate child : getChildren()) {
-            builder.addAll(child.getCorrelatedTo());
-        }
-        return builder.build();
-    }
-
-    @Nonnull
-    @Override
-    public AndOrPredicate rebase(@Nonnull final AliasMap translationMap) {
-        return rebaseWithRebasedChildren(translationMap,
-                getChildren().stream()
-                        .map(child -> child.rebase(translationMap))
-                        .collect(Collectors.toList()));
-    }
-
-    public abstract AndOrPredicate rebaseWithRebasedChildren(final AliasMap translationMap,
-                                                             final List<QueryPredicate> rebasedChildren);
-
     @Override
     @SuppressWarnings({"squid:S1206", "EqualsWhichDoesntCheckParameterClass"})
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.emptyMap());
+        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
     @Override
@@ -104,46 +77,5 @@ public abstract class AndOrPredicate implements QueryPredicate {
     @Override
     public int semanticHashCode() {
         return Objects.hash(ImmutableSet.of(getChildren()));
-    }
-
-    @SuppressWarnings("UnstableApiUsage")
-    @Override
-    public boolean semanticEquals(@Nullable final Object other,
-                                  @Nonnull final AliasMap aliasMap) {
-        if (other == null) {
-            return false;
-        }
-
-        if (this == other) {
-            return true;
-        }
-
-        if (!(other instanceof AndOrPredicate)) {
-            return false;
-        }
-
-        final AndOrPredicate otherAndOrPred = (AndOrPredicate)other;
-        if (!equalsWithoutChildren(otherAndOrPred, aliasMap)) {
-            return false;
-        }
-
-        final List<QueryPredicate> preds = getChildren();
-        final List<QueryPredicate> otherPreds = otherAndOrPred.getChildren();
-        if (preds.size() != otherPreds.size()) {
-            return false;
-        }
-        return Streams
-                .zip(preds.stream(), otherPreds.stream(), Pair::of)
-                .allMatch(pair -> pair.getLeft().semanticEquals(pair.getRight(), aliasMap));
-    }
-
-    @SuppressWarnings({"squid:S1172", "unused"})
-    protected boolean equalsWithoutChildren(@Nonnull final AndOrPredicate other,
-                                            @Nonnull final AliasMap equivalenceMap) {
-        if (this == other) {
-            return true;
-        }
-
-        return other.getClass() == getClass();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AndPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AndPredicate.java
@@ -25,8 +25,6 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.temp.AliasMap;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Message;
@@ -89,17 +87,32 @@ public class AndPredicate extends AndOrPredicate {
         }
     }
 
+    @Nonnull
     @Override
-    public AndPredicate rebaseWithRebasedChildren(final AliasMap translationMap, final List<QueryPredicate> rebasedChildren) {
-        return new AndPredicate(rebasedChildren);
+    public AndPredicate withChildren(final Iterable<? extends QueryPredicate> newChildren) {
+        return new AndPredicate(ImmutableList.copyOf(newChildren));
     }
 
-    public static QueryPredicate and(@Nonnull Collection<QueryPredicate> children) {
-        Verify.verify(!children.isEmpty());
-        if (children.size() == 1) {
-            return Iterables.getOnlyElement(children);
+    public static QueryPredicate and(@Nonnull Collection<QueryPredicate> conjuncts) {
+        if (conjuncts.isEmpty()) {
+            return ConstantPredicate.TRUE;
+        }
+        if (conjuncts.size() == 1) {
+            return Iterables.getOnlyElement(conjuncts);
         }
 
-        return new AndPredicate(ImmutableList.copyOf(children));
+        return new AndPredicate(ImmutableList.copyOf(conjuncts));
+    }
+
+    public static List<? extends QueryPredicate> conjuncts(@Nonnull final QueryPredicate queryPredicate) {
+        if (queryPredicate.isTautology()) {
+            return ImmutableList.of();
+        }
+
+        if (queryPredicate instanceof AndPredicate) {
+            return ((AndPredicate)queryPredicate).getChildren();
+        }
+
+        return ImmutableList.of(queryPredicate);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/ConstantPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/ConstantPredicate.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
  * A predicate with a constant boolean value.
  */
 @API(API.Status.EXPERIMENTAL)
-public class ConstantPredicate implements QueryPredicate {
+public class ConstantPredicate implements LeafQueryPredicate {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Constant-Predicate");
 
     @Nonnull
@@ -84,16 +84,13 @@ public class ConstantPredicate implements QueryPredicate {
 
     @Nonnull
     @Override
-    public QueryPredicate rebase(@Nonnull final AliasMap translationMap) {
+    public QueryPredicate rebaseLeaf(@Nonnull final AliasMap translationMap) {
         return this;
     }
 
     @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap equivalenceMap) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
+    public boolean equalsWithoutChildren(@Nonnull final QueryPredicate other, @Nonnull final AliasMap equivalenceMap) {
+        if (!LeafQueryPredicate.super.equalsWithoutChildren(other, equivalenceMap)) {
             return false;
         }
         final ConstantPredicate that = (ConstantPredicate)other;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/DerivedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/DerivedValue.java
@@ -1,0 +1,90 @@
+/*
+ * MergeValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A value merges the input messages given to it into an output message.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class DerivedValue implements Value, Value.CompileTimeValue {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Derived-Value");
+
+    @Nonnull
+    private final List<? extends Value> children;
+
+    public DerivedValue(@Nonnull Iterable<? extends Value> values) {
+        this.children = ImmutableList.copyOf(values);
+        Preconditions.checkArgument(!children.isEmpty());
+    }
+
+    @Nonnull
+    @Override
+    public Iterable<? extends Value> getChildren() {
+        return children;
+    }
+
+    @Nonnull
+    @Override
+    public DerivedValue withChildren(final Iterable<? extends Value> newChildren) {
+        return new DerivedValue(newChildren);
+    }
+
+    @Override
+    public int semanticHashCode() {
+        return PlanHashable.objectsPlanHash(PlanHashKind.FOR_CONTINUATION, BASE_HASH, children);
+    }
+    
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, children);
+    }
+
+    @Override
+    public String toString() {
+        return "derived(" + children.stream()
+                .map(Value::toString)
+                .collect(Collectors.joining(", ")) + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @Override
+    public boolean equals(final Object other) {
+        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/EmptyValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/EmptyValue.java
@@ -1,0 +1,95 @@
+/*
+ * EmptyValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A value that evaluates to empty.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class EmptyValue implements LeafValue {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Empty-Value");
+
+    @Nullable
+    @Override
+    public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> record, @Nullable final M message) {
+        return Key.Evaluated.EMPTY;
+    }
+
+    @Nonnull
+    @Override
+    public EmptyValue rebaseLeaf(@Nonnull final AliasMap translationMap) {
+        return this;
+    }
+
+    @Override
+    public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        return true;
+    }
+
+    @Override
+    public int semanticHashCode() {
+        return 73;
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        switch (hashKind) {
+            case LEGACY:
+            case FOR_CONTINUATION:
+                return PlanHashable.objectsPlanHash(hashKind, BASE_HASH);
+            case STRUCTURAL_WITHOUT_LITERALS:
+                return PlanHashable.planHash(hashKind, BASE_HASH);
+            default:
+                throw new UnsupportedOperationException("Hash kind " + hashKind.name() + " is not supported");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "empty()";
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @Override
+    public boolean equals(final Object other) {
+        return semanticEquals(other, AliasMap.emptyMap());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/IndexedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/IndexedValue.java
@@ -1,5 +1,5 @@
 /*
- * QuantifiedObjectValue.java
+ * IndexedValue.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -22,28 +22,21 @@ package com.apple.foundationdb.record.query.predicates;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
-import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
- * A value representing the quantifier as an object.
- *
- * For example, this is used to represent non-nested repeated fields.
+ * A value representing the source of a value derivation.
  */
 @API(API.Status.EXPERIMENTAL)
-public class BaseValue implements Value {
-    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Base-Value");
+public class IndexedValue implements LeafValue, Value.CompileTimeValue {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Indexed-Value");
 
     @Nonnull
     @Override
@@ -53,25 +46,13 @@ public class BaseValue implements Value {
 
     @Nonnull
     @Override
-    public BaseValue rebase(@Nonnull final AliasMap translationMap) {
+    public IndexedValue rebaseLeaf(@Nonnull final AliasMap translationMap) {
         return this;
     }
 
-    @Nullable
     @Override
-    public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> record, @Nullable final M message) {
-        return null;
-    }
-
-    @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap equivalenceMap) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        return true;
+    public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        return false;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/LeafQueryPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/LeafQueryPredicate.java
@@ -1,0 +1,46 @@
+/*
+ * LeafQueryPredicate.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Class to model the concept of a predicate. A predicate is a construct that can be evaluated using
+ * three-values logic for a set of given inputs. The caller can then use that result to take appropriate action,
+ * e.g. filter a record out of a set of records, etc.
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface LeafQueryPredicate extends QueryPredicate {
+    @Nonnull
+    @Override
+    default Iterable<? extends QueryPredicate> getChildren() {
+        return ImmutableList.of();
+    }
+
+    @Nonnull
+    @Override
+    default QueryPredicate withChildren(final Iterable<? extends QueryPredicate> newChildren) {
+        return this;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/LeafValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/LeafValue.java
@@ -1,5 +1,5 @@
 /*
- * RecordQueryPlanWithRequiredFields.java
+ * LeafValue.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -18,17 +18,32 @@
  * limitations under the License.
  */
 
-package com.apple.foundationdb.record.query.plan.plans;
+package com.apple.foundationdb.record.query.predicates;
 
-import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.annotation.API;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
-import java.util.Set;
 
 /**
- * Interface for query plans that have fields that must be present for successful execution.
+ * A scalar value type that has children.
  */
-public interface RecordQueryPlanWithRequiredFields extends RecordQueryPlan {
+@API(API.Status.EXPERIMENTAL)
+public interface LeafValue extends Value {
+
+    /**
+     * Method to retrieve a list of children values.
+     * @return a list of children
+     */
     @Nonnull
-    Set<KeyExpression> getRequiredFields();
+    @Override
+    default Iterable<? extends Value> getChildren() {
+        return ImmutableList.of();
+    }
+
+    @Nonnull
+    @Override
+    default LeafValue withChildren(@Nonnull final Iterable<? extends Value> newChildren) {
+        return this;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/LiteralValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/LiteralValue.java
@@ -28,21 +28,18 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
-import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * A wrapper around a literal of the given type.
  * @param <T> the type of the literal
  */
 @API(API.Status.EXPERIMENTAL)
-public class LiteralValue<T> implements Value {
+public class LiteralValue<T> implements LeafValue {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Literal-Value");
 
     @Nullable
@@ -52,32 +49,29 @@ public class LiteralValue<T> implements Value {
         this.value = value;
     }
 
-    @Nonnull
-    @Override
-    public Set<CorrelationIdentifier> getCorrelatedTo() {
-        return Collections.emptySet();
-    }
-
-    @Nonnull
-    @Override
-    public Value rebase(@Nonnull final AliasMap translationMap) {
-        return this;
-    }
-
     @Nullable
     @Override
     public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> record, @Nullable final M message) {
         return value;
     }
 
+    @Nonnull
     @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap equivalenceMap) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
+    public Value rebaseLeaf(@Nonnull final AliasMap translationMap) {
+        return this;
+    }
+
+    @Override
+    public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        return true;
+    }
+
+    @Override
+    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
+        if (!LeafValue.super.equalsWithoutChildren(other, equivalenceMap)) {
             return false;
         }
+
         final LiteralValue<?> that = (LiteralValue<?>)other;
         return Objects.equals(value, that.value);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/MergeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/MergeValue.java
@@ -1,0 +1,169 @@
+/*
+ * MergeValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
+import com.apple.foundationdb.record.query.plan.temp.Quantifier;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * A value merges the input messages given to it into an output message.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class MergeValue implements Value {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Merge-Value");
+
+    @Nonnull
+    private final List<? extends QuantifiedColumnValue> children;
+
+    public MergeValue(@Nonnull Iterable<? extends QuantifiedColumnValue> values) {
+        this.children = ImmutableList.copyOf(values);
+        Preconditions.checkArgument(!children.isEmpty());
+    }
+
+    @Nonnull
+    @Override
+    public Iterable<? extends QuantifiedColumnValue> getChildren() {
+        return children;
+    }
+
+    @Nonnull
+    @Override
+    public MergeValue withChildren(final Iterable<? extends Value> newChildren) {
+        return new MergeValue(StreamSupport.stream(newChildren.spliterator(), false)
+                .map(child -> {
+                    if (child instanceof QuantifiedColumnValue) {
+                        return (QuantifiedColumnValue)child;
+                    }
+                    throw new RecordCoreException("invalid call to withChildren; expected quantified value");
+                })
+                .collect(ImmutableList.toImmutableList()));
+    }
+
+    @Nullable
+    @Override
+    public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> record, @Nullable final M message) {
+        if (message == null) {
+            return null;
+        }
+
+        // TODO For now we'll just go through all the quantifiers and see if they have been bound by the caller.
+        //      If they are set, we happily use their value in the merge. If they are unset, we just skip that reference.
+        //      This can happen in the context of a set operation as the cursors over the e.g. union may only be
+        //      valid for one quantifier (or a subset). Us going through all possible references here will lead to
+        //      sub optimal performance as the caller already knows which quantifiers are bound and which ones are not.
+        //      Suggestion (although not implemented): We can allow the context to tell us which quantifiers are bound
+        //      and which ones are not. EvaluationContext#getBindings() almost does that job except that it also returns
+        //      all purely correlated bindings and not just bindings from the quantifiers this set expression ranges
+        //      over.
+        final ImmutableList<Message> childrenResults =
+                children.stream()
+                        .flatMap(child -> {
+                            final Object childResult = child.eval(store, context, record, message);
+                            if (!(childResult instanceof Message)) {
+                                return Stream.of();
+                            }
+                            return Stream.of((Message)childResult);
+                        }).collect(ImmutableList.toImmutableList());
+
+        return merge(childrenResults);
+    }
+
+    @Nullable
+    @SuppressWarnings("unused")
+    private Message merge(@Nonnull final List<Message> childrenResults) {
+        return null; // TODO do it
+    }
+
+    @Override
+    public int semanticHashCode() {
+        return PlanHashable.objectsPlanHash(PlanHashKind.FOR_CONTINUATION, BASE_HASH, children);
+    }
+    
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, children);
+    }
+
+    @Override
+    public String toString() {
+        return "merge(" + children.stream()
+                .map(Value::toString)
+                .collect(Collectors.joining(", ")) + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @Override
+    public boolean equals(final Object other) {
+        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+    }
+
+    public static List<? extends MergeValue> pivotAndMergeValues(@Nonnull final List<? extends Quantifier> quantifiers) {
+        Verify.verify(!quantifiers.isEmpty());
+        int numberOfFields = -1;
+        final ImmutableList.Builder<List<? extends QuantifiedColumnValue>> allFlowedValuesBuilder = ImmutableList.builder();
+        for (final Quantifier quantifier : quantifiers) {
+            final List<? extends QuantifiedColumnValue> flowedValues = quantifier.getFlowedValues();
+            allFlowedValuesBuilder.add(flowedValues);
+            if (numberOfFields == -1 || numberOfFields > flowedValues.size()) {
+                numberOfFields = flowedValues.size();
+            }
+        }
+
+        final ImmutableList<List<? extends QuantifiedColumnValue>> allFlowedValues = allFlowedValuesBuilder.build();
+        final ImmutableList.Builder<MergeValue> mergeValuesBuilder = ImmutableList.builder();
+
+        for (int i = 0; i < numberOfFields; i ++) {
+            final ImmutableList.Builder<QuantifiedColumnValue> toBeMergedValuesBuilder = ImmutableList.builder();
+            for (final List<? extends QuantifiedColumnValue> allFlowedValuesFromQuantifier : allFlowedValues) {
+                final QuantifiedColumnValue quantifiedColumnValue = allFlowedValuesFromQuantifier.get(i);
+                toBeMergedValuesBuilder.add(quantifiedColumnValue);
+            }
+            mergeValuesBuilder.add(new MergeValue(toBeMergedValuesBuilder.build()));
+        }
+
+        return mergeValuesBuilder.build();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/NotPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/NotPredicate.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
-import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 import com.google.common.collect.ImmutableList;
@@ -38,7 +37,6 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -47,7 +45,7 @@ import java.util.stream.Stream;
  * For tri-valued logic, if the child evaluates to unknown / {@code null}, {@code NOT} is still unknown.
  */
 @API(API.Status.EXPERIMENTAL)
-public class NotPredicate implements QueryPredicate {
+public class NotPredicate implements QueryPredicateWithChild {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Not-Predicate");
 
     @Nonnull
@@ -73,6 +71,7 @@ public class NotPredicate implements QueryPredicate {
     }
 
     @Nonnull
+    @Override
     public QueryPredicate getChild() {
         return child;
     }
@@ -92,19 +91,7 @@ public class NotPredicate implements QueryPredicate {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.emptyMap());
-    }
-
-    @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        final NotPredicate that = (NotPredicate)other;
-        return getChild().semanticEquals(that.getChild(), aliasMap);
+        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
     @Override
@@ -132,13 +119,7 @@ public class NotPredicate implements QueryPredicate {
 
     @Nonnull
     @Override
-    public Set<CorrelationIdentifier> getCorrelatedTo() {
-        return getChild().getCorrelatedTo();
-    }
-
-    @Nonnull
-    @Override
-    public NotPredicate rebase(@Nonnull final AliasMap translationMap) {
-        return new NotPredicate(getChild().rebase(translationMap));
+    public NotPredicate withChild(@Nonnull final QueryPredicate newChild) {
+        return new NotPredicate(newChild);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/OrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/OrPredicate.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -91,9 +90,10 @@ public class OrPredicate extends AndOrPredicate {
         }
     }
 
+    @Nonnull
     @Override
-    public OrPredicate rebaseWithRebasedChildren(final AliasMap translationMap, final List<QueryPredicate> rebasedChildren) {
-        return new OrPredicate(rebasedChildren);
+    public OrPredicate withChildren(final Iterable<? extends QueryPredicate> newChildren) {
+        return new OrPredicate(ImmutableList.copyOf(newChildren));
     }
 
     public static QueryPredicate or(@Nonnull Collection<QueryPredicate> children) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/PredicateWithValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/PredicateWithValue.java
@@ -28,7 +28,10 @@ import javax.annotation.Nonnull;
  * A predicate consisting of a {@link Value}.
  */
 @API(API.Status.EXPERIMENTAL)
-public interface PredicateWithValue extends QueryPredicate {
+public interface PredicateWithValue extends LeafQueryPredicate {
     @Nonnull
     Value getValue();
+
+    @Nonnull
+    PredicateWithValue withValue(@Nonnull Value value);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QuantifiedColumnValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QuantifiedColumnValue.java
@@ -34,8 +34,6 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * A value representing the quantifier as an object.
@@ -43,23 +41,17 @@ import java.util.Set;
  * For example, this is used to represent non-nested repeated fields.
  */
 @API(API.Status.EXPERIMENTAL)
-public class QuantifiedColumnValue implements Value {
+public class QuantifiedColumnValue implements QuantifiedValue {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Quantifier-Column-Value");
 
     @Nonnull
-    private final CorrelationIdentifier identifier;
+    private final CorrelationIdentifier alias;
     private final int ordinalPosition;
 
-
-    public QuantifiedColumnValue(@Nonnull final CorrelationIdentifier identifier,
+    private QuantifiedColumnValue(@Nonnull final CorrelationIdentifier alias,
                                  final int ordinalPosition) {
-        this.identifier = identifier;
+        this.alias = alias;
         this.ordinalPosition = ordinalPosition;
-    }
-
-    @Nonnull
-    public CorrelationIdentifier getIdentifier() {
-        return identifier;
     }
 
     public int getOrdinalPosition() {
@@ -68,15 +60,9 @@ public class QuantifiedColumnValue implements Value {
 
     @Nonnull
     @Override
-    public Set<CorrelationIdentifier> getCorrelatedTo() {
-        return Collections.singleton(identifier);
-    }
-
-    @Nonnull
-    @Override
-    public QuantifiedColumnValue rebase(@Nonnull final AliasMap translationMap) {
-        if (translationMap.containsSource(identifier)) {
-            return new QuantifiedColumnValue(translationMap.getTargetOrThrow(identifier), ordinalPosition);
+    public QuantifiedColumnValue rebaseLeaf(@Nonnull final AliasMap translationMap) {
+        if (translationMap.containsSource(alias)) {
+            return new QuantifiedColumnValue(translationMap.getTargetOrThrow(alias), ordinalPosition);
         }
         return this;
     }
@@ -84,22 +70,22 @@ public class QuantifiedColumnValue implements Value {
     @Nullable
     @Override
     public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> record, @Nullable final M message) {
-        return context.getBinding(identifier);
+        return context.getBinding(alias);
+    }
+
+    @Nonnull
+    @Override
+    public CorrelationIdentifier getAlias() {
+        return alias;
     }
 
     @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap equivalenceMap) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
+    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
+        if (!QuantifiedValue.super.equalsWithoutChildren(other, equivalenceMap)) {
             return false;
         }
         final QuantifiedColumnValue that = (QuantifiedColumnValue)other;
-        if (ordinalPosition != that.getOrdinalPosition()) {
-            return false;
-        }
-        return equivalenceMap.containsMapping(identifier, that.identifier);
+        return ordinalPosition == that.getOrdinalPosition();
     }
 
     @Override
@@ -114,7 +100,7 @@ public class QuantifiedColumnValue implements Value {
 
     @Override
     public String toString() {
-        return "$" + identifier + "[" + ordinalPosition + "]";
+        return "$" + alias + "[" + ordinalPosition + "]";
     }
 
     @Override
@@ -126,6 +112,24 @@ public class QuantifiedColumnValue implements Value {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(ImmutableSet.of(identifier)));
+        return semanticEquals(other, AliasMap.identitiesFor(ImmutableSet.of(alias)));
+    }
+
+    @Override
+    public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        if (otherValue instanceof QuantifiedObjectValue) {
+            return getAlias().equals(((QuantifiedObjectValue)otherValue).getAlias());
+        }
+        if (otherValue instanceof QuantifiedColumnValue) {
+            final QuantifiedColumnValue otherQuantifierColumnValue = (QuantifiedColumnValue)otherValue;
+            return getAlias().equals(otherQuantifierColumnValue.getAlias()) &&
+                   getOrdinalPosition() == (otherQuantifierColumnValue.getOrdinalPosition());
+        }
+        return false;
+    }
+
+    @Nonnull
+    public static QuantifiedColumnValue of(@Nonnull CorrelationIdentifier alias, int ordinal) {
+        return new QuantifiedColumnValue(alias, ordinal);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QuantifiedObjectValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QuantifiedObjectValue.java
@@ -34,8 +34,6 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * A value representing the quantifier as an object.
@@ -43,27 +41,21 @@ import java.util.Set;
  * For example, this is used to represent non-nested repeated fields.
  */
 @API(API.Status.EXPERIMENTAL)
-public class QuantifiedObjectValue implements Value {
+public class QuantifiedObjectValue implements QuantifiedValue {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Quantified-Object-Value");
 
     @Nonnull
-    private final CorrelationIdentifier identifier;
+    private final CorrelationIdentifier alias;
 
-    public QuantifiedObjectValue(@Nonnull final CorrelationIdentifier identifier) {
-        this.identifier = identifier;
+    public QuantifiedObjectValue(@Nonnull final CorrelationIdentifier alias) {
+        this.alias = alias;
     }
 
     @Nonnull
     @Override
-    public Set<CorrelationIdentifier> getCorrelatedTo() {
-        return Collections.singleton(identifier);
-    }
-
-    @Nonnull
-    @Override
-    public QuantifiedObjectValue rebase(@Nonnull final AliasMap translationMap) {
-        if (translationMap.containsSource(identifier)) {
-            return new QuantifiedObjectValue(translationMap.getTargetOrThrow(identifier));
+    public QuantifiedObjectValue rebaseLeaf(@Nonnull final AliasMap translationMap) {
+        if (translationMap.containsSource(alias)) {
+            return new QuantifiedObjectValue(translationMap.getTargetOrThrow(alias));
         }
         return this;
     }
@@ -71,19 +63,13 @@ public class QuantifiedObjectValue implements Value {
     @Nullable
     @Override
     public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> record, @Nullable final M message) {
-        return context.getBinding(identifier);
+        return context.getBinding(alias);
     }
 
+    @Nonnull
     @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap equivalenceMap) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        final QuantifiedObjectValue that = (QuantifiedObjectValue)other;
-        return equivalenceMap.containsMapping(identifier, that.identifier);
+    public CorrelationIdentifier getAlias() {
+        return alias;
     }
 
     @Override
@@ -98,7 +84,7 @@ public class QuantifiedObjectValue implements Value {
 
     @Override
     public String toString() {
-        return "$" + identifier;
+        return "$" + alias;
     }
 
     @Override
@@ -110,6 +96,14 @@ public class QuantifiedObjectValue implements Value {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(ImmutableSet.of(identifier)));
+        return semanticEquals(other, AliasMap.identitiesFor(ImmutableSet.of(alias)));
+    }
+
+    @Override
+    public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        if (otherValue instanceof QuantifiedObjectValue) {
+            return getAlias().equals(((QuantifiedObjectValue)otherValue).getAlias());
+        }
+        return false;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QuantifiedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QuantifiedValue.java
@@ -1,0 +1,54 @@
+/*
+ * QuantifiedValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
+import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+/**
+ * A scalar value type that is directly derived from an alias.
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface QuantifiedValue extends LeafValue {
+
+    CorrelationIdentifier getAlias();
+
+    @Nonnull
+    @Override
+    default Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
+        return ImmutableSet.of(getAlias());
+    }
+
+    @Override
+    default boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
+        if (!LeafValue.super.equalsWithoutChildren(other, equivalenceMap)) {
+            return false;
+        }
+
+        final QuantifiedValue that = (QuantifiedValue)other;
+        return equivalenceMap.containsMapping(getAlias(), that.getAlias());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueriedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueriedValue.java
@@ -36,7 +36,7 @@ import java.util.Set;
  */
 @API(API.Status.EXPERIMENTAL)
 public class QueriedValue implements LeafValue, Value.CompileTimeValue {
-    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Base-Value");
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Queried-Value");
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueriedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueriedValue.java
@@ -1,0 +1,84 @@
+/*
+ * QueriedValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
+import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+/**
+ * A value representing the source of a value derivation.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class QueriedValue implements LeafValue, Value.CompileTimeValue {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Base-Value");
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    public QueriedValue rebaseLeaf(@Nonnull final AliasMap translationMap) {
+        return this;
+    }
+
+    @Override
+    public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        return false;
+    }
+
+    @Override
+    public int semanticHashCode() {
+        return PlanHashable.objectPlanHash(PlanHashKind.FOR_CONTINUATION, BASE_HASH);
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        return PlanHashable.objectsPlanHash(hashKind, BASE_HASH);
+    }
+
+    @Override
+    public String toString() {
+        return "base()";
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @Override
+    public boolean equals(final Object other) {
+        return semanticEquals(other, AliasMap.emptyMap());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryComponentPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryComponentPredicate.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * TODO remove this class eventually
  */
 @API(API.Status.EXPERIMENTAL)
-public class QueryComponentPredicate implements QueryPredicate {
+public class QueryComponentPredicate implements LeafQueryPredicate {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Predicate-With-Query-Component");
 
     @Nonnull
@@ -97,15 +97,12 @@ public class QueryComponentPredicate implements QueryPredicate {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.emptyMap());
+        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
     @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
+    public boolean equalsWithoutChildren(@Nonnull final QueryPredicate other, @Nonnull final AliasMap equivalenceMap) {
+        if (!LeafQueryPredicate.super.equalsWithoutChildren(other, equivalenceMap)) {
             return false;
         }
         final QueryComponentPredicate that = (QueryComponentPredicate)other;
@@ -141,9 +138,9 @@ public class QueryComponentPredicate implements QueryPredicate {
         return correlation == null ? ImmutableSet.of() : ImmutableSet.of(correlation);
     }
 
-    @Nonnull
+    @Nullable
     @Override
-    public QueryComponentPredicate rebase(@Nonnull final AliasMap translationMap) {
+    public QueryComponentPredicate rebaseLeaf(@Nonnull final AliasMap translationMap) {
         if (correlation != null && translationMap.containsSource(correlation)) {
             return new QueryComponentPredicate(getQueryComponent(), translationMap.getTargetOrThrow(correlation));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicate.java
@@ -29,13 +29,17 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
 import com.apple.foundationdb.record.query.plan.temp.Correlated;
+import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.PredicateMultiMap.PredicateMapping;
+import com.apple.foundationdb.record.query.plan.temp.TreeLike;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -45,7 +49,13 @@ import java.util.Set;
  * e.g. filter a record out of a set of records, etc.
  */
 @API(API.Status.EXPERIMENTAL)
-public interface QueryPredicate extends Bindable, PlanHashable, Correlated<QueryPredicate> {
+public interface QueryPredicate extends Bindable, Correlated<QueryPredicate>, TreeLike<QueryPredicate>, PlanHashable {
+
+    @Nonnull
+    @Override
+    default QueryPredicate getThis() {
+        return this;
+    }
 
     /**
      * Determines if this predicate implies some other predicate.
@@ -176,4 +186,93 @@ public interface QueryPredicate extends Bindable, PlanHashable, Correlated<Query
 
     @Nullable
     <M extends Message> Boolean eval(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context, @Nullable FDBRecord<M> record, @Nullable M message);
+
+    @Nonnull
+    @Override
+    default Set<CorrelationIdentifier> getCorrelatedTo() {
+        return fold(QueryPredicate::getCorrelatedToWithoutChildren,
+                (correlatedToWithoutChildren, childrenCorrelatedTo) -> {
+                    ImmutableSet.Builder<CorrelationIdentifier> correlatedToBuilder = ImmutableSet.builder();
+                    correlatedToBuilder.addAll(correlatedToWithoutChildren);
+                    childrenCorrelatedTo.forEach(correlatedToBuilder::addAll);
+                    return correlatedToBuilder.build();
+                });
+    }
+
+    @Nonnull
+    default Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    default boolean semanticEquals(@Nullable final Object other,
+                                   @Nonnull final AliasMap aliasMap) {
+        if (other == null) {
+            return false;
+        }
+
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof QueryPredicate)) {
+            return false;
+        }
+
+        final QueryPredicate otherAndOrPred = (QueryPredicate)other;
+        if (!equalsWithoutChildren(otherAndOrPred, aliasMap)) {
+            return false;
+        }
+
+        final Iterator<? extends QueryPredicate> preds = getChildren().iterator();
+        final Iterator<? extends QueryPredicate> otherPreds = otherAndOrPred.getChildren().iterator();
+
+        while (preds.hasNext()) {
+            if (!otherPreds.hasNext()) {
+                return false;
+            }
+
+            if (!preds.next().semanticEquals(otherPreds.next(), aliasMap)) {
+                return false;
+            }
+        }
+
+        return !otherPreds.hasNext();
+    }
+
+    @SuppressWarnings({"squid:S1172", "unused"})
+    default boolean equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                          @Nonnull final AliasMap equivalenceMap) {
+        if (this == other) {
+            return true;
+        }
+
+        return other.getClass() == getClass();
+    }
+
+    @Nonnull
+    @Override
+    default QueryPredicate rebase(@Nonnull final AliasMap translationMap) {
+        return mapLeavesMaybe(t -> t.rebaseLeaf(translationMap)).orElseThrow(() -> new RecordCoreException("unable to map tree"));
+    }
+
+    @Nullable
+    @SuppressWarnings("unused")
+    default QueryPredicate rebaseLeaf(@Nonnull final AliasMap translationMap) {
+        throw new RecordCoreException("implementor must override");
+    }
+
+    @Nonnull
+    default Optional<QueryPredicate> translateValues(@Nonnull final Map<Value, Value> translationMap) {
+        return mapLeavesMaybe(t -> {
+            if (!(t instanceof PredicateWithValue)) {
+                return this;
+            }
+            final PredicateWithValue predicateWithValue = (PredicateWithValue)t;
+            return predicateWithValue.getValue()
+                            .translate(translationMap)
+                    .map(predicateWithValue::withValue)
+                    .orElse(null);
+        });
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicate.java
@@ -253,7 +253,7 @@ public interface QueryPredicate extends Bindable, Correlated<QueryPredicate>, Tr
     @Nonnull
     @Override
     default QueryPredicate rebase(@Nonnull final AliasMap translationMap) {
-        return mapLeavesMaybe(t -> t.rebaseLeaf(translationMap)).orElseThrow(() -> new RecordCoreException("unable to map tree"));
+        return replaceLeavesMaybe(t -> t.rebaseLeaf(translationMap)).orElseThrow(() -> new RecordCoreException("unable to map tree"));
     }
 
     @Nullable
@@ -264,7 +264,7 @@ public interface QueryPredicate extends Bindable, Correlated<QueryPredicate>, Tr
 
     @Nonnull
     default Optional<QueryPredicate> translateValues(@Nonnull final Map<Value, Value> translationMap) {
-        return mapLeavesMaybe(t -> {
+        return replaceLeavesMaybe(t -> {
             if (!(t instanceof PredicateWithValue)) {
                 return this;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicateWithChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicateWithChild.java
@@ -1,0 +1,61 @@
+/*
+ * ValueWithChild.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * A scalar value type that has children.
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface QueryPredicateWithChild extends QueryPredicate {
+
+    /**
+     * Method to retrieve a list of children values.
+     * @return a list of children
+     */
+    @Nonnull
+    @Override
+    default List<? extends QueryPredicate> getChildren() {
+        return ImmutableList.of(getChild());
+    }
+
+    /**
+     * Method to retrieve the only child predicate.
+     * @return this child {@link QueryPredicate}
+     */
+    @Nonnull
+    QueryPredicate getChild();
+
+    @Nonnull
+    @Override
+    default QueryPredicateWithChild withChildren(@Nonnull final Iterable<? extends QueryPredicate> newChildren) {
+        return withChild(Iterables.getOnlyElement(newChildren));
+    }
+
+    @Nonnull
+    QueryPredicateWithChild withChild(@Nonnull final QueryPredicate rebasedChild);
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/Value.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/Value.java
@@ -23,22 +23,39 @@ package com.apple.foundationdb.record.query.predicates;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.Correlated;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
+import com.apple.foundationdb.record.query.plan.temp.TreeLike;
 import com.apple.foundationdb.record.query.predicates.ValueComparisonRangePredicate.Placeholder;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A scalar value type.
  */
 @API(API.Status.EXPERIMENTAL)
-public interface Value extends Correlated<Value>, PlanHashable {
+public interface Value extends Correlated<Value>, TreeLike<Value>, PlanHashable, KeyExpressionVisitor.Result {
+
+    @Nonnull
+    @Override
+    default Value getThis() {
+        return this;
+    }
 
     @Nullable
     <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable FDBRecord<M> record, @Nullable M message);
@@ -65,5 +82,173 @@ public interface Value extends Correlated<Value>, PlanHashable {
     @Nonnull
     default Placeholder asPlaceholder(@Nonnull final CorrelationIdentifier parameterAlias) {
         return ValueComparisonRangePredicate.placeholder(this, parameterAlias);
+    }
+
+    /**
+     * Method to derive if this value is functionally dependent on another value. In order to produce a meaningful
+     * result that {@code otherValue} and this value must parts of the result values of the same
+     * {@link com.apple.foundationdb.record.query.plan.temp.RelationalExpression}.
+     *
+     * <h2>Example 1</h2>
+     * <pre>
+     * {@code
+     *    SELECT q, q.x, q.y
+     *    FROM T q
+     * }
+     * </pre>
+     * {@code q.x} and {@code q.y} are both functionally dependent on {@code q} meaning that for a given quantified
+     * (bound) value of {@code q} there is exactly one scalar result for this value. In other words, {@code q -> q.x}
+     * and {@code q -> q.y}
+     *
+     * <h2>Example 2</h2>
+     * <pre>
+     * {@code
+     *    SELECT q1, q1.x, q2.y
+     *    FROM S q1, T q2
+     * }
+     * </pre>
+     * {@code q1.x} is functionally dependent on {@code q1} meaning that for a given quantified (bound) value of
+     * {@code q1} there is exactly one scalar result for this value. In other words, {@code q1 -> q1.x}.
+     * {@code q2.x} is functionally dependent on {@code q2} meaning that for a given quantified (bound) value of
+     * {@code q2} there is exactly one scalar result for this value. In other words, {@code q2 -> q2.x}.
+     * Note that it does not hold that {@code q1 -> q2.y} nor that {@code q2 -> q1.x}.
+     *
+     * <h2>Example 3</h2>
+     * <pre>
+     * {@code
+     *    SELECT q1, q2.y
+     *    FROM S q1, (SELECT * FROM EXPLODE(q1.x) q2
+     * }
+     * </pre>
+     * {@code q2.y} is not functionally dependent on {@code q1} as for a given quantified (bound) value of {@code q1}
+     * there may be many or no associated values over {@code q2}.
+     *
+     * <h2>Example 4</h2>
+     * <pre>
+     * {@code
+     *    SELECT q1, 3
+     *    FROM S q1, (SELECT * FROM EXPLODE(q1.x) q2
+     * }
+     * {@code 3} is functionally dependent on {@code q1} as for any given quantified (bound) value of {@code q1}
+     * there is exactly one scalar result for this value (namely {@code 3}).*
+     * </pre>
+     *
+     * Note that if {@code x -> y} and {@code y -> z} then {@code x -> z} should hold. Note that this method attempts
+     * a best effort to establish the functional dependency relationship between the other value and this value. That
+     * means that the caller cannot rely on a {@code false} result to deduce that this value is definitely not
+     * dependent on {@code otherValue}.
+     *
+     * @param otherValue other value to check if this value is functionally dependent on it
+     * @return {@code true} if this value is definitely dependent on {@code otherValue}
+     */
+    default boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        if (!(otherValue instanceof QuantifiedValue)) {
+            return false;
+        }
+
+        return StreamSupport.stream(inPreOrder().spliterator(), false)
+                .flatMap(value -> value instanceof QuantifiedValue ? Stream.of((QuantifiedValue)value) : Stream.empty())
+                .allMatch(quantifiedValue -> quantifiedValue.isFunctionallyDependentOn(otherValue));
+    }
+
+    @Nonnull
+    @Override
+    default Set<CorrelationIdentifier> getCorrelatedTo() {
+        return fold(Value::getCorrelatedToWithoutChildren,
+                (correlatedToWithoutChildren, childrenCorrelatedTo) -> {
+                    ImmutableSet.Builder<CorrelationIdentifier> correlatedToBuilder = ImmutableSet.builder();
+                    correlatedToBuilder.addAll(correlatedToWithoutChildren);
+                    childrenCorrelatedTo.forEach(correlatedToBuilder::addAll);
+                    return correlatedToBuilder.build();
+                });
+    }
+
+    @Nonnull
+    default Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    default Value rebase(@Nonnull final AliasMap translationMap) {
+        return mapLeavesMaybe(t -> t.rebaseLeaf(translationMap)).orElseThrow(() -> new RecordCoreException("unable to map tree"));
+    }
+
+    @Nonnull
+    @SuppressWarnings("unused")
+    default Value rebaseLeaf(@Nonnull final AliasMap translationMap) {
+        throw new RecordCoreException("implementor must override");
+    }
+
+    @Nonnull
+    default Optional<Value> translate(@Nonnull final Map<Value, Value> translationMap) {
+        return mapLeavesMaybe(t -> t.translateLeaf(translationMap));
+    }
+
+    @Nonnull
+    @SuppressWarnings("unused")
+    default Value translateLeaf(@Nonnull final Map<Value, Value> translationMap) {
+        return translationMap.getOrDefault(this, this);
+    }
+
+    @Override
+    default boolean semanticEquals(@Nullable final Object other,
+                                   @Nonnull final AliasMap aliasMap) {
+        if (other == null) {
+            return false;
+        }
+
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof Value)) {
+            return false;
+        }
+
+        final Value otherAndOrPred = (Value)other;
+        if (!equalsWithoutChildren(otherAndOrPred, aliasMap)) {
+            return false;
+        }
+
+        final Iterator<? extends Value> children = getChildren().iterator();
+        final Iterator<? extends Value> otherChildren = otherAndOrPred.getChildren().iterator();
+
+        while (children.hasNext()) {
+            if (!otherChildren.hasNext()) {
+                return false;
+            }
+
+            if (!children.next().semanticEquals(otherChildren.next(), aliasMap)) {
+                return false;
+            }
+        }
+
+        return !otherChildren.hasNext();
+    }
+
+    @SuppressWarnings("unused")
+    default boolean equalsWithoutChildren(@Nonnull final Value other,
+                                          @Nonnull final AliasMap equivalenceMap) {
+        if (this == other) {
+            return true;
+        }
+
+        return other.getClass() == getClass();
+    }
+
+    /**
+     * A scalar value type that can be evaluated.
+     */
+    @API(API.Status.EXPERIMENTAL)
+    interface CompileTimeValue extends Value {
+        @Nullable
+        @Override
+        default <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store,
+                                                @Nonnull final EvaluationContext context,
+                                                @Nullable FDBRecord<M> record,
+                                                @Nullable M message) {
+            throw new RecordCoreException("value is compile-time only and cannot be evaluated");
+        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/Value.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/Value.java
@@ -171,7 +171,7 @@ public interface Value extends Correlated<Value>, TreeLike<Value>, PlanHashable,
     @Nonnull
     @Override
     default Value rebase(@Nonnull final AliasMap translationMap) {
-        return mapLeavesMaybe(t -> t.rebaseLeaf(translationMap)).orElseThrow(() -> new RecordCoreException("unable to map tree"));
+        return replaceLeavesMaybe(t -> t.rebaseLeaf(translationMap)).orElseThrow(() -> new RecordCoreException("unable to map tree"));
     }
 
     @Nonnull
@@ -182,7 +182,7 @@ public interface Value extends Correlated<Value>, TreeLike<Value>, PlanHashable,
 
     @Nonnull
     default Optional<Value> translate(@Nonnull final Map<Value, Value> translationMap) {
-        return mapLeavesMaybe(t -> t.translateLeaf(translationMap));
+        return replaceLeavesMaybe(t -> t.translateLeaf(translationMap));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/ValueWithChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/ValueWithChild.java
@@ -1,0 +1,61 @@
+/*
+ * ValueWithChild.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.predicates;
+
+import com.apple.foundationdb.annotation.API;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * A scalar value type that has children.
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface ValueWithChild extends Value {
+
+    /**
+     * Method to retrieve a list of children values.
+     * @return a list of children
+     */
+    @Nonnull
+    @Override
+    default List<? extends Value> getChildren() {
+        return ImmutableList.of(getChild());
+    }
+
+    /**
+     * Method to retrieve the only child value.
+     * @return this child {@link Value}
+     */
+    @Nonnull
+    Value getChild();
+
+    @Nonnull
+    @Override
+    default ValueWithChild withChildren(@Nonnull final Iterable<? extends Value> newChildren) {
+        return withNewChild(Iterables.getOnlyElement(newChildren));
+    }
+
+    @Nonnull
+    ValueWithChild withNewChild(@Nonnull final Value rebasedChild);
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/VersionValue.java
@@ -22,25 +22,17 @@ package com.apple.foundationdb.record.query.predicates;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
-import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
-import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
-import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * A value representing a version stamp.
  */
 @API(API.Status.EXPERIMENTAL)
-public class VersionValue implements Value {
+public class VersionValue implements LeafValue, Value.CompileTimeValue {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Version-Value");
 
     public VersionValue() {
@@ -49,25 +41,13 @@ public class VersionValue implements Value {
 
     @Nonnull
     @Override
-    public Set<CorrelationIdentifier> getCorrelatedTo() {
-        return Collections.emptySet();
-    }
-
-    @Nonnull
-    @Override
-    public Value rebase(@Nonnull final AliasMap translationMap) {
+    public Value rebaseLeaf(@Nonnull final AliasMap translationMap) {
         return this;
     }
 
-    @Nullable
     @Override
-    public <M extends Message> Object eval(final @Nonnull FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> record, @Nullable final M message) {
-        throw new UnsupportedOperationException("Cannot evaluate version elements yet");
-    }
-
-    @Override
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap equivalenceMap) {
-        return other instanceof VersionValue;
+    public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
+        return true;
     }
 
     @Override
@@ -96,6 +76,6 @@ public class VersionValue implements Value {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.emptyMap());
+        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/UnknownKeyExpression.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/UnknownKeyExpression.java
@@ -25,8 +25,6 @@ import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.expressions.BaseKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
-import com.apple.foundationdb.record.query.plan.temp.ExpansionVisitor;
-import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.temp.KeyExpressionVisitor;
 import com.apple.foundationdb.record.util.HashUtils;
 import com.google.protobuf.Descriptors;
@@ -77,7 +75,7 @@ public class UnknownKeyExpression extends BaseKeyExpression {
 
     @Nonnull
     @Override
-    public <S extends KeyExpressionVisitor.State> GraphExpansion expand(@Nonnull final ExpansionVisitor<S> visitor) {
+    public <S extends KeyExpressionVisitor.State, R extends KeyExpressionVisitor.Result> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         throw new UnsupportedOperationException();
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBAndQueryToIntersectionTest.java
@@ -142,7 +142,7 @@ public class FDBAndQueryToIntersectionTest extends FDBRecordStoreQueryTestBase {
             }
         }
     }
-
+    
     /**
      * Verify that a complex query with an AND of more than two fields with compatibly ordered indexes generates an intersection plan.
      */

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcher.java
@@ -21,7 +21,8 @@
 package com.apple.foundationdb.record.query.plan.match;
 
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicateFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
+import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -43,8 +44,8 @@ public class FilterMatcher extends PlanMatcherWithChild {
     @Override
     public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
         final QueryPredicate predicate;
-        if (plan instanceof RecordQueryPredicateFilterPlan) {
-            predicate = ((RecordQueryPredicateFilterPlan)plan).getPredicate();
+        if (plan instanceof RecordQueryPredicatesFilterPlan) {
+            predicate = AndPredicate.and(((RecordQueryPredicatesFilterPlan)plan).getPredicates());
         } else {
             return false;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcherWithComponent.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcherWithComponent.java
@@ -23,10 +23,11 @@ package com.apple.foundationdb.record.query.plan.match;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicateFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
+import com.apple.foundationdb.record.query.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.predicates.PredicateWithValue;
 import com.apple.foundationdb.record.query.predicates.QueryComponentPredicate;
 import com.apple.foundationdb.record.query.predicates.QueryPredicate;
@@ -41,12 +42,12 @@ import java.util.function.Supplier;
 
 /**
  * A specialized Hamcrest matcher that recognizes both {@link RecordQueryFilterPlan}s and the {@link QueryComponent}s
- * that they use <em>and</em> {@link RecordQueryPredicateFilterPlan}s and the {@link QueryPredicate}s that they use.
+ * that they use <em>and</em> {@link RecordQueryPredicatesFilterPlan}s and the {@link QueryPredicate}s that they use.
  * This is designed to support the current {@link com.apple.foundationdb.record.provider.foundationdb.query.DualPlannerTest}
  * infrastructure where we run exactly the same unit tests using both the
  * {@link com.apple.foundationdb.record.query.plan.RecordQueryPlanner} (which produces {@link RecordQueryFilterPlan}s)
  * and the {@link com.apple.foundationdb.record.query.plan.temp.CascadesPlanner} (which produces
- * {@link RecordQueryPredicateFilterPlan}).
+ * {@link RecordQueryPredicatesFilterPlan}).
  */
 public class FilterMatcherWithComponent extends PlanMatcherWithChild {
     @Nonnull
@@ -74,12 +75,12 @@ public class FilterMatcherWithComponent extends PlanMatcherWithChild {
     public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
         if (plan instanceof RecordQueryFilterPlan) {
             return component.equals(((RecordQueryFilterPlan)plan).getFilter()) && super.matchesSafely(plan);
-        } else if (plan instanceof RecordQueryPredicateFilterPlan) {
+        } else if (plan instanceof RecordQueryPredicatesFilterPlan) {
             // todo make more robust as this will currently only work with the simplest of all cases
 
             // we lazily convert the given component to a predicate and let semantic equals establish equality
             // under the given equivalence: baseAlias <-> planBaseAlias
-            final QueryPredicate predicate = ((RecordQueryPredicateFilterPlan)plan).getPredicate();
+            final QueryPredicate predicate = AndPredicate.and(((RecordQueryPredicatesFilterPlan)plan).getPredicates());
             final CorrelationIdentifier planBaseAlias = Iterables.getOnlyElement(plan.getQuantifiers()).getAlias();
 
             if (predicate instanceof PredicateWithValue) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcherWithComponent.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcherWithComponent.java
@@ -74,7 +74,7 @@ public class FilterMatcherWithComponent extends PlanMatcherWithChild {
     @Override
     public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
         if (plan instanceof RecordQueryFilterPlan) {
-            return component.equals(((RecordQueryFilterPlan)plan).getFilter()) && super.matchesSafely(plan);
+            return component.equals(((RecordQueryFilterPlan)plan).getConjunctedFilter()) && super.matchesSafely(plan);
         } else if (plan instanceof RecordQueryPredicatesFilterPlan) {
             // todo make more robust as this will currently only work with the simplest of all cases
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/MemoExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/MemoExpressionTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.temp;
 
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
@@ -240,6 +241,12 @@ public class MemoExpressionTest {
         @Override
         public SyntheticPlannerExpression rebase(@Nonnull final AliasMap translationMap) {
             return this;
+        }
+
+        @Nonnull
+        @Override
+        public List<? extends Value> getResultValues() {
+            return ImmutableList.of();
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/TreeLikeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/TreeLikeTest.java
@@ -219,7 +219,7 @@ public class TreeLikeTest {
                                 node("e")));
 
         final Optional<TreeNode> mappedTreeOptional =
-                t.mapLeavesMaybe(n -> {
+                t.replaceLeavesMaybe(n -> {
                     if (n.getContents().equals("d")) {
                         return node("d'");
                     } else if (n.getContents().equals("e")) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/TreeLikeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/TreeLikeTest.java
@@ -1,0 +1,299 @@
+/*
+ * TreeLikeTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.temp;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link TreeLike}.
+ */
+public class TreeLikeTest {
+
+    @Test
+    void testPreOrder1() {
+        final TreeNode t = node("a", node("b"), node("c"));
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
+        assertEquals(ImmutableList.of("a", "b", "c"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+    }
+
+    @Test
+    void testPreOrder2() {
+        final TreeNode t =
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d"),
+                                node("e")));
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
+        assertEquals(ImmutableList.of("a", "b", "c", "d", "e"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+    }
+
+    @Test
+    void testPreOrderSingle() {
+        final TreeNode t = node("a");
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
+        assertEquals(ImmutableList.of("a"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+    }
+
+    @Test
+    void testPostOrder1() {
+        final TreeNode t = node("a", node("b"), node("c"));
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPostOrder());
+        assertEquals(ImmutableList.of("b", "c", "a"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+    }
+
+    @Test
+    void testPostOrder2() {
+        final TreeNode t =
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d"),
+                                node("e")));
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPostOrder());
+        assertEquals(ImmutableList.of("b", "d", "e", "c", "a"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+    }
+
+    @Test
+    void testPostOrderSingle() {
+        final TreeNode t = node("a");
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPostOrder());
+        assertEquals(ImmutableList.of("a"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+    }
+
+    @Test
+    void testFold1() {
+        final TreeNode t =
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d"),
+                                node("e")));
+
+        final int count =
+                t.fold(n -> 1,
+                        (c, foldedChildren) -> c + StreamSupport.stream(foldedChildren.spliterator(), false)
+                                .mapToInt(childrenCount -> childrenCount)
+                                .sum());
+        assertEquals(5, count);
+    }
+
+    @Test
+    void testFold2() {
+        final TreeNode t =
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d"),
+                                node("e")));
+
+        final String stringified =
+                t.fold(TreeNode::getContents,
+                        (n, foldedChildren) -> {
+                            if (Iterables.isEmpty(foldedChildren)) {
+                                return n;
+                            } else {
+                                return n + "(" +
+                                       StreamSupport.stream(foldedChildren.spliterator(), false)
+                                               .collect(Collectors.joining(", ")) + ")";
+                            }
+                        });
+        assertEquals("a(b, c(d, e))", stringified);
+    }
+
+    @Test
+    void testMap() {
+        final TreeNode t =
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d"),
+                                node("e")));
+
+        // replace "c" with a "c'" with no children
+        final Optional<TreeNode> mappedTreeOptional =
+                t.mapMaybe((n, foldedChildren) -> {
+                    final ImmutableList.Builder<TreeNode> builder = ImmutableList.builder();
+                    final Iterator<? extends TreeNode> foldedChildrenIterator = foldedChildren.iterator();
+                    for (final TreeNode child : n.getChildren()) {
+                        if (!foldedChildrenIterator.hasNext()) {
+                            return null;
+                        }
+                        if (child.getContents().equals("c")) {
+                            builder.add(node("c'"));
+                        } else {
+                            builder.add(foldedChildrenIterator.next());
+                        }
+                    }
+                    return new TreeNode(n.getContents(), builder.build());
+                });
+
+        assertTrue(mappedTreeOptional.isPresent());
+        assertEquals(
+                node("a",
+                        node("b"),
+                        node("c'")),
+                mappedTreeOptional.get());
+    }
+
+    @Test
+    void testMapWithNull() {
+        final TreeNode t =
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d"),
+                                node("e")));
+
+        final Optional<TreeNode> mappedTreeOptional =
+                t.mapMaybe((n, foldedChildren) -> {
+                    final ImmutableList.Builder<TreeNode> builder = ImmutableList.builder();
+                    final Iterator<? extends TreeNode> foldedChildrenIterator = foldedChildren.iterator();
+                    for (final TreeNode child : n.getChildren()) {
+                        if (!foldedChildrenIterator.hasNext()) {
+                            return null;
+                        }
+                        if (child.getContents().equals("c")) {
+                            return null;
+                        } else {
+                            builder.add(foldedChildrenIterator.next());
+                        }
+                    }
+                    return new TreeNode(n.getContents(), builder.build());
+                });
+
+        assertFalse(mappedTreeOptional.isPresent());
+    }
+
+    @Test
+    void testMapLeaves() {
+        final TreeNode t =
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d"),
+                                node("e")));
+
+        final Optional<TreeNode> mappedTreeOptional =
+                t.mapLeavesMaybe(n -> {
+                    if (n.getContents().equals("d")) {
+                        return node("d'");
+                    } else if (n.getContents().equals("e")) {
+                        return node("e'");
+                    } else {
+                        return n;
+                    }
+                });
+        assertTrue(mappedTreeOptional.isPresent());
+        assertEquals(
+                node("a",
+                        node("b"),
+                        node("c",
+                                node("d'"),
+                                node("e'"))),
+                mappedTreeOptional.get());
+    }
+
+    private static class TreeNode implements TreeLike<TreeNode> {
+        private final String contents;
+        private final List<TreeNode> children;
+
+        public TreeNode(@Nonnull final String contents, final Iterable<? extends TreeNode> children) {
+            this.contents = contents;
+            this.children = ImmutableList.copyOf(children);
+        }
+
+        @Nonnull
+        public String getContents() {
+            return contents;
+        }
+
+        @Nonnull
+        @Override
+        public TreeNode getThis() {
+            return this;
+        }
+
+        @Nonnull
+        @Override
+        public Iterable<? extends TreeNode> getChildren() {
+            return children;
+        }
+
+        @Nonnull
+        @Override
+        public TreeNode withChildren(@Nonnull final Iterable<? extends TreeNode> newChildren) {
+            return new TreeNode(this.contents, newChildren);
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TreeNode)) {
+                return false;
+            }
+            final TreeNode treeNode = (TreeNode)o;
+            return Objects.equal(getContents(), treeNode.getContents()) && Objects.equal(getChildren(), treeNode.getChildren());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getContents(), getChildren());
+        }
+
+        @Override
+        public String toString() {
+            return "(" + contents + "; " + getChildren() + ")";
+        }
+    }
+    
+    private static TreeNode node(@Nonnull final String contents, final TreeNode... nodes) {
+        return new TreeNode(contents, ImmutableList.copyOf(nodes));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/rules/CombineFilterRuleTest.java
@@ -55,7 +55,7 @@ public class CombineFilterRuleTest {
                                                               @Nonnull RelationalExpression inner) {
         final Quantifier.ForEach innerQuantifier = Quantifier.forEach(GroupExpressionRef.of(inner));
         return new LogicalFilterExpression(
-                queryComponent.expand(innerQuantifier.getAlias()).asAndPredicate(),
+                queryComponent.expand(innerQuantifier.getAlias()).getPredicates(),
                 innerQuantifier);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/view/FieldValueMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/view/FieldValueMatcher.java
@@ -34,10 +34,10 @@ import java.util.List;
  */
 public class FieldValueMatcher extends ValueMatcher {
     @Nonnull
-    private final List<String> fieldNames;
+    private final List<String> fieldPath;
 
-    public FieldValueMatcher(@Nonnull List<String> fieldNames) {
-        this.fieldNames = fieldNames;
+    public FieldValueMatcher(@Nonnull List<String> fieldPath) {
+        this.fieldPath = fieldPath;
     }
 
     public FieldValueMatcher(@Nonnull String fieldName) {
@@ -47,11 +47,11 @@ public class FieldValueMatcher extends ValueMatcher {
     @Override
     protected boolean matchesSafely(final Value element) {
         return element instanceof FieldValue &&
-               ((FieldValue)element).getFieldNames().equals(fieldNames);
+               ((FieldValue)element).getFieldPath().equals(fieldPath);
     }
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(String.join(".", fieldNames));
+        description.appendText(String.join(".", fieldPath));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/predicates/QueryPredicateTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/predicates/QueryPredicateTest.java
@@ -27,17 +27,14 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.Bindable;
-import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.matchers.ExpressionMatcher;
 import com.apple.foundationdb.record.query.plan.temp.matchers.PlannerBindings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,7 +60,7 @@ public class QueryPredicateTest {
         return new OrPredicate(ImmutableList.copyOf(predicates));
     }
 
-    private abstract static class TestPredicate implements QueryPredicate {
+    private abstract static class TestPredicate implements LeafQueryPredicate {
         @Override
         public int planHash(@Nonnull final PlanHashKind hashKind) {
             return 0;
@@ -73,19 +70,6 @@ public class QueryPredicateTest {
         @Override
         public Stream<PlannerBindings> bindTo(@Nonnull final PlannerBindings outerBindings, @Nonnull ExpressionMatcher<? extends Bindable> matcher) {
             return Stream.empty();
-        }
-
-        @Nonnull
-        @Override
-        public Set<CorrelationIdentifier> getCorrelatedTo() {
-            return ImmutableSet.of();
-        }
-
-        @Nonnull
-        @Override
-        public TestPredicate rebase(@Nonnull final AliasMap translationMap) {
-            // TestPredicate is immutable
-            return this;
         }
 
         @Override

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
@@ -33,6 +33,8 @@ import com.apple.foundationdb.record.query.plan.temp.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.temp.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.temp.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.predicates.QueriedValue;
+import com.apple.foundationdb.record.query.predicates.Value;
 import com.apple.foundationdb.record.spatial.common.DoubleValueOrParameter;
 import com.apple.foundationdb.tuple.Tuple;
 import com.geophile.z.SpatialJoin;
@@ -127,6 +129,12 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
     @Override
     public AvailableFields getAvailableFields() {
         return AvailableFields.NO_FIELDS;
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Value> getResultValues() {
+        return ImmutableList.of(new QueriedValue());
     }
 
     @Override


### PR DESCRIPTION
…well as result values

This PR contains some refactorings that also address the issues in the title. Here is a hopefully comprehensive list:

- filter plans and filter expressions now maintain a list of predicates instead of one conjunct
- the expansion visitor for `KeyExpression.expand()` does no longer need to return a `GraphResult` but can return any result type. That is useful for expansions resulting in structures that are not `RelationalExpression`s but e.g. `Value`s.
- introduction of `TreeLike` some tree-ish operations easier for classes that are trees in nature
- `Value` and `QueryPredicate` both implement `TreeLike`
- removal of some specific tree folds/maps in `Value` and `QueryPredicate` in favor of replacing that logic with `TreeLike`s implementation
- `getResultValues()` for all expressions and plans. That is trivial for most expressions but can be tricky for some.