### PR TITLE
Resolves #1424: Add count and countNonNull to streaming aggregate

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ Another, smaller change that has been made is that by default, new indexes added
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Streaming aggregate operator implementation [(Issue #1376)](https://github.com/FoundationDB/fdb-record-layer/issues/1376)
+* **Feature** Streaming aggregate count and countNonNull [(Issue #1424)](https://github.com/FoundationDB/fdb-record-layer/issues/1424)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/AggregateAccumulators.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/AggregateAccumulators.java
@@ -32,55 +32,55 @@ public class AggregateAccumulators {
     // ------------------ SUM Aggregators ------------------------------
 
     public static RecordValueAccumulator<Integer, Integer> sumInteger(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new IntegerState(PrimitiveAccumulatorOperation.SUM));
+        return new RecordValueAccumulator<>(value, new IntegerState(NumericAccumulatorOperation.SUM));
     }
 
     public static RecordValueAccumulator<Long, Long> sumLong(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new LongState(PrimitiveAccumulatorOperation.SUM));
+        return new RecordValueAccumulator<>(value, new LongState(NumericAccumulatorOperation.SUM));
     }
 
     public static RecordValueAccumulator<Float, Float> sumFloat(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new FloatState(PrimitiveAccumulatorOperation.SUM));
+        return new RecordValueAccumulator<>(value, new FloatState(NumericAccumulatorOperation.SUM));
     }
 
     public static RecordValueAccumulator<Double, Double> sumDouble(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new DoubleState(PrimitiveAccumulatorOperation.SUM));
+        return new RecordValueAccumulator<>(value, new DoubleState(NumericAccumulatorOperation.SUM));
     }
 
     // ------------------ MIN Aggregators ------------------------------
 
     public static RecordValueAccumulator<Integer, Integer> minInteger(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new IntegerState(PrimitiveAccumulatorOperation.MIN));
+        return new RecordValueAccumulator<>(value, new IntegerState(NumericAccumulatorOperation.MIN));
     }
 
     public static RecordValueAccumulator<Long, Long> minLong(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new LongState(PrimitiveAccumulatorOperation.MIN));
+        return new RecordValueAccumulator<>(value, new LongState(NumericAccumulatorOperation.MIN));
     }
 
     public static RecordValueAccumulator<Float, Float> minFloat(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new FloatState(PrimitiveAccumulatorOperation.MIN));
+        return new RecordValueAccumulator<>(value, new FloatState(NumericAccumulatorOperation.MIN));
     }
 
     public static RecordValueAccumulator<Double, Double> minDouble(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new DoubleState(PrimitiveAccumulatorOperation.MIN));
+        return new RecordValueAccumulator<>(value, new DoubleState(NumericAccumulatorOperation.MIN));
     }
 
     // ------------------ MAX Aggregators ------------------------------
 
     public static RecordValueAccumulator<Integer, Integer> maxInteger(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new IntegerState(PrimitiveAccumulatorOperation.MAX));
+        return new RecordValueAccumulator<>(value, new IntegerState(NumericAccumulatorOperation.MAX));
     }
 
     public static RecordValueAccumulator<Long, Long> maxLong(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new LongState(PrimitiveAccumulatorOperation.MAX));
+        return new RecordValueAccumulator<>(value, new LongState(NumericAccumulatorOperation.MAX));
     }
 
     public static RecordValueAccumulator<Float, Float> maxFloat(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new FloatState(PrimitiveAccumulatorOperation.MAX));
+        return new RecordValueAccumulator<>(value, new FloatState(NumericAccumulatorOperation.MAX));
     }
 
     public static RecordValueAccumulator<Double, Double> maxDouble(@Nonnull final Value value) {
-        return new RecordValueAccumulator<>(value, new DoubleState(PrimitiveAccumulatorOperation.MAX));
+        return new RecordValueAccumulator<>(value, new DoubleState(NumericAccumulatorOperation.MAX));
     }
 
     // ------------------ AVERAGE Aggregators ------------------------------
@@ -99,6 +99,16 @@ public class AggregateAccumulators {
 
     public static RecordValueAccumulator<Double, Double> averageDouble(@Nonnull final Value value) {
         return new RecordValueAccumulator<>(value, AverageAccumulatorState.doubleAverageState());
+    }
+
+    // ------------------ COUNT Aggregators ------------------------------
+
+    public static RecordValueAccumulator<Object, Long> count(@Nonnull final Value value) {
+        return new RecordValueAccumulator<>(value, new CountAccumulatorState(CountAccumulatorState.CountType.INCLUDE_NULL));
+    }
+
+    public static RecordValueAccumulator<Object, Long> countNonNull(@Nonnull final Value value) {
+        return new RecordValueAccumulator<>(value, new CountAccumulatorState(CountAccumulatorState.CountType.EXCLUDE_NULL));
     }
 
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/AverageAccumulatorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/AverageAccumulatorState.java
@@ -38,19 +38,19 @@ public class AverageAccumulatorState<T extends Number> implements AccumulatorSta
 
     // Static method to create and return properly wired accumulators.
     public static AverageAccumulatorState<Integer> intAverageState() {
-        return new AverageAccumulatorState<>(new IntegerState(PrimitiveAccumulatorOperation.SUM));
+        return new AverageAccumulatorState<>(new IntegerState(NumericAccumulatorOperation.SUM));
     }
 
     public static AverageAccumulatorState<Long> longAverageState() {
-        return new AverageAccumulatorState<>(new LongState(PrimitiveAccumulatorOperation.SUM));
+        return new AverageAccumulatorState<>(new LongState(NumericAccumulatorOperation.SUM));
     }
 
     public static AverageAccumulatorState<Float> floatAverageState() {
-        return new AverageAccumulatorState<>(new FloatState(PrimitiveAccumulatorOperation.SUM));
+        return new AverageAccumulatorState<>(new FloatState(NumericAccumulatorOperation.SUM));
     }
 
     public static AverageAccumulatorState<Double> doubleAverageState() {
-        return new AverageAccumulatorState<>(new DoubleState(PrimitiveAccumulatorOperation.SUM));
+        return new AverageAccumulatorState<>(new DoubleState(NumericAccumulatorOperation.SUM));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/CountAccumulatorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/CountAccumulatorState.java
@@ -1,0 +1,58 @@
+/*
+ * CountAccumulatorState.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.cursors.aggregate;
+
+import javax.annotation.Nullable;
+
+/**
+ * Accumulator state for Count operations.
+ * The implementation of the state classes is using primitive types in order to minimize Boxing/Unboxing and object
+ * garbage collection. These classes are mutable and perform the accumulation using primitive math operators.
+ * Once {@link #finish} is called, this instance should be recycled and the accumulation started with a new instance.
+ */
+public class CountAccumulatorState implements AccumulatorState<Object, Long> {
+    public enum CountType { INCLUDE_NULL, EXCLUDE_NULL }
+
+    private long currentState;
+    private final CountType countType;
+
+    public CountAccumulatorState(CountType countType) {
+        this.countType = countType;
+        resetState();
+    }
+
+    @Override
+    public void accumulate(@Nullable final Object value) {
+        if ((value != null) || (countType == CountType.INCLUDE_NULL)) {
+            currentState++;
+        }
+    }
+
+    @Override
+    @Nullable
+    public Long finish() {
+        return currentState;
+    }
+
+    private void resetState() {
+        currentState = 0;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/DoubleState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/DoubleState.java
@@ -31,9 +31,9 @@ import javax.annotation.Nullable;
 public class DoubleState implements AccumulatorState<Double, Double> {
     private double currentState;
     private boolean hasValue = false;
-    private final PrimitiveAccumulatorOperation operation;
+    private final NumericAccumulatorOperation operation;
 
-    public DoubleState(PrimitiveAccumulatorOperation operation) {
+    public DoubleState(NumericAccumulatorOperation operation) {
         this.operation = operation;
         resetState(operation);
     }
@@ -68,7 +68,7 @@ public class DoubleState implements AccumulatorState<Double, Double> {
         }
     }
 
-    private void resetState(final PrimitiveAccumulatorOperation operation) {
+    private void resetState(final NumericAccumulatorOperation operation) {
         switch (operation) {
             case SUM:
                 currentState = 0.0d;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/FloatState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/FloatState.java
@@ -31,9 +31,9 @@ import javax.annotation.Nullable;
 public class FloatState implements AccumulatorState<Float, Float> {
     private float currentState;
     private boolean hasValue = false;
-    private final PrimitiveAccumulatorOperation operation;
+    private final NumericAccumulatorOperation operation;
 
-    public FloatState(PrimitiveAccumulatorOperation operation) {
+    public FloatState(NumericAccumulatorOperation operation) {
         this.operation = operation;
         resetState(operation);
     }
@@ -68,7 +68,7 @@ public class FloatState implements AccumulatorState<Float, Float> {
         }
     }
 
-    private void resetState(final PrimitiveAccumulatorOperation operation) {
+    private void resetState(final NumericAccumulatorOperation operation) {
         switch (operation) {
             case SUM:
                 currentState = 0.0f;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/IntegerState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/IntegerState.java
@@ -31,9 +31,9 @@ import javax.annotation.Nullable;
 public class IntegerState implements AccumulatorState<Integer, Integer> {
     private int currentState;
     private boolean hasValue = false;
-    private final PrimitiveAccumulatorOperation operation;
+    private final NumericAccumulatorOperation operation;
 
-    public IntegerState(PrimitiveAccumulatorOperation operation) {
+    public IntegerState(NumericAccumulatorOperation operation) {
         this.operation = operation;
         resetState(operation);
     }
@@ -68,7 +68,7 @@ public class IntegerState implements AccumulatorState<Integer, Integer> {
         }
     }
 
-    private void resetState(final PrimitiveAccumulatorOperation operation) {
+    private void resetState(final NumericAccumulatorOperation operation) {
         switch (operation) {
             case SUM:
                 currentState = 0;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/LongState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/LongState.java
@@ -31,9 +31,9 @@ import javax.annotation.Nullable;
 public class LongState implements AccumulatorState<Long, Long> {
     private long currentState;
     private boolean hasValue = false;
-    private final PrimitiveAccumulatorOperation operation;
+    private final NumericAccumulatorOperation operation;
 
-    public LongState(PrimitiveAccumulatorOperation operation) {
+    public LongState(NumericAccumulatorOperation operation) {
         this.operation = operation;
         resetState(operation);
     }
@@ -68,7 +68,7 @@ public class LongState implements AccumulatorState<Long, Long> {
         }
     }
 
-    private void resetState(final PrimitiveAccumulatorOperation operation) {
+    private void resetState(final NumericAccumulatorOperation operation) {
         switch (operation) {
             case SUM:
                 currentState = 0;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/NumericAccumulatorOperation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/NumericAccumulatorOperation.java
@@ -21,9 +21,9 @@
 package com.apple.foundationdb.record.cursors.aggregate;
 
 /**
- * The types of accumulation operations allowed for a primitive accumulator.
+ * The types of accumulation operations allowed for a primitive numeric accumulator.
  */
-public enum PrimitiveAccumulatorOperation {
+public enum NumericAccumulatorOperation {
     SUM,
     MIN,
     MAX

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AggregateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AggregateValue.java
@@ -49,7 +49,7 @@ public class AggregateValue<T, R> extends DerivedValue {
     @Nonnull
     private final Function<Value, RecordValueAccumulator<T, R>> accumulatorFunction;
 
-    public enum AggregateType { SUM, MIN, MAX, AVG }
+    public enum AggregateType { SUM, MIN, MAX, AVG, COUNT, COUNT_NON_NULL }
 
     /**
      * Package protected constructor for use only by {@link AggregateValues} static methods.
@@ -67,8 +67,7 @@ public class AggregateValue<T, R> extends DerivedValue {
     /**
      * Create a new accumulator from the Value. This accumulator will perform state management and accumulate evaluated
      * values representing this value. Note that the accumulator contains the {@link #getChild} of this value, as this
-     * value
-     * does not evaluate.
+     * value does not evaluate.
      *
      * @return a new {@link RecordValueAccumulator} for aggregating values for this Value.
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AggregateValues.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/AggregateValues.java
@@ -212,4 +212,29 @@ public class AggregateValues {
     public static AggregateValue<Double, Double> averageDouble(@Nonnull Value child) {
         return new AggregateValue<>(child, AggregateValue.AggregateType.AVG, AggregateAccumulators::averageDouble);
     }
+
+    // ------------------ COUNT Aggregators ------------------------------
+
+    /**
+     * Aggregate value for count of values, including nulls in the count.
+     *
+     * @param child the inner value to use to evaluate records with.
+     *
+     * @return an AggregateValue for the operation and inner
+     */
+    public static AggregateValue<Object, Long> count(@Nonnull Value child) {
+        return new AggregateValue<>(child, AggregateValue.AggregateType.COUNT, AggregateAccumulators::count);
+    }
+
+    /**
+     * Aggregate value for count of values, excluding nulls in the count.
+     *
+     * @param child the inner value to use to evaluate records with.
+     *
+     * @return an AggregateValue for the operation and inner
+     */
+    public static AggregateValue<Object, Long> countNonNull(@Nonnull Value child) {
+        return new AggregateValue<>(child, AggregateValue.AggregateType.COUNT_NON_NULL, AggregateAccumulators::countNonNull);
+    }
+
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AggregateValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AggregateValueTest.java
@@ -166,6 +166,30 @@ public class AggregateValueTest {
         accumulateAndAssert(AggregateValues.averageDouble(doubleValueOnlyNull), 1, null);
     }
 
+    @Test
+    void testCount() throws Exception {
+        accumulateAndAssert(AggregateValues.count(intValue), 6, 6L);
+        accumulateAndAssert(AggregateValues.count(longValue), 6, 6L);
+        accumulateAndAssert(AggregateValues.countNonNull(intValue), 6, 6L);
+        accumulateAndAssert(AggregateValues.countNonNull(longValue), 6, 6L);
+    }
+
+    @Test
+    void testCountWithNulls() throws Exception {
+        accumulateAndAssert(AggregateValues.count(intValueWithNulls), 6, 6L);
+        accumulateAndAssert(AggregateValues.count(longValueWithNulls), 6, 6L);
+        accumulateAndAssert(AggregateValues.countNonNull(floatValueWithNulls), 6, 5L);
+        accumulateAndAssert(AggregateValues.countNonNull(doubleValueWithNulls), 6, 5L);
+    }
+
+    @Test
+    void testCountOnlyNulls() throws Exception {
+        accumulateAndAssert(AggregateValues.count(intValueOnlyNull), 1, 1L);
+        accumulateAndAssert(AggregateValues.count(longValueOnlyNull), 1, 1L);
+        accumulateAndAssert(AggregateValues.countNonNull(intValueOnlyNull), 1, 0L);
+        accumulateAndAssert(AggregateValues.countNonNull(longValueOnlyNull), 1, 0L);
+    }
+
     private <S> void accumulateAndAssert(final AggregateValue<?, ?> aggregateValue, final int accumulateCount, final Object value) {
         RecordValueAccumulator<?, ?> accumulator = aggregateValue.createAccumulator();
         accumulate(accumulateCount, accumulator);


### PR DESCRIPTION
Add support and tests for count and countNonNull: #1424. 
Specifically, the following are true for aggregations and counts:
1. Zero records aggregate to NULL (e.g. Sum() and Avg() without any records return null). 
2. Exception to the rule above is *Count*, where:
    2.1. count() with *no aggregation criteria and no records* is 0.
    2.2. count() with *some aggregation criteria and no records* returns empty stream. (Same as SQL). 
3. Empty table (no records at all ) returns empty result (no records).
4. All aggregations *ignore* null values: They are considered a no-op for avg(), sum() etc.
5. Exception to the above rule is *Count* where count() with will include null values.
6. In order to exclude null records from the count, use the countNonNull() aggregation.