### PR TITLE
Adds artifactory publishing logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ buildscript {
 plugins {
     id 'com.github.spotbugs' version '1.6.9'
     id 'org.sonarqube' version '2.6'
+    id 'com.jfrog.artifactory' version '4.21.0'
 }
 
 ext {

--- a/build.py
+++ b/build.py
@@ -136,7 +136,7 @@ def build(release=False, proto2=False, proto3=False, publish=False):
             return False
 
         if publish:
-            success = run_gradle(2, 'bintrayUpload', '-PpublishBuild=true',
+            success = run_gradle(2, 'artifactoryPublish', '-PpublishBuild=true',
                                     '-PreleaseBuild={0}'.format('true' if release else 'false'))
             if not success:
                 return False
@@ -154,14 +154,14 @@ def build(release=False, proto2=False, proto3=False, publish=False):
             return False
 
         if publish:
-            # These are enumerated rather than just using the full project bintrayUpload command to avoid uploading
+            # These are enumerated rather than just using the full project artifactoryPublish command to avoid uploading
             # the fdb-extensions subproject twice. (Note that as overwrite is not supported, doing so would result
             # in the build failing.)
-            success = run_gradle(3, ':fdb-record-layer-core-pb3:bintrayUpload',
-                                    ':fdb-record-layer-core-pb3-shaded:bintrayUpload',
-                                    ':fdb-record-layer-icu-pb3:bintrayUpload',
-                                    ':fdb-record-layer-spatial-pb3:bintrayUpload',
-                                    ':fdb-record-layer-lucene-pb3:bintrayUpload',
+            success = run_gradle(3, ':fdb-record-layer-core-pb3:artifactoryPublish',
+                                    ':fdb-record-layer-core-pb3-shaded:artifactoryPublish',
+                                    ':fdb-record-layer-icu-pb3:artifactoryPublish',
+                                    ':fdb-record-layer-spatial-pb3:artifactoryPublish',
+                                    ':fdb-record-layer-lucene-pb3:artifactoryPublish',
                                     '-PcoreNotStrict',
                                     '-PreleaseBuild={0}'.format('true' if release else 'false'),
                                     '-PpublishBuild=true')

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'
 
 // Add various details to the pom file to allow for publishing
@@ -62,8 +63,8 @@ publishing {
         }
     }
     def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')
+    def isReleaseBuild = Boolean.parseBoolean(findProperty('releaseBuild') ?: 'false')
     if (publishBuild && System.getenv('BINTRAY_USER') != null && System.getenv('BINTRAY_KEY') != null) {
-        def isReleaseBuild = Boolean.parseBoolean(findProperty('releaseBuild') ?: 'false')
         bintray {
             user = System.getenv('BINTRAY_USER')
             key = System.getenv('BINTRAY_KEY')
@@ -80,6 +81,33 @@ publishing {
             }
             override = !isReleaseBuild
             publish = publishBuild
+        }
+    }
+
+    artifactoryPublish {
+        skip = !publishBuild
+        publications(publishing.publications.library)
+    }
+}
+
+if (System.getenv('ARTIFACTORY_USER') != null && System.getenv('ARTIFACTORY_KEY') != null) {
+    artifactory {
+        clientConfig.setIncludeEnvVars(true)
+        publish {
+            def artifactoryUrl = System.getenv('ARTIFACTORY_URL') ?: 'https://ossartifacts.jfrog.io/artifactory/'
+            contextUrl = artifactoryUrl
+            repository {
+                repoKey = System.getenv('ARTIFACTORY_REPO') ?: 'fdb-record-layer'
+                username = System.getenv('ARTIFACTORY_USER')
+                password = System.getenv('ARTIFACTORY_KEY')
+            }
+            defaults {
+                publications('mavenJava')
+                publishPom = publishBuild
+                publishArtifacts = publishBuild
+                publishBuildInfo = publishBuild
+                publishIvy = false
+            }
         }
     }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -63,8 +63,8 @@ publishing {
         }
     }
     def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')
-    def isReleaseBuild = Boolean.parseBoolean(findProperty('releaseBuild') ?: 'false')
     if (publishBuild && System.getenv('BINTRAY_USER') != null && System.getenv('BINTRAY_KEY') != null) {
+        def isReleaseBuild = Boolean.parseBoolean(findProperty('releaseBuild') ?: 'false')
         bintray {
             user = System.getenv('BINTRAY_USER')
             key = System.getenv('BINTRAY_KEY')


### PR DESCRIPTION
This adds the artifactory plugin and switches build.py to start using it. This is to try and make progress on #1248, though I don't necessarily think this is going to be the last PR for that, so I'm not marking this as resolving the issue (yet).