### PR TITLE
Resolves #1248: Switch from bintray to artifactory

### DIFF
--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -103,6 +103,6 @@ publishing {
         }
     }
     artifactoryPublish {
-        publications ('shadow')
+        publications (publishing.publications.shadow)
     }
 }

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -102,4 +102,7 @@ publishing {
             artifact tasks.shadedJavadocJar
         }
     }
+    artifactoryPublish {
+        publications ('shadow')
+    }
 }


### PR DESCRIPTION
I think we published the wrong shadow jar to artifactory based on the file sizes. This switches the publication to the shadow jar, which hopefully is better.

This resolves #1248.