### PR TITLE
Fix log4j config regressions in performance test.

### DIFF
--- a/fdb-record-layer-core/src/test/resources/standalone.log4j.properties
+++ b/fdb-record-layer-core/src/test/resources/standalone.log4j.properties
@@ -18,8 +18,18 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=DEBUG, console
+name = StandaloneConfig
+appenders = console
 
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%-4r %m%n
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %-4r %m%n
+
+rootLogger.level = debug
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+loggers = reversecache
+logger.reversecache.name = com.apple.foundationdb.record.provider.foundationdb.FDBReverseDirectoryCache
+logger.reversecache.level = info

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ jsr305Version=3.0.2
 slf4jVersion=1.7.30
 commonsLang3Version=3.12.0
 commonsMath3Version=3.6.1
-log4jVersion=2.16.0
+log4jVersion=2.17.1
 guavaVersion=30.1-jre
 hamcrestVersion=2.2
 # AutoService kept on 1.0-rc6 to avoid annotation being retained in CLASS. See: https://github.com/FoundationDB/fdb-record-layer/issues/1281


### PR DESCRIPTION
Add a separate test for index scan and deferred fetch. This is more or less identical now, but once index+record fetch is optimized should show
the difference.