### PR TITLE
Resolves #1494: Update log4j version to avoid RCE vulnerability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ jsr305Version=3.0.2
 slf4jVersion=1.7.30
 commonsLang3Version=3.12.0
 commonsMath3Version=3.6.1
-log4jVersion=2.14.1
+log4jVersion=2.16.0
 guavaVersion=30.1-jre
 hamcrestVersion=2.2
 # AutoService kept on 1.0-rc6 to avoid annotation being retained in CLASS. See: https://github.com/FoundationDB/fdb-record-layer/issues/1281


### PR DESCRIPTION
This updates the version of log4j used by our tests and example code to 2.16.0, which removes the JNDI logic and thus patches the RCE vulnerability. As noted in the issue, the main library only exposes slf4j, so an adopter is only vulnerable if they are using the log4j logging implementation with a vulnerable version, but our own tests and example logic were technically vulnerable, though neither exposed remote endpoints.

This resolves #1494.