### PR TITLE
Fixes #1355: RecordQueryInUnionPlan doesn't handle dynamic input of …

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
@@ -117,7 +117,14 @@ public class RecordQueryInUnionPlan implements RecordQueryPlanWithChild {
         if (size > maxNumberOfValuesAllowed) {
             throw new RecordCoreException("too many IN values").addLogInfo("size", size);
         }
+        if (size == 0) {
+            return RecordCursor.empty();
+        }
         final RecordQueryPlan childPlan = getInnerPlan();
+        if (size == 1) {
+            final EvaluationContext childContext = getValuesContexts(context).get(0);
+            return childPlan.executePlan(store, childContext, continuation, executeProperties);
+        }
         final ExecuteProperties childExecuteProperties;
         // Can pass the limit down to all sides, since that is the most we'll take total.
         if (executeProperties.getSkip() > 0) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
@@ -543,11 +543,19 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
             assertEquals(1428066748, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
             assertEquals(1407869064, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
             assertEquals(65237271, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
-            assertEquals(30, querySimpleRecordStore(hook, plan,
-                    () -> EvaluationContext.forBinding("inList", asList(1, 3, 4)),
-                    record -> assertThat(record.getNumValue3Indexed(), anyOf(is(1), is(3), is(4))),
-                    context -> { }));
         }
+        assertEquals(30, querySimpleRecordStore(hook, plan,
+                () -> EvaluationContext.forBinding("inList", asList(1, 3, 4)),
+                record -> assertThat(record.getNumValue3Indexed(), anyOf(is(1), is(3), is(4))),
+                context -> { }));
+        assertEquals(0, querySimpleRecordStore(hook, plan,
+                () -> EvaluationContext.forBinding("inList", asList()),
+                record -> fail("should not have any records"),
+                context -> { }));
+        assertEquals(10, querySimpleRecordStore(hook, plan,
+                () -> EvaluationContext.forBinding("inList", asList(3)),
+                record -> assertThat(record.getNumValue3Indexed(), is(3)),
+                context -> { }));
     }
 
     /**


### PR DESCRIPTION
… 0 or 1 values