### PR TITLE
Some improvements to handling of Lucene stored fields and sorting

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -625,7 +625,7 @@ public class RecordQueryPlanner implements QueryPlanner {
                 p = planRank(candidateScan, index, grouping, filter);
                 indexExpr = grouping.getWholeKey(); // Plan as just value index.
             } else if (!indexTypes.getValueTypes().contains(index.getType())) {
-                p = planOther(candidateScan, index, filter, sort);
+                p = planOther(candidateScan, index, filter, sort, sortReverse);
                 if (p != null) {
                     p = planRemoveDuplicates(planContext, p);
                 }
@@ -1336,18 +1336,19 @@ public class RecordQueryPlanner implements QueryPlanner {
     @Nullable
     protected ScoredPlan planOther(@Nonnull CandidateScan candidateScan,
                                    @Nonnull Index index, @Nonnull QueryComponent filter,
-                                   @Nullable KeyExpression sort) {
+                                   @Nullable KeyExpression sort, boolean sortReverse) {
         if (indexTypes.getTextTypes().contains(index.getType())) {
-            return planText(candidateScan, index, filter, sort);
+            return planText(candidateScan, index, filter, sort, sortReverse);
         } else {
             return null;
         }
     }
 
     @Nullable
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     private ScoredPlan planText(@Nonnull CandidateScan candidateScan,
                                 @Nonnull Index index, @Nonnull QueryComponent filter,
-                                @Nullable KeyExpression sort) {
+                                @Nullable KeyExpression sort, boolean sortReverse) {
         if (sort != null) {
             // TODO: Full Text: Sorts are not supported with full text queries (https://github.com/FoundationDB/fdb-record-layer/issues/55)
             return null;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
@@ -180,9 +180,12 @@ public class LuceneDocumentFromRecord {
         }
 
         @Override
-        public void addField(@Nonnull T source, @Nonnull final String fieldName, @Nullable final Object value, LuceneIndexExpressions.DocumentFieldType type,
-                             final boolean stored, @Nonnull List<Integer> overriddenKeyRanges, int groupingKeyIndex, @Nonnull Map<String, Object> fieldConfigs) {
-            fields.add(new DocumentField(fieldName, value, type, stored, fieldConfigs));
+        public void addField(@Nonnull T source, @Nonnull String fieldName, @Nullable final Object value,
+                             LuceneIndexExpressions.DocumentFieldType type,
+                             boolean stored, boolean sorted,
+                             @Nonnull List<Integer> overriddenKeyRanges, int groupingKeyIndex,
+                             @Nonnull Map<String, Object> fieldConfigs) {
+            fields.add(new DocumentField(fieldName, value, type, stored, sorted, fieldConfigs));
         }
     }
 
@@ -193,15 +196,17 @@ public class LuceneDocumentFromRecord {
         private final Object value;
         private final LuceneIndexExpressions.DocumentFieldType type;
         private final boolean stored;
+        private final boolean sorted;
         @Nonnull
         private final Map<String, Object> fieldConfigs;
 
         public DocumentField(@Nonnull String fieldName, @Nullable Object value, LuceneIndexExpressions.DocumentFieldType type,
-                             boolean stored, @Nonnull Map<String, Object> fieldConfigs) {
+                             boolean stored, boolean sorted, @Nonnull Map<String, Object> fieldConfigs) {
             this.fieldName = fieldName;
             this.value = value;
             this.type = type;
             this.stored = stored;
+            this.sorted = sorted;
             this.fieldConfigs = fieldConfigs;
         }
 
@@ -223,6 +228,10 @@ public class LuceneDocumentFromRecord {
             return stored;
         }
 
+        public boolean isSorted() {
+            return sorted;
+        }
+
         @Nullable
         public Object getConfig(@Nonnull String key) {
             return fieldConfigs.get(key);
@@ -239,6 +248,9 @@ public class LuceneDocumentFromRecord {
 
             final DocumentField that = (DocumentField)o;
             if (stored != that.stored) {
+                return false;
+            }
+            if (sorted != that.sorted) {
                 return false;
             }
             if (!fieldName.equals(that.fieldName)) {
@@ -259,6 +271,7 @@ public class LuceneDocumentFromRecord {
             result = 31 * result + (value != null ? value.hashCode() : 0);
             result = 31 * result + type.hashCode();
             result = 31 * result + (stored ? 1 : 0);
+            result = 31 * result + (sorted ? 1 : 0);
             return result;
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
@@ -155,6 +155,39 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
         }
     }
 
+    /**
+     * The {@code lucene_sorted} key function.
+     * The field argument to this function is additionally sorted in the Lucene index.
+     */
+    public static class LuceneSorted extends LuceneFunctionKeyExpression {
+        public LuceneSorted(@Nonnull String name, @Nonnull KeyExpression arguments) {
+            super(name, arguments);
+        }
+
+        @Override
+        public int getMinArguments() {
+            return 1;
+        }
+
+        @Override
+        public int getMaxArguments() {
+            return 1;
+        }
+
+        @Override
+        public int getColumnSize() {
+            return getSortedExpression().getColumnSize();
+        }
+
+        /**
+         * Get the expression that is marked as stored.
+         * @return the stored expression
+         */
+        @Nonnull
+        public KeyExpression getSortedExpression() {
+            return arguments;
+        }
+    }
 
     /**
      * The {@code lucent_text} key function.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
@@ -40,6 +40,7 @@ public class LuceneFunctionKeyExpressionFactory implements FunctionKeyExpression
     public List<FunctionKeyExpression.Builder> getBuilders() {
         return Arrays.asList(
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_FIELD_NAME, LuceneFunctionKeyExpression.LuceneFieldName::new),
+                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_SORTED, LuceneFunctionKeyExpression.LuceneSorted::new),
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_STORED, LuceneFunctionKeyExpression.LuceneStored::new),
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_TEXT, LuceneFunctionKeyExpression.LuceneText::new),
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_FULL_TEXT_FIELD_INDEX_OPTIONS, LuceneFunctionKeyExpression.LuceneFieldConfig::new),

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.annotation.API;
 @API(API.Status.EXPERIMENTAL)
 public class LuceneFunctionNames {
     public static final String LUCENE_FIELD_NAME = "lucene_field_name";
+    public static final String LUCENE_SORTED = "lucene_sorted";
     public static final String LUCENE_STORED = "lucene_stored";
     public static final String LUCENE_TEXT = "lucene_text";
     public static final String LUCENE_FULL_TEXT_FIELD_INDEX_OPTIONS = "lucene_full_text_field_index_options";

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
@@ -57,7 +57,7 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
                                           @Nonnull String suggestion, @Nonnull Tuple groupingKey) {
         final KeyExpression expression = root instanceof GroupingKeyExpression ? ((GroupingKeyExpression) root).getWholeKey() : root;
         LuceneIndexExpressions.getFieldsRecursively(expression, new PartialRecordBuildSource(null, descriptor, builder),
-                (source, fieldName, value, type, stored, overriddenKeyRanges, groupingKeyIndex, fieldConfigsIgnored) -> {
+                (source, fieldName, value, type, stored, sorted, overriddenKeyRanges, groupingKeyIndex, fieldConfigsIgnored) -> {
                     if (groupingKeyIndex > - 1) {
                         if (groupingKeyIndex > groupingKey.size() - 1) {
                             throw new RecordCoreException("Invalid grouping value tuple given a grouping key")
@@ -244,6 +244,7 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
             buildMessage(value, descriptor.findFieldByName(field), customizedKey, mappedKeyField, forLuceneField);
         }
 
+        @SuppressWarnings("java:S3776")
         private void buildMessage(@Nullable Object value, Descriptors.FieldDescriptor subFieldDescriptor, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
             final Descriptors.FieldDescriptor mappedKeyFieldDescriptor = mappedKeyField == null ? null : descriptor.findFieldByName(mappedKeyField);
             if (mappedKeyFieldDescriptor != null) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
@@ -42,7 +42,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Base class for {@link IndexScanParameters} used by {@code LUCENE} indexes.
@@ -79,9 +78,9 @@ public abstract class LuceneScanParameters implements IndexScanParameters {
     protected static List<String> indexTextFields(@Nonnull Index index, @Nonnull RecordMetaData metaData) {
         final List<String> textFields = new ArrayList<>();
         for (RecordType recordType : metaData.recordTypesForIndex(index)) {
-            for (Map.Entry<String, LuceneIndexExpressions.DocumentFieldDerivation> entry : LuceneIndexExpressions.getDocumentFieldDerivations(index.getRootExpression(), recordType.getDescriptor()).entrySet()) {
-                if (entry.getValue().getType() == LuceneIndexExpressions.DocumentFieldType.TEXT) {
-                    textFields.add(entry.getKey());
+            for (LuceneIndexExpressions.DocumentFieldDerivation documentField : LuceneIndexExpressions.getDocumentFieldDerivations(index.getRootExpression(), recordType.getDescriptor()).values()) {
+                if (documentField.getType() == LuceneIndexExpressions.DocumentFieldType.TEXT) {
+                    textFields.add(documentField.getDocumentField());
                 }
             }
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
@@ -24,8 +24,11 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.tuple.Tuple;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Scan a {@code LUCENE} index using a Lucene {@link Query}.
@@ -33,16 +36,42 @@ import javax.annotation.Nonnull;
 @API(API.Status.UNSTABLE)
 public class LuceneScanQuery extends LuceneScanBounds {
     @Nonnull
-    final Query query;
+    private final Query query;
+    @Nullable
+    private final Sort sort;
+    @Nullable
+    private final List<String> storedFields;
+    @Nullable
+    private final List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes;
 
-    public LuceneScanQuery(@Nonnull IndexScanType scanType, @Nonnull Tuple groupKey, @Nonnull Query query) {
+    public LuceneScanQuery(@Nonnull IndexScanType scanType, @Nonnull Tuple groupKey,
+                           @Nonnull Query query, @Nullable Sort sort,
+                           @Nullable List<String> storedFields, @Nullable List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes) {
         super(scanType, groupKey);
         this.query = query;
+        this.sort = sort;
+        this.storedFields = storedFields;
+        this.storedFieldTypes = storedFieldTypes;
     }
 
     @Nonnull
     public Query getQuery() {
         return query;
+    }
+
+    @Nullable
+    public Sort getSort() {
+        return sort;
+    }
+
+    @Nullable
+    public List<String> getStoredFields() {
+        return storedFields;
+    }
+
+    @Nullable
+    public List<LuceneIndexExpressions.DocumentFieldType> getStoredFieldTypes() {
+        return storedFieldTypes;
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecordTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecordTest.java
@@ -472,12 +472,13 @@ class LuceneDocumentFromRecordTest {
     }
 
     private static LuceneDocumentFromRecord.DocumentField documentField(String name, @Nullable Object value, LuceneIndexExpressions.DocumentFieldType type,
-                                                                        boolean stored, @Nonnull Map<String, Object> fieldConfigs) {
-        return new LuceneDocumentFromRecord.DocumentField(name, value, type, stored, fieldConfigs);
+                                                                        boolean stored, boolean sorted,
+                                                                        @Nonnull Map<String, Object> fieldConfigs) {
+        return new LuceneDocumentFromRecord.DocumentField(name, value, type, stored, sorted, fieldConfigs);
     }
 
     private static LuceneDocumentFromRecord.DocumentField stringField(String name, String value) {
-        return documentField(name, value, LuceneIndexExpressions.DocumentFieldType.STRING, false, Collections.emptyMap());
+        return documentField(name, value, LuceneIndexExpressions.DocumentFieldType.STRING, false, false, Collections.emptyMap());
     }
 
     private static LuceneDocumentFromRecord.DocumentField textField(String name, String value) {
@@ -485,12 +486,12 @@ class LuceneDocumentFromRecordTest {
     }
 
     private static LuceneDocumentFromRecord.DocumentField textField(String name, String value, Map<String, Object> fieldConfigs) {
-        return documentField(name, value, LuceneIndexExpressions.DocumentFieldType.TEXT, false, fieldConfigs);
+        return documentField(name, value, LuceneIndexExpressions.DocumentFieldType.TEXT, false, false, fieldConfigs);
     }
 
 
     private static LuceneDocumentFromRecord.DocumentField intField(String name, int value) {
-        return documentField(name, value, LuceneIndexExpressions.DocumentFieldType.INT, false, Collections.emptyMap());
+        return documentField(name, value, LuceneIndexExpressions.DocumentFieldType.INT, false, false, Collections.emptyMap());
     }
 
 }


### PR DESCRIPTION
Still does not complete the covering optimization because of lack of appropriate `AvailableFields`.
Still does not do index joining because of the lack of appropriate `PlanOrderingKey`.
This should all that is needed for the Cascades planner to support those, though.