### PR TITLE
resolves #1461: parameter comparisons should declare their correlations correctly

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -58,10 +58,6 @@
         <module name="fdb-record-layer.fdb-record-layer-icu.main" />
       </profile>
     </annotationProcessing>
-    <bytecodeTargetLevel target="1.8">
-      <module name="fdb-record-layer" target="11" />
-      <module name="fdb-record-layer.main" target="11" />
-      <module name="fdb-record-layer.test" target="11" />
-    </bytecodeTargetLevel>
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -48,7 +48,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -209,9 +209,11 @@ subprojects {
                 // exclude generated Protobuf classes
                 exclude "**/*Proto.java"
                 exclude "**/*ProtoV3.java"
-                // warnings are errors
-                options.addBooleanOption('Xwerror', true)
-                options.addStringOption('source', '8')
+                // TODO warnings should be errors, however, javadoc in Java 11 is broken with respect to a
+                //      no-modules setup. That is a bug that was fixed in Java 12.
+                //      https://bugs.openjdk.java.net/browse/JDK-8212233
+                options.addBooleanOption('Xwerror', false)
+                options.addStringOption('source', '11')
                 options.with {
                     overview "src/main/javadoc/overview.html"
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Bindings.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Bindings.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.annotation.API;
+import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -61,6 +62,11 @@ public class Bindings {
 
         public String bindingName(@Nonnull String suffix) {
             return value + suffix;
+        }
+
+        public String identifier(@Nonnull String bindingName) {
+            Verify.verify(bindingName.startsWith(value));
+            return bindingName.substring(value.length());
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.temp.AliasMap;
 import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.temp.GraphExpansion;
 import com.apple.foundationdb.record.query.predicates.RecordTypeValue;
@@ -161,6 +162,12 @@ public class RecordTypeKeyComparison implements ComponentWithComparison {
         @Override
         public void validate(@Nonnull Descriptors.FieldDescriptor descriptor, boolean fannedOut) {
             // Do not actually apply to any particular field.
+        }
+
+        @Nonnull
+        @Override
+        public Comparisons.Comparison rebase(@Nonnull final AliasMap translationMap) {
+            return this;
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/AliasMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/AliasMap.java
@@ -162,6 +162,8 @@ import java.util.function.Function;
  *
  */
 public class AliasMap {
+    private static final AliasMap EMPTY = new AliasMap(ImmutableBiMap.of());
+
     private final ImmutableBiMap<CorrelationIdentifier, CorrelationIdentifier> map;
 
     /**
@@ -473,6 +475,72 @@ public class AliasMap {
     }
 
     /**
+     * Find complete matches between two sets of aliases, given their depends-on sets and a
+     * {@link MatchPredicate}.
+     * This method creates an underlying {@link PredicatedMatcher} to do the work.
+     * @param aliases a set of aliases
+     * @param dependsOnFn a function that returns the set of dependencies for a given alias within {@code aliases}
+     * @param otherAliases a set of other aliases
+     * @param otherDependsOnFn a function that returns the set of dependencies for a given alias within {@code otherAliases}
+     * @param matchPredicate match predicate. see {@link MatchPredicate}
+     *        for more info
+     * @return an iterable of {@link AliasMap}s where each individual {@link AliasMap} is considered one match
+     */
+    public Iterable<AliasMap> findCompleteMatches(@Nonnull final Set<CorrelationIdentifier> aliases,
+                                                  @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> dependsOnFn,
+                                                  @Nonnull final Set<CorrelationIdentifier> otherAliases,
+                                                  @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> otherDependsOnFn,
+                                                  @Nonnull final MatchPredicate<CorrelationIdentifier> matchPredicate) {
+        return matcher(
+                aliases,
+                dependsOnFn,
+                otherAliases,
+                otherDependsOnFn,
+                matchPredicate)
+                .findCompleteMatches();
+    }
+
+    /**
+     * Find matches (including partial matches) between two sets of aliases, given their depends-on sets and a
+     * {@link MatchPredicate}.
+     * This method creates an underlying {@link PredicatedMatcher} to do the work.
+     * @param aliases a set of aliases
+     * @param dependsOnFn a function that returns the set of dependencies for a given alias within {@code aliases}
+     * @param otherAliases a set of other aliases
+     * @param otherDependsOnFn a function that returns the set of dependencies for a given alias within {@code otherAliases}
+     * @param matchPredicate match predicate. see {@link MatchPredicate}
+     *        for more info
+     * @return an iterable of {@link AliasMap}s where each individual {@link AliasMap} is considered one match
+     */
+    public Iterable<AliasMap> findMatches(@Nonnull final Set<CorrelationIdentifier> aliases,
+                                          @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> dependsOnFn,
+                                          @Nonnull final Set<CorrelationIdentifier> otherAliases,
+                                          @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> otherDependsOnFn,
+                                          @Nonnull final MatchPredicate<CorrelationIdentifier> matchPredicate) {
+        return matcher(
+                aliases,
+                dependsOnFn,
+                otherAliases,
+                otherDependsOnFn,
+                matchPredicate)
+                .findMatches();
+    }
+
+    private PredicatedMatcher matcher(@Nonnull final Set<CorrelationIdentifier> aliases,
+                                      @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> dependsOnFn,
+                                      @Nonnull final Set<CorrelationIdentifier> otherAliases,
+                                      @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> otherDependsOnFn,
+                                      @Nonnull final MatchPredicate<CorrelationIdentifier> matchPredicate) {
+        return FindingMatcher.onAliases(
+                this,
+                aliases,
+                dependsOnFn,
+                otherAliases,
+                otherDependsOnFn,
+                matchPredicate);
+    }
+
+    /**
      * Create a new empty builder.
      * @return a builder for a new {@link AliasMap}
      */
@@ -497,7 +565,7 @@ public class AliasMap {
      */
     @Nonnull
     public static AliasMap emptyMap() {
-        return new AliasMap(ImmutableBiMap.of());
+        return EMPTY;
     }
 
     /**
@@ -644,71 +712,5 @@ public class AliasMap {
         public AliasMap build() {
             return new AliasMap(ImmutableBiMap.copyOf(map));
         }
-    }
-
-    /**
-     * Find complete matches between two sets of aliases, given their depends-on sets and a
-     * {@link MatchPredicate}.
-     * This method creates an underlying {@link PredicatedMatcher} to do the work.
-     * @param aliases a set of aliases
-     * @param dependsOnFn a function that returns the set of dependencies for a given alias within {@code aliases}
-     * @param otherAliases a set of other aliases
-     * @param otherDependsOnFn a function that returns the set of dependencies for a given alias within {@code otherAliases}
-     * @param matchPredicate match predicate. see {@link MatchPredicate}
-     *        for more info
-     * @return an iterable of {@link AliasMap}s where each individual {@link AliasMap} is considered one match
-     */
-    public Iterable<AliasMap> findCompleteMatches(@Nonnull final Set<CorrelationIdentifier> aliases,
-                                                  @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> dependsOnFn,
-                                                  @Nonnull final Set<CorrelationIdentifier> otherAliases,
-                                                  @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> otherDependsOnFn,
-                                                  @Nonnull final MatchPredicate<CorrelationIdentifier> matchPredicate) {
-        return matcher(
-                aliases,
-                dependsOnFn,
-                otherAliases,
-                otherDependsOnFn,
-                matchPredicate)
-                .findCompleteMatches();
-    }
-
-    /**
-     * Find matches (including partial matches) between two sets of aliases, given their depends-on sets and a
-     * {@link MatchPredicate}.
-     * This method creates an underlying {@link PredicatedMatcher} to do the work.
-     * @param aliases a set of aliases
-     * @param dependsOnFn a function that returns the set of dependencies for a given alias within {@code aliases}
-     * @param otherAliases a set of other aliases
-     * @param otherDependsOnFn a function that returns the set of dependencies for a given alias within {@code otherAliases}
-     * @param matchPredicate match predicate. see {@link MatchPredicate}
-     *        for more info
-     * @return an iterable of {@link AliasMap}s where each individual {@link AliasMap} is considered one match
-     */
-    public Iterable<AliasMap> findMatches(@Nonnull final Set<CorrelationIdentifier> aliases,
-                                          @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> dependsOnFn,
-                                          @Nonnull final Set<CorrelationIdentifier> otherAliases,
-                                          @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> otherDependsOnFn,
-                                          @Nonnull final MatchPredicate<CorrelationIdentifier> matchPredicate) {
-        return matcher(
-                aliases,
-                dependsOnFn,
-                otherAliases,
-                otherDependsOnFn,
-                matchPredicate)
-                .findMatches();
-    }
-
-    private PredicatedMatcher matcher(@Nonnull final Set<CorrelationIdentifier> aliases,
-                                      @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> dependsOnFn,
-                                      @Nonnull final Set<CorrelationIdentifier> otherAliases,
-                                      @Nonnull final Function<CorrelationIdentifier, Set<CorrelationIdentifier>> otherDependsOnFn,
-                                      @Nonnull final MatchPredicate<CorrelationIdentifier> matchPredicate) {
-        return FindingMatcher.onAliases(
-                this,
-                aliases,
-                dependsOnFn,
-                otherAliases,
-                otherDependsOnFn,
-                matchPredicate);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Correlated.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/Correlated.java
@@ -152,6 +152,26 @@ public interface Correlated<S extends Correlated<S>> {
     boolean semanticEquals(@Nullable Object other, @Nonnull AliasMap aliasMap);
 
     /**
+     * Static helper to shorten boilerplate for callers that have to deal with nullable objects.
+     * @param one one instance
+     * @param other another instance
+     * @param aliasMap an {@link AliasMap}
+     * @param <S> the type parameter for {@code Correlated}
+     * @return This method returns {@code true} if both objects passed in are {@code null}, {@code false}
+     *         if {@code one} is {@code null} but {@code another} is not and defers to the instance-based semantic
+     *         equality in any other case.
+     */
+    static <S extends Correlated<S>> boolean semanticEquals(@Nullable Correlated<S> one, @Nullable Correlated<S> other, @Nonnull AliasMap aliasMap) {
+        if (one == null && other == null) {
+            return true;
+        }
+        if (one == null) {
+            return false;
+        }
+        return one.semanticEquals(other, aliasMap);
+    }
+
+    /**
      * Return a semantic hash code for this object. The hash code must obey the convention that for any two objects
      * {@code o1} and {@code o2} and for every {@link AliasMap} {@code aliasMap}:
      *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/InterestingPropertiesMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/InterestingPropertiesMap.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * An map to keep track of interesting physical properties for an expression reference. References ({@link ExpressionRef})
+ * A map to keep track of interesting physical properties for an expression reference. References ({@link ExpressionRef})
  * are a central part of the memoization effort within the {@link CascadesPlanner}. Member expressions contained in
  * a reference all yield the same final result not taking into account physical properties such as sorted-ness,
  * existence of duplicates, etc. A set of plan members of a reference can be partitioned into subsets by physical
@@ -63,7 +63,7 @@ public class InterestingPropertiesMap {
     private long currentTick;
 
     /**
-     * The is the goal tick. This tick is between the {@link #watermarkCommittedTick} and the {@link #currentTick}.
+     * The watermark goal tick. This tick is between the {@link #watermarkCommittedTick} and the {@link #currentTick}.
      * This needs to be tracked as this tick is used to understand that a particular change to the interesting properties
      * has caused a proper (re-)exploration of the affected sub dag. If other pushes happen through other rules,
      * {@link #currentTick} will get further bumped and needs to cause further exploration. This tick tells that

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/RelationalExpressionWithChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/expressions/RelationalExpressionWithChildren.java
@@ -116,4 +116,16 @@ public interface RelationalExpressionWithChildren extends RelationalExpression {
         }
         return unmappedForEachQuantifiers;
     }
+
+    @Nonnull
+    default Set<Quantifier> computeMappedQuantifiers(@Nonnull final PartialMatch partialMatch) {
+        final var matchInfo = partialMatch.getMatchInfo();
+        final var mappedForEachQuantifiers = new LinkedIdentitySet<Quantifier>();
+        for (final Quantifier quantifier : getQuantifiers()) {
+            if (matchInfo.getChildPartialMatch(quantifier.getAlias()).isPresent()) {
+                mappedForEachQuantifiers.add(quantifier);
+            }
+        }
+        return mappedForEachQuantifiers;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/properties/OrderingProperty.java
@@ -242,9 +242,14 @@ public class OrderingProperty implements PlannerProperty<Optional<OrderingProper
         final ImmutableList.Builder<KeyPart> result = ImmutableList.builder();
         for (int i = scanComparisons.getEqualitySize(); i < normalizedKeyExpressions.size(); i++) {
             final KeyExpression currentKeyExpression = normalizedKeyExpressions.get(i);
-            if (currentKeyExpression.createsDuplicates()) {
-                break;
-            }
+
+            //
+            // Note that it is not really important here if the keyExpression can be normalized in a lossless way
+            // or not. A key expression containing repeated fields is sort-compatible with its normalized key
+            // expression. We used to refuse to compute the sort order in the presence of repeats, however,
+            // I think that restriction can be relaxed.
+            //
+
             result.add(KeyPart.of(currentKeyExpression,
                     i == scanComparisons.getEqualitySize()
                     ? ComparisonRange.Type.INEQUALITY

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/InComparisonToExplodeRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/InComparisonToExplodeRule.java
@@ -160,7 +160,7 @@ public class InComparisonToExplodeRule extends PlannerRule<SelectExpression> {
                 final Quantifier.ForEach newQuantifier = Quantifier.forEach(GroupExpressionRef.of(explodeExpression));
                 transformedPredicates.add(
                         new ValuePredicate(((ValuePredicate)predicate).getValue(),
-                                new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, newQuantifier.getAlias().toString(), Bindings.Internal.CORRELATION)));
+                                new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, Bindings.Internal.CORRELATION.bindingName(newQuantifier.getAlias().toString()), Bindings.Internal.CORRELATION)));
                 transformedQuantifiers.add(newQuantifier);
             } else {
                 transformedPredicates.add(predicate);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/temp/rules/RemoveSortRule.java
@@ -83,14 +83,6 @@ public class RemoveSortRule extends PlannerRule<LogicalSortExpression> {
 
         final List<KeyExpression> normalizedSortExpressions = sortKeyExpression.normalizeKeyForPositions();
         for (final KeyExpression normalizedSortExpression : normalizedSortExpressions) {
-            //
-            // A top level sort (which is the only sort supported at this point should not be able to express
-            // and order based on a repeated field).
-            //
-            if (normalizedSortExpression.createsDuplicates()) {
-                return;
-            }
-
             if (equalityBoundKeys.contains(normalizedSortExpression)) {
                 equalityBoundUnsorted--;
                 continue;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/predicates/QueryPredicate.java
@@ -169,13 +169,13 @@ public interface QueryPredicate extends Correlated<QueryPredicate>, TreeLike<Que
     /**
      * Method to find all mappings of this predicate in an {@link Iterable} of candidate predicates. If no mapping can
      * be found at all, this method will then call {@link #impliesCandidatePredicate(AliasMap, QueryPredicate)} using
-     * a tautology predicate as candidate which by should by contract should return a {@link PredicateMapping}.
+     * a tautology predicate as candidate which should by contract should return a {@link PredicateMapping}.
      * @param aliasMap the current alias map
      * @param candidatePredicates an {@link Iterable} of candiate predicates
      * @return a non-empty set of {@link PredicateMapping}s
      */
     default Set<PredicateMapping> findImpliedMappings(@NonNull AliasMap aliasMap,
-                                                      @Nonnull Iterable<QueryPredicate> candidatePredicates) {
+                                                      @Nonnull Iterable<? extends QueryPredicate> candidatePredicates) {
         final ImmutableSet.Builder<PredicateMapping> mappingBuilder = ImmutableSet.builder();
 
         for (final QueryPredicate candidatePredicate : candidatePredicates) {


### PR DESCRIPTION
- `Comparison` now implements `Correlated<Comparison>`
- `ComparisonRange` now implements `Correlated<ComparisonRange`
- `ValuePredicate` and `ValueCoparisonRange.Sargable` both defer to the comparisons/comparison range's `rebase()` in their own `rebase()`.
- matching logic in `SelectExpression` can now match even if predicates declared multiple correlations
- `Compensation` logic was extended to also allow for complicated join-like `Compensation` trees including the compensation of join predicates (aka multi-correlated comparisons)

Note that all of this is necessary to allow `IN-to-UNION` an `IN-to-JOIN` to reason about order better and to allow us to generalize these rules to multiple in clauses and proper order property housekeeping.