### PR TITLE
Upgrading FDB to 6.3.12

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -158,7 +158,7 @@ public class FDBDatabaseFactory {
             }
             if (runLoopProfilingEnabled) {
                 // Note: will be renamed to "run loop profiling" in FDB 6.3
-                options.setEnableSlowTaskProfiling();
+                options.setEnableRunLoopProfiling();
             }
             if (networkExecutor == null) {
                 fdb.startNetwork();

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ group=org.foundationdb
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation
 
-fdbVersion=6.2.10
+fdbVersion=6.3.12
 jsr305Version=3.0.2
 slf4jVersion=1.7.30
 commonsLang3Version=3.10


### PR DESCRIPTION
Upgrades FDB to 6.3.12, and makes sure it compiles. 

This PR makes no use of new FDB6.3.12 features, it just ups the dependency.