### PR TITLE
A few bug fix and optimizations for Lucene search

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -289,6 +289,9 @@ public enum LogMessageKeys {
     FILE_REFERENCE,
     ORIGINAL_DATA_SIZE,
 
+    //Lucene component
+    COMPONENT,
+
     // Record context properties
     PROPERTY_NAME,
     PROPERTY_TYPE,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AutoCompleteSuggesterCommitCheckAsync.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AutoCompleteSuggesterCommitCheckAsync.java
@@ -1,0 +1,115 @@
+/*
+ * AutoCompleteSuggesterCommitCheckAsync.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreStorageException;
+import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedWrappedAnalyzingInfixSuggester;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
+import org.apache.lucene.util.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static com.apple.foundationdb.record.lucene.DirectoryCommitCheckAsync.getOrCreateDirectoryCommitCheckAsync;
+
+/**
+ * This class closes the suggester before commit.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class AutoCompleteSuggesterCommitCheckAsync implements FDBRecordContext.CommitCheckAsync {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutoCompleteSuggesterCommitCheckAsync.class);
+    protected final AnalyzingInfixSuggester suggester;
+    protected final Executor executor;
+
+    /**
+     * Create a suggester for auto-complete search.
+     * @param index the index to suggest for
+     * @param directoryCommitCheckAsync the directoryCommitCheckAsync for the directory
+     * @param indexAnalyzer the analyzer for indexing
+     * @param queryAnalyzer the analyzer for query
+     * @param highlight whether the suggestions have the search term highlighted
+     * @param executor the executor to close the suggester asynchronously
+     */
+    private AutoCompleteSuggesterCommitCheckAsync(final Index index, @Nonnull DirectoryCommitCheckAsync directoryCommitCheckAsync,
+                                                  @Nonnull Analyzer indexAnalyzer, @Nonnull Analyzer queryAnalyzer,
+                                                  boolean highlight, @Nonnull Executor executor) {
+        this.suggester = LuceneOptimizedWrappedAnalyzingInfixSuggester.getSuggester(index, directoryCommitCheckAsync.getDirectory(), indexAnalyzer, queryAnalyzer, highlight);
+        this.executor = executor;
+    }
+
+    /**
+     * Close suggester.
+     *
+     * @return CompletableFuture
+     */
+    @Nonnull
+    @Override
+    public CompletableFuture<Void> checkAsync() {
+        LOGGER.trace("closing suggester check");
+        return CompletableFuture.runAsync(() -> {
+            try {
+                IOUtils.close(suggester);
+            } catch (IOException ioe) {
+                LOGGER.error("AutoCompleteSuggesterCommitCheckAsync Failed", ioe);
+                throw new RecordCoreStorageException("AutoCompleteSuggesterCommitCheckAsync Failed", ioe);
+            }
+        }, executor);
+    }
+
+    @Nonnull
+    public static AnalyzingInfixSuggester getOrCreateSuggester(@Nonnull final IndexMaintainerState state,
+                                                               @Nonnull Analyzer indexAnalyzer, @Nonnull Analyzer queryAnalyzer,
+                                                               boolean highlight, @Nonnull Executor executor, @Nonnull final Tuple groupingKey) {
+        synchronized (state.context) {
+            AutoCompleteSuggesterCommitCheckAsync suggesterAsync = state.context.getInSession(getSuggestionIndexSubspace(state, groupingKey), AutoCompleteSuggesterCommitCheckAsync.class);
+            if (suggesterAsync == null) {
+                suggesterAsync = new AutoCompleteSuggesterCommitCheckAsync(state.index,
+                        getOrCreateDirectoryCommitCheckAsync(state, getSuggestionIndexSubspace(state, groupingKey)), indexAnalyzer, queryAnalyzer, highlight, executor);
+                state.context.addCommitCheck(suggesterAsync);
+                state.context.putInSessionIfAbsent(getSuggestionIndexSubspace(state, groupingKey), suggesterAsync);
+            }
+            return suggesterAsync.suggester;
+        }
+    }
+
+    @Nonnull
+    private static Subspace getSuggestionIndexSubspace(@Nonnull final IndexMaintainerState state, @Nonnull final Tuple groupingKey) {
+        return getSuggestionIndexSubspace(state.indexSubspace, groupingKey);
+    }
+
+    @VisibleForTesting
+    @Nonnull
+    public static Subspace getSuggestionIndexSubspace(@Nonnull final Subspace indexSubspace, @Nonnull final Tuple groupingKey) {
+        return indexSubspace.subspace(groupingKey).subspace(Tuple.from("s"));
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/IndexWriterCommitCheckAsync.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/IndexWriterCommitCheckAsync.java
@@ -82,6 +82,7 @@ public class IndexWriterCommitCheckAsync implements FDBRecordContext.CommitCheck
             }
         });
         indexWriterConfig.setCodec(new LuceneOptimizedCodec(Lucene50StoredFieldsFormat.Mode.BEST_COMPRESSION));
+        indexWriterConfig.setInfoStream(new LuceneLoggerInfoStream(LOGGER));
         this.indexWriter = new IndexWriter(directoryCommitCheckAsync.getDirectory(), indexWriterConfig);
         this.executor = executor;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteResultCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteResultCursor.java
@@ -37,7 +37,6 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.ByteString;
 import org.apache.lucene.search.suggest.Lookup;
 import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
-import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,7 +145,6 @@ public class LuceneAutoCompleteResultCursor implements BaseCursor<IndexEntry> {
 
     @Override
     public void close() {
-        IOUtils.closeWhileHandlingException(suggester);
     }
 
     @Nonnull

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
@@ -237,17 +237,24 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
             return Collections.singletonList(fieldExpression.getFieldName());
         }
 
-        public void buildMessage(@Nonnull Object value, @Nonnull String field, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
+        public void buildMessage(@Nullable Object value, @Nonnull String field, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
             if (hasBeenBuilt()) {
                 return;
             }
             buildMessage(value, descriptor.findFieldByName(field), customizedKey, mappedKeyField, forLuceneField);
         }
 
-        private void buildMessage(@Nonnull Object value, Descriptors.FieldDescriptor subFieldDescriptor, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
+        private void buildMessage(@Nullable Object value, Descriptors.FieldDescriptor subFieldDescriptor, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
             final Descriptors.FieldDescriptor mappedKeyFieldDescriptor = mappedKeyField == null ? null : descriptor.findFieldByName(mappedKeyField);
             if (mappedKeyFieldDescriptor != null) {
+                if (customizedKey == null) {
+                    return;
+                }
                 builder.setField(mappedKeyFieldDescriptor, customizedKey);
+            }
+
+            if (value == null) {
+                return;
             }
             if (subFieldDescriptor.isRepeated()) {
                 if (builder.getRepeatedFieldCount(subFieldDescriptor) > 0) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLoggerInfoStream.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLoggerInfoStream.java
@@ -1,0 +1,56 @@
+/*
+ * LuceneLoggerInfoStream.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import org.apache.lucene.util.InfoStream;
+import org.slf4j.Logger;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Record Layer's implementation of {@link InfoStream} that publishes messages as TRACE logs.
+ */
+@SuppressWarnings("PMD.LoggerIsNotStaticFinal")
+public class LuceneLoggerInfoStream extends InfoStream {
+    private final Logger loggerForStreamOutput;
+
+    public LuceneLoggerInfoStream(@Nonnull Logger loggerForStreamOutput) {
+        this.loggerForStreamOutput = loggerForStreamOutput;
+    }
+
+    @Override
+    public void message(String component, String message) {
+        if (loggerForStreamOutput.isTraceEnabled()) {
+            loggerForStreamOutput.trace(KeyValueLogMessage.of(message, LogMessageKeys.COMPONENT, component));
+        }
+    }
+
+    @Override
+    public boolean isEnabled(String component) {
+        return true;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedAnalyzingInfixSuggester.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedAnalyzingInfixSuggester.java
@@ -22,14 +22,21 @@ package com.apple.foundationdb.record.lucene.codec;
 
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.lucene.LuceneLoggerInfoStream;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
 import org.apache.lucene.search.suggest.analyzing.BlendedInfixSuggester;
 import org.apache.lucene.store.Directory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -39,6 +46,8 @@ import java.io.IOException;
  * Optimized suggester to override the codec for index writer.
  */
 public class LuceneOptimizedWrappedAnalyzingInfixSuggester extends BlendedInfixSuggester {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LuceneOptimizedWrappedAnalyzingInfixSuggester.class);
+
     private static final BlenderType DEFAULT_BLENDER_TYPE = BlenderType.POSITION_LINEAR;
 
     private LuceneOptimizedWrappedAnalyzingInfixSuggester(Directory dir, Analyzer indexAnalyzer, Analyzer queryAnalyzer,
@@ -49,13 +58,27 @@ public class LuceneOptimizedWrappedAnalyzingInfixSuggester extends BlendedInfixS
 
     @Override
     protected IndexWriterConfig getIndexWriterConfig(Analyzer indexAnalyzer, IndexWriterConfig.OpenMode openMode) {
+        TieredMergePolicy tieredMergePolicy = new TieredMergePolicy();
+        tieredMergePolicy.setMaxMergedSegmentMB(5.00);
+        tieredMergePolicy.setMaxMergeAtOnceExplicit(2);
+        tieredMergePolicy.setNoCFSRatio(1.00);
         IndexWriterConfig iwc = super.getIndexWriterConfig(indexAnalyzer, openMode);
+        iwc.setUseCompoundFile(true);
+        iwc.setMergePolicy(tieredMergePolicy);
+        iwc.setMergeScheduler(new ConcurrentMergeScheduler() {
+            @Override
+            protected void doMerge(final IndexWriter writer, final MergePolicy.OneMerge merge) throws IOException {
+                merge.segments.forEach( (segmentCommitInfo) -> LOGGER.trace("Auto-complete index segmentInfo={}", segmentCommitInfo.info.name));
+                super.doMerge(writer, merge);
+            }
+        });
         iwc.setCodec(new LuceneOptimizedCodec(Lucene50StoredFieldsFormat.Mode.BEST_COMPRESSION));
+        iwc.setInfoStream(new LuceneLoggerInfoStream(LOGGER));
         return iwc;
     }
 
     @Nonnull
-    public static AnalyzingInfixSuggester getSuggester(final Index index, @Nonnull Directory dir, @Nonnull Analyzer indexAnalyzer, @Nonnull Analyzer queryAnalyzer, boolean highlight) throws IOException {
+    public static AnalyzingInfixSuggester getSuggester(final Index index, @Nonnull Directory dir, @Nonnull Analyzer indexAnalyzer, @Nonnull Analyzer queryAnalyzer, boolean highlight) {
         String autoCompleteBlenderType = index.getOption(IndexOptions.AUTO_COMPLETE_BLENDER_TYPE);
         String autoCompleteBlenderNumFactor = index.getOption(IndexOptions.AUTO_COMPLETE_BLENDER_NUM_FACTOR);
         String autoCompleteMinPrefixSize = index.getOption(IndexOptions.AUTO_COMPLETE_MIN_PREFIX_SIZE);
@@ -68,8 +91,11 @@ public class LuceneOptimizedWrappedAnalyzingInfixSuggester extends BlendedInfixS
                     autoCompleteBlenderNumFactor == null ? DEFAULT_NUM_FACTOR : Integer.parseInt(autoCompleteBlenderNumFactor),
                     autoCompleteBlenderExponent == null ? null : Double.valueOf(autoCompleteBlenderExponent),
                     highlight);
-        } catch (IllegalArgumentException ex) {
-            throw new RecordCoreArgumentException("Invalid parameter for auto complete suggester", ex)
+        } catch (IllegalArgumentException iae) {
+            throw new RecordCoreArgumentException("Invalid parameter for auto complete suggester", iae)
+                    .addLogInfo(LogMessageKeys.INDEX_NAME, index.getName());
+        } catch (IOException ioe) {
+            throw new RecordCoreArgumentException("Failure with underlying lucene index opening for auto complete suggester", ioe)
                     .addLogInfo(LogMessageKeys.INDEX_NAME, index.getName());
         }
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -702,7 +702,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                     (String) i.getKey().get(i.getKeySize() - 2), IndexScanType.BY_LUCENE_AUTO_COMPLETE));
 
             assertEquals(6, context.getTimer().getCounter(FDBStoreTimer.Counts.LUCENE_SCAN_MATCHED_AUTO_COMPLETE_SUGGESTIONS).getCount());
-            assertEntriesAndSegmentInfoStoredInCompoundFile(DirectoryCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(COMPLEX_MULTIPLE_TEXT_INDEXES_WITH_AUTO_COMPLETE), TupleHelpers.EMPTY),
+            assertEntriesAndSegmentInfoStoredInCompoundFile(AutoCompleteSuggesterCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(COMPLEX_MULTIPLE_TEXT_INDEXES_WITH_AUTO_COMPLETE), TupleHelpers.EMPTY),
                     context, "_0.cfs", true);
 
             // Assert the count of suggestions
@@ -748,7 +748,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             assertEquals("text", result.getKey().get(result.getKeySize() - 2));
 
             assertEquals(1, context.getTimer().getCounter(FDBStoreTimer.Counts.LUCENE_SCAN_MATCHED_AUTO_COMPLETE_SUGGESTIONS).getCount());
-            assertEntriesAndSegmentInfoStoredInCompoundFile(DirectoryCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(SIMPLE_TEXT_WITH_AUTO_COMPLETE), TupleHelpers.EMPTY),
+            assertEntriesAndSegmentInfoStoredInCompoundFile(AutoCompleteSuggesterCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(SIMPLE_TEXT_WITH_AUTO_COMPLETE), TupleHelpers.EMPTY),
                     context, "_0.cfs", true);
         }
     }
@@ -785,7 +785,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             assertEquals(ENGINEER_JOKE, entry.getField(valueDescriptor));
 
             assertEquals(1, context.getTimer().getCounter(FDBStoreTimer.Counts.LUCENE_SCAN_MATCHED_AUTO_COMPLETE_SUGGESTIONS).getCount());
-            assertEntriesAndSegmentInfoStoredInCompoundFile(DirectoryCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(MAP_ON_VALUE_INDEX_WITH_AUTO_COMPLETE), Tuple.from("sampleTextPhrase")),
+            assertEntriesAndSegmentInfoStoredInCompoundFile(AutoCompleteSuggesterCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(MAP_ON_VALUE_INDEX_WITH_AUTO_COMPLETE), Tuple.from("sampleTextPhrase")),
                     context, "_0.cfs", true);
         }
     }
@@ -1047,7 +1047,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                     (String) i.getKey().get(i.getKeySize() - 2), IndexScanType.BY_LUCENE_AUTO_COMPLETE));
 
             assertEquals(6, context.getTimer().getCounter(FDBStoreTimer.Counts.LUCENE_SCAN_MATCHED_AUTO_COMPLETE_SUGGESTIONS).getCount());
-            assertEntriesAndSegmentInfoStoredInCompoundFile(DirectoryCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(SIMPLE_TEXT_WITH_AUTO_COMPLETE), TupleHelpers.EMPTY),
+            assertEntriesAndSegmentInfoStoredInCompoundFile(AutoCompleteSuggesterCommitCheckAsync.getSuggestionIndexSubspace(recordStore.indexSubspace(SIMPLE_TEXT_WITH_AUTO_COMPLETE), TupleHelpers.EMPTY),
                     context, "_0.cfs", true);
         }
     }


### PR DESCRIPTION
This PR is to resolve these issues:
1, Use 1.0 as NoCFSRatio for Lucene segments merging policy, to make sure it always use compound file.
2, Configure a InforSteam to publish log messages to output teams to loggers.
3, Cache the suggester into ```FDBRecordContext``` similarly as the ```indexWriter``` for ordinary search, so it won't be closed until the commit of context. 
4, Fix the partial record build to skip a field if its value is ```null```.