### PR TITLE
Resolves #1577: Lucene FDBDirectory should cache file counter

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,6 +23,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** A file sequence counter used to map file names to an internal ID by the Lucene directory implementation is now cached in memory [(Issue #1577)](https://github.com/FoundationDB/fdb-record-layer/issues/1577)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
This adds a new `AtomicLong` to the `FDBDirectory` where the file sequence counter is cached. The first time a user tries to get an increment, the value is loaded from the database and put into the cache. All subsequent accesses can use that cache, and the `AtomicLong` guarantees thread safety. Note that the FDB read-your-writes cache was already keeping a cached copy, but this removes the extra JNI hop and requirement to go through the FDB network thread in order to get a new increment.

This resolves #1577.