### PR TITLE
Resolves #1520: Expose IndexQueryabilityFilter for Aggregate planning

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,11 +25,15 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Expose IndexQueryabilityFilter for Aggregate planning [(Issue #1520)](https://github.com/FoundationDB/fdb-record-layer/issues/1520)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** As part of [(Issue #1520)](https://github.com/FoundationDB/fdb-record-layer/issues/1520) implementers
+of `FDBRecordStoreBase` need to implement a new overload of `getSnapshotRecordCountForRecordType` and `evaluateAggregateFunction`
+that takes an `IndexQueryabilityFilter`. In addition some methods on `IndexFunctionHelper` and `ComposedBitmapIndexAggregate`
+now take an `IndexQueryabilityFilter`; to preserve backwards compatibility, if all indexes are valid,
+`IndexQueryabilityFilter.TRUE` can be used.
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1610,7 +1610,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     @Override
-    public CompletableFuture<Long> getSnapshotRecordCount(@Nonnull KeyExpression key, @Nonnull Key.Evaluated value) {
+    public CompletableFuture<Long> getSnapshotRecordCount(@Nonnull KeyExpression key, @Nonnull Key.Evaluated value,
+                                                          @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
         if (getRecordMetaData().getRecordCountKey() != null) {
             if (key.getColumnSize() != value.size()) {
                 throw recordCoreException("key and value are not the same size");
@@ -1624,7 +1625,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 return MoreAsyncUtil.reduce(getExecutor(), kvs.iterator(), 0L, (count, kv) -> count + decodeRecordCount(kv.getValue()));
             }
         }
-        return evaluateAggregateFunction(Collections.emptyList(), IndexFunctionHelper.count(key), value, IsolationLevel.SNAPSHOT)
+        return evaluateAggregateFunction(Collections.emptyList(), IndexFunctionHelper.count(key),
+                TupleRange.allOf(value.toTuple()), IsolationLevel.SNAPSHOT, indexQueryabilityFilter)
                 .thenApply(tuple -> tuple.getLong(0));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1423,9 +1423,10 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
     /**
      * Get the number of records in the record store of the given record type.
      *
-     * The record type must have a {@code COUNT} index defined for it.
+     * The record type must have a readable {@code COUNT} index defined for it, that is not excluded by the
+     * {@code indexQueryabilityFilter}.
      * @param recordTypeName record type for which to count records
-     * @param indexQueryabilityFilter a filter to restrict which indexes can be used when planning
+     * @param indexQueryabilityFilter a filter to restrict which indexes can be used when planning.
      * @return a future that will complete to the number of records
      */
     @Nonnull
@@ -1579,7 +1580,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
      * @param range the range of records (group) for which to evaluate
      * @param isolationLevel whether to use snapshot reads
      * @param indexQueryabilityFilter a filter to restrict which indexes can be used when planning. This will not be
-     * consulted if the aggregateFunction already has an index
+     * consulted if the aggregateFunction already has a readable index
      * @return a future that will complete with the result of evaluating the aggregate
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -225,12 +225,6 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
-    public CompletableFuture<Long> getSnapshotRecordCountForRecordType(@Nonnull String recordTypeName) {
-        return untypedStore.getSnapshotRecordCountForRecordType(recordTypeName);
-    }
-
-    @Nonnull
-    @Override
     public CompletableFuture<Long> getSnapshotRecordCountForRecordType(@Nonnull String recordTypeName,
                                                                        @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
         return untypedStore.getSnapshotRecordCountForRecordType(recordTypeName, indexQueryabilityFilter);
@@ -246,15 +240,6 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
     @Override
     public <T> CompletableFuture<T> evaluateStoreFunction(@Nonnull EvaluationContext evaluationContext, @Nonnull StoreRecordFunction<T> function, @Nonnull FDBRecord<M> rec) {
         return untypedStore.evaluateTypedStoreFunction(evaluationContext, function, rec);
-    }
-
-    @Nonnull
-    @Override
-    public CompletableFuture<Tuple> evaluateAggregateFunction(@Nonnull List<String> recordTypeNames,
-                                                              @Nonnull IndexAggregateFunction aggregateFunction,
-                                                              @Nonnull TupleRange range,
-                                                              @Nonnull IsolationLevel isolationLevel) {
-        return untypedStore.evaluateAggregateFunction(recordTypeNames, aggregateFunction, range, isolationLevel);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -219,8 +219,9 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
-    public CompletableFuture<Long> getSnapshotRecordCount(@Nonnull KeyExpression key, @Nonnull Key.Evaluated value) {
-        return untypedStore.getSnapshotRecordCount(key, value);
+    public CompletableFuture<Long> getSnapshotRecordCount(@Nonnull KeyExpression key, @Nonnull Key.Evaluated value,
+                                                          @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
+        return untypedStore.getSnapshotRecordCount(key, value, indexQueryabilityFilter);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -45,6 +45,7 @@ import com.apple.foundationdb.record.provider.common.RecordSerializer;
 import com.apple.foundationdb.record.provider.common.TypedRecordSerializer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.storestate.FDBRecordStoreStateCache;
+import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
@@ -230,6 +231,13 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
+    public CompletableFuture<Long> getSnapshotRecordCountForRecordType(@Nonnull String recordTypeName,
+                                                                       @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
+        return untypedStore.getSnapshotRecordCountForRecordType(recordTypeName, indexQueryabilityFilter);
+    }
+
+    @Nonnull
+    @Override
     public <T> CompletableFuture<T> evaluateIndexRecordFunction(@Nonnull EvaluationContext evaluationContext, @Nonnull IndexRecordFunction<T> function, @Nonnull FDBRecord<M> rec) {
         return untypedStore.evaluateTypedIndexRecordFunction(evaluationContext, function, rec);
     }
@@ -242,8 +250,22 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
-    public CompletableFuture<Tuple> evaluateAggregateFunction(@Nonnull List<String> recordTypeNames, @Nonnull IndexAggregateFunction aggregateFunction, @Nonnull TupleRange range, @Nonnull IsolationLevel isolationLevel) {
+    public CompletableFuture<Tuple> evaluateAggregateFunction(@Nonnull List<String> recordTypeNames,
+                                                              @Nonnull IndexAggregateFunction aggregateFunction,
+                                                              @Nonnull TupleRange range,
+                                                              @Nonnull IsolationLevel isolationLevel) {
         return untypedStore.evaluateAggregateFunction(recordTypeNames, aggregateFunction, range, isolationLevel);
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<Tuple> evaluateAggregateFunction(@Nonnull List<String> recordTypeNames,
+                                                              @Nonnull IndexAggregateFunction aggregateFunction,
+                                                              @Nonnull TupleRange range,
+                                                              @Nonnull IsolationLevel isolationLevel,
+                                                              @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
+        return untypedStore.evaluateAggregateFunction(recordTypeNames, aggregateFunction, range, isolationLevel,
+                indexQueryabilityFilter);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.IndexAggregateGroupKeys;
 import com.apple.foundationdb.record.provider.foundationdb.IndexFunctionHelper;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.BitmapValueIndexMaintainer;
+import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.QueryToKeyMatcher;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.AndOrComponent;
@@ -95,16 +96,19 @@ public class ComposedBitmapIndexAggregate {
      * @param planner a query planner to use to construct the plans
      * @param query a query providing target record type, filter, and required fields
      * @param indexAggregateFunctionCall the function call giving the desired position and grouping
+     * @param indexQueryabilityFilter a filter to restrict which indexes can be used when planning
      * @return an {@code Optional} query plan or {@code Optional.empty} if planning is not possible
      */
     @Nonnull
     public static Optional<RecordQueryPlan> tryPlan(@Nonnull RecordQueryPlanner planner,
                                                     @Nonnull RecordQuery query,
-                                                    @Nonnull IndexAggregateFunctionCall indexAggregateFunctionCall) {
+                                                    @Nonnull IndexAggregateFunctionCall indexAggregateFunctionCall,
+                                                    @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
         if (query.getFilter() == null || query.getSort() != null) {
             return Optional.empty();
         }
-        return tryBuild(planner, query.getRecordTypes(), indexAggregateFunctionCall, query.getFilter())
+        return tryBuild(
+                planner, query.getRecordTypes(), indexAggregateFunctionCall, query.getFilter(), indexQueryabilityFilter)
                 .flatMap(p -> p.tryPlan(planner, query.toBuilder()));
     }
 
@@ -147,13 +151,15 @@ public class ComposedBitmapIndexAggregate {
      * @param recordTypeNames the record types on which the indexes are defined
      * @param indexAggregateFunctionCall the function giving the desired position and grouping
      * @param filter conditions on the groups and position
+     * @param indexQueryabilityFilter a filter to restrict which indexes can be used when planning
      * @return an {@code Optional} composed bitmap or {@code Optional.empty} if there conditions could not be satisfied
      */
     @Nonnull
     public static Optional<ComposedBitmapIndexAggregate> tryBuild(@Nonnull QueryPlanner planner,
                                                                   @Nonnull Collection<String> recordTypeNames,
                                                                   @Nonnull IndexAggregateFunctionCall indexAggregateFunctionCall,
-                                                                  @Nonnull QueryComponent filter) {
+                                                                  @Nonnull QueryComponent filter,
+                                                                  @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
         // The filters that are common to all the composed index queries.
         // They can be equality conditions on the common group prefix (as specified by indexAggregateFunctionCall)
         // or inequalities on the position.
@@ -166,7 +172,8 @@ public class ComposedBitmapIndexAggregate {
             return Optional.empty();
         }
         Builder builder = new Builder(planner, recordTypeNames, commonFilters, indexAggregateFunctionCall);
-        return builder.tryBuild(indexFilters.size() > 1 ? Query.and(indexFilters) : indexFilters.get(0))
+        return builder.tryBuild(indexFilters.size() > 1 ? Query.and(indexFilters) : indexFilters.get(0),
+                        indexQueryabilityFilter)
             .map(ComposedBitmapIndexAggregate::new);
     }
 
@@ -300,15 +307,16 @@ public class ComposedBitmapIndexAggregate {
         }
 
         @Nonnull
-        Optional<Node> tryBuild(@Nonnull QueryComponent indexFilter) {
+        Optional<Node> tryBuild(@Nonnull QueryComponent indexFilter,
+                                @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
             if (indexFilter instanceof ComponentWithComparison) {
-                return indexScan(indexFilter);
+                return indexScan(indexFilter, indexQueryabilityFilter);
             }
             if (indexFilter instanceof AndOrComponent) {
                 final AndOrComponent andOrComponent = (AndOrComponent) indexFilter;
                 List<Node> childNodes = new ArrayList<>(andOrComponent.getChildren().size());
                 for (QueryComponent child : andOrComponent.getChildren()) {
-                    Optional<Node> childNode = tryBuild(child);
+                    Optional<Node> childNode = tryBuild(child, indexQueryabilityFilter);
                     if (!childNode.isPresent()) {
                         return Optional.empty();
                     }
@@ -318,16 +326,17 @@ public class ComposedBitmapIndexAggregate {
                 return Optional.of(new OperatorNode(operator, childNodes));
             }
             if (indexFilter instanceof NotComponent) {
-                return tryBuild(((NotComponent) indexFilter).getChild())
+                return tryBuild(((NotComponent) indexFilter).getChild(), indexQueryabilityFilter)
                         .map(childNode -> new OperatorNode(OperatorNode.Operator.NOT, Collections.singletonList(childNode)));
             }
             return Optional.empty();
         }
 
         @Nonnull
-        Optional<Node> indexScan(@Nonnull QueryComponent indexFilter) {
+        Optional<Node> indexScan(@Nonnull QueryComponent indexFilter,
+                                 @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
             if (bitmapIndexes == null) {
-                bitmapIndexes = findBitmapIndexes(indexAggregateFunctionCall.getFunctionName());
+                bitmapIndexes = findBitmapIndexes(indexAggregateFunctionCall.getFunctionName(), indexQueryabilityFilter);
                 if (bitmapIndexes.isEmpty()) {
                     return Optional.empty();
                 }
@@ -401,7 +410,8 @@ public class ComposedBitmapIndexAggregate {
         }
 
         @Nonnull
-        Map<KeyExpression, Index> findBitmapIndexes(@Nonnull String aggregateFunction) {
+        Map<KeyExpression, Index> findBitmapIndexes(@Nonnull String aggregateFunction,
+                                                    @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
             final String indexType;
             if (BitmapValueIndexMaintainer.AGGREGATE_FUNCTION_NAME.equals(aggregateFunction)) {
                 indexType = IndexTypes.BITMAP_VALUE;
@@ -412,6 +422,7 @@ public class ComposedBitmapIndexAggregate {
             return IndexFunctionHelper.indexesForRecordTypes(planner.getRecordMetaData(), recordTypeNames)
                     .filter(index -> index.getType().equals(indexType))
                     .filter(recordStoreState::isReadable)
+                    .filter(indexQueryabilityFilter::isQueryable)
                     .collect(Collectors.toMap(Index::getRootExpression, Function.identity()));
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -63,6 +63,7 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression.FanType;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.InvalidIndexEntry;
+import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
@@ -305,7 +306,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
 
-            final Optional<IndexAggregateFunction> boundSubtotal = IndexFunctionHelper.bindAggregateFunction(recordStore, subtotal, allTypes);
+            final Optional<IndexAggregateFunction> boundSubtotal = IndexFunctionHelper.bindAggregateFunction(recordStore,
+                    subtotal, allTypes, IndexQueryabilityFilter.DEFAULT);
             assertTrue(boundSubtotal.isPresent(), "should find a suitable index");
             assertEquals("sum", boundSubtotal.get().getIndex());
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/IndexFunctionHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/IndexFunctionHelperTest.java
@@ -46,10 +46,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Tests for {@link IndexFunctionHelper}.
  */
 @Tag(Tags.RequiresFDB)
-public class IndexFunctionHelperTest extends FDBRecordStoreTestBase {
+class IndexFunctionHelperTest extends FDBRecordStoreTestBase {
 
     @Test
-    public void groupSubKeysBasic() {
+    void groupSubKeysBasic() {
         final KeyExpression ungrouped = field("value").ungrouped();
         assertEquals(field("value"), IndexFunctionHelper.getGroupedKey(ungrouped));
         assertEquals(empty(), IndexFunctionHelper.getGroupingKey(ungrouped));
@@ -60,7 +60,7 @@ public class IndexFunctionHelperTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void groupSubKeysNested() {
+    void groupSubKeysNested() {
         final KeyExpression wholeKey = concat(
                 field("a", FanOut).nest(concatenateFields("b", "c")),
                 field("d"),
@@ -101,7 +101,7 @@ public class IndexFunctionHelperTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void groupingKeyEmpty() {
+    void groupingKeyEmpty() {
         final KeyExpression count = empty().groupBy(field("x")); // Like COUNT(*) GROUP BY x
         final KeyExpression sum = field("y").groupBy(field("x"));  // Like SUM(y) GROUP BY x
         assertEquals(IndexFunctionHelper.getGroupingKey(count), IndexFunctionHelper.getGroupingKey(sum));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexTest.java
@@ -94,10 +94,10 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for {@code BITMAP_VALUE} type indexes.
  */
 @Tag(Tags.RequiresFDB)
-public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
+class BitmapValueIndexTest extends FDBRecordStoreTestBase {
 
     @Test
-    public void basic() {
+    void basic() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -127,7 +127,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void aggregateFunction() {
+    void aggregateFunction() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -158,7 +158,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void nonPrimaryKey() {
+    void nonPrimaryKey() {
         final RecordMetaDataHook num_by_num3_hook = metadata -> {
             metadata.addIndex(metadata.getRecordType("MySimpleRecord"),
                               new Index("num_by_num3",
@@ -184,7 +184,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void uniquenessViolationChecked() {
+    void uniquenessViolationChecked() {
         final RecordMetaDataHook num_by_num3_hook_not_unique = metadata -> {
             metadata.removeIndex("MySimpleRecord$num_value_unique");
             metadata.addIndex(metadata.getRecordType("MySimpleRecord"),
@@ -212,7 +212,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void uniquenessViolationNotChecked() {
+    void uniquenessViolationNotChecked() {
         final RecordMetaDataHook num_by_num3_hook_not_unique = metadata -> {
             metadata.removeIndex("MySimpleRecord$num_value_unique");
             metadata.addIndex(metadata.getRecordType("MySimpleRecord"),
@@ -278,7 +278,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void andQuery() {
+    void andQuery() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -308,7 +308,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void andQueryPosition() {
+    void andQueryPosition() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -339,7 +339,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void andOrQuery() {
+    void andOrQuery() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -371,7 +371,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void andOrQueryWithContinuation() {
+    void andOrQueryWithContinuation() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -406,7 +406,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void andOrQueryWithDuplicate() {
+    void andOrQueryWithDuplicate() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -442,7 +442,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void andNotQuery() {
+    void andNotQuery() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -472,7 +472,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void nonOverlappingOrQuery() {
+    void nonOverlappingOrQuery() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             for (int recNo = 100; recNo < 200; recNo++) {
@@ -514,7 +514,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void nestedAndQuery() {
+    void nestedAndQuery() {
         final KeyExpression num_by_str = field("nested").nest(field("entry", FanOut).nest(concatenateFields("str_value", "num_value")));
         final GroupingKeyExpression nested_num_by_str = concat(field("num_value_1"), num_by_str).group(1);
         final KeyExpression nested_num_by_str_num2 = concat(field("num_value_1"), field("num_value_2"), num_by_str).group(1);
@@ -571,7 +571,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void singleQuery() {
+    void singleQuery() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -595,7 +595,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void negatedQuery() {
+    void negatedQuery() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);
@@ -613,7 +613,7 @@ public class BitmapValueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void filterIndexSelection() {
+    void filterIndexSelection() {
         try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, metaData(REC_NO_BY_STR_NUMS_HOOK));
             saveRecords(100, 200);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRestrictedIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRestrictedIndexQueryTest.java
@@ -84,7 +84,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
      * TODO: Abstract out common code in queryWithWriteOnly, queryWithDisabled, queryAggregateWithWriteOnly and queryAggregateWithDisabled (https://github.com/FoundationDB/fdb-record-layer/issues/4)
      */
     @DualPlannerTest
-    public void queryWithWriteOnly() throws Exception {
+    void queryWithWriteOnly() throws Exception {
         RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.field("num_value_3_indexed").greaterThanOrEquals(5))
@@ -162,7 +162,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
      * TODO: Abstract out common code in queryWithWriteOnly, queryWithDisabled, queryAggregateWithWriteOnly and queryAggregateWithDisabled (https://github.com/FoundationDB/fdb-record-layer/issues/4)
      */
     @DualPlannerTest
-    public void queryWithDisabled() throws Exception {
+    void queryWithDisabled() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.markIndexDisabled("MySimpleRecord$str_value_indexed").get();
@@ -422,7 +422,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     @Test
-    public void snapshotRecordCountFiltered() throws Exception {
+    void snapshotRecordCountFiltered() throws Exception {
         Index onType = new Index("onType",
                 new GroupingKeyExpression(Key.Expressions.empty(), 0),
                 IndexTypes.COUNT);
@@ -484,7 +484,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
      * Verify that queries do not use prohibited indexes.
      */
     @DualPlannerTest
-    public void queryAllowedIndexes() {
+    void queryAllowedIndexes() {
         RecordMetaDataHook hook = metaData -> {
             metaData.removeIndex("MySimpleRecord$str_value_indexed");
             metaData.addIndex("MySimpleRecord", new Index("limited_str_value_index", field("str_value_indexed"),
@@ -572,7 +572,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
      * Verify that queries can override prohibited indexes explicitly.
      */
     @DualPlannerTest
-    public void queryAllowedUniversalIndex() {
+    void queryAllowedUniversalIndex() {
         RecordMetaDataHook hook = metaData ->
                 metaData.addUniversalIndex(
                         new Index("universal_num_value_2", field("num_value_2"),
@@ -619,7 +619,7 @@ public class FDBRestrictedIndexQueryTest extends FDBRecordStoreQueryTestBase {
      * If both allowed indexes and a queryability filter are set, verify that the planner uses the allowed indexes.
      */
     @DualPlannerTest
-    public void indexQueryabilityFilter() {
+    void indexQueryabilityFilter() {
         RecordMetaDataHook hook = metaData -> {
             metaData.removeIndex("MySimpleRecord$str_value_indexed");
             metaData.addIndex("MySimpleRecord", new Index("limited_str_value_index", field("str_value_indexed"),


### PR DESCRIPTION
For IndexFunctionHelper and ComposedBitmapIndexAggregate, this change
adds it as a required parameter.

Since FDBRecordStoreBase is MAINTAINED this adds overloads for:
- getSnapshotRecordCountForRecordType
- evaluateAggregateFunction

that take the IndexQueryabilityFilter, using TRUE to maintain
backwards compatibility. The old method is left as a default
method, requiring implementers to add the new method.