### PR TITLE
Resolves #1248: Switch from bintray to artifactory for artifact publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ buildscript {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.7'
         classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
         //classpath 'gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.9'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -43,8 +43,6 @@ services:
       - ARTIFACT_VERSION
       - ARTIFACTORY_USER
       - ARTIFACTORY_KEY
-      - BINTRAY_USER
-      - BINTRAY_KEY
 
   build-snapshot:
     <<: *build-setup
@@ -96,8 +94,6 @@ services:
     environment:
       - ARTIFACTORY_USER
       - ARTIFACTORY_KEY
-      - BINTRAY_USER
-      - BINTRAY_KEY
     entrypoint: /bin/bash
     networks: [test-net]
     environment:

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -102,7 +102,4 @@ publishing {
             artifact tasks.shadedJavadocJar
         }
     }
-    bintray {
-        publications = ["shadow"]
-    }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -19,7 +19,6 @@
  */
 
 apply plugin: 'com.jfrog.artifactory'
-apply plugin: 'com.jfrog.bintray'
 
 // Add various details to the pom file to allow for publishing
 def addPublishingInfo(publication) {
@@ -62,32 +61,9 @@ publishing {
             addPublishingInfo(publication)
         }
     }
-    def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')
-    if (publishBuild && System.getenv('BINTRAY_USER') != null && System.getenv('BINTRAY_KEY') != null) {
-        def isReleaseBuild = Boolean.parseBoolean(findProperty('releaseBuild') ?: 'false')
-        bintray {
-            user = System.getenv('BINTRAY_USER')
-            key = System.getenv('BINTRAY_KEY')
-            publications = ["library"]
-            pkg {
-                version{
-                    name = project.version
-                    mavenCentralSync {
-                        sync = false
-                    }
-                }
-                userOrg = "fdb-apple"
-                repo = "fdb-record-layer"
-                name = project.name
-                licenses = ["Apache-2.0"]
-                vcsUrl = "https://github.com/FoundationDB/fdb-record-layer.git"
-            }
-            override = !isReleaseBuild
-            publish = publishBuild
-        }
-    }
 
     artifactoryPublish {
+        def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')
         skip = !publishBuild
         publications(publishing.publications.library)
     }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -63,8 +63,14 @@ publishing {
     }
 
     artifactoryPublish {
+        // As a safeguard, only actually publish to artifactory if -PpublishBuild=true is passed to gradle
+        // Note: skip is documented, but onlyIf seems to also be required to make this work for some reason
+        // See: https://gist.github.com/DALDEI/40925568cef57e16e8a7
         def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')
         skip = !publishBuild
+        onlyIf {
+            publishBuild
+        }
         publications(publishing.publications.library)
     }
 }


### PR DESCRIPTION
This removes the bintray publishing logic in favor of the Artifactory publishing that was added in some previous PRs (namely #1249 and #1252). This is in anticipation of Bintray being ended on May 1, 2021.

This resolves #1248.