### PR TITLE
Add missing environment variables to release build

### DIFF
--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
       - GIT_COMMITTER_EMAIL='fdbbuild@foundationdb.org'
       - GIT_BRANCH
       - ARTIFACT_VERSION
+      - ARTIFACTORY_USER
+      - ARTIFACTORY_KEY
       - BINTRAY_USER
       - BINTRAY_KEY
 
@@ -92,6 +94,8 @@ services:
   shell:
     <<: *build-setup
     environment:
+      - ARTIFACTORY_USER
+      - ARTIFACTORY_KEY
       - BINTRAY_USER
       - BINTRAY_KEY
     entrypoint: /bin/bash


### PR DESCRIPTION
We pipe through environment variables from CI to the build docker through the `docker-compose.yaml`. I think previous builds failed because it didn't have publishing configured correctly as a result of missing these environment variables.

Part of #1248.