### PR TITLE
Resolves #1575: Lucene FDBDirectory could cache listAll results

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Blocking calls within the Lucene index maintainer implementation now use `asyncToSync` to wrap exceptions, control timeouts, and report metrics [(Issue #1571)](https://github.com/FoundationDB/fdb-record-layer/issues/1571)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** The Lucene directory implementation now caches the complete list of files in a directory [(Issue #1575)](https://github.com/FoundationDB/fdb-record-layer/issues/1575)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -38,20 +38,22 @@ public class LuceneEvents {
      * Main events.
      */
     public enum Events implements StoreTimer.Event {
-        /** Time to read a block from Lucene's FDBDirectory.*/
+        /** Time to read a block from Lucene's FDBDirectory. */
         LUCENE_READ_BLOCK("lucene block reads"),
         /** Time to read a lucene block from FBB loader. */
         LUCENE_FDB_READ_BLOCK("lucene read from fdb"),
-        /** Time to list all files from Lucene's FDBDirectory.*/
+        /** Time to list all files from Lucene's FDBDirectory. */
         LUCENE_LIST_ALL("lucene list all"),
-        /** Number of getFileReference calls in the FDBDirectory.*/
-        LUCENE_GET_FILE_REFERENCE("lucene get file references"),
+        /** Time to load the file cache for Lucene's FDBDirectory. */
+        LUCENE_LOAD_FILE_CACHE("lucene load file cache"),
+        /** Number of file length calls in the FDBDirectory. */
+        LUCENE_GET_FILE_LENGTH("lucene get file length"),
         /** Number of documents returned from a single Lucene Index Scan. */
         LUCENE_INDEX_SCAN("lucene search returned documents"),
         /** Number of suggestions returned from a single Lucene Auto Complete Scan. */
         LUCENE_AUTO_COMPLETE_SUGGESTIONS_SCAN("lucene search returned auto complete suggestions"),
         /** Number of documents returned from a single Lucene spellcheck scan. */
-        LUCENE_SPELLCHECK_SCAN("lucene search returned spellcheck suggestions")
+        LUCENE_SPELLCHECK_SCAN("lucene search returned spellcheck suggestions"),
         ;
 
         private final String title;
@@ -128,6 +130,8 @@ public class LuceneEvents {
         WAIT_LUCENE_GET_FILE_REFERENCE("lucene get file reference"),
         /** Wait to read a data block. */
         WAIT_LUCENE_GET_DATA_BLOCK("lucene get data block"),
+        /** Wait for lucene to load the file cache. */
+        WAIT_LUCENE_LOAD_FILE_CACHE("lucene load file cache"),
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -346,7 +346,6 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             RecordCursor<IndexEntry> indexEntries = recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN);
             assertEquals(1, indexEntries.getCount().join());
             assertEquals(1, context.getTimer().getCounter(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
-            assertCorrectMetricCount(LuceneEvents.Events.LUCENE_GET_FILE_REFERENCE,1);
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", true);
         }


### PR DESCRIPTION
This restructures the way the `FDBDirectory` handles caching the file name to `FDBLuceneFileReference` map. Previously, there was a cache where entries were probably filled by a call to `listAll()` that would happen when the directory was opened anyway, but now, this keeps a full cache of file names and file reference information in memory for the directory. In theory, this could get too big if there are too many files, but the calling code relies on being able to list all files anyway, so at least for now, that's a problem either way. Note that the calling code sometimes makes multiple `listAll()` calls in the same request, and so this cache can speed up calls after the first one.

This also tweaks the way that the list is read from the database in that it uses the `WANT_ALL` streaming mode instead of the (default) `ITERATOR` streaming mode. This streaming mode tries to optimize the number of round trips required to complete a range read, which means that the time to first byte can be longer but the time to the last byte can be shorter. Given that the full list is needed in this case before we can do anything useful with it, optimizing for time to last byte should be an improvement in this case.

This resolves #1575.