### PR TITLE
Resolves #1315: Allow indexes to be marked as replacing existing indexes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,7 +30,7 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Feature** Allow stores to check the total size (in bytes) when determining index states rather than the number of records [(Issue #1239)](https://github.com/FoundationDB/fdb-record-layer/issues/1239)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Indexes can now be marked as being replaced by other indexes [(Issue #1315)](https://github.com/FoundationDB/fdb-record-layer/issues/1315)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -63,6 +63,43 @@ public class IndexOptions {
     public static final Map<String, String> NOT_ALLOWED_FOR_QUERY_OPTIONS = Collections.singletonMap(ALLOWED_FOR_QUERY_OPTION, Boolean.FALSE.toString());
 
     /**
+     * Option indicating one (or more) indexes that replace this index. If this index is replaced by multiple indexes,
+     * then multiple options can be specified by setting multiple options prefixed by this value. The value of each
+     * option should be the name of another index in the meta-data. If for a given
+     * {@linkplain com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore record store}, every index so
+     * specified has been built, then the index with this option will have its data deleted and will be marked as
+     * {@linkplain com.apple.foundationdb.record.IndexState#DISABLED disabled}.
+     *
+     * <p>
+     * Every index in the list should point to another index in the meta-data. Additionally, the graph of replacement
+     * indexes should be acyclic, i.e., indexes cannot be marked as replacing themselves either directly or
+     * transitively. If either requirement is not met, then the index will fail {@linkplain MetaDataValidator
+     * meta-data validation}
+     * </p>
+     *
+     * <p>
+     * This option is useful as it allows the user to replace one index with another without needing to remove the
+     * older index until the newer index has fully rolled out. For example, suppose there is an index {@code a} that
+     * is defined on a single field, but the administrator realizes that as all queries have predicates on at least two,
+     * and so wants to replace the index with two indexes, {@code a,b} and {@code a,c}. However, until those new indexes
+     * have been built, it is preferable to serve queries using the {@code a} index rather than to fallback to a costly
+     * full record store scan. So the options {@code {"replacedBy1": "a,b", "replacedBy2": "a,c"}} can be set on the
+     * index. Until both indexes have been built, queries can continue to use index {@code a}. Once both have been
+     * built, though, the old index will be automatically deleted, freeing up space.
+     * </p>
+     *
+     * <p>
+     * Note that different record stores with identical
+     * {@link com.apple.foundationdb.record.RecordMetaData RecordMetaData} values may have different index states, i.e.,
+     * an index may be built for some record stores but not others. Setting this option will disable the index only on
+     * each store that meets the necessary criteria.
+     * </p>
+     *
+     * @see Index#getReplacedByIndexNames()
+     */
+    public static final String REPLACED_BY_OPTION_PREFIX = "replacedBy";
+
+    /**
      * The name of the {@link com.apple.foundationdb.record.provider.common.text.TextTokenizer} to use with a {@link IndexTypes#TEXT} index.
      */
     public static final String TEXT_TOKENIZER_NAME_OPTION = "textTokenizerName";

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidator.java
@@ -210,6 +210,12 @@ public class IndexValidator {
     @API(API.Status.EXPERIMENTAL)
     protected void validateChangedOptions(@Nonnull Index oldIndex, @Nonnull Set<String> changedOptions) {
         for (String changedOption : changedOptions) {
+            if (changedOption.startsWith(IndexOptions.REPLACED_BY_OPTION_PREFIX)) {
+                // The set of replacement indexes can be safely added or removed on existing indexes as it
+                // does not affect the validity of the data for any READABLE index, only whether an index
+                // will be dropped (or not dropped).
+                continue;
+            }
             switch (changedOption) {
                 case IndexOptions.ALLOWED_FOR_QUERY_OPTION:
                     // This option affects only runtime behavior and can be changed safely.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataValidator.java
@@ -24,17 +24,12 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
-import com.google.common.collect.Sets;
 import com.google.protobuf.Descriptors;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
 
 /**
  * Validator for {@link RecordMetaData}.
@@ -139,33 +134,21 @@ public class MetaDataValidator implements RecordMetaDataProvider {
         final List<String> replacementIndexNames = index.getReplacedByIndexNames();
         if (!replacementIndexNames.isEmpty()) {
             // Make sure all of the indexes are in the meta-data
-            final List<String> missingReplacements = new ArrayList<>(replacementIndexNames.size());
             for (String replacementIndexName : replacementIndexNames) {
-                if (!metaData.hasIndex(replacementIndexName)) {
-                    missingReplacements.add(replacementIndexName);
-                }
-            }
-            if (!missingReplacements.isEmpty()) {
-                throw new MetaDataException("Index " + index.getName() + " has replacement indexes "
-                                            + missingReplacements + " that are not in the meta-data");
-            }
-
-            // Check for cycles in the replacement graph
-            final Queue<String> indexesToCheck = new ArrayDeque<>(metaData.getAllIndexes().size());
-            final Set<String> seenIndexes = Sets.newHashSetWithExpectedSize(metaData.getAllIndexes().size());
-            indexesToCheck.add(index.getName());
-            while (!indexesToCheck.isEmpty()) {
-                final String toCheck = indexesToCheck.remove();
-                if (!seenIndexes.add(toCheck)) {
-                    // Already seen this index. There is a cycle in the replacement graph
-                    throw new MetaDataException("Index " + index.getName() + " has a circular dependency in its replacement index graph");
-                }
-                if (metaData.hasIndex(toCheck)) {
-                    // It's fine if an index is found in the replacement graph that is not in the meta-data. That
-                    // means that there is an index somewhere in the meta-data that lists a replacement index
-                    // that isn't in the meta-data. That index will fail to validate, but we can just ignore it here.
-                    final Index nextIndex = metaData.getIndex(toCheck);
-                    indexesToCheck.addAll(nextIndex.getReplacedByIndexNames());
+                if (metaData.hasIndex(replacementIndexName)) {
+                    // Make sure none of the replacement indexes themselves have any indexes that they are being
+                    // replaced by, as that can either lead to ambiguous situations where indexes may or may not
+                    // be fully replaced (if, for example, its replacement indexes aren't READABLE but the indexes
+                    // replacing its replacements are). In theory, this could be fixed by more complicated replacement
+                    // logic that traverses the replacement graph to make sure all leaves in the graph are built
+                    final Index replacementIndex = metaData.getIndex(replacementIndexName);
+                    if (!replacementIndex.getReplacedByIndexNames().isEmpty()) {
+                        throw new MetaDataException("Index " + index.getName() + " has replacement index "
+                                                    + replacementIndexName + " that itself has replacement indexes");
+                    }
+                } else {
+                    throw new MetaDataException("Index " + index.getName() + " has replacement index "
+                                                + replacementIndexName + " that is not in the meta-data");
                 }
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -695,8 +695,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      *
      * {@link #commit} will wait for the future to be completed (exceptionally if the check fails)
      * before committing the underlying transaction.
-     * <p>
-     * It is possible for this method to throw an exception caused by an earlier unsuccessful check that has become ready in the meantime.
+     *
      * @param check the check to be performed
      */
     public synchronized void addCommitCheck(@Nonnull CompletableFuture<Void> check) {
@@ -720,8 +719,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      * This method is suitable for checks that cannot be started until just before commit.
      * For checks that can be started before {@code addCommitCheck} time, {@link #addCommitCheck(CompletableFuture)}
      * may be more convenient.
-     * <p>
-     * It is possible for this method to throw an exception caused by an earlier unsuccessful check that has become ready in the meantime.
+     *
      * @param check the check to be performed
      */
     public void addCommitCheck(@Nonnull CommitCheckAsync check) {
@@ -742,7 +740,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Fetches a post-commit hook, creating a new one if it does not already exist. The provided supplier will be
+     * Fetches a pre-commit check, creating a new one if it does not already exist. The provided supplier will be
      * invoked if and only if there is not already a commit check of the specified name.
      *
      * @param name the name of the commit check to add
@@ -756,7 +754,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Fetches a previously installed commit check by name. This only works for commit checks that were added
+     * Fetches a previously installed pre-commit check by name. This only works for commit checks that were added
      * via {@link #getOrCreateCommitCheck(String, Function)} or {@link #addCommitCheck(String, CommitCheckAsync)}.
      *
      * @param name the name of the commit check to fetch
@@ -776,7 +774,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @Nonnull
     public CompletableFuture<Void> runCommitChecks() {
         List<CompletableFuture<Void>> futures;
-        synchronized (this) {
+        synchronized (commitChecks) {
             if (commitChecks.isEmpty()) {
                 return AsyncUtil.DONE;
             } else {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -151,7 +151,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @Nullable
     private Consumer<FDBStoreTimer.Wait> hookForAsyncToSync = null;
     @Nonnull
-    private final Queue<CommitCheckAsync> commitChecks = new ArrayDeque<>();
+    private final Map<String, CommitCheckAsync> commitChecks = new LinkedHashMap<>();
     @Nonnull
     private final Map<String, PostCommit> postCommits = new LinkedHashMap<>();
     private boolean dirtyStoreState;
@@ -691,27 +691,6 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Add a {@link CommitCheckAsync} to be performed before {@link #commit} finishes.
-     *
-     * This method is suitable for checks that cannot be started until just before commit.
-     * For checks that can be started before {@code addCommitCheck} time, {@link #addCommitCheck(CompletableFuture)}
-     * may be more convenient.
-     * <p>
-     * It is possible for this method to throw an exception caused by an earlier unsuccessful check that has become ready in the meantime.
-     * @param check the check to be performed
-     */
-    public synchronized void addCommitCheck(@Nonnull CommitCheckAsync check) {
-        while (!commitChecks.isEmpty()) {
-            if (commitChecks.peek().isReady()) {
-                asyncToSync(FDBStoreTimer.Waits.WAIT_ERROR_CHECK, commitChecks.remove().checkAsync());
-            } else {
-                break;
-            }
-        }
-        commitChecks.add(check);
-    }
-
-    /**
      * Add a check to be completed before {@link #commit} finishes.
      *
      * {@link #commit} will wait for the future to be completed (exceptionally if the check fails)
@@ -736,6 +715,61 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
+     * Add a {@link CommitCheckAsync} to be performed before {@link #commit} finishes.
+     *
+     * This method is suitable for checks that cannot be started until just before commit.
+     * For checks that can be started before {@code addCommitCheck} time, {@link #addCommitCheck(CompletableFuture)}
+     * may be more convenient.
+     * <p>
+     * It is possible for this method to throw an exception caused by an earlier unsuccessful check that has become ready in the meantime.
+     * @param check the check to be performed
+     */
+    public void addCommitCheck(@Nonnull CommitCheckAsync check) {
+        addAnonymousCommitHookToMap(commitChecks, check);
+    }
+
+    /**
+     * Add a {@link CommitCheckAsync} by name to be performed before {@link #commit()} finishes. This behaves
+     * like {@link #addCommitCheck(CommitCheckAsync)}, but it allows a name to be specified so that different
+     * commit checks can be distinguished.
+     *
+     * @param name the name of the commit check to add
+     * @param check the check to be performed
+     * @see #addCommitCheck(CommitCheckAsync)
+     */
+    public void addCommitCheck(@Nonnull String name, @Nonnull CommitCheckAsync check) {
+        addCommitHook(commitChecks, name, check);
+    }
+
+    /**
+     * Fetches a post-commit hook, creating a new one if it does not already exist. The provided supplier will be
+     * invoked if and only if there is not already a commit check of the specified name.
+     *
+     * @param name the name of the commit check to add
+     * @param ifNotExists supplier to invoke if the commit check does not exist
+     * @return the existing or newly created commit check
+     * @see #addCommitCheck(CommitCheckAsync)
+     */
+    @Nonnull
+    public CommitCheckAsync getOrCreateCommitCheck(@Nonnull String name, @Nonnull Function<String, CommitCheckAsync> ifNotExists) {
+        return getOrCreateCommitHook(commitChecks, name, ifNotExists);
+    }
+
+    /**
+     * Fetches a previously installed commit check by name. This only works for commit checks that were added
+     * via {@link #getOrCreateCommitCheck(String, Function)} or {@link #addCommitCheck(String, CommitCheckAsync)}.
+     *
+     * @param name the name of the commit check to fetch
+     * @return the existing check of {@code null} if no check exists of that name
+     * @see #getOrCreateCommitCheck(String, Function)
+     * @see #addCommitCheck(String, CommitCheckAsync)
+     */
+    @Nullable
+    public CommitCheckAsync getCommitCheck(@Nonnull String name) {
+        return getCommitHook(commitChecks, name);
+    }
+
+    /**
      * Run any {@link CommitCheckAsync}s that are still outstanding.
      * @return a future that is complete when all checks have been performed
      */
@@ -746,7 +780,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
             if (commitChecks.isEmpty()) {
                 return AsyncUtil.DONE;
             } else {
-                futures = commitChecks.stream().map(CommitCheckAsync::checkAsync).collect(Collectors.toList());
+                futures = commitChecks.values().stream().map(CommitCheckAsync::checkAsync).collect(Collectors.toList());
             }
         }
         return AsyncUtil.whenAll(futures);
@@ -780,10 +814,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      */
     @Nonnull
     public PostCommit getOrCreatePostCommit(@Nonnull String name, @Nonnull Function<String, PostCommit> ifNotExists) {
-        checkPostCommitName(name);
-        synchronized (postCommits) {
-            return MapUtils.computeIfAbsent(postCommits, name, ifNotExists);
-        }
+        return getOrCreateCommitHook(postCommits, name, ifNotExists);
     }
 
     /**
@@ -795,14 +826,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      */
     @Nullable
     public PostCommit getPostCommit(@Nonnull String name) {
-        // Callers of the public API cannot "see" anonymous or internal post-commit hooks.
-        if (isInternalCommitHookName(name)) {
-            return null;
-        }
-
-        synchronized (postCommits) {
-            return postCommits.get(name);
-        }
+        return getCommitHook(postCommits, name);
     }
 
     /**
@@ -819,14 +843,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      * @param postCommit the post commit to install
      */
     public void addPostCommit(@Nonnull String name, @Nonnull PostCommit postCommit) {
-        checkPostCommitName(name);
-        synchronized (postCommits) {
-            if (postCommits.containsKey(name)) {
-                throw new RecordCoreArgumentException("Post-commit already exists")
-                        .addLogInfo(LogMessageKeys.COMMIT_NAME, name);
-            }
-            postCommits.put(name, postCommit);
-        }
+        addCommitHook(postCommits, name, postCommit);
     }
 
     /**
@@ -836,13 +853,48 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      * @param postCommit post-commit hook to install
      */
     public void addPostCommit(@Nonnull PostCommit postCommit) {
-        synchronized (postCommits) {
+        addAnonymousCommitHookToMap(postCommits, postCommit);
+    }
+
+    private <T> void addAnonymousCommitHookToMap(@Nonnull Map<String, T> map, @Nonnull T item) {
+        synchronized (map) {
             String name;
             // Yes, a collision is exceedingly unlikely, but...
             do {
                 name = INTERNAL_COMMIT_HOOK_PREFIX + "anon-" + (new Random()).nextInt(Integer.MAX_VALUE);
-            } while (postCommits.containsKey(name));
-            postCommits.put(name, postCommit);
+            } while (map.containsKey(name));
+            map.put(name, item);
+        }
+    }
+
+    private <T> void addCommitHook(@Nonnull Map<String, T> map, @Nonnull String name, @Nonnull T item) {
+        checkCommitHookName(name);
+        synchronized (map) {
+            if (map.containsKey(name)) {
+                throw new RecordCoreArgumentException("Commit hook already exists")
+                        .addLogInfo(LogMessageKeys.COMMIT_NAME, name);
+            }
+            map.put(name, item);
+        }
+    }
+
+    private <T> T getOrCreateCommitHook(@Nonnull Map<String, T> map, @Nonnull String name,
+                                        @Nonnull Function<String, T> ifNotExists) {
+        checkCommitHookName(name);
+        synchronized (map) {
+            return MapUtils.computeIfAbsent(map, name, ifNotExists);
+        }
+    }
+
+    @Nullable
+    private <T> T getCommitHook(@Nonnull Map<String, T> map, @Nonnull String name) {
+        // Callers of the public API cannot "see" anonymous or internal post-commit hooks.
+        if (isInternalCommitHookName(name)) {
+            return null;
+        }
+
+        synchronized (map) {
+            return map.get(name);
         }
     }
 
@@ -853,7 +905,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      */
     @Nullable
     public PostCommit removePostCommit(@Nonnull String name) {
-        checkPostCommitName(name);
+        checkCommitHookName(name);
         synchronized (postCommits) {
             return postCommits.remove(name);
         }
@@ -873,9 +925,9 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         }
     }
 
-    private void checkPostCommitName(@Nonnull String name) {
+    private void checkCommitHookName(@Nonnull String name) {
         if (isInternalCommitHookName(name)) {
-            throw new RecordCoreArgumentException("Invalid post-commit name")
+            throw new RecordCoreArgumentException("Invalid commit hook name")
                     .addLogInfo(LogMessageKeys.COMMIT_NAME, name);
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1994,7 +1994,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * Schedule a post-commit hook to look for replaced indexes. This method delays executing the replaced-indexes
+     * Schedule a pre-commit hook to look for replaced indexes. This method delays executing the replaced-indexes
      * check logic until right before the transaction commits, and it will only schedule the check at most once.
      * This is to prevent multiple instances of that logic running at the same time. Because
      * {@link #removeReplacedIndexes()} needs to both read and (potentially) update the index state information, running

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1500,6 +1499,36 @@ public class MetaDataEvolutionValidatorTest {
         validator.validate(metaData2, metaData3);
         RecordMetaData metaData4 = replaceIndex(metaData3, "MySimpleRecord$str_value_indexed", this::clearOptions);
         validator.validate(metaData3, metaData4);
+    }
+
+    @Test
+    public void changeReplacedByIndex() {
+        RecordMetaData metaData1 = RecordMetaData.build(TestRecords1Proto.getDescriptor());
+        RecordMetaData metaData2 = replaceIndex(metaData1, "MySimpleRecord$str_value_indexed",
+                indexProto -> changeOption(indexProto, IndexOptions.REPLACED_BY_OPTION_PREFIX, "MySimpleRecord$num_value_3_indexed"));
+        assertEquals(Collections.singletonList("MySimpleRecord$num_value_3_indexed"),
+                metaData2.getIndex("MySimpleRecord$str_value_indexed").getReplacedByIndexNames());
+        validator.validate(metaData1, metaData2);
+        RecordMetaData metaData3 = replaceIndex(metaData2, "MySimpleRecord$str_value_indexed", this::clearOptions);
+        assertEquals(Collections.emptyList(),
+                metaData3.getIndex("MySimpleRecord$str_value_indexed").getReplacedByIndexNames());
+        validator.validate(metaData2, metaData3);
+    }
+
+    @Test
+    public void changeReplacedByIndexSet() {
+        RecordMetaData metaData1 = RecordMetaData.build(TestRecords1Proto.getDescriptor());
+        RecordMetaData metaData2 = replaceIndex(metaData1, "MySimpleRecord$str_value_indexed", indexProto ->
+                changeOption(changeOption(indexProto, IndexOptions.REPLACED_BY_OPTION_PREFIX + "_0", "MySimpleRecord$num_value_3_indexed"),
+                        IndexOptions.REPLACED_BY_OPTION_PREFIX + "_1", "MySimpleRecord$num_value_unique")
+        );
+        assertThat(metaData2.getIndex("MySimpleRecord$str_value_indexed").getReplacedByIndexNames(),
+                containsInAnyOrder("MySimpleRecord$num_value_3_indexed", "MySimpleRecord$num_value_unique"));
+        validator.validate(metaData1, metaData2);
+        RecordMetaData metaData3 = replaceIndex(metaData2, "MySimpleRecord$str_value_indexed", this::clearOptions);
+        assertEquals(Collections.emptyList(),
+                metaData3.getIndex("MySimpleRecord$str_value_indexed").getReplacedByIndexNames());
+        validator.validate(metaData2, metaData3);
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -941,6 +941,21 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    public void indexesToBuild() throws Exception {
+        final String indexName = "MySimpleRecord$str_value_indexed";
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final Index index = recordStore.getRecordMetaData().getIndex(indexName);
+            assertTrue(recordStore.markIndexDisabled(index).get(), "index should not have been disabled initially");
+            assertTrue(recordStore.getIndexesToBuild().containsKey(index), "index should have been included in indexes to build");
+
+            recordStore.rebuildIndex(index).get();
+            assertEquals(Collections.emptyMap(), recordStore.getIndexesToBuild());
+            commit(context);
+        }
+    }
+
+    @Test
     public void scanDisabledIndex() throws Exception {
         final String indexName = "MySimpleRecord$num_value_3_indexed";
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreReplaceIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreReplaceIndexTest.java
@@ -1,0 +1,326 @@
+/*
+ * FDBRecordStoreReplaceIndexTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that check that an index is removed if its replacement index(es) are all built.
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
+
+    private Index setReplacementIndexes(@Nonnull Index index, Index... replacementIndexes) {
+        final Index newIndex = new Index(index);
+
+        // Remove any existing replacement indexes
+        final List<String> optionsToRemove = newIndex.getOptions().keySet().stream()
+                .filter(option -> option.startsWith(IndexOptions.REPLACED_BY_OPTION_PREFIX))
+                .collect(Collectors.toList());
+        optionsToRemove.forEach(option -> newIndex.getOptions().remove(option));
+
+        // Replace with the new indexes
+        final String[] replacementIndexNames = new String[replacementIndexes.length];
+        for (int i = 0; i < replacementIndexes.length; i++) {
+            final String replacementIndexName = replacementIndexes[i].getName();
+            newIndex.getOptions().put(String.format("%s_%02d", IndexOptions.REPLACED_BY_OPTION_PREFIX, i), replacementIndexName);
+            replacementIndexNames[i] = replacementIndexName;
+        }
+        assertThat(newIndex.getReplacedByIndexNames(), containsInAnyOrder(replacementIndexNames));
+        assertEquals(index.getLastModifiedVersion(), newIndex.getLastModifiedVersion());
+        assertEquals(index.getSubspaceKey(), newIndex.getSubspaceKey());
+
+        return newIndex;
+    }
+
+    private RecordMetaDataHook addIndexHook(@Nonnull String recordTypeName, @Nonnull Index index) {
+        return metaDataBuilder -> metaDataBuilder.addIndex(recordTypeName, index);
+    }
+
+    private RecordMetaDataHook addIndexAndReplacements(@Nonnull String recordTypeName, @Nonnull Index origIndex, @Nonnull Index... newIndexes) {
+        return metaDataBuilder -> {
+            final Index origIndexWithReplacement = setReplacementIndexes(origIndex, newIndexes);
+            metaDataBuilder.addIndex(recordTypeName, origIndexWithReplacement);
+            for (Index newIndex : newIndexes) {
+                metaDataBuilder.addIndex(recordTypeName, newIndex);
+            }
+        };
+    }
+
+    private RecordMetaDataHook bumpMetaDataVersionHook() {
+        return metaDataBuilder -> metaDataBuilder.setVersion(metaDataBuilder.getVersion() + 1);
+    }
+
+    protected RecordMetaDataHook composeHooks(RecordMetaDataHook... hooks) {
+        return metaDataBuilder -> {
+            for (RecordMetaDataHook hook : hooks) {
+                hook.apply(metaDataBuilder);
+            }
+        };
+    }
+
+    private List<IndexEntry> scanIndex(Index index) {
+        return recordStore.getRecordContext().asyncToSync(FDBStoreTimer.Waits.WAIT_SCAN_INDEX_RECORDS, recordStore.scanIndex(
+                recordStore.getRecordMetaData().getIndex(index.getName()),
+                IndexScanType.BY_VALUE,
+                TupleRange.ALL,
+                null,
+                ScanProperties.FORWARD_SCAN
+        ).asList());
+    }
+
+    private boolean disableIndex(Index index) {
+        return recordStore.getRecordContext().asyncToSync(FDBStoreTimer.Waits.WAIT_DROP_INDEX,
+                recordStore.markIndexDisabled(index));
+    }
+
+    private boolean uncheckedMarkIndexReadable(Index index) {
+        return recordStore.getRecordContext().asyncToSync(FDBStoreTimer.Waits.WAIT_ADD_INDEX,
+                recordStore.uncheckedMarkIndexReadable(index.getName()));
+    }
+
+    private void buildIndex(Index index) {
+        recordStore.getRecordContext().asyncToSync(FDBStoreTimer.Waits.WAIT_ONLINE_BUILD_INDEX,
+                recordStore.rebuildIndex(recordStore.getRecordMetaData().getIndex(index.getName())));
+    }
+
+    @Test
+    public void markExistingAsReplacement() {
+        final String recordTypeName = "MyOtherRecord";
+        final Index origIndex = new Index("MyOtherRecord$(num_value_2, num_value_3_indexed)", "num_value_2", "num_value_3_indexed");
+        final Index newIndex = new Index("MyOtherRecord$(num_value_3_indexed, num_value_2)", "num_value_3_indexed", "num_value_2");
+        final RecordMetaDataHook addBothIndexes = composeHooks(addIndexHook(recordTypeName, origIndex), addIndexHook(recordTypeName, newIndex));
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, addBothIndexes);
+            assertTrue(recordStore.isIndexReadable(origIndex), "Old index should be readable at start");
+            assertTrue(recordStore.isIndexReadable(newIndex), "New index should be readable at start");
+
+            recordStore.saveRecord(TestRecords1Proto.MyOtherRecord.newBuilder()
+                    .setRecNo(1415L)
+                    .setNumValue2(42)
+                    .setNumValue3Indexed(3)
+                    .build());
+
+            final List<IndexEntry> oldIndexEntries = scanIndex(origIndex);
+            assertThat(oldIndexEntries, hasSize(1));
+            assertEquals(Tuple.from(1415L), oldIndexEntries.get(0).getPrimaryKey());
+            assertEquals(Tuple.from(42L, 3L, 1415L), oldIndexEntries.get(0).getKey());
+
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, composeHooks(addIndexAndReplacements(recordTypeName, origIndex, newIndex), bumpMetaDataVersionHook()));
+            assertTrue(recordStore.isIndexDisabled(origIndex.getName()));
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, composeHooks(addBothIndexes, bumpMetaDataVersionHook(), bumpMetaDataVersionHook()));
+            assertTrue(uncheckedMarkIndexReadable(origIndex));
+            assertThat(scanIndex(origIndex), empty());
+        }
+    }
+
+    @Test
+    public void buildReplacement() {
+        final String recordTypeName = "MySimpleRecord";
+        final Index origIndex = new Index("MySimpleRecord$(num_value_2, str_value_indexed)", "num_value_2", "str_value_indexed");
+        final Index newIndex = new Index("MySimpleRecord$(str_value_indexed, num_value_2)", "str_value_indexed", "num_value_2");
+        final RecordMetaDataHook addBothIndexes = composeHooks(addIndexHook(recordTypeName, origIndex), addIndexHook(recordTypeName, newIndex));
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, addBothIndexes);
+            assertTrue(disableIndex(newIndex));
+            assertTrue(recordStore.isIndexReadable(origIndex), "Old index should be readable at start");
+
+            recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(1066L)
+                    .setNumValue2(32)
+                    .setStrValueIndexed("hello")
+                    .build());
+
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, composeHooks(addIndexAndReplacements(recordTypeName, origIndex, newIndex), bumpMetaDataVersionHook()));
+            assertTrue(recordStore.isIndexReadable(origIndex.getName()), "Old index should be readable until replacement index is built");
+            final List<IndexEntry> oldIndexEntries = scanIndex(origIndex);
+            assertThat(oldIndexEntries, hasSize(1));
+            assertEquals(Tuple.from(1066L), oldIndexEntries.get(0).getPrimaryKey());
+            assertEquals(Tuple.from(32, "hello", 1066L), oldIndexEntries.get(0).getKey());
+
+            buildIndex(newIndex);
+            assertTrue(recordStore.isIndexDisabled(origIndex.getName()), "Old index should be disabled once replacement index is built");
+            commit(context);
+        }
+
+        // Verify the data in the old index was removed by removing the replacement information and marking the old index as readable, then
+        // scan the index
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, composeHooks(addBothIndexes, bumpMetaDataVersionHook(), bumpMetaDataVersionHook()));
+            assertTrue(uncheckedMarkIndexReadable(origIndex));
+            final List<IndexEntry> oldIndexEntries = scanIndex(origIndex);
+            assertThat("Index data should have been deleted", oldIndexEntries, empty());
+        }
+    }
+
+    @Test
+    public void buildTwoReplacements() {
+        final String recordTypeName = "MySimpleRecord";
+        final Index origIndex = new Index("MySimpleRecord$(str_value_indexed, num_value_2)", "str_value_indexed", "num_value_2");
+        final Index newIndex1 = new Index("MySimpleRecord$(str_value_indexed, num_value_2, num_value_3_indexed)", "str_value_indexed", "num_value_2", "num_value_3_indexed");
+        final Index newIndex2 = new Index("MySimpleRecord$(str_value_indexed, num_value_2, num_value_unique)", "str_value_indexed", "num_value_2", "num_value_unique");
+        final RecordMetaDataHook addAllIndexesHook = composeHooks(addIndexHook(recordTypeName, origIndex), addIndexHook(recordTypeName, newIndex1), addIndexHook(recordTypeName, newIndex2));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, addAllIndexesHook);
+            assertTrue(disableIndex(newIndex1));
+            assertTrue(disableIndex(newIndex2));
+
+            recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(800L)
+                    .setStrValueIndexed("a_value")
+                    .setNumValue2(962)
+                    .setNumValue3Indexed(1806)
+                    .build());
+
+            commit(context);
+        }
+
+        // Mark the index as replaced by the two new indexes and expect the index to be gone once both new indexes are built
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, composeHooks(addIndexAndReplacements(recordTypeName, origIndex, newIndex1, newIndex2), bumpMetaDataVersionHook()));
+
+            assertTrue(recordStore.isIndexReadable(origIndex));
+            final List<IndexEntry> origEntries = scanIndex(origIndex);
+            assertThat(origEntries, hasSize(1));
+            assertEquals(Tuple.from(800L), origEntries.get(0).getPrimaryKey());
+            assertEquals(Tuple.from("a_value", 962L, 800L), origEntries.get(0).getKey());
+
+            buildIndex(newIndex1);
+            assertTrue(recordStore.isIndexReadable(origIndex));
+            assertEquals(origEntries, scanIndex(origIndex));
+
+            disableIndex(newIndex1);
+
+            buildIndex(newIndex2);
+            assertTrue(recordStore.isIndexReadable(origIndex));
+            assertEquals(origEntries, scanIndex(origIndex));
+
+            buildIndex(newIndex1);
+            assertTrue(recordStore.isIndexDisabled(origIndex));
+
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, composeHooks(addAllIndexesHook, bumpMetaDataVersionHook(), bumpMetaDataVersionHook()));
+
+            assertTrue(uncheckedMarkIndexReadable(origIndex));
+            assertThat(scanIndex(origIndex), empty());
+        }
+    }
+
+    @Test
+    public void replacementIndexMissingInMetaDataFails() {
+        try (FDBRecordContext context = openContext()) {
+            MetaDataException err = assertThrows(MetaDataException.class, () -> openSimpleRecordStore(context, metaDataBuilder -> {
+                final Index index = new Index("indexWithFakeReplacement", Key.Expressions.field("num_value_2"),
+                        IndexTypes.VALUE,
+                        Collections.singletonMap(IndexOptions.REPLACED_BY_OPTION_PREFIX, "fakeIndex"));
+                metaDataBuilder.addIndex("MySimpleRecord", index);
+            }));
+            assertThat(err.getMessage(), containsString("Index indexWithFakeReplacement has replacement indexes [fakeIndex] that are not in the meta-data"));
+        }
+    }
+
+    @Test
+    public void replacementIndexPartiallyMissingInMetaDataFails() {
+        try (FDBRecordContext context = openContext()) {
+            MetaDataException err = assertThrows(MetaDataException.class, () -> openSimpleRecordStore(context, metaDataBuilder -> {
+                final Index index = new Index("indexWithOneFakeReplacement", Key.Expressions.field("num_value_2"),
+                        IndexTypes.VALUE,
+                        ImmutableMap.of(
+                                IndexOptions.REPLACED_BY_OPTION_PREFIX + "_00", "fakeIndex",
+                                IndexOptions.REPLACED_BY_OPTION_PREFIX + "_01", "MySimpleRecord$str_value_indexed"));
+                metaDataBuilder.addIndex("MySimpleRecord", index);
+            }));
+            assertThat(err.getMessage(), containsString("Index indexWithOneFakeReplacement has replacement indexes [fakeIndex] that are not in the meta-data"));
+        }
+    }
+
+    @Test
+    public void replacementIndexCycleFails() {
+        try (FDBRecordContext context = openContext()) {
+            MetaDataException err = assertThrows(MetaDataException.class, () -> openSimpleRecordStore(context, metaDataBuilder -> {
+                final Index index1 = new Index("firstIndex", Key.Expressions.field("num_value_2"), IndexTypes.VALUE,
+                        Collections.singletonMap(IndexOptions.REPLACED_BY_OPTION_PREFIX, "secondIndex"));
+                final Index index2 = new Index("secondIndex", Key.Expressions.field("num_value_2"), IndexTypes.VALUE,
+                        Collections.singletonMap(IndexOptions.REPLACED_BY_OPTION_PREFIX, "firstIndex"));
+                metaDataBuilder.addIndex("MySimpleRecord", index1);
+                metaDataBuilder.addIndex("MySimpleRecord", index2);
+            }));
+            assertThat(err.getMessage(), containsString("has a circular dependency in its replacement index graph"));
+        }
+    }
+
+    @Test
+    public void replacementIndexWithSelfCycleFails() {
+        try (FDBRecordContext context = openContext()) {
+            MetaDataException err = assertThrows(MetaDataException.class, () -> openSimpleRecordStore(context, metaDataBuilder -> {
+                final Index index = new Index("indexWithSelfReplacement", Key.Expressions.field("num_value_2"),
+                        IndexTypes.VALUE,
+                        Collections.singletonMap(IndexOptions.REPLACED_BY_OPTION_PREFIX, "indexWithSelfReplacement"));
+                metaDataBuilder.addIndex("MySimpleRecord", index);
+            }));
+            assertThat(err.getMessage(), containsString("Index indexWithSelfReplacement has a circular dependency in its replacement index graph"));
+        }
+    }
+}


### PR DESCRIPTION
This adds a new index option prefix, `replacedBy`. This then allows the user to use the prefix to specify one or more indexes, and when all of those indexes have been built, the index will be disabled and its data deleted. This allows the user to effectively drop an indexe, though only after when the index has been fully replaced by new indexes. This both allows older unused data to be protected while also protecting the user against removing the index before all of the queries that use it have been redirected to other indexes.