### PR TITLE
Resolves #1289: Multi-valued queryable functions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Multi-valued queryable functions [(Issue #1289)](https://github.com/FoundationDB/fdb-record-layer/issues/1289)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpression.java
@@ -149,6 +149,98 @@ public class QueryKeyExpression {
         return parameterComparison(Comparisons.Type.EQUALS, param);
     }
 
+    /**
+     * Add comparisons to one of the values returned by a multi-valued expression.
+     * @return a builder for comparisons
+     */
+    @Nonnull
+    public OneOfThem oneOfThem() {
+        return new OneOfThem();
+    }
+
+    /**
+     * Allow comparisons against a member of a multi-valued expression.
+     */
+    public class OneOfThem {
+        private OneOfThem() {
+        }
+
+        @Nonnull
+        public QueryComponent equalsValue(@Nonnull Object comparand) {
+            return simpleComparison(Comparisons.Type.EQUALS, comparand);
+        }
+
+        @Nonnull
+        public QueryComponent notEquals(@Nonnull Object comparand) {
+            return simpleComparison(Comparisons.Type.NOT_EQUALS, comparand);
+        }
+
+        @Nonnull
+        public QueryComponent greaterThan(@Nonnull Object comparand) {
+            return simpleComparison(Comparisons.Type.GREATER_THAN, comparand);
+        }
+
+        @Nonnull
+        public QueryComponent greaterThanOrEquals(@Nonnull Object comparand) {
+            return simpleComparison(Comparisons.Type.GREATER_THAN_OR_EQUALS, comparand);
+        }
+
+        @Nonnull
+        public QueryComponent lessThan(@Nonnull Object comparand) {
+            return simpleComparison(Comparisons.Type.LESS_THAN, comparand);
+        }
+
+        @Nonnull
+        public QueryComponent lessThanOrEquals(@Nonnull Object comparand) {
+            return simpleComparison(Comparisons.Type.LESS_THAN_OR_EQUALS, comparand);
+        }
+
+        @Nonnull
+        public QueryComponent startsWith(@Nonnull String comparand) {
+            return simpleComparison(Comparisons.Type.STARTS_WITH, comparand);
+        }
+
+        @Nonnull
+        public QueryComponent isNull() {
+            return nullComparison(Comparisons.Type.IS_NULL);
+        }
+
+        @Nonnull
+        public QueryComponent notNull() {
+            return nullComparison(Comparisons.Type.NOT_NULL);
+        }
+
+        @Nonnull
+        public QueryComponent equalsParameter(@Nonnull String param) {
+            return parameterComparison(Comparisons.Type.EQUALS, param);
+        }
+
+        @Nonnull
+        private QueryKeyExpressionWithOneOfComparison simpleComparison(@Nonnull Comparisons.Type type, @Nonnull Object comparand) {
+            final Function<Object, Object> conversion = keyExpression.getComparandConversionFunction();
+            if (conversion != null) {
+                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new ConversionSimpleComparison(type, comparand, conversion));
+            } else {
+                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new Comparisons.SimpleComparison(type, comparand));
+            }
+        }
+
+        @Nonnull
+        private QueryKeyExpressionWithOneOfComparison nullComparison(@Nonnull Comparisons.Type type) {
+            return new QueryKeyExpressionWithOneOfComparison(keyExpression, new Comparisons.NullComparison(type));
+        }
+
+        @Nonnull
+        private QueryKeyExpressionWithOneOfComparison parameterComparison(@Nonnull Comparisons.Type type, @Nonnull String param) {
+            final Function<Object, Object> conversion = keyExpression.getComparandConversionFunction();
+            if (conversion != null) {
+                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new ConversionParameterComparison(type, param, conversion));
+            } else {
+                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new Comparisons.ParameterComparison(type, param));
+            }
+        }
+    }
+
     @Nonnull
     private QueryKeyExpressionWithComparison simpleComparison(@Nonnull Comparisons.Type type, @Nonnull Object comparand) {
         final Function<Object, Object> conversion = keyExpression.getComparandConversionFunction();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithOneOfComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithOneOfComparison.java
@@ -1,0 +1,142 @@
+/*
+ * QueryKeyExpressionWithOneOfComparison.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.expressions;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.metadata.expressions.QueryableKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
+import com.apple.foundationdb.record.util.HashUtils;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link QueryComponent} that implements a {@link Comparisons.Comparison} against a multi-valued {@link QueryableKeyExpression}.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class QueryKeyExpressionWithOneOfComparison implements ComponentWithComparison {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Query-Key-Expression-With-One-Of-Comparison");
+
+    @Nonnull
+    private final QueryableKeyExpression keyExpression;
+    @Nonnull
+    private final Comparisons.Comparison comparison;
+
+    public QueryKeyExpressionWithOneOfComparison(@Nonnull QueryableKeyExpression keyExpression, @Nonnull Comparisons.Comparison comparison) {
+        this.keyExpression = keyExpression;
+        this.comparison = keyExpression.evalForQueryAsTuple() ? new Comparisons.MultiColumnComparison(comparison) : comparison;
+    }
+
+    @Nonnull
+    public QueryableKeyExpression getKeyExpression() {
+        return keyExpression;
+    }
+
+    @Override
+    @Nullable
+    public <M extends Message> Boolean evalMessage(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context, @Nullable FDBRecord<M> record, @Nullable Message message) {
+        final List<Object> values = keyExpression.evalForOneOfQuery(store, context, record, message);
+        for (Object value : values) {
+            final Boolean comp = getComparison().eval(store, context, value);
+            if (Boolean.TRUE.equals(comp)) {
+                return comp;
+            }
+        }
+        return Boolean.FALSE;
+    }
+
+    @Override
+    public void validate(@Nonnull Descriptors.Descriptor descriptor) {
+        keyExpression.validate(descriptor);
+    }
+
+    @Override
+    @Nonnull
+    public Comparisons.Comparison getComparison() {
+        return this.comparison;
+    }
+
+    @Override
+    public GraphExpansion expand(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+        return GraphExpansion.ofPredicate(keyExpression.toValue(baseAlias, fieldNamePrefix).withComparison(comparison));
+    }
+
+    @Override
+    public String toString() {
+        return "ANY " + keyExpression + " " + getComparison();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryKeyExpressionWithOneOfComparison that = (QueryKeyExpressionWithOneOfComparison) o;
+        return Objects.equals(keyExpression, that.keyExpression) &&
+               Objects.equals(getComparison(), that.getComparison());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyExpression, getComparison());
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        switch (hashKind) {
+            case LEGACY:
+                return keyExpression.planHash(hashKind) + getComparison().planHash(hashKind);
+            case FOR_CONTINUATION:
+            case STRUCTURAL_WITHOUT_LITERALS:
+                return PlanHashable.planHash(hashKind, BASE_HASH, keyExpression, getComparison());
+            default:
+                throw new UnsupportedOperationException("Hash kind " + hashKind.name() + " is not supported");
+        }
+    }
+
+    @Override
+    public int queryHash(@Nonnull final QueryHashKind hashKind) {
+        return HashUtils.queryHash(hashKind, BASE_HASH, keyExpression, getComparison());
+    }
+
+    @Override
+    public QueryComponent withOtherComparison(Comparisons.Comparison comparison) {
+        return new QueryKeyExpressionWithOneOfComparison(keyExpression, comparison);
+    }
+
+    @Override
+    public String getName() {
+        return keyExpression.getName();
+    }
+}


### PR DESCRIPTION
A new `QueryKeyExpressionWithOneOfComparison` is available from `Query.function().oneOf()`. It is handled by the (old) planner like `QueryKeyExpressionComparison`, as `OneOfThemWithComparison` is to `FieldWithComparison`. Planning a `QueryableKeyExpression` is mostly just `equals` matching the index's key with the one inside the query predicate.