### PR TITLE
Resolves #1518: Remove ExecutorService from LuceneScanProperties

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/properties/RecordLayerPropertyKey.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb.properties;
 import com.apple.foundationdb.annotation.API;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -39,12 +40,12 @@ import java.util.function.Supplier;
 public final class RecordLayerPropertyKey<T> {
     @Nonnull
     private final String name;
-    @Nonnull
+    @Nullable
     private final T defaultValue;
     @Nonnull
     private final Class<T> type;
 
-    private RecordLayerPropertyKey(@Nonnull final String name, @Nonnull T defaultValue, @Nonnull Class<T> type) {
+    public RecordLayerPropertyKey(@Nonnull final String name, @Nullable T defaultValue, @Nonnull Class<T> type) {
         this.name = name;
         this.defaultValue = defaultValue;
         this.type = type;
@@ -65,7 +66,7 @@ public final class RecordLayerPropertyKey<T> {
         return type;
     }
 
-    @Nonnull
+    @Nullable
     public T getDefaultValue() {
         return defaultValue;
     }
@@ -92,7 +93,7 @@ public final class RecordLayerPropertyKey<T> {
         return Objects.hashCode(name);
     }
 
-    public static RecordLayerPropertyKey<Boolean> booleanPropertyKey(@Nonnull final String name, @Nonnull final boolean defaultValue) {
+    public static RecordLayerPropertyKey<Boolean> booleanPropertyKey(@Nonnull final String name, final boolean defaultValue) {
         return new RecordLayerPropertyKey<>(name, defaultValue, Boolean.class);
     }
 
@@ -100,15 +101,15 @@ public final class RecordLayerPropertyKey<T> {
         return new RecordLayerPropertyKey<>(name, defaultValue, String.class);
     }
 
-    public static RecordLayerPropertyKey<Integer> integerPropertyKey(@Nonnull final String name, @Nonnull final int defaultValue) {
+    public static RecordLayerPropertyKey<Integer> integerPropertyKey(@Nonnull final String name, final int defaultValue) {
         return new RecordLayerPropertyKey<>(name, defaultValue, Integer.class);
     }
 
-    public static RecordLayerPropertyKey<Long> longPropertyKey(@Nonnull final String name, @Nonnull final long defaultValue) {
+    public static RecordLayerPropertyKey<Long> longPropertyKey(@Nonnull final String name, final long defaultValue) {
         return new RecordLayerPropertyKey<>(name, defaultValue, Long.class);
     }
 
-    public static RecordLayerPropertyKey<Double> doublePropertyKey(@Nonnull final String name, @Nonnull final double defaultValue) {
+    public static RecordLayerPropertyKey<Double> doublePropertyKey(@Nonnull final String name, final double defaultValue) {
         return new RecordLayerPropertyKey<>(name, defaultValue, Double.class);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -106,13 +106,16 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
     }
 
     public FDBRecordContext openContext() {
-        final FDBRecordContextConfig config = FDBRecordContextConfig.newBuilder()
+        final FDBRecordContextConfig config = contextConfig().build();
+        return fdb.openContext(config);
+    }
+
+    protected FDBRecordContextConfig.Builder contextConfig() {
+        return FDBRecordContextConfig.newBuilder()
                 .setTimer(timer)
                 .setMdcContext(ImmutableMap.of("uuid", UUID.randomUUID().toString()))
                 .setTrackOpen(true)
-                .setSaveOpenStackTrace(true)
-                .build();
-        return fdb.openContext(config);
+                .setSaveOpenStackTrace(true);
     }
 
     @BeforeEach

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -158,7 +158,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                 parser = new QueryParser(PRIMARY_KEY_SEARCH_NAME, queryAnalyzer);
             }
             Query query = parser.parse(range.getLow().getString(0));
-            return new LuceneRecordCursor(executor, scanProperties, state, query, continuation,
+            return new LuceneRecordCursor(executor, state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_EXECUTOR_SERVICE),
+                    scanProperties, state, query, continuation,
                     state.index.getRootExpression().normalizeKeyForPositions(), Tuple.fromStream(range.getLow().stream().skip(1)));
         } catch (Exception ioe) {
             throw new RecordCoreArgumentException("Unable to parse range given for query", "range", range,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -49,7 +49,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 
 /**
  * A planner to implement lucene query planning so that we can isolate the lucene functionality to
@@ -58,11 +57,8 @@ import java.util.concurrent.ExecutorService;
  */
 public class LucenePlanner extends RecordQueryPlanner {
 
-    private ExecutorService service;
-
-    public LucenePlanner(@Nonnull final RecordMetaData metaData, @Nonnull final RecordStoreState recordStoreState, final PlannableIndexTypes indexTypes, final FDBStoreTimer timer, @Nullable final ExecutorService service) {
+    public LucenePlanner(@Nonnull final RecordMetaData metaData, @Nonnull final RecordStoreState recordStoreState, final PlannableIndexTypes indexTypes, final FDBStoreTimer timer) {
         super(metaData, recordStoreState, indexTypes, timer);
-        this.service = service;
     }
 
     private LuceneIndexQueryPlan getScanForFieldWithComparison(@Nonnull Index index, @Nullable String parentFieldName, @Nonnull FieldWithComparison filter,
@@ -111,7 +107,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         if (filterSatisfiedMask != null) {
             filterSatisfiedMask.setSatisfied(true);
         }
-        return new LuceneIndexQueryPlan(index.getName(), luceneComparison, false, groupingComparisons, this.service);
+        return new LuceneIndexQueryPlan(index.getName(), luceneComparison, false, groupingComparisons);
     }
 
     private LuceneIndexQueryPlan getScanForLuceneComponent(@Nonnull Index index, @Nonnull LuceneQueryComponent filter,
@@ -134,12 +130,12 @@ public class LucenePlanner extends RecordQueryPlanner {
         }
 
         if (comparison.getType().equals(Comparisons.Type.FULL_TEXT_LUCENE_AUTO_COMPLETE)) {
-            return new LuceneIndexQueryPlan(index.getName(), IndexScanType.BY_LUCENE_AUTO_COMPLETE, comparison, false, null, groupingComparisons, this.service);
+            return new LuceneIndexQueryPlan(index.getName(), IndexScanType.BY_LUCENE_AUTO_COMPLETE, comparison, false, null, groupingComparisons);
         }
         if (filter.multiFieldSearch) {
-            return new LuceneIndexQueryPlan(index.getName(), IndexScanType.BY_LUCENE_FULL_TEXT, comparison, false, null, groupingComparisons, this.service);
+            return new LuceneIndexQueryPlan(index.getName(), IndexScanType.BY_LUCENE_FULL_TEXT, comparison, false, null, groupingComparisons);
         }
-        return new LuceneIndexQueryPlan(index.getName(), IndexScanType.BY_LUCENE, comparison, false, null, groupingComparisons, this.service);
+        return new LuceneIndexQueryPlan(index.getName(), IndexScanType.BY_LUCENE, comparison, false, null, groupingComparisons);
     }
 
     private LuceneIndexQueryPlan getScanForAndLucene(@Nonnull Index index, @Nullable String parentFieldName, @Nonnull AndComponent filter,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyKey;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 
+import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
 /**
@@ -58,4 +59,9 @@ public final class LuceneRecordContextProperties {
      * Call {@link RecordLayerPropertyKey#buildValue(Supplier)} with a supplier if you want to override this property with a value other than default.
      */
     public static final RecordLayerPropertyKey<Long> LUCENE_AUTO_COMPLETE_DEFAULT_WEIGHT = RecordLayerPropertyKey.longPropertyKey("com.apple.foundationdb.record.lucene.autoCompleteDefaultWeight", 100L);
+
+    /**
+     * An {@link ExecutorService} to use for parallel execution in {@link LuceneRecordCursor}.
+     */
+    public static final RecordLayerPropertyKey<ExecutorService> LUCENE_EXECUTOR_SERVICE = new RecordLayerPropertyKey<>("com.apple.foundationdb.record.lucene.executorService", null, ExecutorService.class);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanProperties.java
@@ -26,27 +26,17 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.concurrent.ExecutorService;
 
 /**
- * A light wrapper class that supports passing through a designated executor service and sort expression
- * to the LuceneRecordCursor. Due to the recordCursor being wrapped by the store timer
- * instrumentation method the two need to be passed through.
+ * A light wrapper class that supports passing through a sort expression to the LuceneRecordCursor.
  */
 public class LuceneScanProperties extends ScanProperties {
 
     private final KeyExpression sort;
-    private final ExecutorService service;
 
-    public LuceneScanProperties(@Nonnull final ExecuteProperties executeProperties, @Nullable KeyExpression sort,
-                                @Nullable ExecutorService service, boolean reverse) {
+    public LuceneScanProperties(@Nonnull final ExecuteProperties executeProperties, @Nullable KeyExpression sort, boolean reverse) {
         super(executeProperties, reverse);
         this.sort = sort;
-        this.service = service;
-    }
-
-    public ExecutorService getService() {
-        return service;
     }
 
     public KeyExpression getSort() {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -73,7 +73,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -243,14 +242,9 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Override
-    public FDBRecordContext openContext() {
-        final FDBRecordContextConfig config = FDBRecordContextConfig.newBuilder()
-                .setTimer(timer)
-                .setMdcContext(ImmutableMap.of("uuid", UUID.randomUUID().toString()))
-                .setSaveOpenStackTrace(true)
-                .setRecordContextProperties(RecordLayerPropertyStorage.newBuilder().addProp(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED, true).build())
-                .build();
-        return fdb.openContext(config);
+    protected FDBRecordContextConfig.Builder contextConfig() {
+        return super.contextConfig()
+                .setRecordContextProperties(RecordLayerPropertyStorage.newBuilder().addProp(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED, true).build());
     }
 
     @Test

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
@@ -87,7 +87,7 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
                 );
             }
 
-            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer(), null);
+            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
         }
     }
 


### PR DESCRIPTION
Callers will need to be updated to set the context property instead of passing it into the planner constructor.

Note how this changes the property system to allow null default (and therefore actual) values. If that's not desirable, another layer of object could be added.