### PR TITLE
Resolve 1334: Provide a method to clean readable indexes build data

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,7 +30,7 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** `AutoContinuingCursor` continues on retriable exceptions [(Issue #1328)](https://github.com/FoundationDB/fdb-record-layer/issues/1328)
 * **Feature** Validate and repair LocatableResolver mappings [(Issue #1316)](https://github.com/FoundationDB/fdb-record-layer/issues/1316)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Provide a method to clean readable indexes build data [(Issue #1334)](https://github.com/FoundationDB/fdb-record-layer/issues/1334)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -748,6 +748,9 @@ public class OnlineIndexer implements AutoCloseable {
     @Nonnull
     public CompletableFuture<Boolean> markReadableIfBuilt() {
         return getRunner().runAsync(context -> openRecordStore(context).thenCompose(store -> {
+            if (store.isIndexReadable(index)) {
+                return AsyncUtil.READY_TRUE;
+            }
             final RangeSet rangeSet = new RangeSet(store.indexRangeSubspace(index));
             return rangeSet.missingRanges(store.ensureContextActive()).iterator().onHasNext()
                     .thenCompose(hasNext -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -69,6 +69,14 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
                 .build()) {
             indexer.buildIndex(true);
         }
+        vaccumReadableIndexesBuildData(); // clear intermediate build data
+    }
+
+    private void vaccumReadableIndexesBuildData() {
+        try (FDBRecordContext context = openContext()) {
+            recordStore.vaccumReadableIndexesBuildData();
+            context.commit();
+        }
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -71,6 +71,14 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 .build()) {
             indexer.buildIndex(true);
         }
+        vaccumReadableIndexesBuildData();
+    }
+
+    private void vaccumReadableIndexesBuildData() {
+        try (FDBRecordContext context = openContext()) {
+            recordStore.vaccumReadableIndexesBuildData();
+            context.commit();
+        }
     }
 
     private void buildIndexAndCrashHalfway(Index tgtIndex, int chunkSize, int count, FDBStoreTimer timer, @Nullable OnlineIndexer.IndexingPolicy policy) {


### PR DESCRIPTION
   1. Clear build data when index is marked readable
   2. For existing record-stores, provide an API to clear this data for all readable indexes.