### PR TITLE
Fixes #1571: Lucene subproject calls CompletableFuture::join

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Blocking calls within the Lucene index maintainer implementation now use `asyncToSync` to wrap exceptions, control timeouts, and report metrics [(Issue #1571)](https://github.com/FoundationDB/fdb-record-layer/issues/1571)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -118,10 +118,16 @@ public class LuceneEvents {
     public enum Waits implements StoreTimer.Wait {
         /** Wait to delete a file from Lucene's FDBDirectory.*/
         WAIT_LUCENE_DELETE_FILE("lucene delete file"),
-        /** Time to get the length of the a file in Lucene's FDBDirectory.*/
+        /** Wait to get the length of the a file in Lucene's FDBDirectory.*/
         WAIT_LUCENE_FILE_LENGTH("lucene file length"),
-        /** Time to rename a file in Lucene's FDBDirectory.*/
+        /** Wait to rename a file in Lucene's FDBDirectory.*/
         WAIT_LUCENE_RENAME("lucene rename"),
+        /** Wait to get a new file counter increment. */
+        WAIT_LUCENE_GET_INCREMENT("lucene file counter increment"),
+        /** Wait to read a file reference. */
+        WAIT_LUCENE_GET_FILE_REFERENCE("lucene get file reference"),
+        /** Wait to read a data block. */
+        WAIT_LUCENE_GET_DATA_BLOCK("lucene get data block"),
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedIndexInput.java
@@ -49,7 +49,7 @@ public class LuceneOptimizedWrappedIndexInput extends IndexInput {
     public LuceneOptimizedWrappedIndexInput(@Nonnull String name, @Nonnull FDBDirectory directory, boolean isSegmentInfo) {
         super(name);
         this.directory = directory;
-        reference = this.directory.getFDBLuceneFileReference(convertToDataFile(name)).join();
+        reference = this.directory.getFDBLuceneFileReference(convertToDataFile(name));
         value = isSegmentInfo ? reference.getSegmentInfo() : reference.getEntries();
         position = 0;
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -288,7 +288,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "testSynonym[shouldDeferFetch={0}]")
     @BooleanSource
     void testSynonym(boolean shouldDeferFetch) throws Exception {
         initializedWithSynonymIndex("Good morning Mr Tian");
@@ -298,7 +298,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         assertTermIndexedOrNot("full", false, shouldDeferFetch);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "testNgram[shouldDeferFetch={0}]")
     @BooleanSource
     void testNgram(boolean shouldDeferFetch) throws Exception {
         initializeWithNgramIndex("Good morning Mr Tian", false, 3, 5);
@@ -327,7 +327,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         assertTermIndexedOrNot("Mr T", true, shouldDeferFetch);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "testNgramEdgesOnly[shouldDeferFetch={0}]")
     @BooleanSource
     void testNgramEdgesOnly(boolean shouldDeferFetch) throws Exception {
         initializeWithNgramIndex("Good morning Mr Tian", true, 3, 5);
@@ -345,7 +345,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         assertTermIndexedOrNot("rning", false, shouldDeferFetch);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "simpleLuceneScans[shouldDeferFetch={0}]")
     @BooleanSource
     void simpleLuceneScans(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -370,7 +370,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "testThenExpressionBeforeFieldExpression[shouldDeferFetch={0}]")
     @BooleanSource
     void testThenExpressionBeforeFieldExpression(boolean shouldDeferFetch) throws Exception {
         initializeNestedWithField();
@@ -391,7 +391,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "simpleLuceneScansDocId[shouldDeferFetch={0}]")
     @BooleanSource
     void simpleLuceneScansDocId(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -411,7 +411,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "delayFetchOnOrOfLuceneScanWithFieldFilter[shouldDeferFetch={0}]")
     @BooleanSource
     void delayFetchOnOrOfLuceneScanWithFieldFilter(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -444,7 +444,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "delayFetchOnFilterWithSort[shouldDeferFetch={0}]")
     @BooleanSource
     void delayFetchOnLuceneFilterWithSort(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -469,7 +469,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "delayFetchOnAndOfLuceneAndFieldFilter[shouldDeferFetch={0}]")
     @BooleanSource
     void delayFetchOnAndOfLuceneAndFieldFilter(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -499,7 +499,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "delayFetchOnOrOfLuceneFiltersGivesUnion[shouldDeferFetch={0}]")
     @BooleanSource
     void delayFetchOnOrOfLuceneFiltersGivesUnion(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -541,7 +541,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "delayFetchOnAndOfLuceneFilters[shouldDeferFetch={0}]")
     @BooleanSource
     void delayFetchOnAndOfLuceneFilters(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -570,7 +570,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "delayFetchOnLuceneComplexStringAnd[shouldDeferFetch={0}]")
     @BooleanSource
     void delayFetchOnLuceneComplexStringAnd(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -598,7 +598,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "delayFetchOnLuceneComplexStringOr[shouldDeferFetch={0}]")
     @BooleanSource
     void delayFetchOnLuceneComplexStringOr(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -626,7 +626,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "misMatchQueryShouldReturnNoResult[shouldDeferFetch={0}]")
     @BooleanSource
     void misMatchQueryShouldReturnNoResult(boolean shouldDeferFetch) throws Exception {
         initializeFlat();
@@ -697,7 +697,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "nestedLuceneAndQuery[shouldDeferFetch={0}]")
     @BooleanSource
     void nestedLuceneAndQuery(boolean shouldDeferFetch) throws Exception {
         initializeNested();
@@ -725,7 +725,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "nestedLuceneFieldQuery[shouldDeferFetch={0}]")
     @BooleanSource
     void nestedLuceneFieldQuery(boolean shouldDeferFetch) throws Exception {
         initializeNested();
@@ -748,7 +748,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "nestedOneOfThemQuery[shouldDeferFetch={0}]")
     @BooleanSource
     void nestedOneOfThemQuery(boolean shouldDeferFetch) throws Exception {
         initializeNested();
@@ -776,7 +776,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "nestedOneOfThemWithAndQuery[shouldDeferFetch={0}]")
     @BooleanSource
     void nestedOneOfThemWithAndQuery(boolean shouldDeferFetch) throws Exception {
         initializeNested();
@@ -808,7 +808,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "nestedOneOfThemWithOrQuery[shouldDeferFetch={0}]")
     @BooleanSource
     void nestedOneOfThemWithOrQuery(boolean shouldDeferFetch) throws Exception {
         initializeNested();
@@ -839,7 +839,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "longFieldQuery[shouldDeferFetch={0}]")
     @BooleanSource
     public void longFieldQuery(boolean shouldDeferFetch) throws Exception {
         initializeNested();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -1077,7 +1077,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
 
     private static void assertEntriesAndSegmentInfoStoredInCompoundFile(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context, @Nonnull String segment, boolean cleanFiles) {
         try (final FDBDirectory directory = new FDBDirectory(subspace, context)) {
-            final FDBLuceneFileReference reference = directory.getFDBLuceneFileReference(segment).join();
+            final FDBLuceneFileReference reference = directory.getFDBLuceneFileReference(segment);
             Assertions.assertNotNull(reference);
             Assertions.assertTrue(reference.getEntries().length > 0);
             Assertions.assertTrue(reference.getSegmentInfo().length > 0);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
@@ -42,7 +42,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         random.nextBytes(data);
         output.writeBytes(data, data.length);
         output.close();
-        assertEquals(data.length, directory.getFDBLuceneFileReference(FILE_NAME).get().getSize());
+        assertEquals(data.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
     }
     
     @Test
@@ -50,7 +50,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeByte((byte) 0);
         output.close();
-        assertEquals(1, directory.getFDBLuceneFileReference(FILE_NAME).get().getSize());
+        assertEquals(1, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
     }
 
 }


### PR DESCRIPTION
This removes the calls to `CompletableFuture::join` from non-test code within the fdb-record-layer-lucene subproject and replaces them with calls to `FDBRecordContext::asyncToSync` over the future. This also made a few code improvements that I noticed while I was editing things:

1. There were a few remaining calls to `.thenApplyAsync`, which shuffles work onto the common fork join pool, and therefore doesn't work with the Record Layer threading model
1. The `readBlock` method could be pipelined better so that it didn't block on getting the file reference, but instead composed the file-reference future and the future to read the block
1. The parameteried `FDBLuceneQueryTest` tests were hiding their names

This fixes #1571. 