### PR TITLE
Fix example code.

### DIFF
--- a/examples/examples.gradle
+++ b/examples/examples.gradle
@@ -34,4 +34,4 @@ dependencies {
 }
 
 mainClassName = 'com.apple.foundationdb.record.sample.Main'
-applicationDefaultJvmArgs = ["-Dlog4j.configurationFile=${projectDir}/resources/log4j2.properties"]
+applicationDefaultJvmArgs = ["-Dlog4j.configurationFile=${projectDir}/src/main/resources/log4j2.properties"]

--- a/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
+++ b/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
@@ -316,7 +316,7 @@ public class Main {
         recordStoreBuilder.setMetaDataProvider(rmd2);
 
         // Calling "open" on an existing record store with new meta-data will
-        // create the index and place them in a "write-only" mode that means that
+        // create the index and place them in a "disabled" mode that means that
         // they cannot yet be used for queries. (In particular, the query planner
         // will ignore this index and any attempt to read from the index will
         // throw an error.) To enable querying, one must invoke the online index
@@ -332,7 +332,7 @@ public class Main {
         LOGGER.info("Running index builds of new indexes:");
         // Build all of the indexes in parallel by firing off a future for each and
         // then wait for all of them.
-        AsyncUtil.whenAll(storeState.getWriteOnlyIndexNames().stream()
+        AsyncUtil.whenAll(storeState.getDisabledIndexNames().stream()
                 .map(indexName -> {
                     // Build this index. It will begin the background job and return a future
                     // that will complete when the index is ready for querying.


### PR DESCRIPTION
Addresses: https://github.com/FoundationDB/fdb-record-layer/issues/1347

Runs properly after indexing the DISABLED indices (not WRITE_ONLY ones):

````
2021-07-31 05:08:31,714 [INFO] c.a.f.r.s.Main - Clearing the Record Store ...
2021-07-31 05:08:32,661 [INFO] c.a.f.r.s.Main - Writing Vendor and Item record ...
2021-07-31 05:08:32,777 [INFO] c.a.f.r.p.f.FDBRecordStore - new record store format_version="7" key_space_path="/application:22->'record-layer-sample'/environment:'demo'" meta_data_version="2"
2021-07-31 05:08:32,978 [INFO] c.a.f.r.s.Main - Reading Vendor record with primary key 9375L ...
2021-07-31 05:08:33,008 [INFO] c.a.f.r.s.Main -     Result -> Id: 9375, Name: Acme
2021-07-31 05:08:33,009 [INFO] c.a.f.r.s.Main - Looking for item IDs with vendor ID 9375L ...
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main -     Result -> Vendor ID: 9375, Item ID: 4836
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main - Grouping items by vendor ...
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Buy n Large, Item names: [Piles of Garbage, Personal Transport]
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Acme, Item names: [GPS]
2021-07-31 05:08:33,364 [INFO] c.a.f.r.p.f.FDBRecordStore - meta-data version changed key_space_path="/application:22->'record-layer-sample'/environment:'demo'" new_version="8" old_version="2"
2021-07-31 05:08:33,367 [INFO] c.a.f.r.p.f.FDBRecordStore - version check scan found non-empty store key_space_path="/application:22->'record-layer-sample'/environment:'demo'"
2021-07-31 05:08:33,375 [INFO] c.a.f.r.s.Main - Running index builds of new indexes:
2021-07-31 05:08:33,533 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="4" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aee897bd-a491-461a-acc8-799e36c37ccb"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="2" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aae74310-ee45-4815-819f-58c8ad660be8"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="1" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="7" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="80da8441-12dd-499e-9ed7-b654b872c729"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,544 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag" index_version="5" indexer_id="2db9d1cb-28cd-49d7-b99b-0a31a7d7c45e" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aae74310-ee45-4815-819f-58c8ad660be8" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="item_quantity_sum" index_version="8" indexer_id="6d6a3d5e-fb68-4989-921b-2505511aa98b" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="order" index_version="7" indexer_id="0cdc2563-27c7-42fd-b89e-a8fad46224f5" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aee897bd-a491-461a-acc8-799e36c37ccb" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag_count" index_version="6" indexer_id="0182ddc9-fcff-41ef-a4a0-1c9361e6bbfb" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad" should_mark_readable="true"
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of order is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of preference_tag_count is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of item_quantity_sum is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.s.Main -   Index build of preference_tag is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="globalCount" index_version="3" indexer_id="f1201aac-b4a2-473f-a488-14d234b9e286" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="80da8441-12dd-499e-9ed7-b654b872c729" should_mark_readable="true"
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="email_address" index_version="4" indexer_id="03046cbd-8528-407f-9ebf-67672a61d73a" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172" should_mark_readable="true"
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of globalCount is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of email_address is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main - Adding records with new secondary indexes ...
2021-07-31 05:08:33,633 [INFO] c.a.f.r.s.Main - Store contains 7 records.
2021-07-31 05:08:33,634 [INFO] c.a.f.r.s.Main - Retrieving all customers with first name "Jane"...
2021-07-31 05:08:33,654 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | first_name EQUALS Jane"
2021-07-31 05:08:33,664 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,665 [INFO] c.a.f.r.s.Main - Retrieving all customers with last name "Doe"...
2021-07-31 05:08:33,668 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe],[Doe]]) | [Customer]"
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main - Retrieving all customers with name "Jane Doe"...
2021-07-31 05:08:33,712 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe, Jane],[Doe, Jane]]) | [Customer]"
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main - Retrieving all customers with an email address beginning with "john"...
2021-07-31 05:08:33,734 [INFO] c.a.f.r.s.Main - Retrieving all customers with preference tags "books" and "movies"...
2021-07-31 05:08:33,744 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | And([one of preference_tag EQUALS books, one of preference_tag EQUALS movies])"
2021-07-31 05:08:33,751 [INFO] c.a.f.r.s.Main -     Result -> John Smith
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Number of customers with the "books" preference tag: 2
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Retrieving all customers with an order of quantity greater than 2 ...
2021-07-31 05:08:33,806 [INFO] c.a.f.r.s.Main - Query planned plan="Index(order ([2],>) | UnorderedPrimaryKeyDistinct()"
2021-07-31 05:08:33,809 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,814 [INFO] c.a.f.r.s.Main - Total quantity ordered of item 2740L: 4
2021-07-31 05:08:33,818 [INFO] c.a.f.r.s.Main - Total quantity ordered of all items: 6
:examples:run (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 4.649 secs.
2021-07-31 05:08:31,714 [INFO] c.a.f.r.s.Main - Clearing the Record Store ...
2021-07-31 05:08:32,661 [INFO] c.a.f.r.s.Main - Writing Vendor and Item record ...
2021-07-31 05:08:32,777 [INFO] c.a.f.r.p.f.FDBRecordStore - new record store format_version="7" key_space_path="/application:22->'record-layer-sample'/environment:'demo'" meta_data_version="2"
2021-07-31 05:08:32,978 [INFO] c.a.f.r.s.Main - Reading Vendor record with primary key 9375L ...
2021-07-31 05:08:33,008 [INFO] c.a.f.r.s.Main -     Result -> Id: 9375, Name: Acme
2021-07-31 05:08:33,009 [INFO] c.a.f.r.s.Main - Looking for item IDs with vendor ID 9375L ...
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main -     Result -> Vendor ID: 9375, Item ID: 4836
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main - Grouping items by vendor ...
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Buy n Large, Item names: [Piles of Garbage, Personal Transport]
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Acme, Item names: [GPS]
2021-07-31 05:08:33,364 [INFO] c.a.f.r.p.f.FDBRecordStore - meta-data version changed key_space_path="/application:22->'record-layer-sample'/environment:'demo'" new_version="8" old_version="2"
2021-07-31 05:08:33,367 [INFO] c.a.f.r.p.f.FDBRecordStore - version check scan found non-empty store key_space_path="/application:22->'record-layer-sample'/environment:'demo'"
2021-07-31 05:08:33,375 [INFO] c.a.f.r.s.Main - Running index builds of new indexes:
2021-07-31 05:08:33,533 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="4" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aee897bd-a491-461a-acc8-799e36c37ccb"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="2" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aae74310-ee45-4815-819f-58c8ad660be8"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="1" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="7" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="80da8441-12dd-499e-9ed7-b654b872c729"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,544 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag" index_version="5" indexer_id="2db9d1cb-28cd-49d7-b99b-0a31a7d7c45e" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aae74310-ee45-4815-819f-58c8ad660be8" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="item_quantity_sum" index_version="8" indexer_id="6d6a3d5e-fb68-4989-921b-2505511aa98b" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="order" index_version="7" indexer_id="0cdc2563-27c7-42fd-b89e-a8fad46224f5" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aee897bd-a491-461a-acc8-799e36c37ccb" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag_count" index_version="6" indexer_id="0182ddc9-fcff-41ef-a4a0-1c9361e6bbfb" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad" should_mark_readable="true"
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of order is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of preference_tag_count is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of item_quantity_sum is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.s.Main -   Index build of preference_tag is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="globalCount" index_version="3" indexer_id="f1201aac-b4a2-473f-a488-14d234b9e286" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="80da8441-12dd-499e-9ed7-b654b872c729" should_mark_readable="true"
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="email_address" index_version="4" indexer_id="03046cbd-8528-407f-9ebf-67672a61d73a" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172" should_mark_readable="true"
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of globalCount is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of email_address is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main - Adding records with new secondary indexes ...
2021-07-31 05:08:33,633 [INFO] c.a.f.r.s.Main - Store contains 7 records.
2021-07-31 05:08:33,634 [INFO] c.a.f.r.s.Main - Retrieving all customers with first name "Jane"...
2021-07-31 05:08:33,654 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | first_name EQUALS Jane"
2021-07-31 05:08:33,664 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,665 [INFO] c.a.f.r.s.Main - Retrieving all customers with last name "Doe"...
2021-07-31 05:08:33,668 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe],[Doe]]) | [Customer]"
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main - Retrieving all customers with name "Jane Doe"...
2021-07-31 05:08:33,712 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe, Jane],[Doe, Jane]]) | [Customer]"
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main - Retrieving all customers with an email address beginning with "john"...
2021-07-31 05:08:33,734 [INFO] c.a.f.r.s.Main - Retrieving all customers with preference tags "books" and "movies"...
2021-07-31 05:08:33,744 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | And([one of preference_tag EQUALS books, one of preference_tag EQUALS movies])"
2021-07-31 05:08:33,751 [INFO] c.a.f.r.s.Main -     Result -> John Smith
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Number of customers with the "books" preference tag: 2
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Retrieving all customers with an order of quantity greater than 2 ...
2021-07-31 05:08:33,806 [INFO] c.a.f.r.s.Main - Query planned plan="Index(order ([2],>) | UnorderedPrimaryKeyDistinct()"
2021-07-31 05:08:33,809 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,814 [INFO] c.a.f.r.s.Main - Total quantity ordered of item 2740L: 4
2021-07-31 05:08:33,818 [INFO] c.a.f.r.s.Main - Total quantity ordered of all items: 6
:examples:run (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 4.649 secs.2021-07-31 05:08:31,714 [INFO] c.a.f.r.s.Main - Clearing the Record Store ...
2021-07-31 05:08:32,661 [INFO] c.a.f.r.s.Main - Writing Vendor and Item record ...
2021-07-31 05:08:32,777 [INFO] c.a.f.r.p.f.FDBRecordStore - new record store format_version="7" key_space_path="/application:22->'record-layer-sample'/environment:'demo'" meta_data_version="2"
2021-07-31 05:08:32,978 [INFO] c.a.f.r.s.Main - Reading Vendor record with primary key 9375L ...
2021-07-31 05:08:33,008 [INFO] c.a.f.r.s.Main -     Result -> Id: 9375, Name: Acme
2021-07-31 05:08:33,009 [INFO] c.a.f.r.s.Main - Looking for item IDs with vendor ID 9375L ...
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main -     Result -> Vendor ID: 9375, Item ID: 4836
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main - Grouping items by vendor ...
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Buy n Large, Item names: [Piles of Garbage, Personal Transport]
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Acme, Item names: [GPS]
2021-07-31 05:08:33,364 [INFO] c.a.f.r.p.f.FDBRecordStore - meta-data version changed key_space_path="/application:22->'record-layer-sample'/environment:'demo'" new_version="8" old_version="2"
2021-07-31 05:08:33,367 [INFO] c.a.f.r.p.f.FDBRecordStore - version check scan found non-empty store key_space_path="/application:22->'record-layer-sample'/environment:'demo'"
2021-07-31 05:08:33,375 [INFO] c.a.f.r.s.Main - Running index builds of new indexes:
2021-07-31 05:08:33,533 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="4" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aee897bd-a491-461a-acc8-799e36c37ccb"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="2" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aae74310-ee45-4815-819f-58c8ad660be8"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="1" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="7" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="80da8441-12dd-499e-9ed7-b654b872c729"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,544 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag" index_version="5" indexer_id="2db9d1cb-28cd-49d7-b99b-0a31a7d7c45e" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aae74310-ee45-4815-819f-58c8ad660be8" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="item_quantity_sum" index_version="8" indexer_id="6d6a3d5e-fb68-4989-921b-2505511aa98b" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="order" index_version="7" indexer_id="0cdc2563-27c7-42fd-b89e-a8fad46224f5" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aee897bd-a491-461a-acc8-799e36c37ccb" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag_count" index_version="6" indexer_id="0182ddc9-fcff-41ef-a4a0-1c9361e6bbfb" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad" should_mark_readable="true"
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of order is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of preference_tag_count is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of item_quantity_sum is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.s.Main -   Index build of preference_tag is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="globalCount" index_version="3" indexer_id="f1201aac-b4a2-473f-a488-14d234b9e286" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="80da8441-12dd-499e-9ed7-b654b872c729" should_mark_readable="true"
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="email_address" index_version="4" indexer_id="03046cbd-8528-407f-9ebf-67672a61d73a" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172" should_mark_readable="true"
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of globalCount is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of email_address is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main - Adding records with new secondary indexes ...
2021-07-31 05:08:33,633 [INFO] c.a.f.r.s.Main - Store contains 7 records.
2021-07-31 05:08:33,634 [INFO] c.a.f.r.s.Main - Retrieving all customers with first name "Jane"...
2021-07-31 05:08:33,654 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | first_name EQUALS Jane"
2021-07-31 05:08:33,664 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,665 [INFO] c.a.f.r.s.Main - Retrieving all customers with last name "Doe"...
2021-07-31 05:08:33,668 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe],[Doe]]) | [Customer]"
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main - Retrieving all customers with name "Jane Doe"...
2021-07-31 05:08:33,712 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe, Jane],[Doe, Jane]]) | [Customer]"
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main - Retrieving all customers with an email address beginning with "john"...
2021-07-31 05:08:33,734 [INFO] c.a.f.r.s.Main - Retrieving all customers with preference tags "books" and "movies"...
2021-07-31 05:08:33,744 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | And([one of preference_tag EQUALS books, one of preference_tag EQUALS movies])"
2021-07-31 05:08:33,751 [INFO] c.a.f.r.s.Main -     Result -> John Smith
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Number of customers with the "books" preference tag: 2
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Retrieving all customers with an order of quantity greater than 2 ...
2021-07-31 05:08:33,806 [INFO] c.a.f.r.s.Main - Query planned plan="Index(order ([2],>) | UnorderedPrimaryKeyDistinct()"
2021-07-31 05:08:33,809 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,814 [INFO] c.a.f.r.s.Main - Total quantity ordered of item 2740L: 4
2021-07-31 05:08:33,818 [INFO] c.a.f.r.s.Main - Total quantity ordered of all items: 6
:examples:run (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 4.649 secs.2021-07-31 05:08:31,714 [INFO] c.a.f.r.s.Main - Clearing the Record Store ...
2021-07-31 05:08:32,661 [INFO] c.a.f.r.s.Main - Writing Vendor and Item record ...
2021-07-31 05:08:32,777 [INFO] c.a.f.r.p.f.FDBRecordStore - new record store format_version="7" key_space_path="/application:22->'record-layer-sample'/environment:'demo'" meta_data_version="2"
2021-07-31 05:08:32,978 [INFO] c.a.f.r.s.Main - Reading Vendor record with primary key 9375L ...
2021-07-31 05:08:33,008 [INFO] c.a.f.r.s.Main -     Result -> Id: 9375, Name: Acme
2021-07-31 05:08:33,009 [INFO] c.a.f.r.s.Main - Looking for item IDs with vendor ID 9375L ...
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main -     Result -> Vendor ID: 9375, Item ID: 4836
2021-07-31 05:08:33,235 [INFO] c.a.f.r.s.Main - Grouping items by vendor ...
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Buy n Large, Item names: [Piles of Garbage, Personal Transport]
2021-07-31 05:08:33,350 [INFO] c.a.f.r.s.Main -     Result -> Vendor Name: Acme, Item names: [GPS]
2021-07-31 05:08:33,364 [INFO] c.a.f.r.p.f.FDBRecordStore - meta-data version changed key_space_path="/application:22->'record-layer-sample'/environment:'demo'" new_version="8" old_version="2"
2021-07-31 05:08:33,367 [INFO] c.a.f.r.p.f.FDBRecordStore - version check scan found non-empty store key_space_path="/application:22->'record-layer-sample'/environment:'demo'"
2021-07-31 05:08:33,375 [INFO] c.a.f.r.s.Main - Running index builds of new indexes:
2021-07-31 05:08:33,533 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="4" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aee897bd-a491-461a-acc8-799e36c37ccb"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="2" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="aae74310-ee45-4815-819f-58c8ad660be8"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,534 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="1" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,543 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="7" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="80da8441-12dd-499e-9ed7-b654b872c729"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,544 [WARN] c.a.f.r.p.f.FDBDatabaseRunnerImpl - Retrying FDB Exception code="1020" curr_attempt="0" delay="8" max_attempts="10" message="Transaction not committed due to conflict with another transaction" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172"
java.util.concurrent.CompletionException: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367)
        at java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:376)
        at java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1019)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:76)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: com.apple.foundationdb.FDBException: Transaction not committed due to conflict with another transaction
        at com.apple.foundationdb.NativeFuture.Future_getError(Native Method)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:35)
        at com.apple.foundationdb.FutureVoid.getIfDone_internal(FutureVoid.java:25)
        at com.apple.foundationdb.NativeFuture.marshalWhenDone(NativeFuture.java:63)
        ... 6 more
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag" index_version="5" indexer_id="2db9d1cb-28cd-49d7-b99b-0a31a7d7c45e" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aae74310-ee45-4815-819f-58c8ad660be8" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="item_quantity_sum" index_version="8" indexer_id="6d6a3d5e-fb68-4989-921b-2505511aa98b" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="988d0e7d-1150-4bee-85e7-50eebc69835c" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="order" index_version="7" indexer_id="0cdc2563-27c7-42fd-b89e-a8fad46224f5" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="aee897bd-a491-461a-acc8-799e36c37ccb" should_mark_readable="true"
2021-07-31 05:08:33,577 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="preference_tag_count" index_version="6" indexer_id="0182ddc9-fcff-41ef-a4a0-1c9361e6bbfb" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="851b2757-6fa8-4b63-b69d-ac17403fe0ad" should_mark_readable="true"
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of order is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of preference_tag_count is complete.
2021-07-31 05:08:33,578 [INFO] c.a.f.r.s.Main -   Index build of item_quantity_sum is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.s.Main -   Index build of preference_tag is complete.
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="globalCount" index_version="3" indexer_id="f1201aac-b4a2-473f-a488-14d234b9e286" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="80da8441-12dd-499e-9ed7-b654b872c729" should_mark_readable="true"
2021-07-31 05:08:33,581 [INFO] c.a.f.r.p.f.IndexingBase - build index online clear_existing_data="true" do_build_index="true" index_name="email_address" index_version="4" indexer_id="03046cbd-8528-407f-9ebf-67672a61d73a" indexing_method="by records" indexing_policy_desired_action="REBUILD" initial_index_state="DISABLED" records_scanned="0" result="success" session_id="e68c60cc-0c96-409c-8a62-3e1b09236172" should_mark_readable="true"
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of globalCount is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main -   Index build of email_address is complete.
2021-07-31 05:08:33,582 [INFO] c.a.f.r.s.Main - Adding records with new secondary indexes ...
2021-07-31 05:08:33,633 [INFO] c.a.f.r.s.Main - Store contains 7 records.
2021-07-31 05:08:33,634 [INFO] c.a.f.r.s.Main - Retrieving all customers with first name "Jane"...
2021-07-31 05:08:33,654 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | first_name EQUALS Jane"
2021-07-31 05:08:33,664 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,665 [INFO] c.a.f.r.s.Main - Retrieving all customers with last name "Doe"...
2021-07-31 05:08:33,668 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe],[Doe]]) | [Customer]"
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,671 [INFO] c.a.f.r.s.Main - Retrieving all customers with name "Jane Doe"...
2021-07-31 05:08:33,712 [INFO] c.a.f.r.s.Main - Query planned plan="Scan([[Doe, Jane],[Doe, Jane]]) | [Customer]"
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,715 [INFO] c.a.f.r.s.Main - Retrieving all customers with an email address beginning with "john"...
2021-07-31 05:08:33,734 [INFO] c.a.f.r.s.Main - Retrieving all customers with preference tags "books" and "movies"...
2021-07-31 05:08:33,744 [INFO] c.a.f.r.s.Main - Query planned plan="Scan(<,>) | [Customer] | And([one of preference_tag EQUALS books, one of preference_tag EQUALS movies])"
2021-07-31 05:08:33,751 [INFO] c.a.f.r.s.Main -     Result -> John Smith
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Number of customers with the "books" preference tag: 2
2021-07-31 05:08:33,755 [INFO] c.a.f.r.s.Main - Retrieving all customers with an order of quantity greater than 2 ...
2021-07-31 05:08:33,806 [INFO] c.a.f.r.s.Main - Query planned plan="Index(order ([2],>) | UnorderedPrimaryKeyDistinct()"
2021-07-31 05:08:33,809 [INFO] c.a.f.r.s.Main -     Result -> Jane Doe
2021-07-31 05:08:33,814 [INFO] c.a.f.r.s.Main - Total quantity ordered of item 2740L: 4
2021-07-31 05:08:33,818 [INFO] c.a.f.r.s.Main - Total quantity ordered of all items: 6
:examples:run (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 4.649 secs.
````