### PR TITLE
Index scrubber - return the count of bad entries found (#1547)

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,7 +24,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Index scrubber - return the count of bad entries found [(Issue #1547)](https://github.com/FoundationDB/fdb-record-layer/issues/1547)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,7 +24,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Index scrubber - return the count of bad entries found [(Issue #1547)](https://github.com/FoundationDB/fdb-record-layer/issues/1547)
+* **Feature** Index scrubber - return the count of bad entries found [(Issue #1547)](https://github.com/FoundationDB/fdb-record-layer/issues/1547)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -72,15 +72,18 @@ public class IndexingScrubDangling extends IndexingBase {
     @Nonnull private static final IndexBuildProto.IndexBuildIndexingStamp myIndexingTypeStamp = compileIndexingTypeStamp();
 
     @Nonnull private final OnlineIndexScrubber.ScrubbingPolicy scrubbingPolicy;
+    @Nonnull private final AtomicLong danglingCount;
     private long scanCounter = 0;
     private int logWarningCounter;
 
     public IndexingScrubDangling(@Nonnull final IndexingCommon common,
                                  @Nonnull final OnlineIndexer.IndexingPolicy policy,
-                                 @Nonnull final OnlineIndexScrubber.ScrubbingPolicy scrubbingPolicy) {
+                                 @Nonnull final OnlineIndexScrubber.ScrubbingPolicy scrubbingPolicy,
+                                 @Nonnull final AtomicLong danglingCount) {
         super(common, policy, true);
         this.scrubbingPolicy = scrubbingPolicy;
         this.logWarningCounter = scrubbingPolicy.getLogWarningsLimit();
+        this.danglingCount = danglingCount;
     }
 
     @Override
@@ -203,6 +206,7 @@ public class IndexingScrubDangling extends IndexingBase {
 
         if (! indexResult.hasStoredRecord() ) {
             // Here: Oh, No! this index is dangling!
+            danglingCount.incrementAndGet();
             final FDBStoreTimer timer = getRunner().getTimer();
             timerIncrement(timer, FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES);
             final IndexEntry indexEntry = indexResult.getIndexEntry();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -78,11 +78,11 @@ public class IndexingScrubMissing extends IndexingBase {
     public IndexingScrubMissing(@Nonnull final IndexingCommon common,
                                 @Nonnull final OnlineIndexer.IndexingPolicy policy,
                                 @Nonnull final OnlineIndexScrubber.ScrubbingPolicy scrubbingPolicy,
-                                @Nonnull final AtomicLong missingCOunt) {
+                                @Nonnull final AtomicLong missingCount) {
         super(common, policy, true);
         this.scrubbingPolicy = scrubbingPolicy;
         this.logWarningCounter = scrubbingPolicy.getLogWarningsLimit();
-        this.missingCount = missingCOunt;
+        this.missingCount = missingCount;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -71,15 +71,18 @@ public class IndexingScrubMissing extends IndexingBase {
     @Nonnull private static final IndexBuildProto.IndexBuildIndexingStamp myIndexingTypeStamp = compileIndexingTypeStamp();
 
     @Nonnull private final OnlineIndexScrubber.ScrubbingPolicy scrubbingPolicy;
+    @Nonnull private final AtomicLong missingCount;
     private long scanCounter = 0;
     private int logWarningCounter;
 
     public IndexingScrubMissing(@Nonnull final IndexingCommon common,
                                 @Nonnull final OnlineIndexer.IndexingPolicy policy,
-                                @Nonnull final OnlineIndexScrubber.ScrubbingPolicy scrubbingPolicy) {
+                                @Nonnull final OnlineIndexScrubber.ScrubbingPolicy scrubbingPolicy,
+                                @Nonnull final AtomicLong missingCOunt) {
         super(common, policy, true);
         this.scrubbingPolicy = scrubbingPolicy;
         this.logWarningCounter = scrubbingPolicy.getLogWarningsLimit();
+        this.missingCount = missingCOunt;
     }
 
     @Override
@@ -234,6 +237,7 @@ public class IndexingScrubMissing extends IndexingBase {
                                 .addKeysAndValues(common.indexLogMessageKeyValues())
                                 .toString());
                     }
+                    missingCount.incrementAndGet();
                     final FDBStoreTimer timer = getRunner().getTimer();
                     timerIncrement(timer, FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES);
                     if (scrubbingPolicy.allowRepair()) {


### PR DESCRIPTION
   Let the functions scrubDanglingIndexEntries and scrubMissingIndexEntries return the count of bad items found instead of void