### PR TITLE
Example of Multi-Layer Lucene Optimizations

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/IndexWriterCommitCheckAsync.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/IndexWriterCommitCheckAsync.java
@@ -23,13 +23,13 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreStorageException;
+import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCodec;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
-import org.apache.lucene.codecs.lucene70.Lucene70Codec;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -81,7 +81,7 @@ public class IndexWriterCommitCheckAsync implements FDBRecordContext.CommitCheck
                 super.doMerge(writer, merge);
             }
         });
-        indexWriterConfig.setCodec(new Lucene70Codec(Lucene50StoredFieldsFormat.Mode.BEST_COMPRESSION));
+        indexWriterConfig.setCodec(new LuceneOptimizedCodec(Lucene50StoredFieldsFormat.Mode.BEST_COMPRESSION));
         this.indexWriter = new IndexWriter(directoryCommitCheckAsync.getDirectory(), indexWriterConfig);
         this.executor = executor;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
@@ -1,0 +1,126 @@
+/*
+ * LuceneOptimizedCodec.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.codecs.LiveDocsFormat;
+import org.apache.lucene.codecs.NormsFormat;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.SegmentInfoFormat;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.TermVectorsFormat;
+import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
+import org.apache.lucene.codecs.lucene70.Lucene70Codec;
+
+/**
+ *
+ * Codec with a few optimizations for speeding up compound files
+ * sitting on FoundationDB.
+ *
+ * Optimizations:
+ * - .cfe file references are not stored
+ * - .cfe file data is serialized as entries on the current compound file reference (.cfs)
+ * - .si file references are not stored
+ * - .si file data is serialized as segmentInfo on the current compound file reference (.cfs)
+ * - .si diagnostic information is not stored
+ * - Removed checksum validation on Compound File Reader
+ */
+public class LuceneOptimizedCodec extends Codec {
+
+    private final Lucene70Codec baseCodec;
+    private final CompoundFormat compoundFormat;
+    private final LuceneOptimizedSegmentInfoFormat segmentInfoFormat;
+
+    /**
+     * Instantiates a new codec.
+     */
+    public LuceneOptimizedCodec() {
+        this(Lucene50StoredFieldsFormat.Mode.BEST_SPEED);
+    }
+
+    /**
+     * Instantiates a new codec, specifying the stored fields compression
+     * mode to use.
+     * @param mode stored fields compression mode to use for newly
+     *             flushed/merged segments.
+     */
+    public LuceneOptimizedCodec(Lucene50StoredFieldsFormat.Mode mode) {
+        super("RL");
+        baseCodec = new Lucene70Codec(mode);
+        compoundFormat = new LuceneOptimizedCompoundFormat();
+        segmentInfoFormat = new LuceneOptimizedSegmentInfoFormat();
+    }
+
+
+    @Override
+    public PostingsFormat postingsFormat() {
+        return baseCodec.postingsFormat();
+    }
+
+    @Override
+    public DocValuesFormat docValuesFormat() {
+        return baseCodec.docValuesFormat();
+    }
+
+    @Override
+    public StoredFieldsFormat storedFieldsFormat() {
+        return baseCodec.storedFieldsFormat();
+    }
+
+    @Override
+    public TermVectorsFormat termVectorsFormat() {
+        return baseCodec.termVectorsFormat();
+    }
+
+    @Override
+    public FieldInfosFormat fieldInfosFormat() {
+        return baseCodec.fieldInfosFormat();
+    }
+
+    @Override
+    public SegmentInfoFormat segmentInfoFormat() {
+        return segmentInfoFormat;
+    }
+
+    @Override
+    public NormsFormat normsFormat() {
+        return baseCodec.normsFormat();
+    }
+
+    @Override
+    public LiveDocsFormat liveDocsFormat() {
+        return baseCodec.liveDocsFormat();
+    }
+
+    @Override
+    public CompoundFormat compoundFormat() {
+        return compoundFormat;
+    }
+
+    @Override
+    public PointsFormat pointsFormat() {
+        return baseCodec.pointsFormat();
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
@@ -1,0 +1,69 @@
+/*
+ * LuceneOptimizedCompoundFormat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import org.apache.lucene.codecs.CompoundFormat;
+import org.apache.lucene.codecs.lucene50.Lucene50CompoundFormat;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * Wrapper for the Lucene50CompoundFormat to optimize compound files for sitting on FoundationDB.
+ *
+ */
+public class LuceneOptimizedCompoundFormat extends CompoundFormat {
+    /** Extension of compound file. */
+    static final String DATA_EXTENSION = "cfs";
+    /** Extension of compound file entries. */
+    static final String ENTRIES_EXTENSION = "cfe";
+
+    static final String DATA_CODEC = "Lucene50CompoundData";
+    static final String ENTRY_CODEC = "Lucene50CompoundEntries";
+    static final int VERSION_START = 0;
+    static final int VERSION_CURRENT = VERSION_START;
+
+    private Lucene50CompoundFormat compoundFormat;
+
+    public LuceneOptimizedCompoundFormat() {
+        this.compoundFormat = new Lucene50CompoundFormat();
+    }
+
+
+    @Override
+    public Directory getCompoundReader(Directory dir, final SegmentInfo si, final IOContext context) throws IOException {
+        dir = (dir instanceof LuceneOptimizedWrappedDirectory) ? dir : new LuceneOptimizedWrappedDirectory(dir);
+        return new LuceneOptimizedCompoundReader(dir, si, context);
+    }
+
+    @Override
+    public void write(Directory dir, final SegmentInfo si, final IOContext context) throws IOException {
+        compoundFormat.write(new LuceneOptimizedWrappedDirectory(dir), si, context);
+        final String fileName = IndexFileNames.segmentFileName(si.name, "", DATA_EXTENSION);
+        si.setFiles(si.files().stream().filter(file -> !file.equals(fileName)).collect(Collectors.toSet()));
+    }
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
@@ -1,0 +1,218 @@
+/*
+ * LuceneOptimizedCompoundReader.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.Lock;
+import org.apache.lucene.util.IOUtils;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * Borrowed from Lucene to remove checksum from end of file.
+ *
+ * Class for accessing a compound stream.
+ * This class implements a directory, but is limited to only read operations.
+ * Directory methods that would normally modify data throw an exception.
+ * @lucene.experimental
+ */
+final class LuceneOptimizedCompoundReader extends Directory {
+
+    private final Directory directory;
+    private final String segmentName;
+    private final Map<String, FileEntry> entries;
+    private final IndexInput handle;
+
+    /** Offset/Length for a slice inside of a compound file. */
+    public static final class FileEntry {
+        long offset;
+        long length;
+    }
+
+    /**
+     * Create a new CompoundFileDirectory.
+     */
+    // TODO: we should just pre-strip "entries" and append segment name up-front like simpletext?
+    // this need not be a "general purpose" directory anymore (it only writes index files)
+    public LuceneOptimizedCompoundReader(Directory directory, SegmentInfo si, IOContext context) throws IOException {
+        this.directory = directory;
+        this.segmentName = si.name;
+        String entriesFileName = IndexFileNames.segmentFileName(segmentName, "", LuceneOptimizedCompoundFormat.ENTRIES_EXTENSION);
+        this.entries = readEntries(si.getId(), directory, entriesFileName);
+        String dataFileName = IndexFileNames.segmentFileName(segmentName, "", LuceneOptimizedCompoundFormat.DATA_EXTENSION);
+        handle = directory.openInput(dataFileName, context);
+        /* REMOVED TO NOT READ THE CHECKSUM ON EACH SEARCH
+        try {
+            CodecUtil.checkIndexHeader(handle, LuceneOptimizedCompoundFormat.DATA_CODEC, version, version, si.getId(), "");
+
+            // NOTE: data file is too costly to verify checksum against all the bytes on open,
+            // but for now we at least verify proper structure of the checksum footer: which looks
+            // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
+            // such as file truncation.
+            CodecUtil.retrieveChecksum(handle);
+
+            // We also validate length, because e.g. if you strip 16 bytes off the .cfs we otherwise
+            // would not detect it:
+            if (handle.length() != expectedLength) {
+                throw new CorruptIndexException("length should be " + expectedLength + " bytes, but is " + handle.length() + " instead", handle);
+            }
+
+            success = true;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(handle);
+            }
+        }
+         */
+    }
+
+    /** Helper method that reads CFS entries from an input stream. */
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    private Map<String, FileEntry> readEntries(byte[] segmentID, Directory dir, String entriesFileName) throws IOException {
+        Map<String, FileEntry> mapping = null;
+        try (ChecksumIndexInput entriesStream = dir.openChecksumInput(entriesFileName, IOContext.READONCE)) {
+            Throwable priorE = null;
+            try {
+                CodecUtil.checkIndexHeader(entriesStream, LuceneOptimizedCompoundFormat.ENTRY_CODEC,
+                         LuceneOptimizedCompoundFormat.VERSION_START,
+                         LuceneOptimizedCompoundFormat.VERSION_CURRENT, segmentID, "");
+                final int numEntries = entriesStream.readVInt();
+                mapping = new HashMap<>(numEntries);
+                for (int i = 0; i < numEntries; i++) {
+                    final FileEntry fileEntry = new FileEntry();
+                    final String id = entriesStream.readString();
+                    FileEntry previous = mapping.put(id, fileEntry);
+                    if (previous != null) {
+                        throw new CorruptIndexException("Duplicate cfs entry id=" + id + " in CFS ", entriesStream);
+                    }
+                    fileEntry.offset = entriesStream.readLong();
+                    fileEntry.length = entriesStream.readLong();
+                }
+            } catch (Throwable exception) {
+                priorE = exception;
+            } finally {
+                CodecUtil.checkFooter(entriesStream, priorE);
+            }
+        }
+        return Collections.unmodifiableMap(mapping);
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(handle);
+    }
+
+    @Override
+    public IndexInput openInput(String name, IOContext context) throws IOException {
+        ensureOpen();
+        final String id = IndexFileNames.stripSegmentName(name);
+        final FileEntry entry = entries.get(id);
+        if (entry == null) {
+            String datFileName = IndexFileNames.segmentFileName(segmentName, "", LuceneOptimizedCompoundFormat.DATA_EXTENSION);
+            throw new FileNotFoundException("No sub-file with id " + id + " found in compound file \"" + datFileName + "\" (fileName=" + name + " files: " + entries.keySet() + ")");
+        }
+        return handle.slice(name, entry.offset, entry.length);
+    }
+
+    /** Returns an array of strings, one for each file in the directory. */
+    @Override
+    public String[] listAll() {
+        ensureOpen();
+        String[] res = entries.keySet().toArray(new String[entries.size()]);
+
+        // Add the segment name
+        for (int i = 0; i < res.length; i++) {
+            res[i] = segmentName + res[i];
+        }
+        return res;
+    }
+
+    /** Not implemented.
+     * @throws UnsupportedOperationException always: not supported by CFS */
+    @Override
+    public void deleteFile(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** Not implemented.
+     * @throws UnsupportedOperationException always: not supported by CFS */
+    @Override
+    public void rename(String from, String to) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void syncMetaData() {
+    }
+
+    /** Returns the length of a file in the directory.
+     * @throws IOException if the file does not exist */
+    @Override
+    public long fileLength(String name) throws IOException {
+        ensureOpen();
+        FileEntry e = entries.get(IndexFileNames.stripSegmentName(name));
+        if (e == null) {
+            throw new FileNotFoundException(name);
+        }
+        return e.length;
+    }
+
+    @Override
+    public IndexOutput createOutput(String name, IOContext context) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexOutput createTempOutput(String prefix, String suffix, IOContext context) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sync(Collection<String> names) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Lock obtainLock(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        return "CompoundFileDirectory(segment=\"" + segmentName + "\" in dir=" + directory + ")";
+    }
+}
+

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedSegmentInfoFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedSegmentInfoFormat.java
@@ -1,0 +1,62 @@
+/*
+ * LuceneOptimizedSegmentInfoFormat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import org.apache.lucene.codecs.SegmentInfoFormat;
+import org.apache.lucene.codecs.lucene70.Lucene70SegmentInfoFormat;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+public class LuceneOptimizedSegmentInfoFormat extends SegmentInfoFormat {
+    private final SegmentInfoFormat segmentInfosFormat = new Lucene70SegmentInfoFormat();
+
+    public LuceneOptimizedSegmentInfoFormat() {
+    }
+
+    @Override
+    public SegmentInfo read(final Directory directory, final String segmentName, final byte[] segmentID, final IOContext context) throws IOException {
+        SegmentInfo segmentInfo = segmentInfosFormat.read(new LuceneOptimizedWrappedDirectory(directory), segmentName, segmentID, context);
+        SegmentInfo segmentInfoToReturn = new SegmentInfo(directory, segmentInfo.getVersion(), segmentInfo.getMinVersion(), segmentInfo.name,
+                segmentInfo.maxDoc(), segmentInfo.getUseCompoundFile(), segmentInfo.getCodec(), segmentInfo.getDiagnostics(),
+                segmentInfo.getId(),
+                segmentInfo.getAttributes(), segmentInfo.getIndexSort());
+        segmentInfoToReturn.setFiles(segmentInfo.files());
+        return segmentInfoToReturn;
+    }
+
+    @Override
+    public void write(final Directory dir, final SegmentInfo info, final IOContext ioContext) throws IOException {
+        SegmentInfo segmentInfoToWrite = new SegmentInfo(new LuceneOptimizedWrappedDirectory(dir), info.getVersion(), info.getMinVersion(), info.name,
+                info.maxDoc(), info.getUseCompoundFile(), info.getCodec(), Collections.emptyMap(),
+                info.getId(),
+                info.getAttributes(), info.getIndexSort());
+        segmentInfoToWrite.setFiles(info.files());
+        segmentInfosFormat.write(new LuceneOptimizedWrappedDirectory(dir), segmentInfoToWrite, ioContext);
+        final String fileName = IndexFileNames.segmentFileName(info.name, "", Lucene70SegmentInfoFormat.SI_EXTENSION);
+        info.setFiles(info.files().stream().filter(file -> !file.equals(fileName)).collect(Collectors.toSet()));
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
@@ -1,0 +1,139 @@
+/*
+ * WrappedDirectory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
+import org.apache.lucene.store.BufferedChecksumIndexInput;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.Lock;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCompoundFormat.DATA_EXTENSION;
+import static com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCompoundFormat.ENTRIES_EXTENSION;
+import static org.apache.lucene.codecs.lucene70.Lucene70SegmentInfoFormat.SI_EXTENSION;
+
+public class LuceneOptimizedWrappedDirectory extends Directory {
+    private final FDBDirectory fdbDirectory;
+    private final Directory wrappedDirectory;
+
+    public static boolean isSegmentInfo(String name) {
+        return name.endsWith(SI_EXTENSION);
+    }
+
+    public static boolean isCompoundFile(String name) {
+        return name.endsWith(DATA_EXTENSION);
+    }
+
+    public static boolean isEntriesFile(String name) {
+        return name.endsWith(ENTRIES_EXTENSION);
+    }
+
+    public static String convertToDataFile(String name) {
+        if (isSegmentInfo(name)) {
+            return name.substring(0, name.length() - 2) + DATA_EXTENSION;
+        } else if (isEntriesFile(name)) {
+            return name.substring(0, name.length() - 3) + DATA_EXTENSION;
+        } else {
+            return name;
+        }
+
+    }
+
+    public LuceneOptimizedWrappedDirectory(Directory directory) {
+        this.wrappedDirectory = directory;
+        this.fdbDirectory = (FDBDirectory)FilterDirectory.unwrap(directory);
+    }
+
+    @Override
+    public String[] listAll() throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public void deleteFile(final String name) throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public long fileLength(final String name) throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public IndexOutput createOutput(String name, final IOContext context) throws IOException {
+        if (isSegmentInfo(name) || isEntriesFile(name)) {
+            return new LuceneOptimizedWrappedIndexOutput(name, fdbDirectory, isSegmentInfo(name));
+        } else {
+            return wrappedDirectory.createOutput(name, context);
+        }
+    }
+
+    @Override
+    public IndexOutput createTempOutput(final String prefix, final String suffix, final IOContext context) throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public void sync(final Collection<String> names) throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public void syncMetaData() throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public void rename(final String source, final String dest) throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public IndexInput openInput(String name, final IOContext context) throws IOException {
+        if (isSegmentInfo(name) || isEntriesFile(name)) {
+            return new LuceneOptimizedWrappedIndexInput(name, fdbDirectory, isSegmentInfo(name));
+        } else {
+            return wrappedDirectory.openInput(name, context);
+        }
+    }
+
+    @Override
+    public Lock obtainLock(final String name) throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public void close() throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public ChecksumIndexInput openChecksumInput(final String name, final IOContext context) throws IOException {
+        return new BufferedChecksumIndexInput(openInput(name, context));
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedIndexInput.java
@@ -1,0 +1,79 @@
+/*
+ * LuceneOptimizedWrappedIndexInput.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
+import com.apple.foundationdb.record.lucene.directory.FDBLuceneFileReference;
+import org.apache.lucene.store.IndexInput;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+public class LuceneOptimizedWrappedIndexInput extends IndexInput {
+    private final FDBDirectory directory;
+    FDBLuceneFileReference reference;
+    byte[] value;
+    private int position;
+
+    public LuceneOptimizedWrappedIndexInput(@Nonnull String name, @Nonnull FDBDirectory directory, boolean isSegmentInfo) {
+        super(name);
+        this.directory = directory;
+        reference = this.directory.getFDBLuceneFileReference(LuceneOptimizedWrappedDirectory.convertToDataFile(name)).join();
+        value = isSegmentInfo ? reference.getSegmentInfo() : reference.getEntries();
+        position = 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public long getFilePointer() {
+        return position;
+    }
+
+    @Override
+    public void seek(final long pos) throws IOException {
+        position = (int) pos;
+    }
+
+    @Override
+    public long length() {
+        return value.length;
+    }
+
+    @Override
+    public IndexInput slice(final String sliceDescription, final long offset, final long length) throws IOException {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return value[position++];
+    }
+
+    @Override
+    public void readBytes(final byte[] b, final int offset, final int len) throws IOException {
+        System.arraycopy(value, position, b, offset, len);
+        position = position + len;
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedIndexOutput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedIndexOutput.java
@@ -1,0 +1,81 @@
+/*
+ * LuceneOptimizedWrappedIndexOutput.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
+import com.apple.foundationdb.record.lucene.directory.FDBLuceneFileReference;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.IndexOutput;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.CRC32;
+
+public class LuceneOptimizedWrappedIndexOutput extends IndexOutput {
+    private final String name;
+    private final FDBDirectory directory;
+    private final ByteArrayOutputStream outputStream;
+    private final CRC32 crc;
+    private final boolean isSegmentInfo;
+
+    public LuceneOptimizedWrappedIndexOutput(@Nonnull String name, @Nonnull FDBDirectory directory, boolean isSegmentInfo) {
+        super(name, name);
+        this.name = name;
+        this.directory = (FDBDirectory) FilterDirectory.unwrap(directory);
+        this.outputStream = new ByteArrayOutputStream();
+        this.crc = new CRC32();
+        this.isSegmentInfo = isSegmentInfo;
+    }
+
+    @Override
+    public void close() throws IOException {
+        FDBLuceneFileReference reference = new FDBLuceneFileReference(-1, -1, -1);
+        if (isSegmentInfo) {
+            reference.setSegmentInfo(outputStream.toByteArray());
+        } else {
+            reference.setEntries(outputStream.toByteArray());
+        }
+        directory.writeFDBLuceneFileReference(name, reference);
+    }
+
+    @Override
+    public long getFilePointer() {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public long getChecksum() throws IOException {
+        return crc.getValue();
+    }
+
+    @Override
+    public void writeByte(final byte b) throws IOException {
+        outputStream.write(b);
+        crc.update(b);
+    }
+
+    @Override
+    public void writeBytes(final byte[] b, final int offset, final int length) throws IOException {
+        outputStream.write(b, offset, length);
+        crc.update(b, offset, length);
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common classes for lucene index queries.
+ */
+package com.apple.foundationdb.record.lucene.codec;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.tuple.Tuple;
 
 import javax.annotation.Nonnull;
@@ -28,20 +29,29 @@ import javax.annotation.Nonnull;
 /**
  * A File Reference record laying out the id, size, and block size.
  */
+@SpotBugsSuppressWarnings("EI_EXPOSE_REP")
 @API(API.Status.EXPERIMENTAL)
 public class FDBLuceneFileReference {
     private final long id;
     private final long size;
     private final long blockSize;
+    private byte[] segmentInfo;
+    private byte[] entries;
 
     public FDBLuceneFileReference(@Nonnull Tuple tuple) {
-        this(tuple.getLong(0), tuple.getLong(1), tuple.getLong(2));
+        this(tuple.getLong(0), tuple.getLong(1), tuple.getLong(2), tuple.getBytes(3), tuple.getBytes(4));
     }
 
     public FDBLuceneFileReference(long id, long size, long blockSize) {
+        this(id, size, blockSize, null, null);
+    }
+
+    public FDBLuceneFileReference(long id, long size, long blockSize, byte[] segmentInfo, byte[] entries) {
         this.id = id;
         this.size = size;
         this.blockSize = blockSize;
+        this.segmentInfo = segmentInfo;
+        this.entries = entries;
     }
 
     public long getId() {
@@ -56,12 +66,30 @@ public class FDBLuceneFileReference {
         return blockSize;
     }
 
+    public void setSegmentInfo(byte[] segmentInfo) {
+        this.segmentInfo = segmentInfo;
+    }
+
+    public void setEntries(byte[] entries) {
+        this.entries = entries;
+    }
+
+    @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
+    public byte[] getSegmentInfo() {
+        return segmentInfo;
+    }
+
+    @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
+    public byte[] getEntries() {
+        return entries;
+    }
+
     public Tuple getTuple() {
-        return Tuple.from(id, size, blockSize);
+        return Tuple.from(id, size, blockSize, segmentInfo, entries);
     }
 
     @Override
     public String toString() {
-        return "Reference [ id=" + id + ", size=" + size + ", blockSize=" + blockSize + "]";
+        return "Reference [ id=" + id + ", size=" + size + ", blockSize=" + blockSize + ", segmentInfo=" + (getSegmentInfo() == null ? 0 : getSegmentInfo().length) + ", entries=" + (getEntries() == null ? 0 : getEntries().length) + "]";
     }
 }

--- a/fdb-record-layer-lucene/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/fdb-record-layer-lucene/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -1,0 +1,16 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCodec

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecordsTextProto;
 import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
@@ -49,6 +50,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
@@ -522,4 +524,13 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         returnValue[1] = builder.toString();
         return returnValue;
     }
+
+    @Test
+    public void testCompressDecompress() {
+        byte[] foo = "sdfaksdfklasdfkldasfl;dasklf;asdkf;asdkf;".getBytes();
+        byte[] compressedBytes = FDBDirectory.compressBytes(foo);
+        byte[] decompressedBytes = FDBDirectory.decompressBytes(compressedBytes);
+        assertTrue(Arrays.equals(foo, FDBDirectory.decompressBytes(FDBDirectory.compressBytes(foo))));
+    }
+
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
@@ -20,7 +20,9 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
+import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCodec;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedDocValuesField;
@@ -65,6 +67,7 @@ public class FDBLuceneTestIndex {
      */
     public void indexDocument(String title, String body) throws IOException {
         IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
+        indexWriterConfig.setCodec(new LuceneOptimizedCodec(Lucene50StoredFieldsFormat.Mode.BEST_COMPRESSION));
         try (IndexWriter writer = new IndexWriter(directory, indexWriterConfig)) {
             Document document = new Document();
             document.add(new TextField("title", title, Field.Store.YES));


### PR DESCRIPTION
 * Codec with a few optimizations for speeding up compound files
 * sitting on FoundationDB.
 *
 * Optimizations:
 * - .cfe file references are not stored
 * - .cfe file data is serialized as entries on the current compound file reference (.cfs)
 * - .si file references are not stored
 * - .si file data is serialized as segmentInfo on the current compound file reference (.cfs)
 * - .si diagnostic information is not stored
 * - Removed checksum validation on Compound File Reader