### PR TITLE
New ExponentialDelay class, fixes #1565

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** FDBDatabaseRunnerImpl correctly trends towards maxDelayMillis, not 0 [(Issue #1565)](https://github.com/FoundationDB/fdb-record-layer/issues/1565)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** "rebuilding index failed" does not include primary_key [(Issue #1572)](https://github.com/FoundationDB/fdb-record-layer/issues/1572)
 * **Bug fix** Delete records where now handles indexes on key-with-value expressions that split at locations that are in the middle of function key expressions [(Issue #1563)](https://github.com/FoundationDB/fdb-record-layer/issues/1563)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb.runners;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.MoreAsyncUtil;
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
@@ -67,6 +68,7 @@ public class ExponentialDelay {
     }
 
     @Nonnull
+    @VisibleForTesting
     protected CompletableFuture<Void> delayedFuture(final long nextDelayMillis) {
         return MoreAsyncUtil.delayedFuture(nextDelayMillis, TimeUnit.MILLISECONDS);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.async.MoreAsyncUtil;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -62,7 +63,7 @@ public class ExponentialDelay {
 
     @SuppressWarnings("java:S2245") // this source of randomness is not for cryptography/security
     private long calculateNextDelayMillis() {
-        return (long)(Math.random() * currentDelayMillis);
+        return (long)(ThreadLocalRandom.current().nextDouble() * currentDelayMillis);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
@@ -1,0 +1,76 @@
+/*
+ * ExponentialDelay.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.runners;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.MoreAsyncUtil;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class mantains a delay that should be used when retrying transactional operations that have failed due to
+ * something retriable.
+ * <p>
+ *     The goal here is to avoid making the situation worse when the system is overloaded, by backing off.
+ * </p>
+ * <p>
+ *     While the name is "Exponential", it has a pretty aggressive jitter added so that, if there are two transactions
+ *     conflicting, they won't both keep retrying with the same back off on every retry.
+ * </p>
+ *
+ */
+@API(API.Status.INTERNAL)
+public class ExponentialDelay {
+
+    private static final long MIN_DELAY_MILLIS = 2;
+    private final long maxDelayMillis;
+    private long currentDelayMillis;
+    private long nextDelayMillis;
+
+    public ExponentialDelay(final long initialDelayMillis, final long maxDelayMillis) {
+        currentDelayMillis = initialDelayMillis;
+        this.maxDelayMillis = maxDelayMillis;
+        this.nextDelayMillis = calculateNextDelayMillis();
+    }
+
+    public CompletableFuture<Void> delay() {
+        final long delay = nextDelayMillis;
+        currentDelayMillis = Math.max(Math.min(currentDelayMillis * 2, maxDelayMillis), MIN_DELAY_MILLIS);
+        nextDelayMillis = calculateNextDelayMillis();
+        return delayedFuture(delay);
+    }
+
+    @SuppressWarnings("java:S2245") // this source of randomness is not for cryptography/security
+    private long calculateNextDelayMillis() {
+        return (long)(Math.random() * currentDelayMillis);
+    }
+
+    @Nonnull
+    protected CompletableFuture<Void> delayedFuture(final long nextDelayMillis) {
+        return MoreAsyncUtil.delayedFuture(nextDelayMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public long getNextDelayMillis() {
+        return nextDelayMillis;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes for running blocks of asynchronous code with-or-without retries.
+ *
+ * <p>
+ *     Note: for historical/backwards compatibility reasons
+ *     {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner}
+ *     and {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunnerImpl}
+ *     are not included in this package.
+ * </p>
+ */
+package com.apple.foundationdb.record.provider.foundationdb.runners;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelayTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelayTest.java
@@ -1,0 +1,214 @@
+/*
+ * ExponentialDelayTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.runners;
+
+import com.apple.foundationdb.async.AsyncUtil;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExponentialDelayTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExponentialDelayTest.class);
+
+    @RepeatedTest(value = 5, name = "delayIncreases({currentRepetition} of {totalRepetitions})")
+    void delayIncreases() {
+        final Random random = new Random();
+        final long initialDelayMillis = random.nextInt(10) + 45;
+        final long maxDelayMillis = random.nextInt(1000) + 9500;
+        final NoActualDelay exponentialDelay = new NoActualDelay(initialDelayMillis, maxDelayMillis);
+        final int minCount = 100;
+        final int maxCount = 100000;
+        final double minAverage = maxDelayMillis / 2.0 - 100;
+        final List<Long> nextDelays = runUntilAverageMax(exponentialDelay, minCount, maxCount, minAverage);
+
+        assertThat(nextDelays.get(0), Matchers.lessThanOrEqualTo(initialDelayMillis));
+        assertThat(nextDelays.size(), Matchers.allOf(Matchers.greaterThanOrEqualTo(minCount), Matchers.lessThan(maxCount)));
+        assertThat(nextDelays, Matchers.everyItem(Matchers.lessThan(maxDelayMillis)));
+        assertEquals(nextDelays, exponentialDelay.requestedDelays);
+    }
+
+    @RepeatedTest(value = 20, name = "delayIncreasesSlowly({currentRepetition} of {totalRepetitions})")
+    void delayIncreasesSlowly() {
+        final Random random = new Random();
+        final long initialDelayMillis = random.nextInt(90) + 10;
+        final long maxDelayMillis = (long)(Math.pow(2, 20) * initialDelayMillis);
+        final int minCount = 100;
+        final int maxCount = 100000;
+        final double minAverage = maxDelayMillis / 2.0 - 100;
+        List<List<Long>> allDelays = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            allDelays.add(runUntilAverageMax(new NoActualDelay(initialDelayMillis, maxDelayMillis),
+                    minCount, maxCount, minAverage));
+        }
+
+        while (true) {
+            assertThat(allDelays, Matchers.hasSize(Matchers.lessThan(500)));
+            allDelays.add(runUntilAverageMax(new NoActualDelay(initialDelayMillis, maxDelayMillis),
+                    minCount, maxCount, minAverage));
+            final long minLength = allDelays.stream().mapToLong(List::size).min().orElseThrow();
+            final List<Double> averaged = new ArrayList<>();
+            for (int i = 0; i < minLength; i++) {
+                averaged.add(average(forAllGet(allDelays, i)));
+            }
+            assertThat(averaged.size(), Matchers.greaterThan(10));
+            // we want to repeat until the averages are within the bounds of exponential growth
+            final int firstBadIndex = areAveragesApproximatelyExponential(initialDelayMillis, maxDelayMillis, averaged);
+            if (firstBadIndex == -1) {
+                break;
+            }
+            if (allDelays.size() == 500) {
+                LOGGER.debug("avg " + averaged.stream()
+                        .map(val -> String.format("%10d", val.longValue()))
+                        .collect(Collectors.joining(" ")));
+                Stream.concat(Stream.of("^^^^^^^^^^"),
+                                Stream.of((averaged.get(firstBadIndex - 1)).longValue(),
+                                        (long)(averaged.get(firstBadIndex - 1) * 1.5),
+                                        (long)(averaged.get(firstBadIndex - 1) * 2),
+                                        (long)(averaged.get(firstBadIndex - 1) * 2.5),
+                                        (long)(maxDelayMillis * 0.4),
+                                        (long)(maxDelayMillis * 0.6)).map(l -> String.format("%010d", l)))
+                        .forEachOrdered(
+                                str -> {
+                                    LOGGER.debug("    " + IntStream.range(0, averaged.size())
+                                            .mapToObj(i -> i == firstBadIndex ? str : "          ")
+                                            .collect(Collectors.joining(" ")));
+                                });
+                LOGGER.debug("----" + averaged.stream().map(vignore -> "--------").collect(Collectors.joining()));
+            }
+        }
+    }
+
+    @RepeatedTest(value = 50, name = "jitters({currentRepetition} of {totalRepetitions})")
+    void jitters() {
+        // If we have multiple different delays running at the same time, we don't want them both to be delaying the
+        // same amount everytime
+        final Random random = new Random();
+        final long initialDelayMillis = random.nextInt(500) + 1000;
+        final long maxDelayMillis = (long)(Math.pow(2, 20) * initialDelayMillis);
+        final int minCount = 100;
+        final int maxCount = 100000;
+        final double minAverage = maxDelayMillis / 2.0 - 100;
+        List<Set<Long>> allDelays = new ArrayList<>();
+        allDelays.add(new HashSet<>());
+        boolean foundDupe = false;
+        // run 10 different sequences, after that, we should be able to run a sequence, where every delay is different
+        // from the same nth delay.
+        int totalCount = 0;
+        while (allDelays.get(0).size() < 10 || foundDupe) {
+            List<Long> delaySequence = runUntilAverageMax(new NoActualDelay(initialDelayMillis, maxDelayMillis),
+                    minCount, maxCount, minAverage);
+            foundDupe = false;
+            for (int j = 0; j < delaySequence.size(); j++) {
+                while (j >= allDelays.size()) {
+                    allDelays.add(new HashSet<>());
+                }
+                if (!allDelays.get(j).add(delaySequence.get(j))) {
+                    foundDupe = true;
+                }
+            }
+            // just so the test doesn't run until it times out (or runs out of heap space)
+            totalCount++;
+            assertThat(totalCount, Matchers.lessThan(100));
+        }
+    }
+
+    private int areAveragesApproximatelyExponential(final long initialDelayMillis, final long maxDelayMillis,
+                                                    final List<Double> averaged) {
+        if (averaged.get(0) <= initialDelayMillis * 0.25 || averaged.get(0) >= initialDelayMillis * 0.75) {
+            return 0;
+        }
+        for (int i = 1; i < averaged.size(); i++) {
+            if (averaged.get(i) < Math.min(averaged.get(i - 1) * 1.5, maxDelayMillis * 0.4) ||
+                    averaged.get(i) > Math.min(averaged.get(i - 1) * 2.5, maxDelayMillis * 0.6)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Nonnull
+    private List<Long> forAllGet(final List<List<Long>> allDelays, final int index) {
+        return allDelays.stream().map(delays -> delays.get(index)).collect(Collectors.toList());
+    }
+
+    private List<Long> runUntilAverageMax(final NoActualDelay exponentialDelay,
+                                          final int minCount, final int maxCount,
+                                          final double minAverage) {
+        List<Long> nextDelays = new ArrayList<>();
+        AsyncUtil.whileTrue(() -> {
+            nextDelays.add(exponentialDelay.getNextDelayMillis());
+            return exponentialDelay.delay().thenCompose(vignore -> {
+                if (nextDelays.size() < minCount) {
+                    return AsyncUtil.READY_TRUE;
+                } else {
+                    if (nextDelays.size() >= maxCount) {
+                        // don't just let the test run forever
+                        return AsyncUtil.READY_FALSE;
+                    } else {
+                        double recentAverage = average(nextDelays.subList(nextDelays.size() - 20, nextDelays.size()));
+                        return CompletableFuture.completedFuture(recentAverage < minAverage);
+                    }
+                }
+            });
+        }).join();
+        return nextDelays;
+    }
+
+    private double average(final List<Long> values) {
+        return values.stream().mapToLong(Long::longValue).average().orElseThrow();
+    }
+
+
+    /**
+     * A helper implementation to make the test substantially faster.
+     */
+    private static class NoActualDelay extends ExponentialDelay {
+        List<Long> requestedDelays = new ArrayList<>();
+
+        public NoActualDelay(final long initialDelayMillis, final long maxDelayMillis) {
+            super(initialDelayMillis, maxDelayMillis);
+        }
+
+        @Nonnull
+        @Override
+        protected CompletableFuture<Void> delayedFuture(final long nextDelayMillis) {
+            requestedDelays.add(nextDelayMillis);
+            return AsyncUtil.DONE;
+        }
+    }
+
+}


### PR DESCRIPTION
This introduces a new class `ExponentialDelay` that manages a delay that backs off exponentially, along with a jitter.
This replaces two implementations of the same idea, one in `FDBDatabaseRunnerImpl` and one in `IndexingThrottle`.
This also, fixes #1565 by the fact that the new class does not have that bug, so using it in `FDBDatabaseRunnerImpl` will clean that up.

I also introduced a new `runners` package, for this, because I felt as though the root was getting too bloated. I did not move `FDBDatabaseRunnerImpl` to the new package, although that could be done (it is INTERNAL). Move `FDBDatabaseRunner` would be a breaking change. 