### PR TITLE
Rough pass at extracting LimittedRunner

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -3406,7 +3406,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
     @Nonnull
     @SuppressWarnings("squid:S2095")    // Resource usage for indexBuilder is too complicated for rule.
-    public CompletableFuture<Void> rebuildIndex(@Nonnull final Index index, @Nullable final Collection<RecordType> recordTypes, @Nonnull RebuildIndexReason reason) {
+    public CompletableFuture<Void> rebuildIndex(@Nonnull final Index index,
+                                                @Nullable final Collection<RecordType> recordTypes,
+                                                @Nonnull RebuildIndexReason reason) {
         final boolean newStore = reason == RebuildIndexReason.NEW_STORE;
         if (newStore ? LOGGER.isDebugEnabled() : LOGGER.isInfoEnabled()) {
             final KeyValueLogMessage msg = KeyValueLogMessage.build("rebuilding index",

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/ImportRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/ImportRunner.java
@@ -1,0 +1,71 @@
+/*
+ * ImportRunner.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCursor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public abstract class ImportRunner<T> implements LimittedRunner.Runner {
+    private RecordCursor<T> cursor;
+    private final FDBDatabaseRunner runner;
+    private List<T> buffer;
+    int position = 0;
+
+    public ImportRunner(final RecordCursor<T> cursor, FDBDatabaseRunner runner) {
+        this.cursor = cursor;
+        this.runner = runner;
+    }
+
+    protected abstract void save(T value, FDBRecordContext context);
+
+    @Override
+    public CompletableFuture<Boolean> runAsync(int limit) {
+        final CompletableFuture<Void> fillBufferFuture;
+        if (buffer.size() < limit) {
+            fillBufferFuture = cursor.limitRowsTo(limit - buffer.size())
+                    .forEach(val -> buffer.add(val));
+        } else {
+            fillBufferFuture = CompletableFuture.completedFuture(null);
+        }
+        return fillBufferFuture.thenCompose(ignored -> {
+            if (buffer.size() == 0) {
+                return AsyncUtil.READY_FALSE;
+            }
+            return runner.runAsync(context -> {
+                while (position < limit && position < buffer.size()) {
+                    // TODO allow save to return a future
+                    save(buffer.get(position), context);
+                }
+                return AsyncUtil.READY_TRUE;
+            });
+        });
+    }
+
+    @Override
+    public void onSuccess() {
+        // these entries were successfully saved, so remove them from the buffer
+        buffer.subList(0, position).clear();
+        // TODO metrics
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -764,7 +764,8 @@ public abstract class IndexingBase {
 
     protected CompletableFuture<Void> iterateAllRanges(List<Object> additionalLogMessageKeyValues,
                                                        IndexingThrottle.Runner<Boolean> iterateRange,
-                                                       @Nonnull SubspaceProvider subspaceProvider, @Nonnull Subspace subspace) {
+                                                       @Nonnull SubspaceProvider subspaceProvider,
+                                                       @Nonnull Subspace subspace) {
 
         return AsyncUtil.whileTrue(() ->
                     buildCommitRetryAsync(iterateRange,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -600,7 +600,7 @@ public abstract class IndexingBase {
         return throttle.getLimit();
     }
 
-    public <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
+    public <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull IndexingThrottle.Runner<R> buildFunction,
                                                           boolean limitControl,
                                                           @Nullable List<Object> additionalLogMessageKeyValues) {
         return throttle.buildCommitRetryAsync(buildFunction, limitControl, additionalLogMessageKeyValues);
@@ -763,7 +763,7 @@ public abstract class IndexingBase {
     }
 
     protected CompletableFuture<Void> iterateAllRanges(List<Object> additionalLogMessageKeyValues,
-                                                       BiFunction<FDBRecordStore, AtomicLong,  CompletableFuture<Boolean>> iterateRange,
+                                                       IndexingThrottle.Runner<Boolean> iterateRange,
                                                        @Nonnull SubspaceProvider subspaceProvider, @Nonnull Subspace subspace) {
 
         return AsyncUtil.whileTrue(() ->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
@@ -38,7 +38,6 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.RecordType;
-import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
@@ -130,21 +129,20 @@ public class IndexingByIndex extends IndexingBase {
                     return context.getReadVersionAsync()
                             .thenCompose(vignore -> {
                                 SubspaceProvider subspaceProvider = common.getRecordStoreBuilder().getSubspaceProvider();
-                                return subspaceProvider.getSubspaceAsync(context)
-                                        .thenCompose(subspace -> buildIndexFromIndex(subspaceProvider, subspace, null, null));
+                                return buildIndexFromIndex(subspaceProvider, null, null);
                             });
                 }), common.indexLogMessageKeyValues("IndexingByIndex::buildIndexInternalAsync"));
     }
 
     @Nonnull
-    private CompletableFuture<Void> buildIndexFromIndex(@Nonnull SubspaceProvider subspaceProvider, @Nonnull Subspace subspace, @Nullable byte[] start, @Nullable byte[] end) {
+    private CompletableFuture<Void> buildIndexFromIndex(@Nonnull SubspaceProvider subspaceProvider, @Nullable byte[] start, @Nullable byte[] end) {
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildIndexFromIndex",
                 LogMessageKeys.RANGE_START, start,
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
                 (store, recordsScanned, limit) -> buildRangeOnly(store, start, end , recordsScanned, limit),
-                subspaceProvider, subspace);
+                subspaceProvider);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
@@ -143,7 +143,7 @@ public class IndexingByIndex extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
-                (store, recordsScanned) -> buildRangeOnly(store, start, end , recordsScanned),
+                (store, recordsScanned, limit) -> buildRangeOnly(store, start, end , recordsScanned),
                 subspaceProvider, subspace);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
@@ -477,6 +477,8 @@ public class IndexingByRecords extends IndexingBase {
     public CompletableFuture<Key.Evaluated> buildUnbuiltRange(@Nonnull FDBRecordStore store,
                                                               @Nullable Key.Evaluated start,
                                                               @Nullable Key.Evaluated end) {
+        // TODO: this does respect the limit in a sensible-ish way, but given the documentation, I feel like this method
+        //       should either method be removed entirely, or should take a limit
         return buildUnbuiltRange(store, start, end, null, getLimit());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
@@ -161,10 +161,17 @@ public class IndexingByRecords extends IndexingBase {
      * @param recordsScanned continues counter
      * @return a future that will contain the range of records in the interior of the record store
      */
-
     @Nonnull
     public CompletableFuture<TupleRange> buildEndpoints(@Nonnull FDBRecordStore store,
                                                         @Nullable AtomicLong recordsScanned) {
+        return buildEndpoints(store, recordsScanned, Integer.MAX_VALUE);
+    }
+
+    @Nonnull
+    public CompletableFuture<TupleRange> buildEndpoints(@Nonnull FDBRecordStore store,
+                                                        @Nullable AtomicLong recordsScanned,
+                                                        int limit) {
+        // TODO is this needed at all, or can this always be MAX_VALUE
         final RangeSet rangeSet = new RangeSet(store.indexRangeSubspace(common.getIndex()));
         if (TupleRange.ALL.equals(recordsRange)) {
             return buildEndpoints(store, rangeSet, recordsScanned);
@@ -494,7 +501,8 @@ public class IndexingByRecords extends IndexingBase {
                 LogMessageKeys.RANGE_START, start,
                 LogMessageKeys.RANGE_END, end);
 
-        return buildCommitRetryAsync((store, recordsScanned) -> buildUnbuiltRange(store, start, end, recordsScanned),
+        return buildCommitRetryAsync(
+                (store, recordsScanned, limit) -> buildUnbuiltRange(store, start, end, recordsScanned),
                 true,
                 additionalLogMessageKeyValues);
     }
@@ -505,7 +513,8 @@ public class IndexingByRecords extends IndexingBase {
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildUnbuiltRange",
                 LogMessageKeys.RANGE_START, start,
                 LogMessageKeys.RANGE_END, end);
-        return buildCommitRetryAsync((store, recordsScanned) -> buildUnbuiltRange(store, start, end, recordsScanned),
+        return buildCommitRetryAsync(
+                (store, recordsScanned, limit) -> buildUnbuiltRange(store, start, end, recordsScanned),
                 true,
                 additionalLogMessageKeyValues);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
@@ -511,6 +511,8 @@ public class IndexingByRecords extends IndexingBase {
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildUnbuiltRange",
                 LogMessageKeys.RANGE_START, start,
                 LogMessageKeys.RANGE_END, end);
+        // TODO the only usage of this assumes that the whole range will be built, which is not true, it will only
+        //      build up until limit (which may be decreased, if there are failures)
         return buildCommitRetryAsync(
                 (store, recordsScanned, limit) -> buildUnbuiltRange(store, start, end, recordsScanned, limit),
                 true,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -114,12 +114,13 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
-                (store, recordsScanned, limit) -> buildRangeOnly(store, start, end , recordsScanned),
+                (store, recordsScanned, limit) -> buildRangeOnly(store, start, end , recordsScanned, limit),
                 subspaceProvider, subspace);
     }
 
     @Nonnull
-    private CompletableFuture<Boolean> buildRangeOnly(@Nonnull FDBRecordStore store, byte[] startBytes, byte[] endBytes, @Nonnull AtomicLong recordsScanned) {
+    private CompletableFuture<Boolean> buildRangeOnly(@Nonnull FDBRecordStore store, byte[] startBytes, byte[] endBytes,
+                                                      @Nonnull AtomicLong recordsScanned, final int limit) {
         // return false when done
         /* Multi target consistency:
          * 1. Identify missing ranges from only the first index
@@ -138,10 +139,7 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
                 IsolationLevel.SNAPSHOT :
                 IsolationLevel.SERIALIZABLE;
 
-        final ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder()
-                .setIsolationLevel(isolationLevel)
-                .setReturnedRowLimit(getLimit() + 1); // always respect limit in this path; +1 allows a continuation item
-        final ScanProperties scanProperties = new ScanProperties(executeProperties.build());
+        final ScanProperties scanProperties = IndexingUtils.getScanProperties(limit, isolationLevel);
 
         return ranges.onHasNext().thenCompose(hasNext -> {
             if (Boolean.FALSE.equals(hasNext)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -35,7 +35,6 @@ import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
@@ -101,21 +100,21 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
                             .thenCompose(vignore -> {
                                 SubspaceProvider subspaceProvider = common.getRecordStoreBuilder().getSubspaceProvider();
                                 // validation checks, if any, will be performed here
-                                return subspaceProvider.getSubspaceAsync(context)
-                                        .thenCompose(subspace -> buildMultiTargetIndex(subspaceProvider, subspace, null, null));
+                                return buildMultiTargetIndex(subspaceProvider, null, null);
                             })
                 ), common.indexLogMessageKeyValues("IndexingMultiTargetByRecords::buildIndexInternalAsync"));
     }
 
     @Nonnull
-    private CompletableFuture<Void> buildMultiTargetIndex(@Nonnull SubspaceProvider subspaceProvider, @Nonnull Subspace subspace, @Nullable byte[] start, @Nullable byte[] end) {
+    private CompletableFuture<Void> buildMultiTargetIndex(@Nonnull SubspaceProvider subspaceProvider,
+                                                          @Nullable byte[] start, @Nullable byte[] end) {
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex",
                 LogMessageKeys.RANGE_START, start,
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
                 (store, recordsScanned, limit) -> buildRangeOnly(store, start, end , recordsScanned, limit),
-                subspaceProvider, subspace);
+                subspaceProvider);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -114,7 +114,7 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
-                (store, recordsScanned) -> buildRangeOnly(store, start, end , recordsScanned),
+                (store, recordsScanned, limit) -> buildRangeOnly(store, start, end , recordsScanned),
                 subspaceProvider, subspace);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -129,7 +129,7 @@ public class IndexingScrubDangling extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
-                (store, recordsScanned) -> scrubIndexRangeOnly(store, start, end, recordsScanned),
+                (store, recordsScanned, limit) -> scrubIndexRangeOnly(store, start, end, recordsScanned),
                 subspaceProvider, subspace);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -43,7 +43,6 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 import org.slf4j.Logger;
@@ -111,16 +110,13 @@ public class IndexingScrubDangling extends IndexingBase {
                         context.getReadVersionAsync()
                                 .thenCompose(vignore -> {
                                     SubspaceProvider subspaceProvider = common.getRecordStoreBuilder().getSubspaceProvider();
-                                    return subspaceProvider.getSubspaceAsync(context)
-                                            .thenCompose(subspace ->
-                                                    scrubIndex(subspaceProvider, subspace, null, null)
-                                            );
+                                    return scrubIndex(subspaceProvider, null, null);
                                 }),
                 common.indexLogMessageKeyValues("IndexingScrubber::buildIndexInternalAsync"));
     }
 
     @Nonnull
-    private CompletableFuture<Void> scrubIndex(@Nonnull SubspaceProvider subspaceProvider, @Nonnull Subspace subspace,
+    private CompletableFuture<Void> scrubIndex(@Nonnull SubspaceProvider subspaceProvider,
                                                @Nullable byte[] start, @Nullable byte[] end) {
 
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "scrubRecords",
@@ -129,7 +125,7 @@ public class IndexingScrubDangling extends IndexingBase {
 
         return iterateAllRanges(additionalLogMessageKeyValues,
                 (store, recordsScanned, limit) -> scrubIndexRangeOnly(store, start, end, recordsScanned, limit),
-                subspaceProvider, subspace);
+                subspaceProvider);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -42,7 +42,6 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 import org.slf4j.Logger;
@@ -110,15 +109,13 @@ public class IndexingScrubMissing extends IndexingBase {
                         context.getReadVersionAsync()
                                 .thenCompose(vignore -> {
                                     SubspaceProvider subspaceProvider = common.getRecordStoreBuilder().getSubspaceProvider();
-                                    return subspaceProvider.getSubspaceAsync(context)
-                                            .thenCompose(subspace ->
-                                                    scrubRecords(subspaceProvider, subspace, null, null));
+                                    return scrubRecords(subspaceProvider, null, null);
                                 }),
                 common.indexLogMessageKeyValues("IndexingScrubMissing::buildIndexInternalAsync"));
     }
 
     @Nonnull
-    private CompletableFuture<Void> scrubRecords(@Nonnull SubspaceProvider subspaceProvider, @Nonnull Subspace subspace,
+    private CompletableFuture<Void> scrubRecords(@Nonnull SubspaceProvider subspaceProvider,
                                                  @Nullable byte[] start, @Nullable byte[] end) {
 
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "scrubRecords",
@@ -127,7 +124,7 @@ public class IndexingScrubMissing extends IndexingBase {
 
         return iterateAllRanges(additionalLogMessageKeyValues,
                 (store, recordsScanned, limit) -> scrubRecordsRangeOnly(store, start, end , recordsScanned, limit),
-                subspaceProvider, subspace);
+                subspaceProvider);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -127,7 +127,7 @@ public class IndexingScrubMissing extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
-                (store, recordsScanned) -> scrubRecordsRangeOnly(store, start, end , recordsScanned),
+                (store, recordsScanned, limit) -> scrubRecordsRangeOnly(store, start, end , recordsScanned),
                 subspaceProvider, subspace);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncIterator;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
-import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexState;
@@ -127,12 +126,14 @@ public class IndexingScrubMissing extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return iterateAllRanges(additionalLogMessageKeyValues,
-                (store, recordsScanned, limit) -> scrubRecordsRangeOnly(store, start, end , recordsScanned),
+                (store, recordsScanned, limit) -> scrubRecordsRangeOnly(store, start, end , recordsScanned, limit),
                 subspaceProvider, subspace);
     }
 
     @Nonnull
-    private CompletableFuture<Boolean> scrubRecordsRangeOnly(@Nonnull FDBRecordStore store, byte[] startBytes, byte[] endBytes, @Nonnull AtomicLong recordsScanned) {
+    private CompletableFuture<Boolean> scrubRecordsRangeOnly(@Nonnull FDBRecordStore store,
+                                                             byte[] startBytes, byte[] endBytes,
+                                                             @Nonnull AtomicLong recordsScanned, final int limit) {
         // return false when done
         Index index = common.getIndex();
         final RecordMetaData metaData = store.getRecordMetaData();
@@ -150,10 +151,7 @@ public class IndexingScrubMissing extends IndexingBase {
         RangeSet rangeSet = new RangeSet(indexScrubRecordsRangeSubspace(store, index));
         AsyncIterator<Range> ranges = rangeSet.missingRanges(store.ensureContextActive(), startBytes, endBytes).iterator();
 
-        final ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder()
-                .setIsolationLevel(IsolationLevel.SNAPSHOT)
-                .setReturnedRowLimit(getLimit() + 1); // always respectLimit in this path; +1 allows a continuation item
-        final ScanProperties scanProperties = new ScanProperties(executeProperties.build());
+        final ScanProperties scanProperties = IndexingUtils.getScanProperties(limit, IsolationLevel.SNAPSHOT);
 
         return ranges.onHasNext().thenCompose(hasNext -> {
             if (Boolean.FALSE.equals(hasNext)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingUtils.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingUtils.java
@@ -1,0 +1,47 @@
+/*
+ * IndexingUtils.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.ScanProperties;
+
+import javax.annotation.Nonnull;
+
+public class IndexingUtils {
+
+    private IndexingUtils() {
+    }
+
+    static int addOneToAllowForContinuation(final int limit) {
+        // always respect limit in this path; +1 allows a continuation item
+        return limit == Integer.MAX_VALUE ? limit : limit + 1;
+    }
+
+    @Nonnull
+    static ScanProperties getScanProperties(final int limit, final IsolationLevel isolationLevel) {
+        final ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                .setIsolationLevel(isolationLevel)
+                .setReturnedRowLimit(addOneToAllowForContinuation(limit))
+                .build();
+        return new ScanProperties(executeProperties);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/LimittedRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/LimittedRunner.java
@@ -46,8 +46,8 @@ public class LimittedRunner implements AutoCloseable {
     private final Runner runner;
     private int retriesAtMinimum = 0;
     private int successCount = 0;
-    private int increaseLimitAfter = 10; // maybe this should be configurable
-    private int maxRetriesAtMinimum;
+    private final int increaseLimitAfter = 10; // maybe this should be configurable
+    private final int maxRetriesAtMinimum;
     private boolean closed = false;
 
     public LimittedRunner(final int maxLimit, final int maxRetriesAtMinimum, Runner runner) {
@@ -134,7 +134,9 @@ public class LimittedRunner implements AutoCloseable {
     }
 
     public interface Runner {
+
         CompletableFuture<Boolean> runAsync(int limit);
+
         void onSuccess();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/LimittedRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/LimittedRunner.java
@@ -1,0 +1,140 @@
+/*
+ * LimittedRunner.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.FDBError;
+import com.apple.foundationdb.FDBException;
+import com.apple.foundationdb.async.AsyncUtil;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public class LimittedRunner implements AutoCloseable {
+
+    // These error codes represent a list of errors that can occur if there is too much work to be done
+    // in a single transaction.
+    private static final Set<Integer> lessenWorkCodes = Set.of(
+            FDBError.TIMED_OUT.code(),
+            FDBError.TRANSACTION_TOO_OLD.code(),
+            FDBError.NOT_COMMITTED.code(),
+            FDBError.TRANSACTION_TIMED_OUT.code(),
+            FDBError.COMMIT_READ_INCOMPLETE.code(),
+            FDBError.TRANSACTION_TOO_LARGE.code());
+
+    private int currentLimit;
+    private final int maxLimit;
+    private final Runner runner;
+    private int retriesAtMinimum = 0;
+    private int successCount = 0;
+    private int increaseLimitAfter = 10; // maybe this should be configurable
+    private int maxRetriesAtMinimum;
+    private boolean closed = false;
+
+    public LimittedRunner(final int maxLimit, final int maxRetriesAtMinimum, Runner runner) {
+        this.currentLimit = maxLimit;
+        this.maxLimit = maxLimit;
+        this.runner = runner;
+        this.maxRetriesAtMinimum = maxRetriesAtMinimum;
+    }
+
+    public CompletableFuture<Void> runAsync() {
+        final CompletableFuture<Void> overallResult = new CompletableFuture<>();
+        AsyncUtil.whileTrue(() -> {
+            if (closed) {
+                overallResult.completeExceptionally(new FDBDatabaseRunner.RunnerClosed());
+                return AsyncUtil.READY_FALSE;
+            }
+            return runner.runAsync(currentLimit)
+                    .handle((shouldContinue, error) -> handle(overallResult, shouldContinue, error));
+        });
+        return overallResult;
+    }
+
+    private Boolean handle(final CompletableFuture<Void> overallResult, final Boolean shouldContinue, final Throwable error) {
+        if (error == null) {
+            // TODO indexer tracks records scanned only for successful
+            maybeIncreaseLimit();
+            return shouldContinue;
+        } else {
+            successCount = 0;
+            if (!maybeDecreaseLimit(error)) {
+                overallResult.completeExceptionally(error);
+                return false;
+            } else {
+                return true;
+            }
+        }
+    }
+
+    private boolean maybeDecreaseLimit(final Throwable error) {
+        FDBException fdbException = getFDBException(error);
+        if (fdbException != null && lessenWorkCodes.contains(fdbException.getCode())) {
+            if (currentLimit == 1) {
+                retriesAtMinimum++;
+                return retriesAtMinimum < maxRetriesAtMinimum;
+            } else {
+                // TODO should we delay ?
+                // TODO log
+                currentLimit = Math.max(1, (3 * currentLimit) / 4);
+                return true;
+            }
+        } else {
+            // Not something to lessen work, so don't retry
+            return false;
+        }
+    }
+
+    // Finds the FDBException that ultimately caused some throwable or
+    // null if there is none. This can be then used to determine, for
+    // example, the error code associated with this FDBException.
+    @Nullable
+    private FDBException getFDBException(@Nonnull Throwable e) {
+        Throwable curr = e;
+        while (curr != null) {
+            if (curr instanceof FDBException) {
+                return (FDBException)curr;
+            } else {
+                curr = curr.getCause();
+            }
+        }
+        return null;
+    }
+
+    private void maybeIncreaseLimit() {
+        successCount++;
+        if (successCount >= increaseLimitAfter && currentLimit < maxLimit) {
+            currentLimit = Math.min(maxLimit, Math.max(currentLimit + 1, (4 * currentLimit) / 3));
+            // TODO log
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.closed = true;
+    }
+
+    public interface Runner {
+        CompletableFuture<Boolean> runAsync(int limit);
+        void onSuccess();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/LimittedRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/LimittedRunner.java
@@ -129,7 +129,7 @@ public class LimittedRunner implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.closed = true;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -434,7 +434,7 @@ public class OnlineIndexer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
+    <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull IndexingThrottle.Runner<R> buildFunction,
                                                    @Nullable List<Object> additionalLogMessageKeyValues) {
         // test only
         return getIndexer().buildCommitRetryAsync(buildFunction, true, additionalLogMessageKeyValues);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -58,7 +58,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -796,6 +795,7 @@ public class OnlineIndexer implements AutoCloseable {
         return common.getTotalRecordsScanned().get();
     }
 
+    @Nonnull
     private FDBDatabaseRunner getRunner() {
         return runner;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -470,7 +470,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             // Non-retriable error that is in lessen work codes.
             attempts.set(0);
             indexBuilder.buildCommitRetryAsync((store, recordsScanned, innerLimit) -> {
-                assertEquals(indexBuilder.getLimit(), limit.getAndUpdate(x -> Math.max(1, (3 * x) / 4)),
+                assertEquals(innerLimit, limit.getAndUpdate(x -> Math.max(1, (3 * x) / 4)),
                         String.format("Attempt: %02d", attempts.getAndIncrement()));
                 throw new RecordCoreException("Non-retriable", new FDBException("transaction_too_large", 2101));
             }, null).handle((val, e) -> {
@@ -579,7 +579,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                             return AsyncUtil.READY_FALSE;
                         } else {
                             int currentAttempt = attempts.getAndIncrement();
-                            assertEquals(behavior.getLeft().intValue(), indexBuilder.getLimit(),
+                            assertEquals(behavior.getLeft().intValue(), limit,
                                     "Attempt " + currentAttempt);
                             if (behavior.getRight() != null) {
                                 throw behavior.getRight().get();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -470,8 +470,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             // Non-retriable error that is in lessen work codes.
             attempts.set(0);
             indexBuilder.buildCommitRetryAsync((store, recordsScanned, innerLimit) -> {
-                assertEquals(attempts.getAndIncrement(), indexBuilder.getLimit(),
-                        limit.getAndUpdate(x -> Math.max(x, (3 * x) / 4)));
+                assertEquals(indexBuilder.getLimit(), limit.getAndUpdate(x -> Math.max(1, (3 * x) / 4)),
+                        String.format("Attempt: %02d", attempts.getAndIncrement()));
                 throw new RecordCoreException("Non-retriable", new FDBException("transaction_too_large", 2101));
             }, null).handle((val, e) -> {
                 assertNotNull(e);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -449,7 +449,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         }
     }
 
-    private <R> CompletableFuture<R> runAndHandleLessenWorkCodes(OnlineIndexer indexBuilder, @Nonnull Function<FDBRecordStore, CompletableFuture<R>> function) {
+    private <R> CompletableFuture<R> runAndHandleLessenWorkCodes(OnlineIndexer indexBuilder,
+                                                                 @Nonnull Function<FDBRecordStore, CompletableFuture<R>> function) {
         return indexBuilder.throttledRunAsync(function, Pair::of, indexBuilder::decreaseLimit, null);
     }
 
@@ -468,7 +469,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
 
             // Non-retriable error that is in lessen work codes.
             attempts.set(0);
-            indexBuilder.buildCommitRetryAsync((store, recordsScanned) -> {
+            indexBuilder.buildCommitRetryAsync((store, recordsScanned, innerLimit) -> {
                 assertEquals(attempts.getAndIncrement(), indexBuilder.getLimit(),
                         limit.getAndUpdate(x -> Math.max(x, (3 * x) / 4)));
                 throw new RecordCoreException("Non-retriable", new FDBException("transaction_too_large", 2101));
@@ -572,7 +573,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             AtomicInteger attempts = new AtomicInteger();
             attempts.set(0);
             AsyncUtil.whileTrue(() ->
-                    indexBuilder.buildCommitRetryAsync((store, recordsScanned) -> {
+                    indexBuilder.buildCommitRetryAsync((store, recordsScanned, limit) -> {
                         Pair<Integer, Supplier<RuntimeException>> behavior = queue.poll();
                         if (behavior == null) {
                             return AsyncUtil.READY_FALSE;
@@ -628,7 +629,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             AtomicInteger attempts = new AtomicInteger();
             attempts.set(0);
             AsyncUtil.whileTrue(() -> indexBuilder.buildCommitRetryAsync(
-                    (store, recordsScanned) -> {
+                    (store, recordsScanned, limit) -> {
                         Pair<Long, Supplier<RuntimeException>> behavior = queue.poll();
                         if (behavior == null) {
                             return AsyncUtil.READY_FALSE;


### PR DESCRIPTION
In essence, this is an attempt to abstract away IndexingThrottle
so that it could be used for other cross-transaction work that
may want to limit the amount of work that it is touching. One
such example of that would be to Export/Import mechanism, which
would want to do as much work per-transaction as it can, but would
need to save across many transactions.