### PR TITLE
Resolves #1275: query compatibility

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,12 +29,12 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Define query compatibility using store state and pre-bound parameters [(Issue #1275)](https://github.com/FoundationDB/fdb-record-layer/issues/1275)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** IndexQueryabilityFilter is not a functional interface anymore [(Issue #1275)](https://github.com/FoundationDB/fdb-record-layer/issues/1275)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 
 // end next release

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Bindings.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Bindings.java
@@ -88,6 +88,16 @@ public class Bindings {
         }
     }
 
+    public boolean containsBinding(@Nonnull String name) {
+        if (values.containsKey(name)) {
+            return true;
+        } else if (parent != null) {
+            return parent.containsBinding(name);
+        } else {
+            return false;
+        }
+    }
+
     public static Builder newBuilder() {
         return new Builder(null);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/QueryHashable.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/QueryHashable.java
@@ -42,6 +42,7 @@ public interface QueryHashable {
      * The "kinds" of queryHash calculations.
      */
     enum QueryHashKind {
+        STRUCTURAL_WITH_LITERALS,     // include literals and parameter markers
         STRUCTURAL_WITHOUT_LITERALS   // The hash used for query and plan matching: skip all literals and markers
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
@@ -216,7 +216,14 @@ public class LiteralKeyExpression<T> extends BaseKeyExpression implements AtomKe
 
     @Override
     public int queryHash(@Nonnull final QueryHashKind hashKind) {
-        return HashUtils.queryHash(hashKind, BASE_HASH);
+        switch (hashKind) {
+            case STRUCTURAL_WITH_LITERALS:
+                return HashUtils.queryHash(hashKind, BASE_HASH, value);
+            case STRUCTURAL_WITHOUT_LITERALS:
+                return HashUtils.queryHash(hashKind, BASE_HASH);
+            default:
+                throw new UnsupportedOperationException("Hash kind " + hashKind.name() + " is not supported");
+        }
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -78,6 +78,7 @@ import com.apple.foundationdb.record.provider.common.DynamicMessageRecordSeriali
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.storestate.FDBRecordStoreStateCache;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.QueryToKeyMatcher;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.AndComponent;
@@ -1678,11 +1679,10 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
     @Override
     @Nonnull
-    public RecordQueryPlan planQuery(@Nonnull RecordQuery query) {
+    public RecordQueryPlan planQuery(@Nonnull RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
         final RecordQueryPlanner planner = new RecordQueryPlanner(getRecordMetaData(), getRecordStoreState());
-        return planner.plan(query);
+        return planner.plan(query, parameterRelationshipGraph);
     }
-
 
     /**
      * Utility method to be used to specify that new indexes should be {@link IndexState#WRITE_ONLY}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -45,6 +45,7 @@ import com.apple.foundationdb.record.provider.common.RecordSerializer;
 import com.apple.foundationdb.record.provider.common.TypedRecordSerializer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.storestate.FDBRecordStoreStateCache;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
@@ -247,8 +248,14 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
+    public RecordQueryPlan planQuery(@Nonnull final RecordQuery query, @Nonnull final ParameterRelationshipGraph parameterRelationshipGraph) {
+        return untypedStore.planQuery(query, parameterRelationshipGraph);
+    }
+
+    @Nonnull
+    @Override
     public RecordQueryPlan planQuery(@Nonnull RecordQuery query) {
-        return untypedStore.planQuery(query);
+        return planQuery(query, ParameterRelationshipGraph.empty());
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/BoundRecordQuery.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/BoundRecordQuery.java
@@ -1,0 +1,199 @@
+/*
+ * BoundRecordQuery.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query;
+
+import com.apple.foundationdb.record.Bindings;
+import com.apple.foundationdb.record.RecordMetaDataProto;
+import com.apple.foundationdb.record.RecordStoreState;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.query.expressions.Comparisons.ComparisonWithParameter;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static com.apple.foundationdb.record.query.expressions.BooleanComponent.groupedComparisons;
+
+/**
+ * A bound record query wraps an instance of {@link RecordQuery} and {@link RecordStoreState} in order to associate
+ * the query with the state of a store. That allows for differentiation of queries depending on the store state, e.g.
+ * the availability of indexes at the time the query was bound to the state, etc.
+ *
+ * Bound record queries also define {@link #hashCode()} and {@link #equals(Object)} in a way that allows for queries to
+ * be considered compatible to each other which is useful with respect to pre-bound parameter markers.
+ *
+ * Two queries are considered compatible, iff
+ * 1. their query structure is equal (minus their pre-bound parameter markers)
+ * 2. their associated record store state was compatible at the time of binding the {@link RecordQuery} to the
+ *    {@link RecordStoreState}
+ * 3. their pre-bound parameter markers use compatible pre-bound values
+ */
+public class BoundRecordQuery {
+    @Nonnull
+    private final RecordStoreState recordStoreState;
+    @Nonnull
+    private final RecordQuery recordQuery;
+    @Nonnull
+    private final Supplier<Set<String>> parametersSupplier;
+    @Nonnull
+    private final ParameterRelationshipGraph parameterRelationshipGraph;
+    @Nonnull
+    private final Supplier<Integer> hashCodeSupplier;
+
+    public BoundRecordQuery(@Nonnull final RecordStoreState recordStoreState, @Nonnull final RecordQuery recordQuery) {
+        this(recordStoreState, recordQuery, ParameterRelationshipGraph.empty());
+    }
+
+    public BoundRecordQuery(@Nonnull final RecordStoreState recordStoreState, @Nonnull final RecordQuery recordQuery, @Nonnull Bindings perBoundParameterBindings) {
+        this(recordStoreState, recordQuery, ParameterRelationshipGraph.fromRecordQueryAndBindings(recordQuery, perBoundParameterBindings));
+    }
+
+    private BoundRecordQuery(@Nonnull final RecordStoreState recordStoreState, @Nonnull final RecordQuery recordQuery, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        this.recordStoreState = recordStoreState;
+        this.recordQuery = recordQuery;
+        this.parameterRelationshipGraph = parameterRelationshipGraph;
+        this.parametersSupplier = Suppliers.memoize(this::computeParameters);
+        this.hashCodeSupplier = Suppliers.memoize(this::computeHashCode);
+    }
+
+    @Nonnull
+    public RecordStoreState getRecordStoreState() {
+        return recordStoreState;
+    }
+
+    @Nonnull
+    public RecordQuery getRecordQuery() {
+        return recordQuery;
+    }
+
+    public Set<String> getParameters() {
+        return parametersSupplier.get();
+    }
+
+    @Nonnull
+    public ParameterRelationshipGraph getParameterRelationshipGraph() {
+        return parameterRelationshipGraph;
+    }
+
+    /**
+     * Plan this query using the given store.
+     * @param store the store to use
+     * @return a record query plan for this query
+     */
+    @Nonnull
+    public RecordQueryPlan plan(@Nonnull final FDBRecordStore store) {
+        return store.planQuery(getRecordQuery(), parameterRelationshipGraph);
+    }
+
+    /**
+     * Check if a given {@link RecordQueryPlan} for the given store and a set of bindings is compatible to this bound
+     * query.
+     * @param store record store to access
+     * @param parameterBindings evaluation context containing parameter bindings
+     * @return {@code true} if the plan, if it were to be executed on the given store and with the given parameter
+     *         bindings, is compatible with this bound query; {@code false} otherwise
+     */
+    public boolean isCompatible(@Nonnull FDBRecordStore store,
+                                @Nonnull Bindings parameterBindings) {
+        if (!store.getRecordStoreState().compatibleWith(recordStoreState)) {
+            return false;
+        }
+
+        return parameterRelationshipGraph.isCompatible(parameterBindings);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCodeSupplier.get();
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private int computeHashCode() {
+        final HashFunction hashFunction = Hashing.murmur3_32();
+        final Hasher hasher = hashFunction.newHasher();
+        hasher.putInt(recordQuery.hashCode());
+        hasher.putInt(recordStoreState.getIndexStates().hashCode());
+        final RecordMetaDataProto.DataStoreInfo storeHeader = recordStoreState.getStoreHeader();
+        hasher.putInt(storeHeader.getMetaDataversion());
+        hasher.putInt(storeHeader.getUserVersion());
+        hasher.putInt(getParameters().hashCode());
+        hasher.putInt(parameterRelationshipGraph.hashCode());
+        return hasher.hash().asInt();
+    }
+
+    @Nonnull
+    private Set<String> computeParameters() {
+        final QueryComponent filter = recordQuery.getFilter();
+        if (filter != null) {
+            return groupedComparisons(filter)
+                    .flatMap(pair -> pair.getRight().stream())
+                    .map(ComparisonWithParameter::getParameter)
+                    .collect(ImmutableSet.toImmutableSet());
+        }
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BoundRecordQuery)) {
+            return false;
+        }
+        final BoundRecordQuery other = (BoundRecordQuery)o;
+
+        if (!getRecordQuery().equals(other.getRecordQuery())) {
+            return false;
+        }
+
+        if (!getParameters().equals(other.getParameters())) {
+            return false;
+        }
+
+        final RecordStoreState otherRecordStoreState = other.getRecordStoreState();
+        final RecordMetaDataProto.DataStoreInfo storeHeader = recordStoreState.getStoreHeader();
+        final RecordMetaDataProto.DataStoreInfo otherStoreHeader = otherRecordStoreState.getStoreHeader();
+        if (storeHeader.getMetaDataversion() != otherStoreHeader.getMetaDataversion()) {
+            return false;
+        }
+        if (storeHeader.getUserVersion() != otherStoreHeader.getUserVersion()) {
+            return false;
+        }
+        if (!this.recordStoreState.compatibleWith(otherRecordStoreState)) {
+            return false;
+        }
+
+        return parameterRelationshipGraph.equals(other.getParameterRelationshipGraph());
+    }
+
+    @Override
+    public String toString() {
+        return recordQuery.toString();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/IndexQueryabilityFilter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/IndexQueryabilityFilter.java
@@ -31,8 +31,32 @@ import javax.annotation.Nonnull;
  * A filter used to determine whether an index should be considered when planning queries.
  */
 @API(API.Status.EXPERIMENTAL)
-@FunctionalInterface
 public interface IndexQueryabilityFilter extends QueryHashable {
+
+    IndexQueryabilityFilter TRUE = new IndexQueryabilityFilter() {
+        @Override
+        public boolean isQueryable(@Nonnull final Index index) {
+            return true;
+        }
+
+        @Override
+        public int queryHash(@Nonnull final QueryHashKind hashKind) {
+            return 11;
+        }
+    };
+
+    IndexQueryabilityFilter FALSE = new IndexQueryabilityFilter() {
+        @Override
+        public boolean isQueryable(@Nonnull final Index index) {
+            return false;
+        }
+
+        @Override
+        public int queryHash(@Nonnull final QueryHashKind hashKind) {
+            return 59;
+        }
+    };
+
     /**
      * The default index queryability filter which uses all indexes except those with the
      * {@link IndexOptions#ALLOWED_FOR_QUERY_OPTION} set to {@code false}.
@@ -67,7 +91,5 @@ public interface IndexQueryabilityFilter extends QueryHashable {
      * @return 0 as the calculated hash in all cases, to have no impact on query hashes.
      */
     @Override
-    default int queryHash(@Nonnull final QueryHashable.QueryHashKind hashKind) {
-        return 0;
-    }
+    int queryHash(@Nonnull final QueryHashable.QueryHashKind hashKind);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/ParameterRelationshipGraph.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/ParameterRelationshipGraph.java
@@ -1,0 +1,272 @@
+/*
+ * ParameterRelationshipGraph.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.Bindings;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.graph.ImmutableNetwork;
+import com.google.common.graph.Network;
+import com.google.common.graph.NetworkBuilder;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import static com.apple.foundationdb.record.query.expressions.BooleanComponent.groupedComparisons;
+import static com.apple.foundationdb.record.query.plan.temp.CrossProduct.crossProduct;
+
+/**
+ * A class to keep track of the relationships of parameters in a query given a {@link RecordQuery} and a set of
+ * pre-bindings. This will allow the query planner to find potential additional optimizations and also it helps
+ * define plan-compatibility between two queries before actually planning them. That property is the crucial
+ * for any meaningful implementation of a plan cache that is not dependent on literal constants in the query.
+ */
+@API(API.Status.INTERNAL)
+@SuppressWarnings("UnstableApiUsage")
+public class ParameterRelationshipGraph {
+    private static final ParameterRelationshipGraph UNBOUND = empty();
+
+    /**
+     * The guava network backing the parameter relationships. Note that a {@link Network} is a kind of graph
+     * implementation that imposes uniqueness on nodes and edges. The nodes in the network are parameters,
+     * edges are relationships between parameters like equality, etc. For our purposes, parameter names (the nodes) are
+     * considered unique per definition. Edges are created upon insertion and are considered unique by
+     * {@code (from, to, relationship type)}.
+     * Two parameters can be connected by more than one edge as they may participate in more than one relationship.
+     * This graph should not really grow beyond a manageable limit.  Relationships are always computed based on a set
+     * of pre-bound parameters.
+     */
+    @Nonnull
+    private final ImmutableNetwork<String, Relationship> network;
+
+    private ParameterRelationshipGraph(@Nonnull final Network<String, Relationship> network) {
+        this.network = ImmutableNetwork.copyOf(network);
+    }
+
+    public boolean isUnbound() {
+        return this == unbound();
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public int hashCode() {
+        return network.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ParameterRelationshipGraph)) {
+            return false;
+        }
+        final ParameterRelationshipGraph that = (ParameterRelationshipGraph)o;
+        return network.equals(that.network);
+    }
+
+    /**
+     * Derive a relationship graph from a {@link RecordQuery} and a set of pre-bound parameters in handing in
+     * as a {@link Bindings} object.
+     * <p>
+     * Note that we do not derive additional relationships (yet). So for instance a query
+     * </p>
+     * <p>
+     * {@code
+     * ...
+     * WHERE x < $p1 AND x = $p2 AND y < $p2 AND y = $p3
+     * }
+     * </p>
+     * with pre-bindings {@code p1 -> 10, p2 -> 10, p3 -> 10} would result in a graph containing
+     * <p>
+     * {@code
+     * p1 EQUALS p1
+     * p1 EQUALS p2
+     * p2 EQUALS p1
+     * p2 EQUALS p2
+     * p2 EQUALS p3
+     * p3 EQUALS p2
+     * p3 EQUALS p3
+     * }
+     * </p>
+     * but it would not contain
+     * <p>
+     * {@code
+     * p1 EQUALS p3
+     * p3 EQUALS p1
+     * }
+     * </p>
+     * @param recordQuery query
+     * @param preBoundParameterBindings parameter bindings already known at planning time
+     * @return a new {@link ParameterRelationshipGraph}
+     */
+    @Nonnull
+    public static ParameterRelationshipGraph fromRecordQueryAndBindings(@Nonnull final RecordQuery recordQuery,
+                                                                        @Nonnull final Bindings preBoundParameterBindings) {
+        final QueryComponent filter = recordQuery.getFilter();
+        final ImmutableNetwork.Builder<String, Relationship> networkBuilder =
+                NetworkBuilder.directed()
+                        .allowsSelfLoops(true)
+                        .allowsParallelEdges(true)
+                        .immutable();
+
+        if (filter != null) {
+            groupedComparisons(filter)
+                    .flatMap(entry -> StreamSupport.stream(crossProduct(ImmutableList.of(entry.getValue(), entry.getValue())).spliterator(), false))
+                    .map(list -> Pair.of(list.get(0), list.get(1)))
+                    .forEach(pair -> {
+                        final Comparisons.ComparisonWithParameter left = pair.getLeft();
+                        final Comparisons.ComparisonWithParameter right = pair.getRight();
+
+                        if (left.getParameter().equals(right.getParameter())) {
+                            Relationship.addEdge(networkBuilder, RelationshipType.EQUALS, left.getParameter(), right.getParameter());
+                            Relationship.addEdge(networkBuilder, RelationshipType.EQUALS, right.getParameter(), left.getParameter());
+                        } else if (preBoundParameterBindings.containsBinding(left.getParameter()) &&  // It is possible that some of the parameters are not pre-bound. That's not an error,
+                                   preBoundParameterBindings.containsBinding(right.getParameter())) { // it just means we cannot establish any sort of relationship between them.
+
+                            final Object leftComparand = preBoundParameterBindings.get(left.getParameter());
+                            final Object rightComparand = preBoundParameterBindings.get(right.getParameter());
+
+                            if (Objects.equals(leftComparand, rightComparand)) {
+                                Relationship.addEdge(networkBuilder, RelationshipType.EQUALS, left.getParameter(), right.getParameter());
+                                Relationship.addEdge(networkBuilder, RelationshipType.EQUALS, right.getParameter(), left.getParameter());
+                            }
+                        }
+                    });
+        }
+        return new ParameterRelationshipGraph(networkBuilder.build());
+    }
+
+    @Nonnull
+    public static ParameterRelationshipGraph empty() {
+        return new ParameterRelationshipGraph(NetworkBuilder.directed().allowsSelfLoops(true).allowsParallelEdges(true).<String, Relationship>immutable().build());
+    }
+
+    /**
+     * Returns a specific instance that must be considered as a {@code null} element.
+     * @return the unbound instance
+     */
+    public static ParameterRelationshipGraph unbound() {
+        return UNBOUND;
+    }
+
+    @Nonnull
+    public Set<String> getRelatedParameters(@Nonnull final String parameter, @Nonnull final RelationshipType relationshipType) {
+        return network.outEdges(parameter)
+                .stream()
+                .filter(relationship -> relationship.getRelationshipKind() == relationshipType)
+                .map(relationship -> network.incidentNodes(relationship).nodeV())
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+    public boolean containsParameter(@Nonnull final String parameter) {
+        return network.nodes().contains(parameter);
+    }
+
+    public boolean isCompatible(@Nonnull final Bindings parameterBindings) {
+        return network.edges()
+                .stream()
+                .allMatch(edge -> {
+                    final String parameter1 = edge.getParameter1();
+                    final String parameter2 = edge.getParameter2();
+                    if (edge.getRelationshipKind() == RelationshipType.EQUALS &&
+                            !parameter1.equals(parameter2)) {
+                        if (!parameterBindings.containsBinding(parameter1) ||
+                                !parameterBindings.containsBinding(parameter2)) {
+                            return false;
+                        }
+                        return Objects.equals(parameterBindings.get(parameter1), parameterBindings.get(parameter2));
+                    }
+                    return true;
+                });
+    }
+
+    public enum RelationshipType {
+        EQUALS,
+        NOT_EQUALS
+    }
+
+    public static class Relationship {
+        @Nonnull
+        private final RelationshipType relationshipType;
+        @Nonnull
+        private final String parameter1;
+        @Nonnull
+        private final String parameter2;
+
+        public Relationship(@Nonnull final RelationshipType relationshipType, @Nonnull final String parameter1, @Nonnull final String parameter2) {
+            this.relationshipType = relationshipType;
+            this.parameter1 = parameter1;
+            this.parameter2 = parameter2;
+        }
+
+        @Nonnull
+        public RelationshipType getRelationshipKind() {
+            return relationshipType;
+        }
+
+        @Nonnull
+        public String getParameter1() {
+            return parameter1;
+        }
+
+        @Nonnull
+        public String getParameter2() {
+            return parameter2;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Relationship)) {
+                return false;
+            }
+            final Relationship that = (Relationship)o;
+            return relationshipType == that.relationshipType && getParameter1().equals(that.getParameter1()) && getParameter2().equals(that.getParameter2());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(relationshipType, getParameter1(), getParameter2());
+        }
+
+        @SuppressWarnings("SameParameterValue")
+        private static void addEdge(@Nonnull ImmutableNetwork.Builder<String, Relationship> networkBuilder,
+                                    @Nonnull final RelationshipType relationshipType,
+                                    @Nonnull final String parameter1,
+                                    @Nonnull final String parameter2) {
+            networkBuilder.addEdge(parameter1, parameter2, new Relationship(relationshipType, parameter1, parameter2));
+        }
+
+        @Override
+        public String toString() {
+            return getParameter1() + " --" + getRelationshipKind().name() + "--> " + getParameter2();
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/AndOrComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/AndOrComponent.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
  * The common base class for Boolean {@code And} and {@code Or} query components.
  */
 @API(API.Status.INTERNAL)
-public abstract class AndOrComponent extends SimpleComponentWithChildren implements ComponentWithChildren {
+public abstract class AndOrComponent extends SimpleComponentWithChildren implements ComponentWithChildren, BooleanComponent {
 
     protected abstract boolean isOr();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BooleanComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/BooleanComponent.java
@@ -1,0 +1,158 @@
+/*
+ * BooleanComponent.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.expressions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Streams;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A boolean component is a component representing an operation in the boolean algebra, e.g. and, or, not.
+ * This class is more of a tag interface from that perspective.
+ *
+ * Within the {@link QueryComponent} hierarchy, the query components are structured into islands of functionally
+ * evaluated boolean components as well as structural components that e.g. span a new level of nesting, represent
+ * something that itself can evaluated to to a boolean (e.g. a comparison). This class contains helpers for navigation
+ * within and for the collection of useful information from an arbitrary query component tree.
+ */
+public interface BooleanComponent extends QueryComponent {
+    /**
+     * Starting from this boolean component find all sub components that itself are not considered {@link BooleanComponent}s.
+     * @return a stream of non-boolean sub components.
+     */
+    @Nonnull
+    default Stream<QueryComponent> nonBooleanSubComponents() {
+        if (this instanceof ComponentWithChildren) {
+            final ComponentWithChildren componentWithChildren = (ComponentWithChildren)this;
+
+            return componentWithChildren.getChildren()
+                    .stream()
+                    .flatMap(child -> {
+                        if (child instanceof BooleanComponent) {
+                            return ((BooleanComponent)child).nonBooleanSubComponents();
+                        }
+                        return Stream.of(child);
+                    });
+        } else if (this instanceof ComponentWithSingleChild) {
+            final ComponentWithSingleChild componentWithSingleChild = (ComponentWithSingleChild)this;
+            final QueryComponent child = componentWithSingleChild.getChild();
+
+            if (child instanceof BooleanComponent) {
+                return ((BooleanComponent)child).nonBooleanSubComponents();
+            }
+            return Stream.of(child);
+        }
+
+        return Stream.empty();
+    }
+
+    /**
+     * Starting from an arbitrary query component collect all {@link ComponentWithComparison}s within the sub tree
+     * spanned by the {@code queryComponent} handed in and group each of these components with all comparisons
+     * referring to them.
+     * @param queryComponent the {@link QueryComponent} as the root of the search
+     * @return a stream of pairs of {@link ComponentWithComparison} and associated {@link Comparisons.Comparison}s
+     */
+    @Nonnull
+    static Stream<Pair<String, List<Comparisons.ComparisonWithParameter>>> groupedComparisons(@Nonnull final QueryComponent queryComponent) {
+        final Stream<BooleanComponent> booleanComponents = BooleanComponent.topBooleanComponents(queryComponent);
+        return booleanComponents
+                .flatMap(booleanComponent -> {
+                    // find all the comparisons within this boolean component
+                    final List<QueryComponent> nonBooleanSubComponents =
+                            booleanComponent.nonBooleanSubComponents().collect(ImmutableList.toImmutableList());
+
+                    final Stream<Pair<String, List<Comparisons.ComparisonWithParameter>>> nestedGroupedComparisons =
+                            nestedComponents(nonBooleanSubComponents.stream())
+                            .flatMap(BooleanComponent::groupedComparisons);
+
+                    final Stream<ComponentWithComparison> comparisons = comparisons(nonBooleanSubComponents.stream());
+                    final Map<String, ? extends List<Comparisons.ComparisonWithParameter>> partitionedComparisonsMap =
+                            groupedComparisonsMap(comparisons);
+
+                    //
+                    // Each entry in that map represents a comparison that may have a number of occurrences:
+                    //
+                    // x < :p1 and x > :p2
+                    // would manifest itself in the map as such:
+                    // x -> { x < :p1, x > :p2 }
+                    //
+                    // Note that each entry is considered independent to each other entry.
+                    //
+                    final Stream<Pair<String, List<Comparisons.ComparisonWithParameter>>> dependentComparisons =
+                            partitionedComparisonsMap.entrySet()
+                                    .stream()
+                                    .map(entry -> Pair.of(entry.getKey(), entry.getValue()));
+
+                    return Streams.concat(nestedGroupedComparisons, dependentComparisons);
+                });
+    }
+
+    @Nonnull
+    static Map<String, ImmutableList<Comparisons.ComparisonWithParameter>> groupedComparisonsMap(final Stream<ComponentWithComparison> comparisons) {
+        return comparisons
+                .filter(componentWithComparison -> componentWithComparison.getComparison() instanceof Comparisons.ComparisonWithParameter)
+                .collect(Collectors.groupingBy(ComponentWithComparison::getName,
+                        Maps::newLinkedHashMap,
+                        Collectors.mapping(componentWithComparison -> (Comparisons.ComparisonWithParameter)componentWithComparison.getComparison(),
+                                ImmutableList.toImmutableList())));
+    }
+    
+    @Nonnull
+    static Stream<ComponentWithComparison> comparisons(@Nonnull final Stream<QueryComponent> nonBooleanSubComponents) {
+        return nonBooleanSubComponents
+                .filter(queryComponent -> queryComponent instanceof ComponentWithComparison)
+                .map(queryComponent -> (ComponentWithComparison)queryComponent);
+    }
+
+    @Nonnull
+    static Stream<QueryComponent> nestedComponents(@Nonnull final Stream<QueryComponent> nonBooleanSubComponents) {
+        return nonBooleanSubComponents
+                .filter(queryComponent -> !(queryComponent instanceof ComponentWithComparison));
+    }
+
+    @Nonnull
+    static Stream<BooleanComponent> topBooleanComponents(@Nonnull final QueryComponent queryComponent) {
+        if (queryComponent instanceof BooleanComponent) {
+            return Stream.of((BooleanComponent)queryComponent);
+        }
+
+        if (queryComponent instanceof ComponentWithChildren) {
+            final ComponentWithChildren componentWithChildren = (ComponentWithChildren)queryComponent;
+            return componentWithChildren.getChildren()
+                    .stream()
+                    .flatMap(BooleanComponent::topBooleanComponents);
+        } else if (queryComponent instanceof ComponentWithSingleChild) {
+            final ComponentWithSingleChild componentWithSingleChild = (ComponentWithSingleChild)queryComponent;
+            final QueryComponent child = componentWithSingleChild.getChild();
+            return topBooleanComponents(child);
+        }
+
+        return Stream.empty();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/ComponentWithChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/ComponentWithChildren.java
@@ -21,6 +21,8 @@
 package com.apple.foundationdb.record.query.expressions;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -34,4 +36,14 @@ public interface ComponentWithChildren extends QueryComponent {
     List<QueryComponent> getChildren();
 
     QueryComponent withOtherChildren(List<QueryComponent> newChildren);
+
+    @Nonnull
+    @Override
+    default QueryComponent withParameterRelationshipMap(@Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        return withOtherChildren(
+                getChildren()
+                        .stream()
+                        .map(child -> child.withParameterRelationshipMap(parameterRelationshipGraph))
+                        .collect(ImmutableList.toImmutableList()));
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/ComponentWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/ComponentWithComparison.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.expressions;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 
 import javax.annotation.Nonnull;
 
@@ -35,4 +36,10 @@ public interface ComponentWithComparison extends ComponentWithNoChildren {
     QueryComponent withOtherComparison(Comparisons.Comparison comparison);
 
     String getName();
+
+    @Nonnull
+    @Override
+    default QueryComponent withParameterRelationshipMap(@Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        return withOtherComparison(getComparison().withParameterRelationshipMap(parameterRelationshipGraph));
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/ComponentWithSingleChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/ComponentWithSingleChild.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.expressions;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 
 import javax.annotation.Nonnull;
 
@@ -33,4 +34,10 @@ public interface ComponentWithSingleChild extends QueryComponent {
     QueryComponent getChild();
 
     QueryComponent withOtherChild(QueryComponent newChild);
+
+    @Nonnull
+    @Override
+    default QueryComponent withParameterRelationshipMap(@Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        return withOtherChild(getChild().withParameterRelationshipMap(parameterRelationshipGraph));
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NotComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/NotComponent.java
@@ -45,7 +45,7 @@ import java.util.concurrent.CompletableFuture;
  * For tri-valued logic, if the child evaluates to unknown / {@code null}, {@code NOT} is still unknown.
  */
 @API(API.Status.MAINTAINED)
-public class NotComponent implements ComponentWithSingleChild {
+public class NotComponent implements ComponentWithSingleChild, BooleanComponent {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Not-Component");
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryComponent.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryComponent.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.QueryHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.google.protobuf.Descriptors;
@@ -167,4 +168,9 @@ public interface QueryComponent extends PlanHashable, QueryHashable {
      */
     @API(API.Status.EXPERIMENTAL)
     GraphExpansion expand(@Nonnull CorrelationIdentifier baseAlias, @Nonnull List<String> fieldNamePrefix);
+
+    @Nonnull
+    default QueryComponent withParameterRelationshipMap(@Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        return this;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanner.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordStoreState;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 
@@ -61,11 +62,26 @@ public interface QueryPlanner {
      * Create a plan to get the results of the provided query.
      *
      * @param query a query for records on this planner's metadata
+     * @param parameterRelationshipGraph a set of bindings and their relationships that provide additional information
+     *        to the planner that may improve plan quality but may also tighten requirements imposed on the parameter
+     *        bindings that are used to execute the query
      * @return a plan that will return the results of the provided query when executed
      * @throws com.apple.foundationdb.record.RecordCoreException if the planner cannot plan the query
      */
     @Nonnull
-    RecordQueryPlan plan(@Nonnull RecordQuery query);
+    RecordQueryPlan plan(@Nonnull RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph);
+
+    /**
+     * Create a plan to get the results of the provided query.
+     *
+     * @param query a query for records on this planner's metadata
+     * @return a plan that will return the results of the provided query when executed
+     * @throws com.apple.foundationdb.record.RecordCoreException if the planner cannot plan the query
+     */
+    @Nonnull
+    default RecordQueryPlan plan(@Nonnull RecordQuery query) {
+        return plan(query, ParameterRelationshipGraph.empty());
+    }
 
     /**
      * Create a plan to get the results of the provided query.
@@ -73,11 +89,19 @@ public interface QueryPlanner {
      * with additional information provided in the {@link QueryPlanInfo}
      *
      * @param query a query for records on this planner's metadata
+     * @param parameterRelationshipGraph a set of bindings and their relationships that provide additional information
+     *        to the planner that may improve plan quality but may also tighten requirements imposed on the parameter
+     *        bindings that are used to execute the query
      * @return a {@link QueryPlanResult} that contains the plan for the query with additional information
      * @throws com.apple.foundationdb.record.RecordCoreException if the planner cannot plan the query
      */
     @Nonnull
-    QueryPlanResult planQuery(@Nonnull RecordQuery query);
+    QueryPlanResult planQuery(@Nonnull RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph);
+
+    @Nonnull
+    default QueryPlanResult planQuery(@Nonnull RecordQuery query) {
+        return planQuery(query, ParameterRelationshipGraph.empty());
+    }
 
     /**
      * Get the {@link RecordMetaData} for this planner.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/BooleanNormalizer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/BooleanNormalizer.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.query.expressions.AndComponent;
+import com.apple.foundationdb.record.query.expressions.BooleanComponent;
 import com.apple.foundationdb.record.query.expressions.ComponentWithChildren;
 import com.apple.foundationdb.record.query.expressions.ComponentWithSingleChild;
 import com.apple.foundationdb.record.query.expressions.NotComponent;
@@ -183,9 +184,7 @@ public class BooleanNormalizer {
     }
 
     private boolean isBooleanPredicate(@Nullable final QueryComponent predicate) {
-        return predicate instanceof AndComponent ||
-               predicate instanceof OrComponent ||
-               predicate instanceof NotComponent;
+        return predicate instanceof BooleanComponent;
     }
 
     int getNormalizedSize(@Nullable final QueryComponent predicate) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/InExtractor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/InExtractor.java
@@ -83,8 +83,8 @@ public class InExtractor {
                 }
                 KeyExpression orderingKey = getOrderingKey(nestedFields);
 
-                if (withComparison.getComparison() instanceof Comparisons.ParameterComparison) {
-                    final String parameterName = ((Comparisons.ParameterComparison)withComparison.getComparison()).getParameter();
+                if (withComparison.getComparison() instanceof Comparisons.ComparisonWithParameter) {
+                    final String parameterName = ((Comparisons.ComparisonWithParameter)withComparison.getComparison()).getParameter();
                     inClauses.add(new InParameterClause(bindingName, parameterName, orderingKey));
                 } else {
                     final List<Object> comparand = (List<Object>) withComparison.getComparison().getComparand();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/CascadesPlanner.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.plan.QueryPlanInfoKeys;
 import com.apple.foundationdb.record.query.plan.QueryPlanResult;
@@ -219,7 +220,7 @@ public class CascadesPlanner implements QueryPlanner {
 
     @Nonnull
     @Override
-    public RecordQueryPlan plan(@Nonnull RecordQuery query) {
+    public RecordQueryPlan plan(@Nonnull RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
         final PlanContext context = new MetaDataPlanContext(metaData, recordStoreState, query);
         Debugger.query(query, context);
         try {
@@ -245,8 +246,8 @@ public class CascadesPlanner implements QueryPlanner {
 
     @Nonnull
     @Override
-    public QueryPlanResult planQuery(@Nonnull final RecordQuery query) {
-        QueryPlanResult result = new QueryPlanResult(plan(query));
+    public QueryPlanResult planQuery(@Nonnull final RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        QueryPlanResult result = new QueryPlanResult(plan(query, parameterRelationshipGraph));
         result.getPlanInfo().put(QueryPlanInfoKeys.TOTAL_TASK_COUNT, taskCount);
         result.getPlanInfo().put(QueryPlanInfoKeys.MAX_TASK_QUEUE_SIZE, maxQueueSize);
         return result;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBFilterCoalescingQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBFilterCoalescingQueryTest.java
@@ -228,7 +228,7 @@ public class FDBFilterCoalescingQueryTest extends FDBRecordStoreQueryTestBase {
                         .collect(Collectors.toList()))))));
         assertEquals(241654378, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-833909187, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(2046922955, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1191595574, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
@@ -149,7 +149,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                         .where(queryComponents(exactly(equalsObject(filter)))));
         assertEquals(-1677754212, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-192829430, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(871680640, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-192829430, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(33, querySimpleRecordStore(NO_HOOK, plan,
                 () -> EvaluationContext.forBinding("valuesThree", asList(1, 3)),
                 record -> assertThat(record.getNumValue2(), anyOf(is(1), is(3))),
@@ -178,7 +178,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(ls))));
         assertEquals(-2004060310, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(1111143844, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(619086974, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1111112996, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(60, querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty,
                 record -> assertThat(record.getNumValue3Indexed(), anyOf(is(1), is(2), is(4))),
                 TestHelpers::assertDiscardedNone));
@@ -205,7 +205,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(RecordQueryPlanMatchers.inParameter(equalsObject("valueThrees"))));
         assertEquals(883815022, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(1054651695, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(562625673, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1054651695, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         int count = querySimpleRecordStore(NO_HOOK, plan,
                 () -> EvaluationContext.forBinding("valueThrees", asList(1, 3, 4)),
                 myrec -> assertThat(myrec.getNumValue3Indexed(), anyOf(is(1), is(3), is(4))),
@@ -234,7 +234,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(RecordQueryPlanMatchers.inParameter(equalsObject("valueThrees"))));
         assertEquals(883815022, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(1054651695, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(562625673, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1054651695, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(0, querySimpleRecordStore(NO_HOOK, plan,
                 () -> EvaluationContext.forBinding("valueThrees", Collections.emptyList()),
                 myrec -> fail("There should be no results")));
@@ -267,7 +267,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .where(queryComponents(exactly(equalsObject(filter)))));
         assertEquals(1667070490, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(1804602975, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-557106421, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1804602975, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(100, querySimpleRecordStore(NO_HOOK, plan,
                 () -> EvaluationContext.forBinding("valueThrees", Collections.emptyList()),
                 myrec -> {
@@ -301,7 +301,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(asList(1, 2, 4)))));
         assertEquals(-2004060309, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(1111138078, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(619081208, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1111107230, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(60, querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty,
                 record -> assertThat(record.getNumValue3Indexed(), anyOf(is(1), is(2), is(4))),
                 TestHelpers::assertDiscardedNone));
@@ -511,7 +511,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(ls))));
         assertEquals(1075889283, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-347431998, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(677597961, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1328020884, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         queryRecordsWithHeader(recordMetaDataHook, plan, cursor ->
                         assertEquals(asList( "_56", "_6", "_1", "_51", "_11", "_61"),
                                 cursor.map(TestRecordsWithHeaderProto.MyRecord.Builder::getStrValue).asList().get()),
@@ -559,7 +559,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
 
         assertEquals(-1869764109, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(12526355, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(1467763781, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-925258159, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         queryRecordsWithHeader(recordMetaDataHook, plan, cursor ->
                         assertEquals(asList("_56", "_6", "_1", "_51", "_34", "_84"),
                                 cursor.map(TestRecordsWithHeaderProto.MyRecord.Builder::getStrValue).asList().get()),
@@ -604,7 +604,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
 
         assertEquals(303286809, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-535785429, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-1305077319, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-1772065181, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         queryRecordsWithHeader(recordMetaDataHook, plan, cursor ->
                         assertEquals(asList("1:String1", "1:String1", "1:String6", "1:String6", "4:String34", "4:String34"),
                                 cursor.map(m -> m.getHeader().getRecNo() + ":" + m.getHeader().getPath()).asList().get()),
@@ -643,7 +643,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(ls))));
         assertEquals(1075889283, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-347431998, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(677597961, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1328020884, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         queryRecordsWithHeader(recordMetaDataHook, plan, null, 3, cursor ->
                         assertEquals(asList( "_56", "_6", "_1"),
                                 cursor.map(TestRecordsWithHeaderProto.MyRecord.Builder::getStrValue).asList().get()),
@@ -682,7 +682,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(ls))));
         assertEquals(1075745133, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-347576148, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(677597961, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1328020884, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         // result: [ "_1", "_51", "_56", "_6", "_11", "_61"]
         final Holder<byte[]> continuation = new Holder<>();
         queryRecordsWithHeader(recordMetaDataHook, plan, null, 10,
@@ -750,7 +750,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(ls))));
         assertEquals(503365581, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(936275728, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(953683456, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(936274312, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(50, querySimpleRecordStore(recordMetaDataHook, plan, EvaluationContext::empty,
                 record -> assertThat(record.getRecNo() % 4, anyOf(is(3L), is(2L))),
                 TestHelpers::assertDiscardedNone));
@@ -779,7 +779,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(RecordQueryPlanMatchers.inParameter(equalsObject("values"))));
         assertEquals(-320448635, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(1463061327, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(1480470471, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1463061327, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(50, querySimpleRecordStore(recordMetaDataHook, plan,
                 () -> EvaluationContext.forBinding("values", Arrays.asList(13L, 11L)),
                 record -> assertThat(record.getRecNo() % 4, anyOf(is(3L), is(1L))),
@@ -844,7 +844,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(ls))));
         assertEquals(-778840248, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(1033565169, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-2129258919, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1423674072, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         List<Long> recNos = new ArrayList<>();
         querySimpleRecordStore(recordMetaDataHook, plan, EvaluationContext::empty,
                 record -> recNos.add(record.getRecNo()),
@@ -877,7 +877,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 ).where(inValuesList(equalsObject(ls))));
         assertEquals(1518925028, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-2030955860, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(752828544, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-2030986740, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         List<Long> recNos = new ArrayList<>();
         querySimpleRecordStore(recordMetaDataHook, plan, EvaluationContext::empty,
                 record -> recNos.add(record.getRecNo()),
@@ -911,7 +911,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                         .where(comparisonKey(concat(field("num_value_unique"), primaryKey("MySimpleRecord")))));
         assertEquals(1116661716, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-923557660, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(851868784, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-925294376, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(53, querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty,
                 record -> assertThat(record.getNumValueUnique(), anyOf(is(901), is(903), is(905), greaterThan(950))),
                 TestHelpers::assertDiscardedNone));
@@ -945,7 +945,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                         ).where(inValuesList(equalsObject(Arrays.asList(904, 905, 906))))));
         assertEquals(218263868, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-1594325702, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(2007968440, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(34930104, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         Set<Long> dupes = new HashSet<>();
         assertEquals(5, querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty,
                 record -> {
@@ -1017,7 +1017,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                         indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 0, 4],[odd, 0]]")))));
         assertEquals(468569345, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(2017733085, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-1668679064, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1850128386, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(3 + 4 + 4, querySimpleRecordStore(hook, plan, EvaluationContext::empty,
                 record -> {
                     assertThat(record.getStrValueIndexed(), is("odd"));
@@ -1086,7 +1086,7 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
         assertFalse(plan.hasRecordScan(), "should not use record scan");
         assertEquals(-520431454, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(-456008302, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-1863352727, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-460562518, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
 
         try (FDBRecordContext context = openContext()) {
             openEnumRecordStore(context, hook);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBQueryCompatibilityTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBQueryCompatibilityTest.java
@@ -1,0 +1,426 @@
+/*
+ * FDBQueryCompatibilityTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.query;
+
+import com.apple.foundationdb.record.Bindings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.RecordCursorIterator;
+import com.apple.foundationdb.record.TestHelpers;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.query.BoundRecordQuery;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.test.Tags;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag(Tags.RequiresFDB)
+class FDBQueryCompatibilityTest extends FDBRecordStoreQueryTestBase {
+    /**
+     * Verify that a complex query with an appropriate multi-field index uses the index.
+     */
+    @Test
+    void testQueryCompatibilityDifferentStructure() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+        BoundRecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord1")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("num_value_2").equalsParameter("p3")))
+                .buildAndBind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", 3)
+                                .set("p3", 0)
+                                .build());
+
+        BoundRecordQuery query2 = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("num_value_2").equalsParameter("p3")))
+                .buildAndBind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", 3)
+                                .set("p3", 0)
+                                .build());
+
+        assertNotEquals(query.hashCode(), query2.hashCode());
+        assertNotEquals(query, query2);
+    }
+
+    @Test
+    void testQueryCompatibilityUniqueUsages() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+        BoundRecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("num_value_2").equalsParameter("p3")))
+                .buildAndBind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", 3)
+                                .set("p3", 0)
+                                .build());
+
+        BoundRecordQuery query2 = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("num_value_2").equalsParameter("p3")))
+                .buildAndBind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", 3)
+                                .set("p3", 0)
+                                .build());
+
+        assertEquals(query.hashCode(), query2.hashCode());
+        assertEquals(query2, query);
+    }
+
+    @Test
+    void testQueryCompatibilityDifferentParameters() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+        BoundRecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("num_value_2").equalsParameter("p3")))
+                .buildAndBind(recordStore);
+
+        BoundRecordQuery query2 = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("pa"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("num_value_2").equalsParameter("p3")))
+                .buildAndBind(recordStore);
+
+        assertNotEquals(query.hashCode(), query2.hashCode());
+        assertNotEquals(query2, query);
+    }
+
+    @Test
+    void testQueryCompatibilityNestedStructure() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("nested").oneOfThem()
+                                .matches(Query.and(
+                                        Query.field("str_value_indexed").equalsParameter("p3"),
+                                        Query.field("num_value_3_indexed").equalsParameter("p4")))))
+                .build();
+        BoundRecordQuery boundQuery = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", 3)
+                                .set("p3", "even")
+                                .set("p4", 4)
+                                .build());
+
+        BoundRecordQuery boundQuery2 = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "odd")
+                                .set("p2", 3)
+                                .set("p3", "odd")
+                                .set("p4", 4)
+                                .build());
+
+        assertEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertEquals(boundQuery2, boundQuery);
+
+        boundQuery2 = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "odd")
+                                .set("p2", 3)
+                                .set("p3", "even")
+                                .set("p4", 4)
+                                .build());
+
+        assertEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertEquals(boundQuery2, boundQuery);
+    }
+
+    @Test
+    void testQueryCompatibilityNestedStructure2() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("num_value_3_indexed").equalsParameter("p2"),
+                        Query.field("nested").oneOfThem()
+                                .matches(Query.and(
+                                        Query.field("str_value_indexed").equalsParameter("p3"),
+                                        Query.field("str_value_indexed").equalsParameter("p4"),
+                                        Query.field("num_value_3_indexed").equalsParameter("p5")))))
+                .build();
+
+        BoundRecordQuery boundQuery = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", 3)
+                                .set("p3", "even")
+                                .set("p4", "even")
+                                .set("p5", 4)
+                                .build());
+
+        BoundRecordQuery boundQuery2 = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "whatever")
+                                .set("p2", 3)
+                                .set("p3", "odd")
+                                .set("p4", "odd")
+                                .set("p5", 4)
+                                .build());
+
+        assertEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertEquals(boundQuery2, boundQuery);
+
+        boundQuery2 = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "whatever")
+                                .set("p2", 3)
+                                .set("p3", "odd")
+                                .set("p4", "even")
+                                .set("p5", 4)
+                                .build());
+
+        assertNotEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertNotEquals(boundQuery2, boundQuery);
+    }
+
+    @Test
+    void testQueryCompatibilityConstraintSimple() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("str_value_indexed").equalsParameter("p2"),
+                        Query.field("num_value_3_indexed").equalsParameter("p3"),
+                        Query.field("num_value_2").equalsParameter("p4")))
+                .build();
+
+        BoundRecordQuery boundQuery =
+                query.bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", "even")
+                                .set("p3", 3)
+                                .set("p4", 0)
+                                .build());
+
+        BoundRecordQuery boundQuery2 =
+                query.bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", "even")
+                                .set("p3", 3)
+                                .set("p4", 0)
+                                .build());
+
+        assertEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertEquals(boundQuery2, boundQuery);
+
+        boundQuery2 =
+                query.bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", "odd")
+                                .set("p3", 3)
+                                .set("p4", 0)
+                                .build());
+
+        assertNotEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertNotEquals(boundQuery2, boundQuery);
+
+        boundQuery2 =
+                query.bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "odd")
+                                .set("p2", "odd")
+                                .set("p3", 3)
+                                .set("p4", 0)
+                                .build());
+
+        assertEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertEquals(boundQuery2, boundQuery);
+    }
+
+    @Test
+    void testQueryCompatibilityConstraintComplex() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("str_value_indexed").equalsParameter("p2"),
+                        Query.field("str_value_indexed").equalsParameter("p3"),
+                        Query.field("str_value_indexed").equalsParameter("p4"),
+                        Query.field("str_value_indexed").equalsParameter("p5"),
+                        Query.field("str_value_indexed").equalsParameter("p6"),
+                        Query.field("str_value_indexed").equalsParameter("p7"),
+                        Query.field("str_value_indexed").equalsParameter("p8"),
+                        Query.field("num_value_3_indexed").equalsParameter("p9"),
+                        Query.field("num_value_2").equalsParameter("p10")))
+                .build();
+        BoundRecordQuery boundQuery = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", "even")
+                                .set("p3", "even")
+                                .set("p4", "even")
+                                .set("p5", "even")
+                                .set("p6", "even")
+                                .set("p7", "even")
+                                .set("p8", "even")
+                                .set("p9", 3)
+                                .set("p10", 0)
+                                .build());
+
+        BoundRecordQuery boundQuery2 = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "even")
+                                .set("p2", "even")
+                                .set("p3", "even")
+                                .set("p4", "odd")
+                                .set("p5", "odd")
+                                .set("p6", "even")
+                                .set("p7", "even")
+                                .set("p8", "even")
+                                .set("p9", 3)
+                                .set("p10", 0)
+                                .build());
+
+        assertNotEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertNotEquals(boundQuery2, boundQuery);
+
+        boundQuery2 = query
+                .bind(recordStore,
+                        Bindings.newBuilder()
+                                .set("p1", "odd")
+                                .set("p2", "odd")
+                                .set("p3", "odd")
+                                .set("p4", "odd")
+                                .set("p5", "odd")
+                                .set("p6", "odd")
+                                .set("p7", "odd")
+                                .set("p8", "odd")
+                                .set("p9", 3)
+                                .set("p10", 0)
+                                .build());
+
+        assertEquals(boundQuery.hashCode(), boundQuery2.hashCode());
+        assertEquals(boundQuery2, boundQuery);
+    }
+
+    @DualPlannerTest
+    public void testParameterBindings() throws Exception {
+        RecordMetaDataHook hook = complexQuerySetupHook();
+        complexQuerySetup(hook);
+        BoundRecordQuery boundQuery = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.and(
+                        Query.field("str_value_indexed").equalsParameter("p1"),
+                        Query.field("str_value_indexed").equalsParameter("p2"),
+                        Query.field("num_value_3_indexed").equalsParameter("p3"),
+                        Query.field("num_value_2").equalsValue(0)))
+                .buildAndBind(recordStore, Bindings.newBuilder()
+                        .set("p1", "whatever")
+                        .set("p2", "whatever")
+                        .set("p3", "-10")
+                        .build());
+
+        final RecordQueryPlan plan = planner.plan(boundQuery.getRecordQuery());
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            final Bindings compatibleBindings =
+                    Bindings.newBuilder()
+                            .set("p1", "even")
+                            .set("p2", "even")
+                            .set("p3", 3)
+                            .build();
+            assertTrue(boundQuery.isCompatible(recordStore, compatibleBindings));
+
+            final Bindings incompatibleBindings =
+                    Bindings.newBuilder()
+                            .set("p1", "even")
+                            .set("p2", "odd")
+                            .set("p3", 3)
+                            .build();
+            assertFalse(boundQuery.isCompatible(recordStore, incompatibleBindings));
+
+            int i = 0;
+            try (RecordCursorIterator<FDBQueriedRecord<Message>> cursor = plan.execute(recordStore, EvaluationContext.forBindings(compatibleBindings)).asIterator()) {
+                while (cursor.hasNext()) {
+                    FDBQueriedRecord<Message> rec = cursor.next();
+                    TestRecords1Proto.MySimpleRecord.Builder myrec = TestRecords1Proto.MySimpleRecord.newBuilder();
+                    myrec.mergeFrom(Objects.requireNonNull(rec).getRecord());
+                    assertEquals("even", myrec.getStrValueIndexed());
+                    assertEquals(0, (myrec.getNumValue2() % 3));
+                    assertEquals(3, (myrec.getNumValue3Indexed() % 5));
+                    i++;
+                }
+            }
+            assertEquals(3, i);
+            TestHelpers.assertDiscardedNone(context);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTest.java
@@ -434,7 +434,7 @@ class FDBRecordStoreQueryTest extends FDBRecordStoreQueryTestBase {
                 indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[EQUALS $1, EQUALS $2]"))));
         assertEquals(584809367, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
         assertEquals(729798781, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(1546643292, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(729798781, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRestrictedIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRestrictedIndexQueryTest.java
@@ -37,6 +37,7 @@ import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
@@ -529,7 +530,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
         RecordQuery query2 = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.field("str_value_indexed").equalsValue("abc"))
-                .setIndexQueryabilityFilter(index -> true)
+                .setIndexQueryabilityFilter(IndexQueryabilityFilter.TRUE)
                 .build();
 
         // Index(limited_str_value_index [[abc],[abc]])
@@ -543,7 +544,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
         RecordQuery query3 = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.field("str_value_indexed").equalsValue("abc"))
-                .setIndexQueryabilityFilter(index -> false)
+                .setIndexQueryabilityFilter(IndexQueryabilityFilter.FALSE)
                 .setAllowedIndex("limited_str_value_index")
                 .build();
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryHashTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryHashTest.java
@@ -53,40 +53,42 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests for QueryHash on queries.
  */
 @Tag(Tags.RequiresFDB)
-public class QueryHashTest extends FDBRecordStoreQueryTestBase {
+class QueryHashTest extends FDBRecordStoreQueryTestBase {
 
     @Test
-    public void testSingleEqualsFilter() throws Exception {
-        RecordQuery qyery1 = createQuery("MySimpleRecord", Query.field("num_value_2").equalsValue(1));
-        RecordQuery qyery2 = createQuery("MySimpleRecord", Query.field("num_value_2").equalsValue(2));
-        RecordQuery query3 = createQuery("MySimpleRecord", Query.field("num_value_2").equalsParameter("x"));
+    void testSingleEqualsFilter() {
+        final RecordQuery qyery1 = createQuery("MySimpleRecord", Query.field("num_value_2").equalsValue(1));
+        final RecordQuery qyery2 = createQuery("MySimpleRecord", Query.field("num_value_2").equalsValue(2));
+        final RecordQuery query3 = createQuery("MySimpleRecord", Query.field("num_value_2").equalsParameter("x"));
+        final RecordQuery query4 = createQuery("MySimpleRecord", Query.field("num_value_2").equalsParameter("y"));
 
-        assertEquals(947189211, qyery1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(947189211, qyery2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(qyery1, 602828722, 947189211);
+        assertHash(qyery2, 602858513, 947189211);
         // Note that the value and the parameter hashes are different.
-        assertEquals(820394820, query3.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query3, 970715026, 970715026);
+        assertHash(query4, 970744817, 970744817);
     }
 
     @Test
-    public void testSingleGtFilter() throws Exception {
+    void testSingleGtFilter() {
         RecordQuery query1 = createQuery("MySimpleRecord", Query.field("num_value_2").greaterThan(1));
         RecordQuery query2 = createQuery("MySimpleRecord", Query.field("num_value_2").greaterThan(2));
 
-        assertEquals(2043962708, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(2043962708, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 243068761, 2043962708);
+        assertHash(query2, 243098552, 2043962708);
     }
 
     @Test
-    public void testSingleGteFilter() throws Exception {
+    void testSingleGteFilter() {
         RecordQuery query1 = createQuery("MySimpleRecord", Query.field("num_value_2").greaterThanOrEquals(1));
         RecordQuery query2 = createQuery("MySimpleRecord", Query.field("num_value_2").greaterThanOrEquals(2));
 
-        assertEquals(-349000904, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-349000904, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -924359179, -349000904);
+        assertHash(query2, -924329388, -349000904);
     }
 
     @Test
-    public void testOrEqualsFilter() throws Exception {
+    void testOrEqualsFilter() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.or(
                         Query.field("num_value_2").equalsValue(1),
@@ -100,14 +102,14 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_2").equalsParameter("5"),
                         Query.field("num_value_2").equalsParameter("6")));
 
-        assertEquals(969320472, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(969320472, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1460250793, 969320472);
+        assertHash(query2, -1458344169, 969320472);
         // Note that the value and the parameter hashes are different.
-        assertEquals(1206867256, query3.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query3, 1658304439, 1658304439);
     }
 
     @Test
-    public void testAndGtFilter() throws Exception {
+    void testAndGtFilter() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.and(
                         Query.field("num_value_2").greaterThan(1),
@@ -117,12 +119,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_2").greaterThan(2),
                         Query.field("num_value_2").lessThan(4)));
 
-        assertEquals(1154381483, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1154381483, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1995304341, 1154381483);
+        assertHash(query2, -1994351029, 1154381483);
     }
 
     @Test
-    public void testOrGtFilter() throws Exception {
+    void testOrGtFilter() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.or(
                         Query.field("num_value_2").greaterThan(1),
@@ -132,43 +134,43 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_2").greaterThan(2),
                         Query.field("num_value_2").lessThan(4)));
 
-        assertEquals(1661143543, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1661143543, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1488542281, 1661143543);
+        assertHash(query2, -1487588969, 1661143543);
     }
 
 
     @Test
-    public void testNotEqualsFilter() throws Exception {
+    void testNotEqualsFilter() {
         RecordQuery query1 = createQuery("MySimpleRecord", Query.not(Query.field("num_value_2").equalsValue(1)));
         RecordQuery query2 = createQuery("MySimpleRecord", Query.not(Query.field("num_value_2").equalsValue(2)));
         RecordQuery query3 = createQuery("MySimpleRecord", Query.not(Query.field("num_value_2").equalsParameter("3")));
 
-        assertEquals(-1665088707, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-1665088707, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -2009449196, -1665088707);
+        assertHash(query2, -2009419405, -1665088707);
         // Note that value and parameter hashes are not the same
-        assertEquals(-1791883098, query3.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query3, -1643618471, -1643618471);
     }
 
     @Test
-    public void testNotGtFilter() throws Exception {
+    void testNotGtFilter() {
         RecordQuery query1 = createQuery("MySimpleRecord", Query.not(Query.field("num_value_2").greaterThan(1)));
         RecordQuery query2 = createQuery("MySimpleRecord", Query.not(Query.field("num_value_2").greaterThan(2)));
 
-        assertEquals(-568315210, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-568315210, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 1925758139, -568315210);
+        assertHash(query2, 1925787930, -568315210);
     }
 
     @Test
-    public void testRank() throws Exception {
+    void testRank() {
         RecordQuery query1 = createQuery("MySimpleRecord", Query.rank("num_value_2").equalsValue(2L));
         RecordQuery query2 = createQuery("MySimpleRecord", Query.rank("num_value_2").equalsValue(3L));
 
-        assertEquals(273555036, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(273555036, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -70775662, 273555036);
+        assertHash(query2, -70745871, 273555036);
     }
 
     @Test
-    public void testComplexQuery1g() throws Exception {
+    void testComplexQuery1g() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.and(
                         Query.field("str_value_indexed").equalsValue("a"),
@@ -178,12 +180,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("str_value_indexed").equalsValue("b"),
                         Query.field("num_value_3_indexed").equalsValue(3)));
 
-        assertEquals(-897358891, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-897358891, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 1056724947, -897358891);
+        assertHash(query2, 1057648468, -897358891);
     }
 
     @Test
-    public void testComplexQueryAndWithIncompatibleFilters() throws Exception {
+    void testComplexQueryAndWithIncompatibleFilters() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.and(
                         Query.field("str_value_indexed").startsWith("e"),
@@ -193,12 +195,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("str_value_indexed").startsWith("f"),
                         Query.field("num_value_3_indexed").equalsValue(3)));
 
-        assertEquals(-429556342, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-429556342, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1617571134, -429556342);
+        assertHash(query2, -1616647613, -429556342);
     }
 
     @Test
-    public void intersectionVersusRange() throws Exception {
+    void intersectionVersusRange() {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, metaData -> {
                 metaData.addIndex("MySimpleRecord", "num_value_2");
@@ -228,13 +230,13 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_3_indexed").greaterThanOrEquals(3),
                         Query.field("num_value_3_indexed").lessThanOrEquals(3)));
 
-        assertEquals(593786046, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(593786046, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(593786046, query3.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1326035963, 593786046);
+        assertHash(query2, 540891455, 593786046);
+        assertHash(query3, 541814976, 593786046);
     }
 
     @Test
-    public void sortedIntersectionBounded() throws Exception {
+    void sortedIntersectionBounded() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.and(Query.field("num_value_unique").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(2)),
@@ -244,12 +246,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_3_indexed").equalsValue(4)),
                 field("num_value_3_indexed"));
 
-        assertEquals(-1605161468, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-1605161468, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 260234563, -1605161468);
+        assertHash(query2, 262141187, -1605161468);
     }
 
     @Test
-    public void sortedIntersectionUnbound() throws Exception {
+    void sortedIntersectionUnbound() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.and(Query.field("num_value_unique").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(2)),
@@ -259,12 +261,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_3_indexed").equalsValue(4)),
                 field("rec_no"));
 
-        assertEquals(1122317778, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1122317778, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1307253487, 1122317778);
+        assertHash(query2, -1305346863, 1122317778);
     }
 
     @Test
-    public void collateNoIndex() throws Exception {
+    void collateNoIndex() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.keyExpression(function("collate_jre", field("str_value_indexed"))).equalsValue("a"),
                 null,
@@ -274,12 +276,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 null,
                 Collections.singletonList(field("str_value_indexed")));
 
-        assertEquals(-207710934, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-207710934, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 509275846, -207710934);
+        assertHash(query2, -1298178617, -207710934);
     }
 
     @Test
-    public void coveringIndex() throws Exception {
+    void coveringIndex() {
         // Note how the name field needs to be repeated in the value because it can't be recovered from an index
         // entry after transformation to a collation key.
         final KeyExpression collateKey1 = function("collate_jre", concat(field("str_value_indexed"), value("da_DK")));
@@ -301,12 +303,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 null,
                 Collections.singletonList(field("str_value_indexed")));
 
-        assertEquals(-313391822, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-313391822, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 1814534013, -313391822);
+        assertHash(query2, -1718938913, -313391822);
     }
 
     @Test
-    public void compareParameter() throws Exception {
+    void compareParameter() {
         final KeyExpression key1 = function("collate_jre", concat(field("str_value_indexed"), value("de_DE")));
         final KeyExpression key2 = function("collate_jre", concat(field("str_value_indexed"), value("en_EN")));
         final RecordMetaDataHook hook = md -> {
@@ -324,12 +326,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 null,
                 Collections.singletonList(field("str_value_indexed")));
 
-        assertEquals(2089264010, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(2089264010, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 334321807, -113593969);
+        assertHash(query2, -1234725093, -278982629);
     }
 
     @Test
-    public void coveringSimple() throws Exception {
+    void coveringSimple() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.field("num_value_unique").greaterThan(990),
                 field("num_value_unique"),
@@ -339,12 +341,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 field("num_value_unique"),
                 Collections.singletonList(field("num_value_unique")));
 
-        assertEquals(1019582585, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1019582585, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -751848063, 1019582585);
+        assertHash(query2, -549984247, 1019582585);
     }
 
     @Test
-    public void coveringSimpleInsufficient() throws Exception {
+    void coveringSimpleInsufficient() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.field("num_value_unique").greaterThan(990),
                 field("num_value_unique"),
@@ -354,12 +356,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 field("num_value_unique"),
                 Arrays.asList(field("num_value_unique"), field("num_value_3_indexed")));
 
-        assertEquals(1019582585, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1019582585, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -751848063, 1019582585);
+        assertHash(query2, -549984247, 1019582585);
     }
 
     @Test
-    public void coveringWithAdditionalFilter() throws Exception {
+    void coveringWithAdditionalFilter() {
         RecordMetaDataHook hook = metaData -> {
             metaData.removeIndex("MySimpleRecord$num_value_3_indexed");
             metaData.addIndex("MySimpleRecord", new Index("multi_index", "num_value_3_indexed", "num_value_2"));
@@ -379,12 +381,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 null,
                 Collections.singletonList(field("num_value_3_indexed")));
 
-        assertEquals(1306898425, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1306898425, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -920276680, 1306898425);
+        assertHash(query2, -918370056, 1306898425);
     }
 
     @Test
-    public void testMultiRecordTypeIndexScan() throws Exception {
+    void testMultiRecordTypeIndexScan() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openUnionRecordStore(context);
             commit(context);
@@ -399,12 +401,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.field("etag").equalsValue(8),
                 null, null);
 
-        assertEquals(1598221676, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1598221676, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 1254039933, 1598221676);
+        assertHash(query2, 1254069724, 1598221676);
     }
 
     @Test
-    public void testInQueryNoIndex() throws Exception {
+    void testInQueryNoIndex() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.field("num_value_2").in(asList(0, 2)),
                 null, null);
@@ -412,12 +414,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.field("num_value_2").in(asList(1, 3)),
                 null, null);
 
-        assertEquals(-936101258, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-936101258, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1564723747, -936101258);
+        assertHash(query2, -1535171075, -936101258);
     }
 
     @Test
-    public void testInQueryNoIndexWithParameter() throws Exception {
+    void testInQueryNoIndexWithParameter() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.field("num_value_2").in("valuesThree"),   // num_value_2 is i%3
                 null, null);
@@ -425,12 +427,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.field("num_value_2").in("valuesFour"),   // num_value_2 is i%3
                 null, null);
 
-        assertEquals(1554768926, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1554768926, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -1521180076, -1521180076);
+        assertHash(query2, 998194952, 998194952);
     }
 
     @Test
-    public void testInQueryIndex() throws Exception {
+    void testInQueryIndex() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.field("num_value_3_indexed").in(asList(1, 2, 3, 4)),
                 null, null);
@@ -438,12 +440,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.field("num_value_3_indexed").in(asList(5, 6)),
                 null, null);
 
-        assertEquals(-193254231, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-193254231, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 88717328, -193254231);
+        assertHash(query2, -675036881, -193254231);
     }
 
     @Test
-    public void testNotInQuery() throws Exception {
+    void testNotInQuery() {
         RecordQuery query1 = createQuery("MySimpleRecord",
                 Query.not(Query.field("num_value_2").in(asList(0, 2))),
                 null, null);
@@ -451,12 +453,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.not(Query.field("num_value_2").in(asList(1, 3))),
                 null, null);
 
-        assertEquals(746588120, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(746588120, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 117965631, 746588120);
+        assertHash(query2, 147518303, 746588120);
     }
 
     @Test
-    public void testFullTextCovering() throws Exception {
+    void testFullTextCovering() {
         final List<TestRecordsTextProto.SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.AETHELRED,
@@ -477,12 +479,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.field("text").text().contains("duty"),
                 null, null);
 
-        assertEquals(269491435, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(269491435, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 1728588239, 269491435);
+        assertHash(query2, -42098996, 269491435);
     }
 
     @Test
-    public void testTextWithcontainsAll() throws Exception {
+    void testTextWithcontainsAll() {
         final List<TestRecordsTextProto.SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.AETHELRED,
@@ -503,12 +505,12 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.field("text").text().containsAll("duty", 1),
                 null, null);
 
-        assertEquals(-97516745, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(-97516745, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, -398367993, -97516745);
+        assertHash(query2, 544783406, -97516745);
     }
 
     @Test
-    public void testTextWithContainsAllPrefix() throws Exception {
+    void testTextWithContainsAllPrefix() {
         final List<TestRecordsTextProto.SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.AETHELRED,
@@ -529,11 +531,17 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 Query.field("text").text().containsAllPrefixes("duty", true, 3L, 4.0),
                 null, null);
 
-        assertEquals(1603894354, query1.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(1603894354, query2.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertHash(query1, 46244221, 1603894354);
+        assertHash(query2, 989514784, 1603894354);
     }
 
 
+    private void assertHash(final RecordQuery query, final int withLiterals, final int withoutLiterals) {
+        assertEquals(withLiterals, query.queryHash(QueryHashKind.STRUCTURAL_WITH_LITERALS));
+        assertEquals(withoutLiterals, query.queryHash(QueryHashKind.STRUCTURAL_WITHOUT_LITERALS));
+    }
+
+    @SuppressWarnings("SameParameterValue")
     private RecordQuery createQuery(String recordType, QueryComponent filter) {
         return createQuery(recordType, filter, null);
     }
@@ -559,14 +567,14 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
         return builder.build();
     }
 
-    protected void runHook(RecordMetaDataHook hook) throws Exception {
+    protected void runHook(RecordMetaDataHook hook) {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
             commit(context);
         }
     }
 
-    protected void setupTextStore(FDBRecordContext context) throws Exception {
+    protected void setupTextStore(FDBRecordContext context) {
         setupTextStore(context, store -> {
         });
     }
@@ -580,5 +588,4 @@ public class QueryHashTest extends FDBRecordStoreQueryTestBase {
                 .uncheckedOpen();
         setupPlanner(null);
     }
-
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanHashTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanHashTest.java
@@ -84,7 +84,7 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
         assertEquals(389700067, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(389700067, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         // Note that value and parameter comparisons are not the same
-        assertEquals(-1370475238, plan3.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-441871545, plan3.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
         assertEquals(1479481542, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(1479481542, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         // Note that the value and the parameter hashes are different.
-        assertEquals(988446630, plan3.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(638993799, plan3.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test
@@ -220,7 +220,7 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
         assertEquals(1484150721, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         assertEquals(1484150721, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         // Note that value and parameter hashes are not the same
-        assertEquals(-276024584, plan3.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(652579109, plan3.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test
@@ -479,8 +479,8 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
         assertEquals(-1845828406, plan1.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
         assertEquals(365593790, plan2.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
 
-        assertEquals(983661352, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(983661352, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-1442703229, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(768718967, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test
@@ -628,8 +628,8 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
         assertEquals(-192829430, plan1.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
         assertEquals(-1889048618, plan2.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
 
-        assertEquals(871680640, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(871680640, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-192829430, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-1889048618, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test
@@ -649,8 +649,8 @@ public class QueryPlanHashTest extends FDBRecordStoreQueryTestBase {
         assertEquals(1112068357, plan1.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
         assertEquals(1111114148, plan2.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
 
-        assertEquals(619086974, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
-        assertEquals(619086974, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1111112996, plan1.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1111112996, plan2.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
 
     @Test

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/GeoPointWithinDistanceComponent.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/GeoPointWithinDistanceComponent.java
@@ -133,6 +133,7 @@ public class GeoPointWithinDistanceComponent implements ComponentWithNoChildren 
             case LEGACY:
                 return PlanHashable.objectsPlanHash(hashKind, centerLatitude, centerLongitude, distance, latitudeFieldName, longitudeFieldName);
             case FOR_CONTINUATION:
+                return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, centerLatitude, centerLongitude, distance, latitudeFieldName, longitudeFieldName);
             case STRUCTURAL_WITHOUT_LITERALS:
                 return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, latitudeFieldName, longitudeFieldName);
             default:
@@ -142,7 +143,14 @@ public class GeoPointWithinDistanceComponent implements ComponentWithNoChildren 
 
     @Override
     public int queryHash(@Nonnull final QueryHashKind hashKind) {
-        return HashUtils.queryHash(hashKind, BASE_HASH, latitudeFieldName, longitudeFieldName);
+        switch (hashKind) {
+            case STRUCTURAL_WITH_LITERALS:
+                return HashUtils.queryHash(hashKind, BASE_HASH, centerLatitude, centerLongitude, distance, latitudeFieldName, longitudeFieldName);
+            case STRUCTURAL_WITHOUT_LITERALS:
+                return HashUtils.queryHash(hashKind, BASE_HASH, latitudeFieldName, longitudeFieldName);
+            default:
+                throw new UnsupportedOperationException("Hash kind " + hashKind.name() + " is not supported");
+        }
     }
 
     @Override


### PR DESCRIPTION
We define a new class `BoundQueryRecord` which wraps `RecordQuery` and `FDBRecordStoreState`. That allows us to associate e.g. readable indexes of a query at the time a query is planned (actually before that). This allows us to understand when a query `q1` is compatible to another query `q2`, meaning that a cached `RecordQueryPlan` for `q1` can be reused for `q2`. This allows clients to implement a query to plan cache.
As a second important property of query compatibility we strive to not consider queries incompatible if they are identical in structure but just use different literals. For instance

```
RecordQuery.newBuilder()
                .setRecordType("MySimpleRecord")
                .setFilter(
                        Query.field("str_value_indexed").equalsParameter("p"))
                .buildAndBindToStore(recordStore);
```

should be considered the same regardless of what the actual value of `p` is.

With this PR we allow clients to hand in a `Bindings` object if known at planning time that can help the planner to establish plan compatibility based on the relationship of certain parameters:

```
RecordQuery.newBuilder()
                .setRecordType("MySimpleRecord")
                .setFilter(Query.or(
                        Query.field("str_value_indexed").equalsParameter("p1")),
                        Query.field("str_value_indexed").greaterThanParameter("p2"))
                .buildAndBindToStore(recordStore,
                        Bindings.newBuilder() 
                                .set("p1", "even")
                                .set("p2", "even")
                                .build() );
```
may cause a different plan to be generated compared to this bound query:
```
RecordQuery.newBuilder()
                .setRecordType("MySimpleRecord")
                .setFilter(Query.or(
                        Query.field("str_value_indexed").equalsParameter("p1")),
                        Query.field("str_value_indexed").greaterThanParameter("p2"))
                .buildAndBindToStore(recordStore,
                        Bindings.newBuilder() 
                                .set("p1", "even")
                                .set("p2", "odd")
                                .build() );
```

as in one case we may get a single index scan while in the other one we may get a union of two scans. These plans should not be considered equivalent and their queries should therefore not be considered compatible.

This PR contains a logic to distill under what circumstances queries can be considered compatible using the state of the record store as well as information about which pre-bound parameter was equals to which other one, etc.

A bound `BoundRecordQuery` defines hash code and equality based on query compatibility, which allows us to use a bound query object as a key in a plan cache. Any compatible query produces a plan that yields the same result and offers comparable performance to plans from any other compatible query.