### PR TITLE
Resolves #1229: Expose range size estimate on Record Stores

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Methods to estimate the size of a record store are now exposed [(Issue #1229)](https://github.com/FoundationDB/fdb-record-layer/issues/1229)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1285,6 +1285,56 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
     }
 
     /**
+     * Compute an estimated size of the store in bytes. The estimate will include all data in the store, including
+     * all records and indexes.
+     *
+     * <p>
+     * This uses a sample maintained by the database to efficiently compute an estimate for the size of the store
+     * without needing to scan all data. Because keys in this data structure are sampled, the value will not be
+     * exact. If an exact size is needed, the
+     * {@link com.apple.foundationdb.record.provider.foundationdb.cursors.SizeStatisticsCollectorCursor} can
+     * be used, though note that that cursor must read the entire store to produce its statistics.
+     * </p>
+     *
+     * @return a future that will contain an estimate for the size of the store
+     */
+    @Nonnull
+    CompletableFuture<Long> estimateStoreSizeAsync();
+
+    /**
+     * Compute an estimated size of all records in the store in bytes. The estimate will only include the space used
+     * by the records and excludes all other data maintained by the store. (For example, index data is <em>not</em>
+     * included in the returned estimate.)
+     *
+     * <p>
+     * This uses the same method for computing the estimate as {@link #estimateStoreSizeAsync()}.
+     * </p>
+     *
+     * @return a future that will contain an estimate for the size of all records in the store
+     * @see #estimateStoreSizeAsync()
+     */
+    @Nonnull
+    default CompletableFuture<Long> estimateRecordsSizeAsync() {
+        return estimateRecordsSizeAsync(TupleRange.ALL);
+    }
+
+    /**
+     * Compute an estimated size in bytes of all records in the store within the given primary key range. The estimate
+     * will only include the space used by the records and excludes all other data maintained by the store. (For
+     * example, index data is <em>not</em> included in the returned estimate.)
+     *
+     * <p>
+     * This uses the same method for computing the estimate as {@link #estimateStoreSizeAsync()}.
+     * </p>
+     *
+     * @param range range of records to estimate the size of
+     * @return a future that will contain an estimate for the size of all records in the store
+     * @see #estimateStoreSizeAsync()
+     */
+    @Nonnull
+    CompletableFuture<Long> estimateRecordsSizeAsync(@Nonnull TupleRange range);
+
+    /**
      * Get the number of records in the record store.
      *
      * There must be a suitable {@code COUNT} type index defined.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -91,6 +91,8 @@ public class FDBStoreTimer extends StoreTimer {
         COMMIT_READ_ONLY("commit read-only transaction"),
         /** The amount of time taken committing transactions that did not succeed. */
         COMMIT_FAILURE("commit transaction with failure"),
+        /** The amount of time estimating the size of a key range. See {@link FDBRecordStore#estimateStoreSizeAsync()}. */
+        ESTIMATE_SIZE("estimate the size of a key range"),
         /** The amount of time taken persisting meta-data to a {@link FDBMetaDataStore}. */
         SAVE_META_DATA("save meta-data"),
         /** The amount of time taken loading meta-data from a {@link FDBMetaDataStore}. */
@@ -303,6 +305,10 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_GET_READ_VERSION("get_read_version"),
         /** Wait for a transaction to commit. */
         WAIT_COMMIT("wait for commit"),
+        /** Wait to compute the approximate transaction size. See {@link FDBRecordContext#getApproximateTransactionSize()}. */
+        WAIT_APPROXIMATE_TRANSACTION_SIZE("wait to get the approximate transaction size"),
+        /** Wait to estimate the size of a key range. See {@link FDBRecordStore#estimateStoreSizeAsync()}. */
+        WAIT_ESTIMATE_SIZE("wait to estimate the size of a key range"),
         /** Wait for saving meta-data to a {@link FDBMetaDataStore}. */
         WAIT_SAVE_META_DATA("wait for save meta-data"),
         /** Wait for loading meta-data from a {@link FDBMetaDataStore}. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -205,6 +205,18 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
+    public CompletableFuture<Long> estimateStoreSizeAsync() {
+        return untypedStore.estimateStoreSizeAsync();
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Long> estimateRecordsSizeAsync(@Nonnull TupleRange range) {
+        return untypedStore.estimateRecordsSizeAsync(range);
+    }
+
+    @Nonnull
+    @Override
     public CompletableFuture<Long> getSnapshotRecordCount(@Nonnull KeyExpression key, @Nonnull Key.Evaluated value) {
         return untypedStore.getSnapshotRecordCount(key, value);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
@@ -180,6 +180,16 @@ abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements
     }
 
     @Override
+    public CompletableFuture<Long> getEstimatedRangeSizeBytes(final byte[] begin, final byte[] end) {
+        return underlying.getEstimatedRangeSizeBytes(begin, end);
+    }
+
+    @Override
+    public CompletableFuture<Long> getEstimatedRangeSizeBytes(final Range range) {
+        return underlying.getEstimatedRangeSizeBytes(range);
+    }
+
+    @Override
     public TransactionOptions options() {
         return underlying.options();
     }
@@ -197,16 +207,6 @@ abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements
     @Override
     public Executor getExecutor() {
         return underlying.getExecutor();
-    }
-
-    @Override
-    public CompletableFuture<Long> getEstimatedRangeSizeBytes(final byte[] begin, final byte[] end) {
-        return underlying.getEstimatedRangeSizeBytes(begin, end);
-    }
-
-    @Override
-    public CompletableFuture<Long> getEstimatedRangeSizeBytes(final Range range) {
-        return underlying.getEstimatedRangeSizeBytes(range);
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedTransaction.java
@@ -191,16 +191,6 @@ public class InstrumentedTransaction extends InstrumentedReadTransaction<Transac
         underlying.setReadVersion(l);
     }
 
-    @Override
-    public CompletableFuture<Long> getEstimatedRangeSizeBytes(final byte[] begin, final byte[] end) {
-        return underlying.getEstimatedRangeSizeBytes(begin, end);
-    }
-
-    @Override
-    public CompletableFuture<Long> getEstimatedRangeSizeBytes(final Range range) {
-        return underlying.getEstimatedRangeSizeBytes(range);
-    }
-
     private static class Snapshot extends InstrumentedReadTransaction<ReadTransaction> implements ReadTransaction {
         public Snapshot(@Nullable StoreTimer timer, @Nonnull ReadTransaction underlying, boolean enableAssertions) {
             super(timer, underlying, enableAssertions);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreEstimateSizeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreEstimateSizeTest.java
@@ -1,0 +1,213 @@
+/*
+ * FDBRecordStoreEstimatedSizeTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.EndpointType;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.provider.foundationdb.cursors.SizeStatisticsCollectorCursor;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.protobuf.Message;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests of the methods on an {@link FDBRecordStore} around estimating the size of a store.
+ *
+ * <p>
+ * Note that as the guarantees of the "estimate size" APIs are relatively weak, these tests mostly assert that the
+ * estimate happened without error, though they can occasionally make more sophisticated assertions like "this estimate
+ * should be less than this other estimate".
+ * </p>
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBRecordStoreEstimateSizeTest extends FDBRecordStoreTestBase {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBRecordStoreEstimateSizeTest.class);
+
+    @Test
+    public void estimatedSize() throws Exception {
+        populateStore(1_000, 1_000_000L);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            long estimatedStoreSize = estimateStoreSize(recordStore);
+            long exactStoreSize = getExactStoreSize(recordStore);
+            LOGGER.info(KeyValueLogMessage.of("calculated estimated store size",
+                    "estimated", estimatedStoreSize,
+                    "exact", exactStoreSize));
+
+            long estimatedRecordsSize = estimateRecordsSize(recordStore);
+            long exactRecordsSize = getExactRecordsSize(recordStore);
+            LOGGER.info(KeyValueLogMessage.of("calculated estimated records size",
+                    "estimated", estimatedRecordsSize,
+                    "exact", exactRecordsSize));
+
+            assertThat("estimated record size should be less than estimated store size",
+                    estimatedRecordsSize, lessThanOrEqualTo(estimatedStoreSize));
+
+            commit(context); // commit as that logs the store timer stats
+        }
+    }
+
+    @Disabled("too expensive but useful for smoke-checking the performance on large stores")
+    @Test
+    public void estimateLargeStore() throws Exception {
+        populateStore(200_000, 1_000_000_000L);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            long estimatedStoreSize = estimateStoreSize(recordStore);
+            long estimatedRecordsSize = estimateRecordsSize(recordStore);
+            LOGGER.info(KeyValueLogMessage.of("calculated estimated record size on 1 GB store",
+                    "estimated_store_size", estimatedStoreSize,
+                    "estimated_records_size", estimatedRecordsSize));
+            assertThat(estimatedRecordsSize, lessThanOrEqualTo(estimatedStoreSize));
+
+            commit(context);
+        }
+    }
+
+    @Test
+    public void estimateEmptyStore() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            long estimatedStoreSize = estimateStoreSize(recordStore);
+            long estimatedRecordsSize = estimateRecordsSize(recordStore);
+            LOGGER.info(KeyValueLogMessage.of("estimated size of empty store",
+                    "estimated_store_size", estimatedStoreSize,
+                    "estimated_record_size", estimatedRecordsSize));
+            assertThat(estimatedRecordsSize, lessThanOrEqualTo(estimatedStoreSize));
+
+            commit(context);
+        }
+    }
+
+    @Test
+    public void estimateSingleRecord() throws Exception {
+        populateStore(1, 5_000L);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            long estimatedStoreSize = estimateStoreSize(recordStore);
+            long estimatedRecordsSize = estimateRecordsSize(recordStore);
+            LOGGER.info(KeyValueLogMessage.of("estimated size of store with a single record",
+                    "estimated_store_size", estimatedStoreSize,
+                    "estimated_record_size", estimatedRecordsSize));
+            assertThat(estimatedRecordsSize, lessThanOrEqualTo(estimatedStoreSize));
+
+            commit(context);
+        }
+    }
+
+    @Test
+    public void estimateInTwoRanges() throws Exception {
+        final int recordCount = 500;
+        populateStore(recordCount, recordCount * 5_000);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            long estimatedRecordSize = estimateRecordsSize(recordStore);
+            final Tuple halfWayTuple = Tuple.from(recordCount / 2);
+            final TupleRange firstHalf = new TupleRange(null, halfWayTuple, EndpointType.TREE_START, EndpointType.RANGE_EXCLUSIVE);
+            long estimatedFirstHalf = estimateRecordsSize(recordStore, firstHalf);
+            final TupleRange secondHalf = new TupleRange(halfWayTuple, null, EndpointType.RANGE_INCLUSIVE, EndpointType.TREE_END);
+            long estimatedSecondHalf = estimateRecordsSize(recordStore, secondHalf);
+            LOGGER.info(KeyValueLogMessage.of("estimated both halves of records",
+                    "estimated_records_size", estimatedRecordSize,
+                    "estimated_first_half_size", estimatedFirstHalf,
+                    "estimated_second_half_size", estimatedSecondHalf));
+
+            assertEquals(estimatedFirstHalf + estimatedSecondHalf, estimatedRecordSize,
+                    "expected first half size (" + estimatedFirstHalf + ") and second half size (" + estimatedSecondHalf + ") to match full size");
+
+            commit(context);
+        }
+    }
+
+    private static long estimateStoreSize(@Nonnull FDBRecordStore store) {
+        return store.getRecordContext().asyncToSync(FDBStoreTimer.Waits.WAIT_ESTIMATE_SIZE, store.estimateStoreSizeAsync());
+    }
+
+    private static long estimateRecordsSize(@Nonnull FDBRecordStore store) {
+        return store.getRecordContext().asyncToSync(FDBStoreTimer.Waits.WAIT_ESTIMATE_SIZE, store.estimateRecordsSizeAsync());
+    }
+
+    private static long estimateRecordsSize(@Nonnull FDBRecordStore store, @Nonnull TupleRange range) {
+        return store.getRecordContext().asyncToSync(FDBStoreTimer.Waits.WAIT_ESTIMATE_SIZE, store.estimateRecordsSizeAsync(range));
+    }
+
+    private static long getExactStoreSize(@Nonnull FDBRecordStore store) {
+        SizeStatisticsCollectorCursor statsCursor = SizeStatisticsCollectorCursor.ofStore(store, store.getContext(), ScanProperties.FORWARD_SCAN, null);
+        return getTotalSize(statsCursor);
+    }
+
+    private static long getExactRecordsSize(@Nonnull FDBRecordStore store) {
+        SizeStatisticsCollectorCursor statsCursor = SizeStatisticsCollectorCursor.ofRecords(store, store.getContext(), ScanProperties.FORWARD_SCAN, null);
+        return getTotalSize(statsCursor);
+    }
+
+    private static long getTotalSize(@Nonnull SizeStatisticsCollectorCursor statsCursor) {
+        final RecordCursorResult<SizeStatisticsCollectorCursor.SizeStatisticsResults> result = statsCursor.getNext();
+        assertTrue(result.hasNext());
+        return result.get().getTotalSize();
+    }
+
+    private void populateStore(int recordCount, long byteCount) throws Exception {
+        int bytesPerRecord = (int)(byteCount / recordCount);
+        final String data = StringUtils.repeat('x', bytesPerRecord);
+
+        int currentRecord = 0;
+        while (currentRecord < recordCount) {
+            try (FDBRecordContext context = openContext()) {
+                openSimpleRecordStore(context);
+
+                long transactionSize;
+                do {
+                    final Message record = TestRecords1Proto.MySimpleRecord.newBuilder()
+                            .setRecNo(currentRecord)
+                            .setStrValueIndexed(data)
+                            .build();
+                    recordStore.saveRecord(record);
+                    transactionSize = context.asyncToSync(FDBStoreTimer.Waits.WAIT_APPROXIMATE_TRANSACTION_SIZE,
+                            context.getApproximateTransactionSize());
+                    currentRecord++;
+                } while (currentRecord < recordCount && transactionSize < 1_000_000);
+
+                commit(context);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Exposes methods that use the new FDB 6.3 API for estimating the size of a range to estimate the size of a record store and of the records within.