### PR TITLE
Begin #1422: Rename variables called "record"

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBQueriedRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBQueriedRecord.java
@@ -69,8 +69,8 @@ public abstract class FDBQueriedRecord<M extends Message> implements FDBRecord<M
         return new Stored<>(stored);
     }
 
-    public static <M extends Message> FDBQueriedRecord<M> covered(@Nonnull Index index, @Nonnull IndexEntry indexEntry, @Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record) {
-        return new Covered<>(index, indexEntry, primaryKey, recordType, record);
+    public static <M extends Message> FDBQueriedRecord<M> covered(@Nonnull Index index, @Nonnull IndexEntry indexEntry, @Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M protoRecord) {
+        return new Covered<>(index, indexEntry, primaryKey, recordType, protoRecord);
     }
 
     @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
@@ -195,14 +195,14 @@ public abstract class FDBQueriedRecord<M extends Message> implements FDBRecord<M
         @Nonnull
         private final RecordType recordType;
         @Nonnull
-        private final M record;
+        private final M protoRecord;
 
-        public Covered(@Nonnull Index index, @Nonnull IndexEntry indexEntry, @Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record) {
+        public Covered(@Nonnull Index index, @Nonnull IndexEntry indexEntry, @Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M protoRecord) {
             this.index = index;
             this.indexEntry = indexEntry;
             this.primaryKey = primaryKey;
             this.recordType = recordType;
-            this.record = record;
+            this.protoRecord = protoRecord;
         }
 
         @Nullable
@@ -232,7 +232,7 @@ public abstract class FDBQueriedRecord<M extends Message> implements FDBRecord<M
         @Nonnull
         @Override
         public M getRecord() {
-            return record;
+            return protoRecord;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
@@ -43,7 +43,7 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     @Nonnull
     private final RecordType recordType;
     @Nonnull
-    private final M record;
+    private final M protoRecord;
     @Nullable
     private final FDBRecordVersion recordVersion;
 
@@ -53,19 +53,19 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     private final boolean split;
     private final boolean versionedInline;
 
-    public FDBStoredRecord(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record,
+    public FDBStoredRecord(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M protoRecord,
                            @Nonnull FDBStoredSizes size, @Nullable FDBRecordVersion recordVersion) {
-        this(primaryKey, recordType, record, size.getKeyCount(), size.getKeySize(), size.getValueSize(), size.isSplit(), size.isVersionedInline(), recordVersion);
+        this(primaryKey, recordType, protoRecord, size.getKeyCount(), size.getKeySize(), size.getValueSize(), size.isSplit(), size.isVersionedInline(), recordVersion);
     }
 
     @API(API.Status.INTERNAL)
     @SuppressWarnings("squid:S00107")
-    public FDBStoredRecord(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record,
+    public FDBStoredRecord(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M protoRecord,
                            int keyCount, int keySize, int valueSize, boolean split, boolean versionedInline, @Nullable FDBRecordVersion recordVersion) {
 
         this.primaryKey = primaryKey;
         this.recordType = recordType;
-        this.record = record;
+        this.protoRecord = protoRecord;
 
         this.keyCount = keyCount;
         this.keySize = keySize;
@@ -90,7 +90,7 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     @Override
     @Nonnull
     public M getRecord() {
-        return record;
+        return protoRecord;
     }
 
     @Override
@@ -141,13 +141,13 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
 
     /**
      * Get a builder for a stored record.
-     * @param record Protobuf record
+     * @param protoRecord Protobuf record
      * @param <M> type used to represent stored records
      * @return a new builder initialized with the record
      */
     @Nonnull
-    public static <M extends Message> FDBStoredRecordBuilder<M> newBuilder(@Nonnull M record) {
-        return new FDBStoredRecordBuilder<>(record);
+    public static <M extends Message> FDBStoredRecordBuilder<M> newBuilder(@Nonnull M protoRecord) {
+        return new FDBStoredRecordBuilder<>(protoRecord);
     }
 
     /**
@@ -157,7 +157,7 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
      */
     @Nonnull
     public FDBStoredRecord<M> withVersion(@Nullable FDBRecordVersion recordVersion) {
-        return new FDBStoredRecord<>(primaryKey, recordType, record, this, recordVersion);
+        return new FDBStoredRecord<>(primaryKey, recordType, protoRecord, this, recordVersion);
     }
 
     /**
@@ -193,7 +193,7 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
         if (!recordType.getName().equals(that.recordType.getName())) {
             return false;
         }
-        if (!record.equals(that.record)) {
+        if (!protoRecord.equals(that.protoRecord)) {
             return false;
         }
         if (recordVersion == null && that.recordVersion != null || recordVersion != null && !recordVersion.equals(that.recordVersion)) {
@@ -208,7 +208,7 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     public int hashCode() {
         int result = primaryKey.hashCode();
         result = 31 * result + recordType.getName().hashCode();
-        result = 31 * result + record.hashCode();
+        result = 31 * result + protoRecord.hashCode();
         result = 31 * result + keyCount;
         result = 31 * result + keySize;
         result = 31 * result + valueSize;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
@@ -40,7 +40,7 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
     @Nullable
     private RecordType recordType;
     @Nullable
-    private M record;
+    private M protoRecord;
     @Nullable
     private FDBRecordVersion recordVersion;
 
@@ -55,8 +55,8 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
     }
 
     // Having this means the diamond operator can be used more often.
-    public FDBStoredRecordBuilder(@Nonnull M record) {
-        this.record = record;
+    public FDBStoredRecordBuilder(@Nonnull M protoRecord) {
+        this.protoRecord = protoRecord;
     }
 
     @Override
@@ -80,10 +80,10 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
     @Override
     @Nonnull
     public M getRecord() {
-        if (record == null) {
+        if (protoRecord == null) {
             throw new RecordCoreException("record has not been set");
         }
-        return record;
+        return protoRecord;
     }
 
     @Override
@@ -133,7 +133,7 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
     }
 
     public FDBStoredRecordBuilder<M> setRecord(M record) {
-        this.record = record;
+        this.protoRecord = record;
         return this;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSyntheticRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSyntheticRecord.java
@@ -50,7 +50,7 @@ public class FDBSyntheticRecord implements FDBIndexableRecord<Message> {
     @Nonnull
     private final SyntheticRecordType<?> recordType;
     @Nonnull
-    private final Message record;
+    private final Message protoRecord;
     @Nonnull
     private final Map<String, FDBStoredRecord<? extends Message>> constituents;
 
@@ -58,11 +58,11 @@ public class FDBSyntheticRecord implements FDBIndexableRecord<Message> {
     private final int keySize;
     private final int valueSize;
 
-    protected FDBSyntheticRecord(@Nonnull Tuple primaryKey, @Nonnull SyntheticRecordType<?> recordType, @Nonnull Message record,
+    protected FDBSyntheticRecord(@Nonnull Tuple primaryKey, @Nonnull SyntheticRecordType<?> recordType, @Nonnull Message protoRecord,
                                  @Nonnull FDBStoredSizes size, @Nonnull Map<String, FDBStoredRecord<? extends Message>> constituents) {
         this.primaryKey = primaryKey;
         this.recordType = recordType;
-        this.record = record;
+        this.protoRecord = protoRecord;
         this.constituents = constituents;
         this.keyCount = size.getKeyCount();
         this.keySize = size.getKeySize();
@@ -113,7 +113,7 @@ public class FDBSyntheticRecord implements FDBIndexableRecord<Message> {
     @Nonnull
     @Override
     public Message getRecord() {
-        return record;
+        return protoRecord;
     }
 
     /**
@@ -195,7 +195,7 @@ public class FDBSyntheticRecord implements FDBIndexableRecord<Message> {
         if (!recordType.getName().equals(that.recordType.getName())) {
             return false;
         }
-        if (!record.equals(that.record)) {
+        if (!protoRecord.equals(that.protoRecord)) {
             return false;
         }
 
@@ -204,7 +204,7 @@ public class FDBSyntheticRecord implements FDBIndexableRecord<Message> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(primaryKey, recordType, record, constituents, keyCount, keySize, valueSize);
+        return Objects.hash(primaryKey, recordType, protoRecord, constituents, keyCount, keySize, valueSize);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
@@ -68,14 +68,14 @@ public class SortedRecordSerializer<M extends Message> {
         @Nonnull
         private final RecordType recordType;
         @Nonnull
-        private final M record;
+        private final M protoRecord;
         @Nullable
         private final FDBRecordVersion version;
 
-        public Sorted(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M record, FDBRecordVersion version) {
+        public Sorted(@Nonnull Tuple primaryKey, @Nonnull RecordType recordType, @Nonnull M protoRecord, FDBRecordVersion version) {
             this.primaryKey = primaryKey;
             this.recordType = recordType;
-            this.record = record;
+            this.protoRecord = protoRecord;
             this.version = version;
         }
 
@@ -106,7 +106,7 @@ public class SortedRecordSerializer<M extends Message> {
         @Nonnull
         @Override
         public M getRecord() {
-            return record;
+            return protoRecord;
         }
 
         @Override
@@ -127,22 +127,22 @@ public class SortedRecordSerializer<M extends Message> {
         }
     }
 
-    public void write(@Nonnull FDBRecord<M> record, CodedOutputStream stream) throws IOException {
-        stream.writeMessageNoTag(toProto(record));
+    public void write(@Nonnull FDBRecord<M> rec, CodedOutputStream stream) throws IOException {
+        stream.writeMessageNoTag(toProto(rec));
     }
 
     @Nonnull
-    public byte[] serialize(@Nonnull FDBRecord<M> record) {
-        return toProto(record).toByteArray();
+    public byte[] serialize(@Nonnull FDBRecord<M> rec) {
+        return toProto(rec).toByteArray();
     }
 
     @Nonnull
-    public RecordSortingProto.SortedRecord toProto(@Nonnull FDBRecord<M> record) {
+    public RecordSortingProto.SortedRecord toProto(@Nonnull FDBRecord<M> rec) {
         final RecordSortingProto.SortedRecord.Builder builder = RecordSortingProto.SortedRecord.newBuilder();
-        builder.setPrimaryKey(ByteString.copyFrom(record.getPrimaryKey().pack()));
-        builder.setMessage(ByteString.copyFrom(serializer.serialize(recordMetaData, record.getRecordType(), record.getRecord(), timer)));
-        if (record.hasVersion()) {
-            builder.setVersion(ByteString.copyFrom(record.getVersion().toBytes()));
+        builder.setPrimaryKey(ByteString.copyFrom(rec.getPrimaryKey().pack()));
+        builder.setMessage(ByteString.copyFrom(serializer.serialize(recordMetaData, rec.getRecordType(), rec.getRecord(), timer)));
+        if (rec.hasVersion()) {
+            builder.setVersion(ByteString.copyFrom(rec.getVersion().toBytes()));
         }
         return builder.build();
     }
@@ -181,9 +181,9 @@ public class SortedRecordSerializer<M extends Message> {
         return new Sorted<>(primaryKey, recordType, record, version);
     }
 
-    public void writeSortKeyAndRecord(@Nonnull Tuple sortKey, @Nonnull FDBRecord<M> record, @Nonnull CodedOutputStream stream) throws IOException {
+    public void writeSortKeyAndRecord(@Nonnull Tuple sortKey, @Nonnull FDBRecord<M> rec, @Nonnull CodedOutputStream stream) throws IOException {
         stream.writeByteArrayNoTag(sortKey.pack());
-        write(record, stream);
+        write(rec, stream);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/UnstoredRecord.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/UnstoredRecord.java
@@ -36,10 +36,10 @@ import javax.annotation.Nullable;
  * For evaluation unit tests.
  */
 public class UnstoredRecord<M extends Message> implements FDBRecord<M> {
-    final M record;
+    final M protoRecord;
 
-    public UnstoredRecord(M record) {
-        this.record = record;
+    public UnstoredRecord(M protoRecord) {
+        this.protoRecord = protoRecord;
     }
 
     @Nonnull
@@ -57,7 +57,7 @@ public class UnstoredRecord<M extends Message> implements FDBRecord<M> {
     @Nonnull
     @Override
     public M getRecord() {
-        return record;
+        return protoRecord;
     }
 
     @Override


### PR DESCRIPTION
During some down time, I began removing some of the places we call a variable "record" in anticipation of Java 17 making that a reserved word. I suspect we'll end up wanting to break this one up over many PRs given the number of instances of this that we need. This handles the `FDBRecord` interface and its implementations. In those classes, I turned `record` into `protoRecord` if it was a `Message` type (or subclass), which also distinguishes it from the wrapper "record". In a few places, it became `rec` if the `record` in question was already a wrapper.

This is part of the work for #1422.