### PR TITLE
Fixes #1281: AutoService missing from Record Layer runtime dependencies

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <resourceExtensions>
-      <entry name=".+\\.(properties|xml|html|dtd|tld)" />
-      <entry name=".+\\.(gif|png|jpeg|jpg)" />
-    </resourceExtensions>
     <wildcardResourcePatterns>
       <entry name="?*.properties" />
       <entry name="?*.xml" />
@@ -43,8 +39,8 @@
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0-rc7/894e4af172edf98872bf87f5a90912f86f3e9158/auto-service-1.0-rc7.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service-annotations/1.0-rc7/8849037b03b10cd3d71cce67f8b99aed183971cb/auto-service-annotations-1.0-rc7.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0-rc6/4586e4191111b24135ffac93d3e1a91e91bf71d3/auto-service-1.0-rc6.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service-annotations/1.0-rc6/32c6a6313217c949396376d9caddb6b8c8f4e7c3/auto-service-annotations-1.0-rc6.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/0.10/c8f153ebe04a17183480ab4016098055fb474364/auto-common-0.10.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/27.0.1-jre/bd41a290787b5301e63929676d792c507bbc00ae/guava-27.0.1-jre.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar" />
@@ -63,29 +59,9 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="1.8">
-      <module name="examples_integrationTest" target="1.8" />
-      <module name="examples_main" target="1.8" />
-      <module name="examples_test" target="1.8" />
-      <module name="fdb-extensions_integrationTest" target="1.8" />
-      <module name="fdb-extensions_main" target="1.8" />
-      <module name="fdb-extensions_test" target="1.8" />
       <module name="fdb-record-layer" target="11" />
-      <module name="fdb-record-layer-core-shaded_integrationTest" target="1.8" />
-      <module name="fdb-record-layer-core-shaded_main" target="1.8" />
-      <module name="fdb-record-layer-core-shaded_test" target="1.8" />
-      <module name="fdb-record-layer-core_integrationTest" target="1.8" />
-      <module name="fdb-record-layer-core_main" target="1.8" />
-      <module name="fdb-record-layer-core_test" target="1.8" />
-      <module name="fdb-record-layer-icu_integrationTest" target="1.8" />
-      <module name="fdb-record-layer-icu_main" target="1.8" />
-      <module name="fdb-record-layer-icu_test" target="1.8" />
-      <module name="fdb-record-layer-spatial_integrationTest" target="1.8" />
-      <module name="fdb-record-layer-spatial_main" target="1.8" />
-      <module name="fdb-record-layer-spatial_test" target="1.8" />
       <module name="fdb-record-layer.main" target="11" />
       <module name="fdb-record-layer.test" target="11" />
-      <module name="fdb-record-layer_main" target="1.8" />
-      <module name="fdb-record-layer_test" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ Another, smaller change that has been made is that by default, new indexes added
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `AutoService` annotations are no longer retained at in published jars as was the case prior to [3.0.181.0](#301810) [(Issue #1281)](https://github.com/FoundationDB/fdb-record-layer/issues/1281)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,8 @@ commonsMath3Version=3.6.1
 log4jVersion=2.14.1
 guavaVersion=30.1-jre
 hamcrestVersion=2.2
-autoServiceVersion=1.0-rc7
+# AutoService kept on 1.0-rc4 to avoid annotation being retained in CLASS. See: https://github.com/FoundationDB/fdb-record-layer/issues/1281
+autoServiceVersion=1.0-rc6
 jcommanderVersion=1.81
 jlineVersion=3.19.0
 junitPlatformVersion=1.7.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ commonsMath3Version=3.6.1
 log4jVersion=2.14.1
 guavaVersion=30.1-jre
 hamcrestVersion=2.2
-# AutoService kept on 1.0-rc4 to avoid annotation being retained in CLASS. See: https://github.com/FoundationDB/fdb-record-layer/issues/1281
+# AutoService kept on 1.0-rc6 to avoid annotation being retained in CLASS. See: https://github.com/FoundationDB/fdb-record-layer/issues/1281
 autoServiceVersion=1.0-rc6
 jcommanderVersion=1.81
 jlineVersion=3.19.0


### PR DESCRIPTION
This reverts our `AutoService` dependency to 1.0-rc6, which was the previous version. At that version, the `AutoService` annotation is retained at `SOURCE` only, which means that it is not included in the generated `.class` files, so our downstream dependencies don't need to worry about what version of `AutoService` we're using or even that we're using `AutoService` at all (and are free to use their own version or an alternative mechanism for adding to the service registry entirely). However, with 1.0-rc7, the annotation became a `CLASS` retained object, which means that it would need to start being something our downstream dependencies would need to worry about. To avoid putting that onto our dependencies, this just reverts the upgrade. I'm not excited about us being stuck on this older version, but I think it's more expedient, at least until we can get Java 11 modules all worked out.

This fixes #1281.