### PR TITLE
Remove io.protostuff.protostuff-jetbrains-plugin, which isn't supported …

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="ExternalDependencies">
     <plugin id="CheckStyle-IDEA" />
-    <plugin id="io.protostuff.protostuff-jetbrains-plugin" />
   </component>
 </project>


### PR DESCRIPTION
…any more.

See, for instance, https://youtrack.jetbrains.com/issue/RUBY-28557.

The bundled Protobuf plugin is mostly good enough.