### PR TITLE
Resolve #1269 Allow data types other than FDBQueriedRecord to flow from plans and cursors.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBQueriedRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBQueriedRecord.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.query.plan.plans.QueryResultElement;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
@@ -35,7 +36,7 @@ import javax.annotation.Nullable;
  * @param <M> type used to represent stored records
  */
 @API(API.Status.MAINTAINED)
-public abstract class FDBQueriedRecord<M extends Message> implements FDBRecord<M> {
+public abstract class FDBQueriedRecord<M extends Message> implements FDBRecord<M>, QueryResultElement {
     /**
      * Get the stored record, if any, that produced this query result record.
      * <code>null</code> if this query result record was assembled without loading the whole record,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
@@ -28,10 +28,10 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithNoChildren;
@@ -87,9 +87,10 @@ public class ComposedBitmapIndexQueryPlan implements RecordQueryPlanWithNoChildr
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation, @Nonnull ExecuteProperties executeProperties) {
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
         final ExecuteProperties scanExecuteProperties = executeProperties.getSkip() > 0 ? executeProperties.clearSkipAndAdjustLimit() : executeProperties;
         final List<Function<byte[], RecordCursor<IndexEntry>>> cursorFunctions = indexPlans.stream()
                 .map(RecordQueryCoveringIndexPlan::getIndexPlan)
@@ -98,7 +99,8 @@ public class ComposedBitmapIndexQueryPlan implements RecordQueryPlanWithNoChildr
         return ComposedBitmapIndexCursor.create(cursorFunctions, composer, continuation, store.getTimer())
                 // Composers can return null bitmaps when empty, which is then left out of the result set.
                 .filter(indexEntry -> indexEntry.getValue().get(0) != null)
-                .map(indexPlans.get(0).indexEntryToQueriedRecord(store));
+                .map(indexPlans.get(0).indexEntryToQueriedRecord(store))
+                .map(QueryResult::of);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
@@ -41,7 +41,7 @@ import java.util.List;
  * This class is immutable - all modify operations will cause a new instance to be created with the modified value, leaving
  * the original instance intact. The internal data structure is also immutable.
  */
-@API(API.Status.UNSTABLE)
+@API(API.Status.EXPERIMENTAL)
 public class QueryResult {
     @Nonnull
     private final List<QueryResultElement> elements;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
@@ -44,11 +44,11 @@ import java.util.List;
 @API(API.Status.UNSTABLE)
 public class QueryResult {
     @Nonnull
-    private final List<Object> elements;
+    private final List<QueryResultElement> elements;
 
     private static final QueryResult EMPTY = new QueryResult(Collections.emptyList());
 
-    private QueryResult(@Nonnull List<Object> elements) {
+    private QueryResult(@Nonnull List<QueryResultElement> elements) {
         this.elements = elements;
     }
 
@@ -66,7 +66,7 @@ public class QueryResult {
      * @return the newly created result
      */
     @Nonnull
-    public static QueryResult of(@Nullable Object element) {
+    public static QueryResult of(@Nullable QueryResultElement element) {
         return new QueryResult(Collections.singletonList(element));
     }
 
@@ -75,7 +75,7 @@ public class QueryResult {
      * @param elements the collection of elements to populate in the result
      * @return the newly created result
      */
-    public static QueryResult of(Collection<?> elements) {
+    public static QueryResult of(Collection<QueryResultElement> elements) {
         return new QueryResult(ImmutableList.copyOf(elements));
     }
 
@@ -84,8 +84,8 @@ public class QueryResult {
      * @param addedElement the element to add to the result
      * @return the newly created result that combines the existing elements with the new one
      */
-    public QueryResult with(Object addedElement) {
-        return new QueryResult(new ImmutableList.Builder<>().addAll(elements).add(addedElement).build());
+    public QueryResult with(QueryResultElement addedElement) {
+        return new QueryResult(new ImmutableList.Builder<QueryResultElement>().addAll(elements).add(addedElement).build());
     }
 
     /**
@@ -93,8 +93,8 @@ public class QueryResult {
      * @param addedElements the elements to add to the result
      * @return the newly created result that combines the existing elements with the new ones
      */
-    public QueryResult with(Object... addedElements) {
-        return new QueryResult(new ImmutableList.Builder<>().addAll(elements).add(addedElements).build());
+    public QueryResult with(QueryResultElement... addedElements) {
+        return new QueryResult(new ImmutableList.Builder<QueryResultElement>().addAll(elements).add(addedElements).build());
     }
 
     /**
@@ -104,7 +104,7 @@ public class QueryResult {
      * @throws IndexOutOfBoundsException if the index is out of range
      */
     @Nullable
-    public Object get(int i) {
+    public QueryResultElement get(int i) {
         return elements.get(i);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
@@ -1,0 +1,161 @@
+/*
+ * QueryResult.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * QueryResult is the general result that encapsulates the data that is flowing up from plan to consumer. The QueryResult
+ * can hold several elements for each result. The elements are opaque from the result perspective, but are known at planning time
+ * so that the planner can address them as needed and extract and transfer them from one cursor to another.
+ * This class is immutable - all modify operations will cause a new instance to be created with the modified value, leaving
+ * the original instance intact. The internal data structure is also immutable.
+ */
+@API(API.Status.UNSTABLE)
+public class QueryResult {
+    @Nonnull
+    private final List<Object> elements;
+
+    private static QueryResult EMPTY = new QueryResult(Collections.emptyList());
+
+    private QueryResult(@Nonnull List<Object> elements) {
+        this.elements = elements;
+    }
+
+    /**
+     * Get an empty result.
+     * @return An immutable empty result.
+     */
+    public QueryResult empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Create a new result with the given element.
+     * @param element the given element
+     * @return the newly created result
+     */
+    @Nonnull
+    public static QueryResult of(@Nullable Object element) {
+        return new QueryResult(Collections.singletonList(element));
+    }
+
+    /**
+     * Create a new result with the given elements.
+     * @param elements the collection of elements to populate in the result
+     * @return the newly created result
+     */
+    public static QueryResult of(Collection<?> elements) {
+        return new QueryResult(new ImmutableList.Builder<>().addAll(elements).build());
+    }
+
+    /**
+     * Create a new result that extends the current result with an additional element.
+     * @param addedElement the element to add to the result
+     * @return the newly created result that combines the existing elements with the new one
+     */
+    public QueryResult with(Object addedElement) {
+        return new QueryResult(new ImmutableList.Builder<>().addAll(elements).add(addedElement).build());
+    }
+
+    /**
+     * Create a new result that extends the current result with additional elements.
+     * @param addedElements the elements to add to the result
+     * @return the newly created result that combines the existing elements with the new ones
+     */
+    public QueryResult with(Object... addedElements) {
+        return new QueryResult(new ImmutableList.Builder<>().addAll(elements).add(addedElements).build());
+    }
+
+    /**
+     * Retrieve the element at the ith position in the result (0 based).
+     * @param i the index of the requested element.
+     * @return the required element
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    @Nullable
+    public Object get(int i) {
+        return elements.get(i);
+    }
+
+    /**
+     * FDBQueriedRecord compatibility method. Return the element in a position, assuming that it is a {@link FDBQueriedRecord}
+     * @param i the index of the requested element.
+     * @return the element, in case it is of the right type
+     * @throws ClassCastException in case the element is of the wrong type
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    @Nullable
+    public <M extends Message> FDBQueriedRecord<M> getQueriedRecord(int i) {
+        return ((FDBQueriedRecord<M>)elements.get(i));
+    }
+
+    /**
+     * FDBQueriedRecord compatibility method. Return the stored record from the element in a position, assuming that it is a {@link FDBQueriedRecord}
+     * @param i the index of the requested element.
+     * @return the element, in case it is of the right type
+     * @throws ClassCastException in case the element is of the wrong type
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    @Nullable
+    public FDBStoredRecord<Message> getStoredRecord(int i) {
+        FDBQueriedRecord<Message> record = getQueriedRecord(i);
+        return (record == null) ? null : record.getStoredRecord();
+    }
+
+    /**
+     * FDBQueriedRecord compatibility method. Return the index from the element in a position, assuming that it is a {@link FDBQueriedRecord}
+     * @param i the index of the requested element.
+     * @return the element, in case it is of the right type
+     * @throws ClassCastException in case the element is of the wrong type
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    @Nullable
+    public Index getIndex(int i) {
+        FDBQueriedRecord<Message> record = getQueriedRecord(i);
+        return (record == null) ? null : record.getIndex();
+    }
+
+    /**
+     * FDBQueriedRecord compatibility method. Return the indexEntry from the element in a position, assuming that it is a {@link FDBQueriedRecord}
+     * @param i the index of the requested element.
+     * @return the element, in case it is of the right type
+     * @throws ClassCastException in case the element is of the wrong type
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    @Nullable
+    public IndexEntry getIndexEntry(int i) {
+        FDBQueriedRecord<Message> record = getQueriedRecord(i);
+        return (record == null) ? null : record.getIndexEntry();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
@@ -116,6 +116,7 @@ public class QueryResult {
      * @throws IndexOutOfBoundsException if the index is out of range
      */
     @Nullable
+    @SuppressWarnings("unchecked") // Intend to throw ClassCast in case the element is of teh wrong type
     public <M extends Message> FDBQueriedRecord<M> getQueriedRecord(int i) {
         return ((FDBQueriedRecord<M>)elements.get(i));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
@@ -46,7 +46,7 @@ public class QueryResult {
     @Nonnull
     private final List<Object> elements;
 
-    private static QueryResult EMPTY = new QueryResult(Collections.emptyList());
+    private static final QueryResult EMPTY = new QueryResult(Collections.emptyList());
 
     private QueryResult(@Nonnull List<Object> elements) {
         this.elements = elements;
@@ -76,7 +76,7 @@ public class QueryResult {
      * @return the newly created result
      */
     public static QueryResult of(Collection<?> elements) {
-        return new QueryResult(new ImmutableList.Builder<>().addAll(elements).build());
+        return new QueryResult(ImmutableList.copyOf(elements));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
@@ -111,6 +111,7 @@ public class QueryResult {
     /**
      * FDBQueriedRecord compatibility method. Return the element in a position, assuming that it is a {@link FDBQueriedRecord}
      * @param i the index of the requested element.
+     * @param <M> the type of record the store is providing (for the {@link FDBQueriedRecord} compatibility)
      * @return the element, in case it is of the right type
      * @throws ClassCastException in case the element is of the wrong type
      * @throws IndexOutOfBoundsException if the index is out of range

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResult.java
@@ -56,6 +56,7 @@ public class QueryResult {
      * Get an empty result.
      * @return An immutable empty result.
      */
+    @Nonnull
     public QueryResult empty() {
         return EMPTY;
     }
@@ -66,8 +67,8 @@ public class QueryResult {
      * @return the newly created result
      */
     @Nonnull
-    public static QueryResult of(@Nullable QueryResultElement element) {
-        return new QueryResult(Collections.singletonList(element));
+    public static QueryResult of(@Nonnull QueryResultElement element) {
+        return new QueryResult(ImmutableList.of(element));
     }
 
     /**
@@ -75,7 +76,8 @@ public class QueryResult {
      * @param elements the collection of elements to populate in the result
      * @return the newly created result
      */
-    public static QueryResult of(Collection<QueryResultElement> elements) {
+    @Nonnull
+    public static QueryResult of(@Nonnull Collection<QueryResultElement> elements) {
         return new QueryResult(ImmutableList.copyOf(elements));
     }
 
@@ -84,7 +86,8 @@ public class QueryResult {
      * @param addedElement the element to add to the result
      * @return the newly created result that combines the existing elements with the new one
      */
-    public QueryResult with(QueryResultElement addedElement) {
+    @Nonnull
+    public QueryResult with(@Nonnull QueryResultElement addedElement) {
         return new QueryResult(new ImmutableList.Builder<QueryResultElement>().addAll(elements).add(addedElement).build());
     }
 
@@ -93,7 +96,8 @@ public class QueryResult {
      * @param addedElements the elements to add to the result
      * @return the newly created result that combines the existing elements with the new ones
      */
-    public QueryResult with(QueryResultElement... addedElements) {
+    @Nonnull
+    public QueryResult with(@Nonnull QueryResultElement... addedElements) {
         return new QueryResult(new ImmutableList.Builder<QueryResultElement>().addAll(elements).add(addedElements).build());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResultElement.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/QueryResultElement.java
@@ -1,0 +1,27 @@
+/*
+ * QueryResultElement.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+/**
+ * Marker interface for the elements that can be stored in a {@link QueryResult}.
+ */
+public interface QueryResultElement {
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -86,13 +86,14 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                         @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
         return indexPlan
                 .executeEntries(store, context, continuation, executeProperties)
-                .map(indexEntryToQueriedRecord(store));
+                .map(indexEntryToQueriedRecord(store))
+                .map(QueryResult::of);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlanBase.java
@@ -75,6 +75,7 @@ abstract class RecordQueryFilterPlanBase implements RecordQueryPlanWithChild {
                                                                                       @Nullable FDBRecord<M> record);
 
     @Nonnull
+    @Override
     public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
                                                                      @Nonnull final EvaluationContext context,
                                                                      @Nullable final byte[] continuation,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlanBase.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.PipelineOperation;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
@@ -75,24 +74,22 @@ abstract class RecordQueryFilterPlanBase implements RecordQueryPlanWithChild {
                                                                                       @Nonnull EvaluationContext context,
                                                                                       @Nullable FDBRecord<M> record);
 
-
     @Nonnull
-    @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                         @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
-        final RecordCursor<FDBQueriedRecord<M>> results = getInnerPlan().execute(store, context, continuation, executeProperties.clearSkipAndLimit());
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
+        final RecordCursor<QueryResult> results = getInnerPlan().executePlan(store, context, continuation, executeProperties.clearSkipAndLimit());
 
         if (hasAsyncFilter()) {
             return results
-                    .filterAsyncInstrumented(record -> evalFilterAsync(store, context, record),
+                    .filterAsyncInstrumented(result -> evalFilterAsync(store, context, result.getQueriedRecord(0)),
                             store.getPipelineSize(PipelineOperation.RECORD_ASYNC_FILTER),
                             store.getTimer(), inCounts, duringEvents, successCounts, failureCounts)
                     .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
         } else {
             return results
-                    .filterInstrumented(record -> evalFilter(store, context, record), store.getTimer(),
+                    .filterInstrumented(result -> evalFilter(store, context, result.getQueriedRecord(0)), store.getTimer(),
                             inCounts, duringEvents, successCounts, failureCounts)
                     .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -94,8 +94,8 @@ public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren 
                 }, store.getPipelineSize(PipelineOperation.KEY_TO_RECORD))
                 .filter(Objects::nonNull)
                 .map(store::queriedRecord)
-                .map(QueryResult::of)
-                .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
+                .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit())
+                .map(QueryResult::of);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -117,7 +117,7 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
      * @param <M> type used to represent stored records
      * @return a cursor of {@link QueryResult} that match the query criteria
      */
-    @API(API.Status.UNSTABLE)
+    @API(API.Status.EXPERIMENTAL)
     @Nonnull
     <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull FDBRecordStoreBase<M> store,
                                                               @Nonnull EvaluationContext context,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -110,8 +110,10 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
 
     /**
      * Execute this plan, returning a {@link RecordCursor} to {@link QueryResult} result.
-     * @param store record store to access
+     * @param store record store from which to fetch records
      * @param context evaluation context containing parameter bindings
+     * @param continuation continuation from a previous execution of this same plan
+     * @param executeProperties limits on execution
      * @param <M> type used to represent stored records
      * @return a cursor of {@link QueryResult} that match the query criteria
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -68,10 +68,13 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
      * @return a cursor of records that match the query criteria
      */
     @Nonnull
-    <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
+    default <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
                                                                   @Nonnull EvaluationContext context,
                                                                   @Nullable byte[] continuation,
-                                                                  @Nonnull ExecuteProperties executeProperties);
+                                                                  @Nonnull ExecuteProperties executeProperties) {
+        return executePlan(store, context, continuation, executeProperties)
+                .map(result -> result.getQueriedRecord(0));
+    }
 
     @Nonnull
     @Override
@@ -104,6 +107,20 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
     default <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context) {
         return execute(store, context, null, ExecuteProperties.SERIAL_EXECUTE);
     }
+
+    /**
+     * Execute this plan, returning a {@link RecordCursor} to {@link QueryResult} result.
+     * @param store record store to access
+     * @param context evaluation context containing parameter bindings
+     * @param <M> type used to represent stored records
+     * @return a cursor of {@link QueryResult} that match the query criteria
+     */
+    @API(API.Status.UNSTABLE)
+    @Nonnull
+    <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull FDBRecordStoreBase<M> store,
+                                                              @Nonnull EvaluationContext context,
+                                                              @Nullable byte[] continuation,
+                                                              @Nonnull ExecuteProperties executeProperties);
 
     /**
      * Returns the (zero or more) {@code RecordQueryPlan} children of this plan.
@@ -245,7 +262,7 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
                     boundCorrelatedToBuilder.put(quantifier.getAlias(), otherQuantifier.getAlias());
                 }
             }
-                
+
             if (i == quantifiers.size() && (equalsWithoutChildren(otherExpression, boundCorrelatedToMap))) {
                 return true;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithIndex.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.IndexOrphanBehavior;
 import com.apple.foundationdb.record.query.plan.temp.explain.Attribute;
@@ -70,13 +69,14 @@ public interface RecordQueryPlanWithIndex extends RecordQueryPlan {
 
     @Nonnull
     @Override
-    default <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                          @Nonnull EvaluationContext context,
-                                                                          @Nullable byte[] continuation,
-                                                                          @Nonnull ExecuteProperties executeProperties) {
+    default <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull FDBRecordStoreBase<M> store,
+                                                                      @Nonnull EvaluationContext context,
+                                                                      @Nullable byte[] continuation,
+                                                                      @Nonnull ExecuteProperties executeProperties) {
         final RecordCursor<IndexEntry> entryRecordCursor = executeEntries(store, context, continuation, executeProperties);
         return store.fetchIndexRecords(entryRecordCursor, IndexOrphanBehavior.ERROR, executeProperties.getState())
-                .map(store::queriedRecord);
+                .map(store::queriedRecord)
+                .map(QueryResult::of);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
@@ -108,15 +107,16 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                         @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
         final TupleRange range = comparisons.toTupleRange(store, context);
         return store.scanRecords(
                 range.getLow(), range.getHigh(), range.getLowEndpoint(), range.getHighEndpoint(), continuation,
                 executeProperties.asScanProperties(reverse))
-                .map(store::queriedRecord);
+                .map(store::queriedRecord)
+                .map(QueryResult::of);
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.RankedSetIndexHelper;
@@ -118,12 +117,12 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                         @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
         return RecordCursor.mapFuture(store.getExecutor(), bindScores(store, context, executeProperties.getIsolationLevel()), continuation,
-                (innerContext, innerContinuation) -> getChild().execute(store, innerContext, innerContinuation, executeProperties));
+                (innerContext, innerContinuation) -> getChild().executePlan(store, innerContext, innerContinuation, executeProperties));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
@@ -92,14 +91,14 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                         @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
-        final RecordCursor<FDBQueriedRecord<M>> results = getInnerPlan().execute(store, context, continuation, executeProperties.clearSkipAndLimit());
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
+        final RecordCursor<QueryResult> results = getInnerPlan().executePlan(store, context, continuation, executeProperties.clearSkipAndLimit());
 
         return results
-                .filterInstrumented(record -> recordTypes.contains(record.getRecordType().getName()), store.getTimer(),
+                .filterInstrumented(result -> recordTypes.contains(result.getQueriedRecord(0).getRecordType().getName()), store.getTimer(),
                         inCounts, duringEvents, successCounts, failureCounts)
                 .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
@@ -96,15 +95,15 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                         @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
         final Set<Key.Evaluated> seen = new HashSet<>();
-        return getInner().execute(store, context, continuation, executeProperties.clearSkipAndLimit())
-            .filterInstrumented(record -> seen.add(getComparisonKey().evaluateSingleton(record)),
-                store.getTimer(), Collections.emptySet(), duringEvents, uniqueCounts, duplicateCounts)
-            .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
+        return getInner().executePlan(store, context, continuation, executeProperties.clearSkipAndLimit())
+                .filterInstrumented(result -> seen.add(getComparisonKey().evaluateSingleton(result.getQueriedRecord(0))),
+                        store.getTimer(), Collections.emptySet(), duringEvents, uniqueCounts, duplicateCounts)
+                .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.temp.AliasMap;
@@ -88,15 +87,15 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
 
     @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> execute(@Nonnull FDBRecordStoreBase<M> store,
-                                                                         @Nonnull EvaluationContext context,
-                                                                         @Nullable byte[] continuation,
-                                                                         @Nonnull ExecuteProperties executeProperties) {
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
         final Set<Tuple> seen = new HashSet<>();
-        return getInner().execute(store, context, continuation, executeProperties.clearSkipAndLimit())
-            .filterInstrumented(record -> seen.add(record.getPrimaryKey()), store.getTimer(),
-                Collections.emptySet(), duringEvents, uniqueCounts, duplicateCounts)
-            .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
+        return getInner().executePlan(store, context, continuation, executeProperties.clearSkipAndLimit())
+                .filterInstrumented(result -> seen.add(result.getQueriedRecord(0).getPrimaryKey()), store.getTimer(),
+                        Collections.emptySet(), duringEvents, uniqueCounts, duplicateCounts)
+                .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
     }
 
     @Override


### PR DESCRIPTION
Resolve #1269: Allow data types other than FDBQueriedRecord to flow from plans and cursors.
1. Create new type (`QueryResult`) that contains a list of results for an execution of a query
2. Create new method (`executePlan`) that returns a `Cursor<QueryResult>` (instead of the existing `execute` that returns `Cursor<M extends Message>`)
3. Create backwards compatible `execute` method that uses `executePlan`
4. Convert existing implementations of `execute` to `executePlan`

