### PR TITLE
Resolves #1478: Support properties passing into FDBRecordStore, configured by adopter. Firstly used for Lucene indexing's parameters for compression/encryption.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,7 +24,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Passing properties configured by adopter into FDBRecordContext [(Issue #1478)](https://github.com/FoundationDB/fdb-record-layer/issues/1478)
 * Online Indexer: add time limit to OnlineIndexer.Config [(Issue #1459)](https://github.com/FoundationDB/fdb-record-layer/issues/1459)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -276,7 +276,11 @@ public enum LogMessageKeys {
     FILE_ID("file_id"),
     FILE_NAME("file_name"),
     FILE_REFERENCE("file_reference"),
-    ORIGINAL_DATA_SIZE("original_data-size");
+    ORIGINAL_DATA_SIZE("original_data-size"),
+
+    // Record context properties
+    PROPERTY_NAME("property_name"),
+    PROPERTY_TYPE("property_type");
 
     private final String logKey;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.RecordCoreStorageException;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 import com.apple.foundationdb.record.util.MapUtils;
 import com.apple.foundationdb.system.SystemKeyspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
@@ -160,6 +161,8 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     private long trackOpenTimeNanos;
     @Nonnull
     private final Map<Object, Object> session = new LinkedHashMap<>();
+    @Nonnull
+    private final RecordLayerPropertyStorage propertyStorage;
 
     protected FDBRecordContext(@Nonnull FDBDatabase fdb,
                                @Nonnull Transaction transaction,
@@ -212,6 +215,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         }
 
         this.dirtyStoreState = false;
+        this.propertyStorage = config.getPropertyStorage();
     }
 
     @Nullable
@@ -1386,6 +1390,16 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @API(API.Status.EXPERIMENTAL)
     public synchronized <T> T removeFromSession(@Nonnull String key, @Nonnull Class<T> clazz) {
         return (T) session.remove(key);
+    }
+
+    /**
+     * Get the properties configured by adopter for this FDBRecordContext.
+     *
+     * @return the wrapper of a mapping of the properties
+     */
+    @API(API.Status.EXPERIMENTAL)
+    public RecordLayerPropertyStorage getPropertyStorage() {
+        return propertyStorage;
     }
 
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextConfig.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.TransactionOptions;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,6 +52,8 @@ public class FDBRecordContextConfig {
     private final boolean saveOpenStackTrace;
     @Nullable
     private final TransactionListener listener;
+    @Nonnull
+    private final RecordLayerPropertyStorage propertyStorage;
 
     private FDBRecordContextConfig(@Nonnull Builder builder) {
         this.mdcContext = builder.mdcContext;
@@ -65,6 +68,7 @@ public class FDBRecordContextConfig {
         this.trackOpen = builder.trackOpen;
         this.saveOpenStackTrace = builder.saveOpenStackTrace;
         this.listener = builder.listener;
+        this.propertyStorage = builder.recordContextProperties;
     }
 
     /**
@@ -196,6 +200,16 @@ public class FDBRecordContextConfig {
     }
 
     /**
+     * Get the properties for this context configured by adopter.
+     *
+     * @return a wrapper of the properties mapping
+     */
+    @Nonnull
+    public RecordLayerPropertyStorage getPropertyStorage() {
+        return propertyStorage;
+    }
+
+    /**
      * Convert the current configuration to a builder. This will set all options in the builder to their
      * current values in this configuration object.
      *
@@ -227,6 +241,7 @@ public class FDBRecordContextConfig {
         private boolean trackOpen = false;
         private boolean saveOpenStackTrace = false;
         private TransactionListener listener = null;
+        private RecordLayerPropertyStorage recordContextProperties = RecordLayerPropertyStorage.getEmptyInstance();
 
         private Builder() {
         }
@@ -244,6 +259,7 @@ public class FDBRecordContextConfig {
             this.trackOpen = config.trackOpen;
             this.saveOpenStackTrace = config.saveOpenStackTrace;
             this.listener = config.listener;
+            this.recordContextProperties = config.propertyStorage;
         }
 
         private Builder(@Nonnull Builder config) {
@@ -259,6 +275,7 @@ public class FDBRecordContextConfig {
             this.trackOpen = config.trackOpen;
             this.saveOpenStackTrace = config.saveOpenStackTrace;
             this.listener = config.listener;
+            this.recordContextProperties = config.recordContextProperties;
         }
 
         /**
@@ -556,6 +573,28 @@ public class FDBRecordContextConfig {
 
         public TransactionListener getListener() {
             return listener;
+        }
+
+        /**
+         * Get the properties' wrapper to be used by this context to pass in the parameters configured by adopter.
+         * If no properties specified, this context will use the {@link RecordLayerPropertyStorage#getEmptyInstance()} instance.
+         *
+         * @return the wrapper of the properties
+         */
+        public RecordLayerPropertyStorage getRecordContextProperties() {
+            return recordContextProperties;
+        }
+
+        /**
+         * Set the properties' wrapper to be used by this context to pass in the parameters configured by adopter.
+         * If this method is never called, this context will use the {@link RecordLayerPropertyStorage#getEmptyInstance()} instance.
+         *
+         * @param recordContextProperties the wrapper of properties to be used by this context, configured by adopter
+         * @return this builder
+         */
+        public Builder setRecordContextProperties(@Nonnull final RecordLayerPropertyStorage recordContextProperties) {
+            this.recordContextProperties = recordContextProperties;
+            return this;
         }
 
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyKey.java
@@ -1,0 +1,114 @@
+/*
+ * RecordLayerPropertyKey.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.properties;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * A key for a property that adopter configures for Record Layer.
+ * This is not supposed to be defined by adopter outside Record Layer.
+ * The name, value type, and its default value are defined in this key, which are immutable.
+ * Call {@link #buildValue(Supplier)} with a {@link Supplier} of the value to build a {@link RecordLayerPropertyValue},
+ * to override the value for the property, and then build a {@link RecordLayerPropertyStorage} with the new property value.
+ *
+ * @param <T> the type of the property's value
+ */
+@API(API.Status.EXPERIMENTAL)
+public final class RecordLayerPropertyKey<T> {
+    @Nonnull
+    private final String name;
+    @Nonnull
+    private final T defaultValue;
+    @Nonnull
+    private final Class<T> type;
+
+    private RecordLayerPropertyKey(@Nonnull final String name, @Nonnull T defaultValue, @Nonnull Class<T> type) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.type = type;
+    }
+
+    /**
+     * The name for each property needs to be unique and in a reverse FQDN format according to the package it is located.
+     *
+     * @return the name of this property
+     */
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    @Nonnull
+    public Class<T> getType() {
+        return type;
+    }
+
+    @Nonnull
+    public T getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Nonnull
+    public RecordLayerPropertyValue<T> buildValue(@Nonnull Supplier<T> valueSupplier) {
+        return new RecordLayerPropertyValue<>(this, valueSupplier);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (other.getClass() != this.getClass()) {
+            return false;
+        }
+        RecordLayerPropertyKey<?> otherKey = (RecordLayerPropertyKey<?>) other;
+        return this.name.equals(otherKey.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+
+    public static RecordLayerPropertyKey<Boolean> booleanPropertyKey(@Nonnull final String name, @Nonnull final boolean defaultValue) {
+        return new RecordLayerPropertyKey<>(name, defaultValue, Boolean.class);
+    }
+
+    public static RecordLayerPropertyKey<String> stringPropertyKey(@Nonnull final String name, @Nonnull final String defaultValue) {
+        return new RecordLayerPropertyKey<>(name, defaultValue, String.class);
+    }
+
+    public static RecordLayerPropertyKey<Integer> integerPropertyKey(@Nonnull final String name, @Nonnull final int defaultValue) {
+        return new RecordLayerPropertyKey<>(name, defaultValue, Integer.class);
+    }
+
+    public static RecordLayerPropertyKey<Long> longPropertyKey(@Nonnull final String name, @Nonnull final long defaultValue) {
+        return new RecordLayerPropertyKey<>(name, defaultValue, Long.class);
+    }
+
+    public static RecordLayerPropertyKey<Double> doublePropertyKey(@Nonnull final String name, @Nonnull final double defaultValue) {
+        return new RecordLayerPropertyKey<>(name, defaultValue, Double.class);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyStorage.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyStorage.java
@@ -1,0 +1,116 @@
+/*
+ * RecordLayerPropertyStorage.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.properties;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Adopter can use this mapping of {@link RecordLayerPropertyKey}s to {@link RecordLayerPropertyValue}s to configure Record Layer parameters.
+ * The instances of {@link RecordLayerPropertyKey} and how they are used are defined in Record Layer.
+ * Adopters can populate {@link RecordLayerPropertyValue} and put them into this storage.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class RecordLayerPropertyStorage {
+    private static final RecordLayerPropertyStorage EMPTY_PROPERTY_STORAGE = new RecordLayerPropertyStorage(ImmutableMap.of());
+
+    @Nonnull
+    private final ImmutableMap<RecordLayerPropertyKey<?>, RecordLayerPropertyValue<?>> propertyMap;
+
+    private RecordLayerPropertyStorage(@Nonnull ImmutableMap<RecordLayerPropertyKey<?>, RecordLayerPropertyValue<?>> propertyMap) {
+        this.propertyMap = propertyMap;
+    }
+
+    @Nonnull
+    public ImmutableMap<RecordLayerPropertyKey<?>, RecordLayerPropertyValue<?>> getPropertyMap() {
+        return propertyMap;
+    }
+
+    @Nonnull
+    public <T> T getPropertyValue(@Nonnull RecordLayerPropertyKey<T> propertyKey) {
+        if (propertyMap.containsKey(propertyKey)) {
+            Object value = propertyMap.get(propertyKey).getValue();
+            try {
+                return propertyKey.getType().cast(value);
+            } catch (ClassCastException ex) {
+                throw new RecordCoreException("Invalid type for record context property", ex)
+                        .addLogInfo(LogMessageKeys.PROPERTY_NAME, propertyKey.getName(),
+                                LogMessageKeys.PROPERTY_TYPE, value.getClass().getName());
+            }
+        } else {
+            return propertyKey.getDefaultValue();
+        }
+    }
+
+    @Nonnull
+    public Builder toBuilder() {
+        return new Builder(propertyMap);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static RecordLayerPropertyStorage getEmptyInstance() {
+        return EMPTY_PROPERTY_STORAGE;
+    }
+
+    public static class Builder {
+        private final Map<RecordLayerPropertyKey<?>, RecordLayerPropertyValue<?>> propertyMap;
+
+        private Builder() {
+            this.propertyMap = new HashMap<>();
+        }
+
+        private Builder(ImmutableMap<RecordLayerPropertyKey<?>, RecordLayerPropertyValue<?>> properties) {
+            this.propertyMap = new HashMap<>(properties);
+        }
+
+        public <T> Builder addProp(@Nonnull RecordLayerPropertyValue<T> propValue) {
+            if (this.propertyMap.putIfAbsent(propValue.getKey(), propValue) != null) {
+                throw new RecordCoreException("Duplicate property name is added")
+                        .addLogInfo(LogMessageKeys.PROPERTY_NAME, propValue.getKey().getName());
+            }
+            return this;
+        }
+
+        public <T> Builder addProp(@Nonnull RecordLayerPropertyKey<T> propKey, @Nonnull Supplier<T> valueSupplier) {
+            final RecordLayerPropertyValue<T> propValue = propKey.buildValue(valueSupplier);
+            return this.addProp(propValue);
+        }
+
+        public <T> Builder addProp(@Nonnull RecordLayerPropertyKey<T> propKey, @Nonnull T value) {
+            final RecordLayerPropertyValue<T> propValue = propKey.buildValue(() -> value);
+            return this.addProp(propValue);
+        }
+
+        public RecordLayerPropertyStorage build() {
+            return new RecordLayerPropertyStorage(ImmutableMap.copyOf(propertyMap));
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyStorage.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyStorage.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -51,7 +52,7 @@ public class RecordLayerPropertyStorage {
         return propertyMap;
     }
 
-    @Nonnull
+    @Nullable
     public <T> T getPropertyValue(@Nonnull RecordLayerPropertyKey<T> propertyKey) {
         if (propertyMap.containsKey(propertyKey)) {
             Object value = propertyMap.get(propertyKey).getValue();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyValue.java
@@ -54,16 +54,12 @@ public final class RecordLayerPropertyValue<T> {
         return key;
     }
 
-    @Nonnull
+    @Nullable
     public T getValue() {
         final T defaultValue = key.getDefaultValue();
         if (valueSupplier == null) {
             return defaultValue;
         }
-        T value = valueSupplier.get();
-        if (value == null) {
-            return defaultValue;
-        }
-        return value;
+        return valueSupplier.get();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyValue.java
@@ -1,0 +1,69 @@
+/*
+ * RecordLayerPropertyValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.properties;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * A value and its associated {@link RecordLayerPropertyKey} for a property that adopter configures for Record Layer.
+ * Adopters can populate this value with providing a {@link #valueSupplier}.
+ * The {@link #key} and its name, type and default value are supposed to completely defined by Record Layer.
+ * The value is lazily loaded from the supplier when the property is read.
+ * If no supplier is provided, a default value is used.
+ * If the default value defined by Record Layer is supposed to be used, no need to put it into {@link RecordLayerPropertyStorage},
+ * Record Layer can automatically read its default one.
+ *
+ * @param <T> the type of the property's value
+ */
+@API(API.Status.EXPERIMENTAL)
+public final class RecordLayerPropertyValue<T> {
+    @Nonnull
+    private final RecordLayerPropertyKey<T> key;
+    @Nullable
+    private final Supplier<T> valueSupplier;
+
+    RecordLayerPropertyValue(@Nonnull RecordLayerPropertyKey<T> key, @Nullable Supplier<T> valueSupplier) {
+        this.key = key;
+        this.valueSupplier = valueSupplier;
+    }
+
+    @Nonnull
+    public RecordLayerPropertyKey<T> getKey() {
+        return key;
+    }
+
+    @Nonnull
+    public T getValue() {
+        final T defaultValue = key.getDefaultValue();
+        if (valueSupplier == null) {
+            return defaultValue;
+        }
+        T value = valueSupplier.get();
+        if (value == null) {
+            return defaultValue;
+        }
+        return value;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes for a property mechanism that supports server-side configuration for Record Layer by its adopter.
+ */
+package com.apple.foundationdb.record.provider.foundationdb.properties;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyTest.java
@@ -1,0 +1,65 @@
+/*
+ * RecordLayerPropertyTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.properties;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RecordLayerPropertyTest {
+    @Test
+    void testDefaultPropertyValue() {
+        final RecordLayerPropertyKey<Boolean> propertyKey = getTestPropertyKey();
+        // Build the property storage without configuring the prop with a value supplier
+        final RecordLayerPropertyStorage properties = RecordLayerPropertyStorage.newBuilder()
+                .build();
+        // Assert the prop value is returned as default value false
+        Assertions.assertEquals(false, properties.getPropertyValue(propertyKey), "Unexpected prop value");
+    }
+
+    @Test
+    void testPropertyValueFromSupplier() {
+        final RecordLayerPropertyKey<Boolean> propertyKey = getTestPropertyKey();
+        // Build the property storage with configuring the prop with a value supplier
+        final RecordLayerPropertyStorage properties = RecordLayerPropertyStorage.newBuilder()
+                .addProp(propertyKey, true)
+                .build();
+        // Assert the prop value is returned from supplier as true
+        Assertions.assertEquals(true, properties.getPropertyValue(propertyKey), "Unexpected prop value");
+    }
+
+    @Test
+    void testInvalidPropType() {
+        final RecordLayerPropertyKey<Boolean> propertyKey = getTestPropertyKey();
+        final String propName = propertyKey.getName();
+        // Build the property storage with the boolean prop using a String type value
+        final RecordLayerPropertyStorage properties = RecordLayerPropertyStorage.newBuilder()
+                .addProp(RecordLayerPropertyKey.stringPropertyKey(propName, "invalidStringForBooleanProp"), "invalidStringForBooleanProp")
+                .build();
+        // Assert exception is thrown due to casting a String to Boolean
+        Assertions.assertThrows(RecordCoreException.class,
+                () -> properties.getPropertyValue(propertyKey), "A class cast exception from putting a string in a boolean property is expected");
+    }
+
+    private static RecordLayerPropertyKey<Boolean> getTestPropertyKey() {
+        return RecordLayerPropertyKey.booleanPropertyKey("testProp", false);
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyTest.java
@@ -24,6 +24,8 @@ import com.apple.foundationdb.record.RecordCoreException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Objects;
+
 public class RecordLayerPropertyTest {
     @Test
     void testDefaultPropertyValue() {
@@ -32,7 +34,7 @@ public class RecordLayerPropertyTest {
         final RecordLayerPropertyStorage properties = RecordLayerPropertyStorage.newBuilder()
                 .build();
         // Assert the prop value is returned as default value false
-        Assertions.assertEquals(false, properties.getPropertyValue(propertyKey), "Unexpected prop value");
+        Assertions.assertEquals(false, Objects.requireNonNull(properties.getPropertyValue(propertyKey)), "Unexpected prop value");
     }
 
     @Test
@@ -43,7 +45,7 @@ public class RecordLayerPropertyTest {
                 .addProp(propertyKey, true)
                 .build();
         // Assert the prop value is returned from supplier as true
-        Assertions.assertEquals(true, properties.getPropertyValue(propertyKey), "Unexpected prop value");
+        Assertions.assertEquals(true, Objects.requireNonNull(properties.getPropertyValue(propertyKey)), "Unexpected prop value");
     }
 
     @Test
@@ -56,7 +58,7 @@ public class RecordLayerPropertyTest {
                 .build();
         // Assert exception is thrown due to casting a String to Boolean
         Assertions.assertThrows(RecordCoreException.class,
-                () -> properties.getPropertyValue(propertyKey), "A class cast exception from putting a string in a boolean property is expected");
+                () -> Objects.requireNonNull(properties.getPropertyValue(propertyKey)), "A class cast exception from putting a string in a boolean property is expected");
     }
 
     private static RecordLayerPropertyKey<Boolean> getTestPropertyKey() {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -1,0 +1,45 @@
+/*
+ * LuceneRecordContextProperties.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyKey;
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
+
+import java.util.function.Supplier;
+
+/**
+ * The list of {@link RecordLayerPropertyKey} for configuration of the lucene indexing for a {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext}.
+ */
+public final class LuceneRecordContextProperties {
+    /**
+     * A defined {@link RecordLayerPropertyKey} for Boolean type to control whether the compression of lucene index is enabled.
+     * It is used as a key to get the property value from {@link RecordLayerPropertyStorage#getPropertyValue(RecordLayerPropertyKey)}.
+     * Call {@link RecordLayerPropertyKey#buildValue(Supplier)} with a supplier if you want to override this property with a value other than default.
+     */
+    public static final RecordLayerPropertyKey<Boolean> LUCENE_INDEX_COMPRESSION_ENABLED = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.compressionEnabled", false);
+
+    /**
+     * A defined {@link RecordLayerPropertyKey} for Boolean type to control whether the encryption of lucene index is enabled.
+     * It is used as a key to get the property value from {@link RecordLayerPropertyStorage#getPropertyValue(RecordLayerPropertyKey)}.
+     * Call {@link RecordLayerPropertyKey#buildValue(Supplier)} with a supplier if you want to override this property with a value other than default.
+     */
+    public static final RecordLayerPropertyKey<Boolean> LUCENE_INDEX_ENCRYPTION_ENABLED = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.encryptionEnabled", false);
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.logging.CompletionExceptionLogHelper;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
@@ -104,6 +105,9 @@ public class FDBDirectory extends Directory {
     private final Cache<String, FDBLuceneFileReference> fileReferenceCache;
     private final Cache<Pair<Long, Integer>, CompletableFuture<byte[]>> blockCache;
 
+    private final boolean compressionEnabled;
+    private final boolean encryptionEnabled;
+
     public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context) {
         this(subspace, context, NoLockFactory.INSTANCE);
     }
@@ -112,7 +116,8 @@ public class FDBDirectory extends Directory {
         this(subspace, context, lockFactory, DEFAULT_BLOCK_SIZE, DEFAULT_INITIAL_CAPACITY, DEFAULT_MAXIMUM_SIZE, DEFAULT_CONCURRENCY_LEVEL);
     }
 
-    FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context, @Nonnull LockFactory lockFactory, int blockSize, final int initialCapacity, final int maximumSize, final int concurrencyLevel) {
+    FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context, @Nonnull LockFactory lockFactory,
+                 int blockSize, final int initialCapacity, final int maximumSize, final int concurrencyLevel) {
         Verify.verify(subspace != null);
         Verify.verify(context != null);
         Verify.verify(lockFactory != null);
@@ -135,6 +140,8 @@ public class FDBDirectory extends Directory {
                 .maximumSize(maximumSize)
                 .recordStats()
                 .build();
+        this.compressionEnabled = context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED);
+        this.encryptionEnabled = context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED);
     }
 
     /**
@@ -249,7 +256,7 @@ public class FDBDirectory extends Directory {
             }
         }
         final byte[] fileReferenceBytes = reference.getBytes();
-        final byte[] encodedBytes = LuceneSerializer.encode(reference.getBytes(), true, false);
+        final byte[] encodedBytes = LuceneSerializer.encode(reference.getBytes(), compressionEnabled, encryptionEnabled);
         increment(FDBStoreTimer.Counts.LUCENE_WRITE_FILE_REFERENCE_SIZE, encodedBytes.length);
         increment(FDBStoreTimer.Counts.LUCENE_WRITE_FILE_REFERENCE_CALL);
         if (LOGGER.isTraceEnabled()) {
@@ -270,7 +277,7 @@ public class FDBDirectory extends Directory {
      * @param value the data to be stored
      */
     public void writeData(long id, int block, @Nonnull byte[] value) {
-        final byte[] encodedBytes = LuceneSerializer.encode(value, true, false);
+        final byte[] encodedBytes = LuceneSerializer.encode(value, compressionEnabled, encryptionEnabled);
         //This may not be correct transactionally
         increment(FDBStoreTimer.Counts.LUCENE_WRITE_SIZE, encodedBytes.length);
         increment(FDBStoreTimer.Counts.LUCENE_WRITE_CALL);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -140,8 +141,8 @@ public class FDBDirectory extends Directory {
                 .maximumSize(maximumSize)
                 .recordStats()
                 .build();
-        this.compressionEnabled = context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED);
-        this.encryptionEnabled = context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED);
+        this.compressionEnabled = Objects.requireNonNullElse(context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED), false);
+        this.encryptionEnabled = Objects.requireNonNullElse(context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED), false);
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
@@ -20,11 +20,15 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
+import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTransactionPriority;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 import com.apple.foundationdb.subspace.Subspace;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -54,8 +58,16 @@ public abstract class FDBDirectoryBaseTest {
             context.ensureActive().clear(subspace.range());
             return null;
         });
-        FDBRecordContext context = fdb.openContext(null,timer);
+        FDBRecordContext context = fdb.openContext(getContextConfig());
         directory = new FDBDirectory(subspace, context);
+    }
+
+    private FDBRecordContextConfig getContextConfig() {
+        return FDBRecordContextConfig.newBuilder()
+                .setTimer(timer)
+                .setPriority(FDBTransactionPriority.DEFAULT)
+                .setRecordContextProperties(RecordLayerPropertyStorage.newBuilder().addProp(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED, true).build())
+                .build();
     }
 
     protected int randomInt(int minimum) {


### PR DESCRIPTION
…dopter, and use it to pass in the config for compression/encryption for lucene index