### PR TITLE
Fixes #1294: Scanning a store with a limit can result in "attempted to return a result with NoNextReason of SOURCE_EXHAUSTED but a non-end continuation"

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ Another, smaller change that has been made is that by default, new indexes added
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Scanning a record store with split records and a scan limit could sometimes result in errors with the message `attempted to return a result with NoNextReason of SOURCE_EXHAUSTED but a non-end continuation` [(Issue #1294)](https://github.com/FoundationDB/fdb-record-layer/issues/1294)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
This adds a guard to checkout for the an exhausted inner cursor, and if that happens, the scanning logic will now return an exhausted record cursor instead of trying to create a result with `SOURCE_EXHAUSTED` as the no-next-reason and a non-end continuation. Note that this bug requires that the final record in a store be split record with multiple parts and the out-of-band limit has to line up with hitting that record, so in practice, this should be a fairly rare occurrence, even though I could write a test that hit this 100% of the time.

This fixes #1294.