### PR TITLE
Resolves #1304: Expose transaction option setServerRequestTracing in context config

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,7 +30,7 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** FDB server request tracing is now exposed through one of the context configuration options [(Issue #1304)](https://github.com/FoundationDB/fdb-record-layer/issues/1304)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -178,6 +178,9 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
                 logTransaction();
             }
         }
+        if (config.isServerRequestTracing()) {
+            tr.options().setServerRequestTracing();
+        }
 
         // If a causal read risky is requested, we set the corresponding transaction option
         this.weakReadSemantics = config.getWeakReadSemantics();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
@@ -473,7 +473,7 @@ public class FDBRecordContextConfig {
 
         /**
          * Set whether FDB server request tracing is enabled for this transaction. If this flag is set to {@code true},
-         * this enables additional logging tracing each FDB server operation associated with this transaction in the
+         * this enables additional logging tracing for each FDB server operation associated with this transaction in the
          * FDB client and server logs. This can be useful for debugging performance problems, but it is also fairly
          * high overhead so it should be enabled sparingly. If a {@linkplain #setTransactionId(String) transaction ID}
          * is set, then the specified ID will be included in one of the client log messages in order to correlate the

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
@@ -46,6 +46,7 @@ public class FDBRecordContextConfig {
     private final long transactionTimeoutMillis;
     private final boolean enableAssertions;
     private final boolean logTransaction;
+    private final boolean serverRequestTracing;
     private final boolean trackOpen;
     private final boolean saveOpenStackTrace;
 
@@ -58,6 +59,7 @@ public class FDBRecordContextConfig {
         this.transactionTimeoutMillis = builder.transactionTimeoutMillis;
         this.enableAssertions = builder.enableAssertions;
         this.logTransaction = builder.logTransaction;
+        this.serverRequestTracing = builder.serverRequestTracing;
         this.trackOpen = builder.trackOpen;
         this.saveOpenStackTrace = builder.saveOpenStackTrace;
     }
@@ -145,6 +147,16 @@ public class FDBRecordContextConfig {
     }
 
     /**
+     * Get whether FDB server request tracing is enabled.
+     * @return {@code true} if FDB server request tracing is enabled
+     * @see FDBRecordContextConfig.Builder#setServerRequestTracing(boolean)
+     * @see TransactionOptions#setServerRequestTracing()
+     */
+    public boolean isServerRequestTracing() {
+        return serverRequestTracing;
+    }
+
+    /**
      * Get whether open context is tracked in the associated {@link FDBDatabase}.
      * @return {@code true} if context is tracked.
      */
@@ -198,6 +210,7 @@ public class FDBRecordContextConfig {
         private long transactionTimeoutMillis = FDBDatabaseFactory.DEFAULT_TR_TIMEOUT_MILLIS;
         private boolean enableAssertions = false;
         private boolean logTransaction = false;
+        private boolean serverRequestTracing = false;
         private boolean trackOpen = false;
         private boolean saveOpenStackTrace = false;
 
@@ -213,6 +226,7 @@ public class FDBRecordContextConfig {
             this.transactionTimeoutMillis = config.transactionTimeoutMillis;
             this.enableAssertions = config.enableAssertions;
             this.logTransaction = config.logTransaction;
+            this.serverRequestTracing = config.serverRequestTracing;
             this.trackOpen = config.trackOpen;
             this.saveOpenStackTrace = config.saveOpenStackTrace;
         }
@@ -226,6 +240,7 @@ public class FDBRecordContextConfig {
             this.transactionTimeoutMillis = config.transactionTimeoutMillis;
             this.enableAssertions = config.enableAssertions;
             this.logTransaction = config.logTransaction;
+            this.serverRequestTracing = config.serverRequestTracing;
             this.trackOpen = config.trackOpen;
             this.saveOpenStackTrace = config.saveOpenStackTrace;
         }
@@ -355,6 +370,7 @@ public class FDBRecordContextConfig {
          * @return this builder
          * @see FDBRecordContextConfig#getTransactionId()
          * @see FDBRecordContext#getTransactionId()
+         * @see TransactionOptions#setDebugTransactionIdentifier(String)
          */
         @Nonnull
         public Builder setTransactionId(@Nullable String transactionId) {
@@ -442,6 +458,33 @@ public class FDBRecordContextConfig {
          */
         public Builder setLogTransaction(final boolean logTransaction) {
             this.logTransaction = logTransaction;
+            return this;
+        }
+
+        /**
+         * Get whether FDB server request tracing is enabled for this transaction.
+         * @return {@code true} if the transaction will have additional server-side tracing enabled
+         * @see TransactionOptions#setServerRequestTracing()
+         * @see #setServerRequestTracing(boolean)
+         */
+        public boolean isServerRequestTracing() {
+            return serverRequestTracing;
+        }
+
+        /**
+         * Set whether FDB server request tracing is enabled for this transaction. If this flag is set to {@code true},
+         * this enables additional logging tracing each FDB server operation associated with this transaction in the
+         * FDB client and server logs. This can be useful for debugging performance problems, but it is also fairly
+         * high overhead so it should be enabled sparingly. If a {@linkplain #setTransactionId(String) transaction ID}
+         * is set, then the specified ID will be included in one of the client log messages in order to correlate the
+         * request tracing logs with the transaction.
+         *
+         * @param serverRequestTracing whether or not FDB server-side request tracing should be enabled
+         * @return this builder
+         * @see TransactionOptions#setServerRequestTracing()
+         */
+        public Builder setServerRequestTracing(boolean serverRequestTracing) {
+            this.serverRequestTracing = serverRequestTracing;
             return this;
         }
 


### PR DESCRIPTION
This adds a configuration option to transactions that allows server request tracing to be enabled for that transaction. The ergonomics at the moment are a little bit weird, as if you set the option and provide a transaction identifier, then there's a single trace log message saying which random trace ID correlates with that transaction ID. However, individual sub-components of the transaction will have their own IDs (partially necessary to support many-to-one relationships between parents and children, which is required to accurately represent the effects of batching within FDB internals), so that only gets you so far. But this is what's required to make what is currently exposed work.

This resolves #1304.