### PR TITLE
Continue #1422: Remove record variables from RecordSerializer hierarchy

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/DynamicMessageRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/DynamicMessageRecordSerializer.java
@@ -70,17 +70,17 @@ public class DynamicMessageRecordSerializer implements RecordSerializer<Message>
     @Override
     public byte[] serialize(@Nonnull RecordMetaData metaData,
                             @Nonnull RecordType recordType,
-                            @Nonnull Message record,
+                            @Nonnull Message rec,
                             @Nullable StoreTimer timer) {
         long startTime = System.nanoTime();
         try {
             // Wrap in union message, if needed.
-            Message storedRecord = record;
+            Message storedRecord = rec;
             Descriptors.Descriptor unionDescriptor = metaData.getUnionDescriptor();
             if (unionDescriptor != null) {
                 DynamicMessage.Builder unionBuilder = DynamicMessage.newBuilder(unionDescriptor);
                 Descriptors.FieldDescriptor unionField = metaData.getUnionFieldForRecordType(recordType);
-                unionBuilder.setField(unionField, record);
+                unionBuilder.setField(unionField, rec);
                 storedRecord = unionBuilder.build();
             }
             return serializeToBytes(storedRecord);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializer.java
@@ -43,9 +43,9 @@ public class MessageBuilderRecordSerializer extends MessageBuilderRecordSerializ
     protected void setUnionField(@Nonnull RecordMetaData metaData,
                                  @Nonnull RecordType recordType,
                                  @Nonnull Message.Builder unionBuilder,
-                                 @Nonnull Message record) {
+                                 @Nonnull Message rec) {
         Descriptors.FieldDescriptor unionField = metaData.getUnionFieldForRecordType(recordType);
-        unionBuilder.setField(unionField, record);
+        unionBuilder.setField(unionField, rec);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializerBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MessageBuilderRecordSerializerBase.java
@@ -54,7 +54,7 @@ public abstract class MessageBuilderRecordSerializerBase<M extends Message, U ex
     @Override
     public byte[] serialize(@Nonnull RecordMetaData metaData,
                             @Nonnull RecordType recordType,
-                            @Nonnull M record,
+                            @Nonnull M rec,
                             @Nullable StoreTimer timer) {
         long startTime = System.nanoTime();
         try {
@@ -66,7 +66,7 @@ public abstract class MessageBuilderRecordSerializerBase<M extends Message, U ex
                         .addLogInfo("unionDescriptorFullName", metaData.getUnionDescriptor().getFullName())
                         .addLogInfo(LogMessageKeys.META_DATA_VERSION, metaData.getVersion());
             }
-            setUnionField(metaData, recordType, unionBuilder, record);
+            setUnionField(metaData, recordType, unionBuilder, rec);
             @SuppressWarnings("unchecked")
             U storedRecord = (U) unionBuilder.build();
             return storedRecord.toByteArray();
@@ -80,7 +80,7 @@ public abstract class MessageBuilderRecordSerializerBase<M extends Message, U ex
     protected abstract void setUnionField(@Nonnull RecordMetaData metaData,
                                           @Nonnull RecordType recordType,
                                           @Nonnull B unionBuilder,
-                                          @Nonnull M record);
+                                          @Nonnull M rec);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializer.java
@@ -53,13 +53,13 @@ public interface RecordSerializer<M extends Message> {
      *
      * @param metaData the store's meta-data
      * @param recordType the record type of the message
-     * @param record the Protobuf record to serialize
+     * @param rec the Protobuf record to serialize
      * @param timer a timer used to instrument serialization
      * @return the serialized record
      */
     @Nonnull
     byte[] serialize(@Nonnull RecordMetaData metaData, @Nonnull RecordType recordType,
-                     @Nonnull M record, @Nullable StoreTimer timer);
+                     @Nonnull M rec, @Nullable StoreTimer timer);
 
     /**
      * Convert a byte array to a Protobuf record. This should be the inverse of the

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -202,9 +202,9 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
     @Override
     public byte[] serialize(@Nonnull RecordMetaData metaData,
                             @Nonnull RecordType recordType,
-                            @Nonnull M record,
+                            @Nonnull M rec,
                             @Nullable StoreTimer timer) {
-        byte[] innerSerialized = inner.serialize(metaData, recordType, record, timer);
+        byte[] innerSerialized = inner.serialize(metaData, recordType, rec, timer);
 
         TransformState state = new TransformState(innerSerialized);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TypedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TypedRecordSerializer.java
@@ -89,7 +89,7 @@ public class TypedRecordSerializer<M extends Message, U extends Message, B exten
     protected void setUnionField(@Nonnull RecordMetaData metaData,
                                  @Nonnull RecordType recordType,
                                  @Nonnull B unionBuilder,
-                                 @Nonnull M record) {
+                                 @Nonnull M rec) {
         final String typeName = recordType.getName();
         final String valid =  validRecordType.get();
         if (!typeName.equals(valid)) {
@@ -102,7 +102,7 @@ public class TypedRecordSerializer<M extends Message, U extends Message, B exten
             }
             validRecordType.compareAndSet(valid, typeName);
         }
-        setter.accept(unionBuilder, record);
+        setter.accept(unionBuilder, rec);
     }
 
     @Nonnull


### PR DESCRIPTION
This removes any variables called `record` from the `RecordSerializer` hierarchy, replacing them with `rec`. This is in anticipation of the Java 17 `record` feature.

This continues the work part of #1422.