### PR TITLE
Deal with asynchrony issues in FDBDirectory

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IgnoreBlockingInAsync.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IgnoreBlockingInAsync.java
@@ -1,0 +1,39 @@
+/*
+ * IgnoreAsyncBlocking.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specify this annotation when you <em>know</em>, with absolute certainty, that a specific method
+ * uses a blocking call within an async context, but is nevertheless safe. <em>Always</em> include
+ * adequate documentation describing exactly <em>how</em> you know that it is safe to do so, so that
+ * future programmers will know.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IgnoreBlockingInAsync {
+}

--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -54,6 +54,10 @@ test {
         if (skipSlow) {
             excludeTags 'Slow'
         }
+        // Configure whether or not tests will validate that asyncToSync isn't being called in async
+        // context.  See BlockingInAsyncDetection class for details on values.
+        systemProperties = ["com.apple.foundationdb.record.blockingInAsyncDetection":
+                                    System.getenv('BLOCKING_DETECTION') ?: "IGNORE_COMPLETE_EXCEPTION_BLOCKING"]
     }
 }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.NoSuchFileException;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -97,7 +98,13 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
     @Test
     public void testMissingSeek() {
-        assertThrows(RecordCoreArgumentException.class, () -> directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1));
+        assertThrows(RecordCoreArgumentException.class, () -> {
+            try {
+                directory.readBlock("testDescription", directory.getFDBLuceneFileReference("testReference"), 1).get();
+            } catch (ExecutionException ee) {
+                throw ee.getCause();
+            }
+        });
     }
 
     @Test
@@ -136,7 +143,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         directory.deleteFile("test1");
         assertEquals(directory.listAll().length, 0);
 
-        assertCorrectMetricCount(FDBStoreTimer.Waits.WAIT_LUCENE_DELETE_FILE,2);
+        assertCorrectMetricCount(FDBStoreTimer.Waits.WAIT_LUCENE_DELETE_FILE,1);
     }
 
     @Test


### PR DESCRIPTION
see #1322 for more information about the bug. This fix is somewhat temporary, and accomplishes 3 things:

1. Resolves some spotty blocking calls in `FDBDirectory` so that they block less
2. Ensures that the forced synchronous methods in `FDBDirectory` are not called on the context's executor, to avoid deadlocks (still potential performance problems due to waiting for an open FJ thread, but at least it's less likely to actually break)
3. Add the ability to ignore blocking in asynchronous methods when we know that they are safe (for now)

A very good question would be: why do we have to be asynchronous here? and the answer is--because Lucene requires us to, and I'm not in a position to rewrite Lucene's entire API in order to support asynchronous method execution (I'm not even really sure that Lucene's thread model would support it). So here we are.

In the long term, we'll need to move blocking operations to a separate blocking thread pool in order to avoid potential performance bottlenecks, but this should serve in the short term.