### PR TITLE
Resolves #1213: New indexes should generally begin life as DISABLED instead of WRITE_ONLY if not READABLE

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
@@ -57,6 +57,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -361,10 +362,9 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
             Index countIndex = recordStore.getRecordMetaData().getIndex("record_count");
-            assertThat(recordStore.getRecordStoreState().isWriteOnly(countIndex), is(true));
-            recordStore.getSnapshotRecordCount().get();
-            fail("evaluated count with write-only index");
-        } catch (RecordCoreException e) {
+            assertThat(recordStore.getRecordStoreState().isReadable(countIndex), is(false));
+            assertThat(recordStore.getRecordStoreState().isDisabled(countIndex), is(true));
+            RecordCoreException e = assertThrows(RecordCoreException.class, () -> recordStore.getSnapshotRecordCount().get());
             assertThat(e.getMessage(), containsString("requires appropriate index"));
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -126,7 +126,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             recordStore = recordStore.asBuilder().setMetaDataProvider(metaDataBuilder).open();
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
-            assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getWriteOnlyIndexNames());
+            assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getDisabledIndexNames());
             assertEquals(version + 2, recordStore.getRecordMetaData().getVersion());
 
             final FDBRecordStore.Builder staleBuilder = recordStore.asBuilder().setMetaDataProvider(staleMetaData);
@@ -184,7 +184,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             recordStore = FDBRecordStore.newBuilder().setContext(context).setSubspace(expectedSubspace).setMetaDataStore(metaDataStore).open();
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
-            assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getWriteOnlyIndexNames());
+            assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getDisabledIndexNames());
             assertEquals(version + 2, recordStore.getRecordMetaData().getVersion());
 
             // The stale meta-data store uses the cached meta-data, hence the stale version exception

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -596,7 +596,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             uncheckedOpenSimpleRecordStore(context, hook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
-            assertTrue(recordStore.isIndexWriteOnly("newIndex"));
+            assertTrue(recordStore.isIndexDisabled("newIndex"));
 
             timer.reset();
 


### PR DESCRIPTION
This updates the default value in the check version logic and also in the `UserVersionChecker`'s default implementation of `needRebuildIndex`. It leaves the old method around so that users can opt in to the old behavior by providing a `UserVersionChecker` with that old method around. Javadoc has been added in a few places to tell the user what the point of that method is and what the return value means, and also points them to those existing static utility methods that they can use within their implementations. The `OnlineIndexer` already had a default `IndexStatePrecondition` that was compatible with this change, so I mentioned in the release notes how one can change it if one is using the only incompatible `IndexStatePrecondition`. The other changes are to tests, usually to ones that were explicitly testing that an index began as `WRITE_ONLY`, but they usually really only cared that the index wasn't `READABLE`, as that would imply a bug where indexes were being made `READABLE` before they were built. But the tests didn't _actually_ care about the difference between an index being `DISABLED` or `WRITE_ONLY`.