### PR TITLE
Fixes #1583: Indexes with groups erroneously accept deleteRecordsWhere queries on grouped columns

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,6 +17,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Delete records where limits indexes on grouping key expressions to predicates that can be satisfied by only the grouping columns [(Issue #1583)](https://github.com/FoundationDB/fdb-record-layer/issues/1583)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Blocking calls within the Lucene index maintainer implementation now use `asyncToSync` to wrap exceptions, control timeouts, and report metrics [(Issue #1571)](https://github.com/FoundationDB/fdb-record-layer/issues/1571)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -274,10 +274,20 @@ public interface KeyExpression extends PlanHashable, QueryHashable {
     }
 
     /**
-     * Returns a sub-set of the key expression.
-     * @param start starting position
-     * @param end ending position
+     * Returns a sub-set of the key expression based on the column indexes into the expression.
+     * Column indexes start at zero. If {@code start} is equal to {@code end}, this
+     * should return an {@link EmptyKeyExpression}, and if {@code start} is equal to zero and
+     * {@code end} is equal to {@link #getColumnSize()}, then this should return the original
+     * key expression.
+     *
+     * @param start inclusive starting column index
+     * @param end exclusive ending column index
      * @return a key expression for the subkey between {@code start} and {@code end}
+     * @throws com.apple.foundationdb.record.metadata.expressions.BaseKeyExpression.IllegalSubKeyException
+     *     if {@code start} or {@code end} are outside the expected range or if {@code end < start}
+     * @throws com.apple.foundationdb.record.metadata.expressions.BaseKeyExpression.UnsplittableKeyExpressionException
+     *     if the key expression cannot be split at the current location because a split point would land in the
+     *     middle of a key expression that does not support being split
      */
     @Nonnull
     KeyExpression getSubKey(int start, int end);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
@@ -621,6 +621,15 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
         return canDeleteWhere(state, match, evaluated);
     }
 
+    protected boolean canDeleteGroup(@Nonnull QueryToKeyMatcher matcher, @Nonnull Key.Evaluated evaluated) {
+        KeyExpression rootExpression = state.index.getRootExpression();
+        if (!(rootExpression instanceof GroupingKeyExpression)) {
+            return false;
+        }
+        final QueryToKeyMatcher.Match match = matcher.matchesSatisfyingQuery(rootExpression);
+        return canDeleteWhere(state, match, evaluated);
+    }
+
     // Update index for deleting records where primary key starts with prefix. Prefix must be a prefix of the index grouping.
     @Override
     public CompletableFuture<Void> deleteWhere(Transaction tr, @Nonnull Tuple prefix) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainer.java
@@ -497,12 +497,7 @@ public class TextIndexMaintainer extends StandardIndexMaintainer {
      */
     @Override
     public boolean canDeleteWhere(@Nonnull QueryToKeyMatcher matcher, @Nonnull Key.Evaluated evaluated) {
-        if (state.index.getRootExpression() instanceof GroupingKeyExpression) {
-            final QueryToKeyMatcher.Match match = matcher.matchesSatisfyingQuery(((GroupingKeyExpression) state.index.getRootExpression()).getGroupingSubKey());
-            return canDeleteWhere(state, match, evaluated);
-        } else {
-            return false;
-        }
+        return canDeleteGroup(matcher, evaluated);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryToKeyMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryToKeyMatcher.java
@@ -514,7 +514,7 @@ public class QueryToKeyMatcher {
         return null;
     }
 
-    @Nullable
+    @Nonnull
     private KeyExpression extractPrefixUntilSplittable(KeyExpression wholeKeyExpression, int originalSplitPoint) {
         int adjustedSplitPoint = originalSplitPoint - 1;
         while (adjustedSplitPoint >= 0) {
@@ -524,7 +524,10 @@ public class QueryToKeyMatcher {
                 adjustedSplitPoint--;
             }
         }
-        return null;
+        // We should always be able to extract 0 columns, so this should be unreachable code
+        throw new RecordCoreException("unable to extract splittable prefix from key expression")
+                .addLogInfo(LogMessageKeys.KEY_EXPRESSION, wholeKeyExpression)
+                .addLogInfo(LogMessageKeys.COLUMN_SIZE, originalSplitPoint);
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/UnknownKeyExpression.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/UnknownKeyExpression.java
@@ -100,4 +100,9 @@ public class UnknownKeyExpression extends BaseKeyExpression {
     public int queryHash(@Nonnull final QueryHashKind hashKind) {
         return HashUtils.queryHash(hashKind, BASE_HASH);
     }
+
+    @Override
+    public String toString() {
+        return "UNKNOWN";
+    }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreDeleteWhereTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreDeleteWhereTest.java
@@ -20,30 +20,42 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.FunctionNames;
 import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecordsWithHeaderProto;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -54,12 +66,21 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.keyWithValue;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.value;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTupleString;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scoreForRank;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests related to {@link FDBRecordStore#deleteRecordsWhere(QueryComponent)} and its variants.
@@ -67,17 +88,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag(Tags.RequiresFDB)
 public class FDBRecordStoreDeleteWhereTest extends FDBRecordStoreTestBase {
 
-    @Test
-    void testDeleteWhereCountIndex() throws Exception {
-        testDeleteWhere(true);
-    }
-
-    @Test
-    void testDeleteWhere() throws Exception {
-        testDeleteWhere(false);
-    }
-
-    private void testDeleteWhere(boolean useCountIndex) throws Exception {
+    @ParameterizedTest(name = "testDeleteWhere[useCountIndex={0}]" )
+    @BooleanSource
+    void testDeleteWhere(boolean useCountIndex) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeaderPrimaryKey(context, useCountIndex);
 
@@ -89,7 +102,7 @@ public class FDBRecordStoreDeleteWhereTest extends FDBRecordStoreTestBase {
             saveHeaderRecord(2, "b", 4, "leopard");
             saveHeaderRecord(2, "c", 5, "lion");
             saveHeaderRecord(2, "d", 6, "tiger");
-            context.commit();
+            commit(context);
         }
 
         try (FDBRecordContext context = openContext()) {
@@ -98,7 +111,7 @@ public class FDBRecordStoreDeleteWhereTest extends FDBRecordStoreTestBase {
             assertEquals(3, recordStore.getSnapshotRecordCount(groupExpr, Key.Evaluated.scalar(1)).join().longValue());
 
             recordStore.deleteRecordsWhere(Query.field("header").matches(Query.field("rec_no").equalsValue(1)));
-            context.commit();
+            commit(context);
         }
 
         try (FDBRecordContext context = openContext()) {
@@ -120,7 +133,7 @@ public class FDBRecordStoreDeleteWhereTest extends FDBRecordStoreTestBase {
                 assertEquals(expectedNum++, record.getHeader().getNum());
             }
             assertEquals(7, expectedNum);
-            context.commit();
+            commit(context);
         }
     }
 
@@ -150,7 +163,7 @@ public class FDBRecordStoreDeleteWhereTest extends FDBRecordStoreTestBase {
             saveHeaderRecord(2, "b", 4, "leopard");
             saveHeaderRecord(2, "c", 5, "lion");
             saveHeaderRecord(2, "d", 6, "tiger");
-            context.commit();
+            commit(context);
         }
         try (FDBRecordContext context = openContext()) {
             openRecordWithHeader(context, hook);
@@ -170,7 +183,294 @@ public class FDBRecordStoreDeleteWhereTest extends FDBRecordStoreTestBase {
             // Deleting by group prefix resets the update counter for the group(s)
             assertEquals(1, recordStore.getSnapshotRecordUpdateCount(groupExpr, Key.Evaluated.scalar(1)).join().longValue());
 
-            context.commit();
+            commit(context);
+        }
+    }
+
+    private long getGroupedSum(Index sumIndex, Key.Evaluated evaluated) {
+        IndexAggregateFunction sumAggregate = new IndexAggregateFunction(FunctionNames.SUM, sumIndex.getRootExpression(), sumIndex.getName());
+        Tuple sumTuple = recordStore.evaluateAggregateFunction(List.of("MyRecord"), sumAggregate, evaluated, IsolationLevel.SERIALIZABLE)
+                .join();
+        assertNotNull(sumTuple, "sum aggregate result should not be null");
+        return sumTuple.getLong(0);
+    }
+
+    private long getGroupedSumByPath(Index sumIndex, String path) {
+        return getGroupedSum(sumIndex, Key.Evaluated.scalar(path));
+    }
+
+    @Test
+    void testDeleteWhereGroupedSum() throws Exception {
+        final Random random = new Random();
+        final Index sumIndex = new Index("MyRecord$sum_num_by_path",
+                new GroupingKeyExpression(field("header").nest(concatenateFields("path", "num")), 1),
+                IndexTypes.SUM);
+        RecordMetaDataHook hook = metaData -> {
+            final RecordTypeBuilder recordType = metaData.getRecordType("MyRecord");
+            recordType.setPrimaryKey(field("header").nest(concatenateFields("path", "num", "rec_no")));
+            metaData.addIndex(recordType, sumIndex);
+        };
+
+        final List<String> paths = List.of("a", "b", "c", "d");
+        final List<TestRecordsWithHeaderProto.MyRecord> saved = new ArrayList<>();
+        final Map<String, Integer> sumForPath = new HashMap<>();
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+            final long maxRecNo = 20L;
+            for (String path : paths) {
+                for (int recNo = 0; recNo < maxRecNo; recNo++) {
+                    saved.add(saveHeaderRecord(recNo, path, random.nextInt(20), "str_value"));
+                }
+            }
+            for (String path : paths) {
+                int expectedSum = saved.stream()
+                        .filter(record -> record.getHeader().getPath().equals(path))
+                        .mapToInt(record -> record.getHeader().getNum())
+                        .sum();
+                assertEquals(expectedSum, getGroupedSumByPath(sumIndex, path));
+                sumForPath.put(path, expectedSum);
+            }
+            commit(context);
+        }
+
+        // Delete single path
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+
+            final String pathToDelete = paths.get(random.nextInt(paths.size()));
+            recordStore.deleteRecordsWhere(Query.field("header").matches(Query.field("path").equalsValue(pathToDelete)));
+            List<TestRecordsWithHeaderProto.MyRecord> remaining = recordStore.executeQuery(RecordQuery.newBuilder().setRecordType("MyRecord").build())
+                    .map(FDBRecord::getRecord)
+                    .map(this::parseMyRecord)
+                    .asList()
+                    .get();
+            remaining.forEach(remainingRecord -> assertNotEquals(pathToDelete, remainingRecord.getHeader().getPath(),
+                    () -> String.format("record with path %s should have been deleted: %s", pathToDelete, remainingRecord)));
+            assertThat(remaining, containsInAnyOrder(saved.stream()
+                    .filter(rec -> !rec.getHeader().getPath().equals(pathToDelete))
+                    .map(Matchers::equalTo)
+                    .collect(Collectors.toList())));
+
+            for (String path : paths) {
+                int expectedSum = path.equals(pathToDelete) ? 0 : sumForPath.get(path);
+                assertEquals(expectedSum, getGroupedSumByPath(sumIndex, path), "sum should be unaffected by delete where except for deleted range");
+            }
+
+            // do not commit
+        }
+
+        // Attempt to delete in a way that crosses grouping key of count index
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+
+            final String pathToDelete = paths.get(random.nextInt(paths.size()));
+            TestRecordsWithHeaderProto.MyRecord myRecord = saved.stream()
+                    .filter(savedRecord -> savedRecord.getHeader().getPath().equals(pathToDelete))
+                    .findAny()
+                    .orElseGet(() -> fail("should have saved header records for every path including " + pathToDelete));
+            TestRecordsWithHeaderProto.HeaderRecord header = myRecord.getHeader();
+            final Tuple primaryKey = Tuple.from(header.getPath(), header.getNum(), header.getRecNo());
+            assertNotNull(recordStore.loadRecord(primaryKey), "record should be present before delete where");
+            Query.InvalidExpressionException err = assertThrows(Query.InvalidExpressionException.class,
+                    () -> recordStore.deleteRecordsWhere(Query.field("header").matches(Query.and(
+                            Query.field("path").equalsValue(pathToDelete),
+                            Query.field("num").equalsValue(myRecord.getHeader().getNum())))));
+            assertThat(err.getMessage(), containsString(String.format("deleteRecordsWhere not supported by index %s", sumIndex.getName())));
+            assertNotNull(recordStore.loadRecord(primaryKey), "record should not have been deleted by unsuccessful delete where");
+        }
+    }
+
+    @Test
+    void testDeleteWhereGroupSumSplitsFunction() throws Exception {
+        final Random random = new Random();
+        // The "transpose" function flips its arguments, so this index is effectively "sum the rec_no field, grouped by path and num
+        final Index sumIndex = new Index("MyRecord$sum_rec_no_by_path_and_num",
+                new GroupingKeyExpression(concat(field("header").nest(field("path")), function("transpose", field("header").nest(concatenateFields("rec_no", "num")))), 1),
+                IndexTypes.SUM);
+        RecordMetaDataHook hook = metaData -> {
+            final RecordTypeBuilder recordType = metaData.getRecordType("MyRecord");
+            recordType.setPrimaryKey(field("header").nest(concatenateFields("path", "rec_no")));
+            metaData.addIndex(recordType, sumIndex);
+        };
+
+        final List<String> paths = List.of("gravel", "dirt", "bike", "garden", "brick");
+        final List<TestRecordsWithHeaderProto.MyRecord> saved = new ArrayList<>();
+        final Map<String, Long> sumsByPath = new HashMap<>();
+        final Map<String, Map<Integer, Long>> sumsByPathAndNum = new HashMap<>();
+        final int maxNum = 5;
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+            for (String path : paths) {
+                for (int recNo = 0; recNo < 30; recNo++) {
+                    saved.add(saveHeaderRecord(recNo, path, random.nextInt(maxNum), "unread"));
+                }
+            }
+
+            for (String path : paths) {
+                Map<Integer, Long> sumsByNum = new HashMap<>();
+                for (int i = 0; i < maxNum; i++) {
+                    final int num = i;
+                    long expectedSum = saved.stream()
+                            .filter(savedRecord -> savedRecord.getHeader().getPath().equals(path) && savedRecord.getHeader().getNum() == num)
+                            .mapToLong(savedRecord -> savedRecord.getHeader().getRecNo())
+                            .sum();
+                    assertEquals(expectedSum, getGroupedSum(sumIndex, Key.Evaluated.concatenate(path, num)));
+                    sumsByNum.put(num, expectedSum);
+                }
+                sumsByPathAndNum.put(path, sumsByNum);
+
+                long expectedSum = sumsByNum.values().stream()
+                        .mapToLong(Long::longValue)
+                        .sum();
+                assertEquals(expectedSum, getGroupedSumByPath(sumIndex, path));
+                sumsByPath.put(path, expectedSum);
+
+            }
+
+            commit(context);
+        }
+
+        // Delete a single path. This should work because header.path is a prefix of (though not the full prefix of)
+        // the key expression on which the index is defined
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+
+            final String pathToDelete = paths.get(random.nextInt(paths.size()));
+            recordStore.deleteRecordsWhere(Query.field("header").matches(Query.field("path").equalsValue(pathToDelete)));
+
+            // Assert that the deleted path is gone, but all other path sums should be the same
+            for (String path : paths) {
+                // Get the sum for each value of num
+                Map<Integer, Long> sumByNum = sumsByPathAndNum.get(path);
+                for (Map.Entry<Integer, Long> numAndSum : sumByNum.entrySet()) {
+                    long expectedSum = path.equals(pathToDelete) ? 0L : numAndSum.getValue();
+                    assertEquals(expectedSum, getGroupedSum(sumIndex, Key.Evaluated.concatenate(path, numAndSum.getKey())));
+                }
+
+                // Get the aggregate sum for an entire path
+                long expectedSum = path.equals(pathToDelete) ? 0L : sumsByPath.get(path);
+                assertEquals(expectedSum, getGroupedSumByPath(sumIndex, path));
+            }
+
+            // do not commit
+        }
+
+        // Try to delete in a way that would be inconsistent with the sum index
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+            final String pathToDelete = paths.get(random.nextInt(paths.size()));
+            Query.InvalidExpressionException err = assertThrows(Query.InvalidExpressionException.class,
+                    () -> recordStore.deleteRecordsWhere(Query.field("header").matches(Query.and(
+                            Query.field("path").equalsValue(pathToDelete),
+                            Query.field("rec_no").equalsValue(3L)))));
+
+            assertThat(err.getMessage(), containsString(String.format("deleteRecordsWhere not supported by index %s", sumIndex.getName())));
+        }
+    }
+
+    @Test
+    void testDeleteWhereRank() throws Exception {
+        final Random random = new Random();
+        final Index rankIndex = new Index(
+                "MyRecord$num_by_path",
+                new GroupingKeyExpression(field("header").nest(concatenateFields("path", "num")), 1),
+                IndexTypes.RANK);
+        RecordMetaDataHook hook = metaData -> {
+            final RecordTypeBuilder recordType = metaData.getRecordType("MyRecord");
+            recordType.setPrimaryKey(field("header").nest(concatenateFields("path", "num", "rec_no")));
+            metaData.addIndex(recordType, rankIndex);
+        };
+
+        final List<String> paths = List.of("newark", "hoboken", "journal_square", "33rd_street");
+        final RecordQueryPlan plan;
+        final Map<String, List<TestRecordsWithHeaderProto.MyRecord>> queryResultsByPath = new HashMap<>();
+
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+            final List<TestRecordsWithHeaderProto.MyRecord> savedRecords = new ArrayList<>();
+            for (String path : paths) {
+                for (long recNo = 0; recNo < 15; recNo++) {
+                    savedRecords.add(saveHeaderRecord(recNo, path, random.nextInt(10), "unused"));
+                }
+            }
+
+            GroupingKeyExpression rankGroup = (GroupingKeyExpression) rankIndex.getRootExpression();
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MyRecord")
+                    .setFilter(Query.and(
+                            Query.field("header").matches(Query.field("path").equalsParameter("path_value")),
+                            Query.rank(rankGroup).greaterThan(2),
+                            Query.rank(rankGroup).lessThanOrEquals(6)))
+                    .build();
+            plan = recordStore.planQuery(query);
+            // Plan should use the index to get ranks for the endpoints, and then it can scan the main record index between
+            // the bounds to resolve the records
+            assertThat(plan, scoreForRank(containsInAnyOrder(
+                    hasToString("__rank_0 = " + rankIndex.getName() +  ".score_for_rank($path_value, 2)"),
+                    hasToString("__rank_1 = " + rankIndex.getName() + ".score_for_rank_else_skip($path_value, 6)")
+            ), scan(bounds(hasTupleString("[EQUALS $path_value, [GREATER_THAN $__rank_0 && LESS_THAN_OR_EQUALS $__rank_1]]")))));
+
+            for (String path : paths) {
+                List<TestRecordsWithHeaderProto.MyRecord> sortedForPath = savedRecords.stream()
+                        .filter(myRecord -> myRecord.getHeader().getPath().equals(path))
+                        .sorted((rec1, rec2) -> {
+                            int numComparison = Integer.compare(rec1.getHeader().getNum(), rec2.getHeader().getNum());
+                            if (numComparison != 0) {
+                                return numComparison;
+                            } else {
+                                return Long.compare(rec1.getHeader().getRecNo(), rec2.getHeader().getRecNo());
+                            }
+                        })
+                        .collect(Collectors.toList());
+                Set<Integer> numsInRankRange = sortedForPath.stream()
+                        .map(myRecord -> myRecord.getHeader().getNum())
+                        .distinct()
+                        .skip(3)
+                        .limit(4)
+                        .collect(Collectors.toSet());
+                List<TestRecordsWithHeaderProto.MyRecord> expectedResults = sortedForPath.stream()
+                        .filter(myRecord -> numsInRankRange.contains(myRecord.getHeader().getNum()))
+                        .collect(Collectors.toList());
+
+                assertEquals(expectedResults, plan.execute(recordStore, EvaluationContext.forBinding("path_value", path))
+                        .map(FDBQueriedRecord::getRecord)
+                        .map(this::parseMyRecord)
+                        .asList()
+                        .join());
+                queryResultsByPath.put(path, expectedResults);
+            }
+
+            commit(context);
+        }
+
+        // Try to delete a single path
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+
+            String pathToDelete = paths.get(random.nextInt(paths.size()));
+            recordStore.deleteRecordsWhere(Query.field("header").matches(Query.field("path").equalsValue(pathToDelete)));
+
+            for (String path : paths) {
+                final List<TestRecordsWithHeaderProto.MyRecord> recordsAfterDelete = plan.execute(recordStore, EvaluationContext.forBinding("path_value", path))
+                        .map(FDBQueriedRecord::getRecord)
+                        .map(this::parseMyRecord)
+                        .asList()
+                        .join();
+                assertEquals(path.equals(pathToDelete) ? Collections.emptyList() : queryResultsByPath.get(path), recordsAfterDelete);
+            }
+
+            // do not commit
+        }
+
+        // Attempt to delete with a group that would cross the group boundary of the rank index
+        try (FDBRecordContext context = openContext()) {
+            openRecordWithHeader(context, hook);
+            String pathToDelete = paths.get(random.nextInt(paths.size()));
+            Query.InvalidExpressionException err = assertThrows(Query.InvalidExpressionException.class,
+                    () -> recordStore.deleteRecordsWhere(Query.field("header").matches(Query.and(
+                            Query.field("path").equalsValue(pathToDelete),
+                            Query.field("num").equalsValue(4)))));
+            assertThat(err.getMessage(), containsString(String.format("deleteRecordsWhere not supported by index %s", rankIndex.getName())));
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -319,14 +319,16 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
                 .build());
     }
 
-    protected void saveHeaderRecord(long rec_no, String path, int num, String str) {
-        TestRecordsWithHeaderProto.MyRecord.Builder recBuilder = TestRecordsWithHeaderProto.MyRecord.newBuilder();
-        TestRecordsWithHeaderProto.HeaderRecord.Builder headerBuilder = recBuilder.getHeaderBuilder();
-        headerBuilder.setRecNo(rec_no);
-        headerBuilder.setPath(path);
-        headerBuilder.setNum(num);
-        recBuilder.setStrValue(str);
-        recordStore.saveRecord(recBuilder.build());
+    protected TestRecordsWithHeaderProto.MyRecord saveHeaderRecord(long rec_no, String path, int num, String str) {
+        TestRecordsWithHeaderProto.MyRecord.Builder recBuilder = TestRecordsWithHeaderProto.MyRecord.newBuilder()
+                .setStrValue(str);
+        recBuilder.getHeaderBuilder()
+                .setRecNo(rec_no)
+                .setPath(path)
+                .setNum(num);
+        TestRecordsWithHeaderProto.MyRecord rec = recBuilder.build();
+        recordStore.saveRecord(rec);
+        return rec;
     }
 
     protected TestRecordsWithHeaderProto.MyRecord parseMyRecord(Message message) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -139,8 +139,11 @@ import static com.apple.foundationdb.record.RecordCursor.NoNextReason.SOURCE_EXH
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
 import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexBunchedSerializerTest.entryOf;
 import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.COMPLEX_DOC;
+import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.MAP_DOC;
+import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.MULTI_DOC;
 import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.SIMPLE_DOC;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.coveringIndexScan;
@@ -163,9 +166,11 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -211,10 +216,9 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     private static final Index MAP_ON_VALUE_PREFIX = new Index("Map$entry-value_prefix", new GroupingKeyExpression(field("entry", FanType.FanOut).nest(concatenateFields("key", "value")), 1), IndexTypes.TEXT,
             ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, PrefixTextTokenizer.NAME, IndexOptions.TEXT_TOKENIZER_VERSION_OPTION, "1"));
     private static final Index MAP_ON_VALUE_GROUPED_INDEX = new Index("Map$entry-value_by_group", new GroupingKeyExpression(concat(field("group"), field("entry", FanType.FanOut).nest(concatenateFields("key", "value"))), 1), IndexTypes.TEXT);
-    private static final String MAP_DOC = "MapDocument";
 
     @BeforeEach
-    public void resetRegistry() {
+    void resetRegistry() {
         TextTokenizerRegistryImpl.instance().reset();
     }
 
@@ -403,7 +407,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveSimpleDocuments() throws Exception {
+    void saveSimpleDocuments() throws Exception {
         final SimpleDocument simpleDocument = SimpleDocument.newBuilder()
                 .setDocId(1066L)
                 .setText("This is a simple document. There isn't much going on here, if I'm honest.")
@@ -521,7 +525,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     // be returned after the scan that were both greater than the map key due to a race condition.
     // This was able to reproduce the error when run alone.
     @Test
-    public void backwardsRangeScanRaceCondition() throws Exception {
+    void backwardsRangeScanRaceCondition() throws Exception {
         final Random r = new Random(0x5ca1ab1e);
         final List<String> lexicon = Arrays.asList(TextSamples.ROMEO_AND_JULIET_PROLOGUE.split(" "));
         final SimpleDocument bigDocument = getRandomRecords(r, 1, lexicon, 100, 0).get(0);
@@ -554,7 +558,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveSimpleDocumentsWithPrefix() throws Exception {
+    void saveSimpleDocumentsWithPrefix() throws Exception {
         final SimpleDocument shakespeareDocument = SimpleDocument.newBuilder()
                 .setDocId(1623L)
                 .setText(TextSamples.ROMEO_AND_JULIET_PROLOGUE)
@@ -593,7 +597,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveSimpleDocumentsWithFilter() throws Exception {
+    void saveSimpleDocumentsWithFilter() throws Exception {
         final SimpleDocument russianDocument = SimpleDocument.newBuilder()
                 .setDocId(1547L)
                 .setText(TextSamples.RUSSIAN)
@@ -625,7 +629,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveSimpleDocumentsWithSuffixes() throws Exception {
+    void saveSimpleDocumentsWithSuffixes() throws Exception {
         final SimpleDocument germanDocument = SimpleDocument.newBuilder()
                 .setDocId(1623L)
                 .setText(TextSamples.GERMAN)
@@ -655,7 +659,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveSimpleDocumentsWithNoPositions() throws Exception {
+    void saveSimpleDocumentsWithNoPositions() throws Exception {
         final SimpleDocument shakespeareDocument = SimpleDocument.newBuilder()
                 .setDocId(1623L)
                 .setText(TextSamples.ROMEO_AND_JULIET_PROLOGUE)
@@ -700,7 +704,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveSimpleDocumentsWithPositionsOptionChange() throws Exception {
+    void saveSimpleDocumentsWithPositionsOptionChange() throws Exception {
         final SimpleDocument shakespeareDocument = SimpleDocument.newBuilder()
                 .setDocId(1623L)
                 .setText(TextSamples.ROMEO_AND_JULIET_PROLOGUE)
@@ -749,7 +753,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveComplexDocuments() throws Exception {
+    void saveComplexDocuments() throws Exception {
         ComplexDocument complexDocument = ComplexDocument.newBuilder()
                 .setGroup(0)
                 .setDocId(1066L)
@@ -832,7 +836,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveComplexMultiDocuments() throws Exception {
+    void saveComplexMultiDocuments() throws Exception {
         final ComplexDocument shakespeareDocument = ComplexDocument.newBuilder()
                 .setGroup(0)
                 .setDocId(1623L)
@@ -871,7 +875,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveMapDocuments() throws Exception {
+    void saveMapDocuments() throws Exception {
         final MapDocument firstDocument = MapDocument.newBuilder()
                 .setDocId(1066L)
                 .addEntry(MapDocument.Entry.newBuilder()
@@ -928,7 +932,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveCombinedByGroup() throws Exception {
+    void saveCombinedByGroup() throws Exception {
         final SimpleDocument simpleDocument = SimpleDocument.newBuilder()
                 .setGroup(0)
                 .setDocId(1907L)
@@ -992,7 +996,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveSimpleWithAggressiveConflictRanges() throws Exception {
+    void saveSimpleWithAggressiveConflictRanges() throws Exception {
         // These two documents are from different languages and thus have no conflicts, so
         // without the aggressive conflict ranges, they wouldn't conflict if not
         // for the aggressive conflict ranges
@@ -1017,7 +1021,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void saveComplexWithAggressiveConflictRanges() throws Exception {
+    void saveComplexWithAggressiveConflictRanges() throws Exception {
         // These two documents are in different groups, so even with aggressive conflict
         // ranges, they should be able to be committed concurrently.
         final ComplexDocument zeroGroupDocument = ComplexDocument.newBuilder()
@@ -1039,7 +1043,167 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void tokenizerVersionChange() throws Exception {
+    void deleteWhereSimpleDocuments() {
+        final SimpleDocument doc1 = SimpleDocument.newBuilder()
+                .setDocId(1623L)
+                .setGroup(0)
+                .setText("foo bar")
+                .build();
+        final SimpleDocument doc2 = SimpleDocument.newBuilder()
+                .setDocId(1945L)
+                .setGroup(0)
+                .setText("foo bar")
+                .build();
+        final RecordMetaDataHook hook = metaDataBuilder -> {
+            TextIndexTestUtils.addRecordTypePrefix(metaDataBuilder);
+            // Add "text" to the simple document primary key so that when we issue a delete where based
+            // on the first field of the SimpleDocument$text index, it will align with the primary key
+            metaDataBuilder.getRecordType(SIMPLE_DOC)
+                    .setPrimaryKey(concat(recordType(), field("text"), field("doc_id")));
+        };
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, hook);
+            recordStore.saveRecord(doc1);
+            recordStore.saveRecord(doc2);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, hook);
+            Query.InvalidExpressionException err = assertThrows(Query.InvalidExpressionException.class,
+                    () -> recordStore.deleteRecordsWhere(SIMPLE_DOC, Query.field("text").equalsValue("foo bar")));
+            assertThat(err.getMessage(), containsString("deleteRecordsWhere not supported by index SimpleDocument$text"));
+        }
+    }
+
+    @Test
+    void deleteWhereComplexByGroup() {
+        final ComplexDocument zeroGroupDocument = ComplexDocument.newBuilder()
+                .setGroup(0)
+                .setDocId(1623L)
+                .setText(TextSamples.ROMEO_AND_JULIET_PROLOGUE)
+                .build();
+        final ComplexDocument oneGroupDocument = ComplexDocument.newBuilder()
+                .setGroup(1)
+                .setDocId(1623L)
+                .setText(TextSamples.ROMEO_AND_JULIET_PROLOGUE)
+                .build();
+        final RecordMetaDataHook hook = metaDataBuilder -> {
+            TextIndexTestUtils.addRecordTypePrefix(metaDataBuilder);
+            metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_TEXT_BY_GROUP);
+        };
+
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, hook);
+            recordStore.saveRecord(zeroGroupDocument);
+            recordStore.saveRecord(oneGroupDocument);
+            context.commit();
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, hook);
+
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType(COMPLEX_DOC)
+                    .setFilter(Query.and(
+                            Query.field("group").equalsParameter("group_value"),
+                            Query.field("text").text().containsPhrase("nought could remove")
+                    ))
+                    .build();
+            RecordQueryPlan plan = recordStore.planQuery(query);
+
+            // Both groups should have a single element before delete where
+            assertThat(plan.execute(recordStore, EvaluationContext.forBinding("group_value", 0)).asList().join(), hasSize(1));
+            assertThat(plan.execute(recordStore, EvaluationContext.forBinding("group_value", 1)).asList().join(), hasSize(1));
+
+            recordStore.deleteRecordsWhere(COMPLEX_DOC, Query.field("group").equalsValue(0));
+
+            // Group zero should be gone but group 1 should still have an element remaining
+            assertThat(plan.execute(recordStore, EvaluationContext.forBinding("group_value", 0)).asList().join(), empty());
+            assertThat(plan.execute(recordStore, EvaluationContext.forBinding("group_value", 1)).asList().join(), hasSize(1));
+        }
+    }
+
+    @Test
+    void deleteWhereGroupedMap() {
+        MapDocument doc1 = MapDocument.newBuilder()
+                .setDocId(42)
+                .setGroup(1066L)
+                .addEntry(MapDocument.Entry.newBuilder()
+                        .setKey("foo")
+                        .setValue(TextSamples.ANGSTROM)
+                        .build())
+                .build();
+        MapDocument doc2 = MapDocument.newBuilder()
+                .setDocId(42)
+                .setGroup(1623L)
+                .addEntry(MapDocument.Entry.newBuilder()
+                        .setKey("foo")
+                        .setValue(TextSamples.ANGSTROM)
+                        .build())
+                .build();
+
+        final RecordMetaDataHook hook = metaDataBuilder -> {
+            TextIndexTestUtils.addRecordTypePrefix(metaDataBuilder);
+            final RecordTypeBuilder mapDoc = metaDataBuilder.getRecordType(MAP_DOC);
+            mapDoc.setPrimaryKey(concat(recordType(), field("group"), field("doc_id")));
+            metaDataBuilder.addIndex(mapDoc, MAP_ON_VALUE_GROUPED_INDEX);
+        };
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, hook);
+            recordStore.saveRecord(doc1);
+            recordStore.saveRecord(doc2);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, hook);
+
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType(MAP_DOC)
+                    .setFilter(Query.and(
+                            Query.field("group").equalsParameter("group_value"),
+                            Query.field("entry").oneOfThem().matches(Query.and(
+                                    Query.field("key").equalsValue("foo"),
+                                    Query.field("value").text().containsAll("unit named", 4)
+                            ))
+                    ))
+                    .setRemoveDuplicates(false)
+                    .build();
+            RecordQueryPlan plan = recordStore.planQuery(query);
+            assertThat(plan, textIndexScan(indexName(MAP_ON_VALUE_GROUPED_INDEX.getName())));
+
+            assertEquals(Collections.singletonList(doc1),
+                    plan.execute(recordStore, EvaluationContext.forBinding("group_value", doc1.getGroup()))
+                            .map(FDBQueriedRecord::getRecord)
+                            .map(rec -> MapDocument.newBuilder().mergeFrom(rec).build())
+                            .asList()
+                            .join());
+            assertEquals(Collections.singletonList(doc2),
+                    plan.execute(recordStore, EvaluationContext.forBinding("group_value", doc2.getGroup()))
+                            .map(FDBQueriedRecord::getRecord)
+                            .map(rec -> MapDocument.newBuilder().mergeFrom(rec).build())
+                            .asList()
+                            .join());
+
+            // Delete where for one of the two groups
+            recordStore.deleteRecordsWhere(MAP_DOC, Query.field("group").equalsValue(doc1.getGroup()));
+
+            assertEquals(Collections.emptyList(),
+                    plan.execute(recordStore, EvaluationContext.forBinding("group_value", doc1.getGroup()))
+                            .map(FDBQueriedRecord::getRecord)
+                            .map(rec -> MapDocument.newBuilder().mergeFrom(rec).build())
+                            .asList()
+                            .join());
+            assertEquals(Collections.singletonList(doc2),
+                    plan.execute(recordStore, EvaluationContext.forBinding("group_value", doc2.getGroup()))
+                            .map(FDBQueriedRecord::getRecord)
+                            .map(rec -> MapDocument.newBuilder().mergeFrom(rec).build())
+                            .asList()
+                            .join());
+        }
+    }
+
+    @Test
+    void tokenizerVersionChange() throws Exception {
         final SimpleDocument shakespeareDocument = SimpleDocument.newBuilder()
                 .setDocId(1623L)
                 .setText(TextSamples.ROMEO_AND_JULIET_PROLOGUE)
@@ -1112,7 +1276,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void tokenizerVersionChangeWithMultipleEntries() throws Exception {
+    void tokenizerVersionChangeWithMultipleEntries() throws Exception {
         final MapDocument map1 = MapDocument.newBuilder()
                 .setDocId(1066L)
                 .addEntry(MapDocument.Entry.newBuilder().setKey("fr").setValue(TextSamples.FRENCH))
@@ -1239,7 +1403,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         }
     }
 
-    public void scanWithSkip(@Nonnull Index index, @Nonnull String token, int skip, int limit, boolean reverse) throws Exception {
+    void scanWithSkip(@Nonnull Index index, @Nonnull String token, int skip, int limit, boolean reverse) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
             final List<IndexEntry> fullResults = scanIndex(recordStore, index, TupleRange.allOf(Tuple.from(token)));
@@ -1266,7 +1430,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void scan() throws Exception {
+    void scan() throws Exception {
         final Random r = new Random(0x5ca1ab1e);
         List<SimpleDocument> records = getRandomRecords(r, 50);
         try (FDBRecordContext context = openContext()) {
@@ -1297,7 +1461,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void invalidScans() throws Exception {
+    void invalidScans() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
             final Index index = recordStore.getRecordMetaData().getIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
@@ -1365,12 +1529,6 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
                 .get();
     }
 
-    @Nonnull
-    private List<Long> querySimpleDocumentsWithIndex(@Nonnull QueryComponent filter, int planHash, boolean isCoveringIndexExpected,
-                                                     @Nonnull Matcher<? super Comparisons.TextComparison> comparisonMatcher) throws InterruptedException, ExecutionException {
-        return querySimpleDocumentsWithIndex(filter, TextIndexTestUtils.SIMPLE_DEFAULT_NAME, planHash, isCoveringIndexExpected, comparisonMatcher);
-    }
-
     @Nullable
     private List<Long> querySimpleDocumentsWithIndex(@Nonnull QueryComponent filter, @Nonnull String indexName, @Nonnull QueryComponent textFilter, int planHash, boolean isCoveringIndexExpected) throws InterruptedException, ExecutionException {
         if (textFilter instanceof ComponentWithComparison && ((ComponentWithComparison)textFilter).getComparison() instanceof Comparisons.TextComparison) {
@@ -1402,7 +1560,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void querySimpleDocuments() throws Exception {
+    void querySimpleDocuments() throws Exception {
         final List<SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.AETHELRED,
@@ -1518,7 +1676,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void queryDocumentsWithScanLimit() throws Exception {
+    void queryDocumentsWithScanLimit() throws Exception {
         // Load a big (ish) data set
         final int recordCount = 100;
         final int batchSize = 10;
@@ -1575,7 +1733,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void querySimpleDocumentsWithAdditionalFilters() throws Exception {
+    void querySimpleDocumentsWithAdditionalFilters() throws Exception {
         final List<SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ROMEO_AND_JULIET_PROLOGUE,
                 TextSamples.ROMEO_AND_JULIET_PROLOGUE,
@@ -1679,7 +1837,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void querySimpleDocumentsWithDifferentTokenizers() throws Exception {
+    void querySimpleDocumentsWithDifferentTokenizers() throws Exception {
         final List<SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ROMEO_AND_JULIET_PROLOGUE,
                 TextSamples.RUSSIAN,
@@ -1753,7 +1911,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void querySimpleDocumentsMaybeCovering() throws Exception {
+    void querySimpleDocumentsMaybeCovering() throws Exception {
         final List<SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.AETHELRED,
@@ -1918,7 +2076,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void querySimpleDocumentsWithoutPositions() throws Exception {
+    void querySimpleDocumentsWithoutPositions() throws Exception {
         final List<SimpleDocument> documents = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.AETHELRED,
@@ -2051,7 +2209,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void queryComplexDocuments() throws Exception {
+    void queryComplexDocuments() throws Exception {
         final List<String> textSamples = Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.ROMEO_AND_JULIET_PROLOGUE,
@@ -2097,7 +2255,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void queryComplexDocumentsWithAdditionalFilters() throws Exception {
+    void queryComplexDocumentsWithAdditionalFilters() throws Exception {
         final List<String> textSamples = Arrays.asList(
                 TextSamples.ANGSTROM,
                 TextSamples.ROMEO_AND_JULIET_PROLOGUE,
@@ -2200,7 +2358,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void queryComplexDocumentsCovering() throws Exception {
+    void queryComplexDocumentsCovering() throws Exception {
         final List<String> textSamples = Arrays.asList(
                 TextSamples.FRENCH,
                 TextSamples.GERMAN,
@@ -2300,7 +2458,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void queryMultiTypeDocuments() throws Exception {
+    void queryMultiTypeDocuments() throws Exception {
         final List<String> bothTypes = Arrays.asList(SIMPLE_DOC, COMPLEX_DOC);
         final List<String> simpleTypes = Collections.singletonList(SIMPLE_DOC);
         final List<String> complexTypes = Collections.singletonList(COMPLEX_DOC);
@@ -2412,7 +2570,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void queryMapDocuments() throws Exception {
+    void queryMapDocuments() throws Exception {
         final List<String> textSamples = Arrays.asList(
                 TextSamples.ROMEO_AND_JULIET_PROLOGUE,
                 TextSamples.AETHELRED,
@@ -2507,7 +2665,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void queryMapsWithGroups() throws Exception {
+    void queryMapsWithGroups() throws Exception {
         final List<String> textSamples = Arrays.asList(
                 TextSamples.ROMEO_AND_JULIET_PROLOGUE,
                 TextSamples.AETHELRED,
@@ -2621,7 +2779,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
      */
     @MethodSource("indexArguments")
     @ParameterizedTest
-    public void queryScanEquivalence(@Nonnull Index index) throws Exception {
+    void queryScanEquivalence(@Nonnull Index index) throws Exception {
         final Random r = new Random(0xba5eba1L + index.getName().hashCode());
         final int recordCount = 100;
         final int recordBatch = 25;
@@ -2740,7 +2898,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void invalidQueries() {
+    void invalidQueries() {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, metaDataBuilder -> metaDataBuilder.addIndex(SIMPLE_DOC, new Index("SimpleDocument$max_group", field("group").ungrouped(), IndexTypes.MAX_EVER_TUPLE)));
             List<RecordQuery> queries = Arrays.asList(
@@ -2787,7 +2945,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void invalidIndexes() {
+    void invalidIndexes() {
         final String testIndex = "test_index";
         List<KeyExpression> expressions = Arrays.asList(
                 // VersionKeyExpression.VERSION, // no version expression allowed
@@ -2804,7 +2962,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         }
 
         // Verify doesn't work with repeated fields but in a case where a repeated field is possible.
-        invalidateIndex(KeyExpression.InvalidExpressionException.class, "MultiDocument",
+        invalidateIndex(KeyExpression.InvalidExpressionException.class, MULTI_DOC,
                 new Index(testIndex, field("text", FanType.FanOut), IndexTypes.TEXT));
 
         // Verify that unique indexes are invalid
@@ -2945,7 +3103,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
 
     @Tag(Tags.Performance)
     @Test
-    public void textIndexPerf1000SerialInsert() throws Exception {
+    void textIndexPerf1000SerialInsert() throws Exception {
         // Create 1000 records
         Random r = new Random();
         List<SimpleDocument> records = getRandomRecords(r, 1000);
@@ -2969,7 +3127,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
 
     @Tag(Tags.Performance)
     @Test
-    public void textIndexPerf100InsertOneBatch() throws Exception {
+    void textIndexPerf100InsertOneBatch() throws Exception {
         // Create 1000 records
         Random r = new Random();
         List<SimpleDocument> records = getRandomRecords(r, 100);
@@ -2991,7 +3149,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
 
     @Tag(Tags.Performance)
     @Test
-    public void textIndexPerf1000SerialInsertNoBatching() throws Exception {
+    void textIndexPerf1000SerialInsertNoBatching() throws Exception {
         // Create 1000 records
         Random r = new Random();
         List<SimpleDocument> records = getRandomRecords(r, 1000);
@@ -3013,7 +3171,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
 
     @Tag(Tags.Performance)
     @Test
-    public void textIndexPerf1000ParallelInsert() throws Exception {
+    void textIndexPerf1000ParallelInsert() throws Exception {
         // Create 1000 records
         Random r = new Random();
         List<SimpleDocument> records = getRandomRecords(r, 1000);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTestUtils.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTestUtils.java
@@ -20,8 +20,11 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestRecordsTextProto;
+import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
 import com.apple.foundationdb.record.provider.common.TransformedRecordSerializer;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -29,12 +32,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
+
 /**
  * Utility functions and constants for tests involving full text queries.
  */
 public class TextIndexTestUtils {
     public static final String SIMPLE_DOC = "SimpleDocument";
     public static final String COMPLEX_DOC = "ComplexDocument";
+    public static final String MAP_DOC = "MapDocument";
+    public static final String MULTI_DOC = "MultiDocument";
+    public static final List<String> ALL_DOC_TYPES = List.of(SIMPLE_DOC, COMPLEX_DOC, MAP_DOC, MULTI_DOC);
     public static final TransformedRecordSerializer<Message> COMPRESSING_SERIALIZER =
             TransformedRecordSerializer.newDefaultBuilder().setCompressWhenSerializing(true).build();
     public static final String SIMPLE_DEFAULT_NAME = "SimpleDocument$text";
@@ -44,6 +53,21 @@ public class TextIndexTestUtils {
         return IntStream.range(0, textSamples.size())
                 .mapToObj(i -> TestRecordsTextProto.SimpleDocument.newBuilder().setDocId(i).setGroup(i % 2).setText(textSamples.get(i)).build())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Adds a record type key prefix to each primary key. This is useful for text index tests, as it makes the
+     * text index types behave more like relational database tables, which in turn enables things like single-
+     * type {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore#deleteRecordsWhere(QueryComponent) deleteRecordsWhere()}
+     * operations.
+     *
+     * @param metaDataBuilder the meta-data builder to add record type prefixes for each document type
+     */
+    public static void addRecordTypePrefix(RecordMetaDataBuilder metaDataBuilder) {
+        for (String type : ALL_DOC_TYPES) {
+            final RecordTypeBuilder typeBuilder = metaDataBuilder.getRecordType(type);
+            typeBuilder.setPrimaryKey(concat(recordType(), typeBuilder.getPrimaryKey()));
+        }
     }
 
     private TextIndexTestUtils() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/QueryToKeyMatcherTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/QueryToKeyMatcherTest.java
@@ -38,13 +38,18 @@ import com.apple.foundationdb.record.query.plan.temp.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.predicates.Value;
 import com.google.auto.service.AutoService;
 import com.google.protobuf.Message;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import static com.apple.foundationdb.record.metadata.Key.Evaluated.scalar;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
@@ -61,597 +66,622 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class QueryToKeyMatcherTest {
 
-    @Test
-    public void testSingleFieldEquality() {
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(queryField("a").equalsValue(7));
-        Match match = matcher.matchesSatisfyingQuery(keyField("a"));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(7), match.getEquality());
-
-
-        match = matcher.matchesSatisfyingQuery(concatenateFields("a", "b"));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(7), match.getEquality());
-
-
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("b")));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a", FanType.FanOut)));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a", FanType.Concatenate)));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("b").nest("a")));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a").nest("b")));
-
-        assertNoMatch(matcher.matchesSatisfyingQuery(concatenateFields("b", "a")));
-    }
-
-    @Test
-    public void testMatchKeyWithValue() {
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(
-                Query.and(
-                        queryField("f1").equalsValue(7),
-                        queryField("f2").equalsValue(11)));
-
-        Match match = matcher.matchesSatisfyingQuery(keyWithValue(concatenateFields("f1", "f2", "f3", "f4"), 2));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.concatenate(7, 11), match.getEquality());
-    }
-
-    @Test
-    public void testMatchWithFunctionExpression() {
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(queryField("f1").equalsValue("hello!"));
-        Match match = matcher.matchesSatisfyingQuery(keyWithValue(function("nada", concatenateFields("f1", "f2", "f3")), 1));
-        assertEquals(MatchType.NO_MATCH, match.getType());
-    }
-
-    @Test
-    public void testMatchWithValueExpression() {
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(queryField("f1").equalsValue("hello!"));
-        Match match = matcher.matchesSatisfyingQuery(value(4));
-        assertEquals(MatchType.NO_MATCH, match.getType());
-    }
-
-    @Test
-    public void testSingleNestedFieldEquality() {
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(queryField("a").matches(queryField("ax").equalsValue(10)));
-        Match match = matcher.matchesSatisfyingQuery(keyField("a").nest("ax"));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(10), match.getEquality());
-
-        match = matcher.matchesSatisfyingQuery(concat(keyField("a").nest("ax"), keyField("b")));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(10), match.getEquality());
-
-        match = matcher.matchesCoveringKey(concat(keyField("a").nest(keyField("ax")), keyField("b")));
-        assertEquals(MatchType.NO_MATCH, match.getType());
-
-        match = matcher.matchesSatisfyingQuery(keyField("a").nest(concat(keyField("ax"), keyField("b"))));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(10), match.getEquality());
-
-        match = matcher.matchesCoveringKey(keyField("a").nest(concat(keyField("ax"), keyField("b"))));
-        assertEquals(MatchType.NO_MATCH, match.getType());
-
-        final Match match2 = matcher.matchesSatisfyingQuery(keyField("a"));
-        assertNoMatch(match2);
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a", FanType.FanOut)));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a", FanType.Concatenate)));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a", FanType.FanOut).nest("ax")));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a").nest("ax", FanType.FanOut)));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a").nest("ax", FanType.Concatenate)));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("b").nest("ax")));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a").nest("bx")));
-
-        assertNoMatch(matcher.matchesSatisfyingQuery(concat(keyField("b").nest("ax"), keyField("a").nest("ax"))));
-        assertNoMatch(matcher.matchesSatisfyingQuery(keyField("a").nest(concat(keyField("bx"), keyField("ax")))));
-    }
-
-    @Test
-    public void testThen() {
-        assertEquality(MatchType.EQUALITY,
-                queryField("a").equalsValue(1),
-                concatenateFields("a", "b"));
-
-        assertEquality(MatchType.NO_MATCH,
-                queryField("a").equalsValue(1),
-                concatenateFields("b", "a"));
-
-        assertEqualityCoveringKey(MatchType.NO_MATCH,
-                queryField("a").equalsValue(1),
-                concatenateFields("a", "b"));
-
-        assertEquality(MatchType.EQUALITY,
-                queryField("a").oneOfThem().equalsValue(1),
-                concat(keyField("a", FanType.FanOut), keyField("b")));
-
-        assertEquality(MatchType.NO_MATCH,
-                queryField("a").oneOfThem().equalsValue(1),
-                concat(keyField("b"), keyField("a", FanType.FanOut)));
-
-        assertEqualityCoveringKey(MatchType.NO_MATCH,
-                queryField("a").oneOfThem().equalsValue(1),
-                concat(keyField("a", FanType.FanOut), keyField("b")));
-
-        assertEquality(MatchType.EQUALITY,
-                new RecordTypeKeyComparison("ErsatzRecordType"),
-                concat(recordType(), keyField("a")));
-
-        assertEquality(MatchType.NO_MATCH,
-                new RecordTypeKeyComparison("ErsatzRecordType"),
-                concat(keyField("a"), recordType()));
-
-        assertEqualityCoveringKey(MatchType.NO_MATCH,
-                new RecordTypeKeyComparison("ErsatzRecordType"),
-                concat(recordType(), keyField("a")));
-    }
-
-    @Test
-    public void testQueryAndPatterns() {
-        assertEquality(MatchType.NO_MATCH,
-                queryField("p").matches(
+    @SuppressWarnings("unused") // used as arguments for parameterized test
+    static Stream<Arguments> testQueryAndPatterns() {
+        return Stream.of(
+                Arguments.of(
+                        queryField("a").matches(queryField("ax").equalsValue(10)),
+                        keyField("a").nest(concat(keyField("ax"), keyField("b"))),
+                        MatchType.EQUALITY,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("a").equalsValue(1),
+                        concatenateFields("a", "b"),
+                        MatchType.EQUALITY,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("a").equalsValue(1),
+                        concatenateFields("b", "a"),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("a").oneOfThem().equalsValue(1),
+                        concat(keyField("a", FanType.FanOut), keyField("b")),
+                        MatchType.EQUALITY,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("a").oneOfThem().equalsValue(1),
+                        concat(keyField("b"), keyField("a", FanType.FanOut)),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        new RecordTypeKeyComparison("ErsatzRecordType"),
+                        concat(recordType(), keyField("a")),
+                        MatchType.EQUALITY,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        new RecordTypeKeyComparison("ErsatzRecordType"),
+                        concat(keyField("a"), recordType()),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("p").matches(
+                                Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2))),
+                        keyField("p").nest(concatenateFields("a", "c", "b")),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("p").matches(
+                                Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2))),
+                        keyField("p").nest(
+                                keyField("a"),
+                                keyField("q").nest(
+                                        keyField("c"),
+                                        keyField("d")),
+                                keyField("b")),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("p").matches(
+                                Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2))),
+                        keyField("p").nest(
+                                keyField("a"),
+                                keyField("b"),
+                                keyField("q").nest(keyField("c"), keyField("d"))),
+                        MatchType.EQUALITY,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("p").matches(
+                                Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2),
+                                        queryField("c").equalsValue(3))),
+                        keyField("p").nest(concatenateFields("c", "b", "a", "extra")),
+                        MatchType.EQUALITY,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        queryField("p").matches(
+                                Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2),
+                                        queryField("c").equalsValue(3))),
+                        keyField("p").nest(concatenateFields("c", "b")),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
+                        queryField("p").matches(
+                                Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2),
+                                        queryField("c").equalsValue(3))),
+                        keyField("p").nest(concatenateFields("c", "b", "a")),
+                        MatchType.EQUALITY,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
                         Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2))),
-                keyField("p").nest(concatenateFields("a", "c", "b")));
-
-        assertEquality(MatchType.NO_MATCH,
-                queryField("p").matches(
+                                queryField("a").lessThanOrEquals(1),
+                                queryField("b").equalsValue(2),
+                                queryField("c").equalsValue(3)),
+                        concatenateFields("c", "b", "a"),
+                        MatchType.INEQUALITY,
+                        MatchType.INEQUALITY
+                ),
+                Arguments.of(
                         Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2))),
-                keyField("p").nest(keyField("a"), keyField("q").nest(keyField("c"), keyField("d")), keyField("b")));
-
-        assertEquality(MatchType.EQUALITY,
-                queryField("p").matches(
-                        Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2))),
-                keyField("p").nest(keyField("a"), keyField("b"), keyField("q").nest(keyField("c"), keyField("d"))));
-
-        assertEqualityCoveringKey(MatchType.NO_MATCH,
-                queryField("p").matches(
-                        Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2))),
-                keyField("p").nest(keyField("a"), keyField("b"), keyField("q").nest(keyField("c"), keyField("d"))));
-
-        assertEquality(MatchType.EQUALITY,
-                queryField("p").matches(
+                                queryField("a").lessThanOrEquals(1),
+                                queryField("b").equalsValue(2)),
+                        concatenateFields("a", "b", "c", "d"),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
                         Query.and(
                                 queryField("a").equalsValue(1),
                                 queryField("b").equalsValue(2),
-                                queryField("c").equalsValue(3))),
-                keyField("p").nest(concatenateFields("c", "b", "a", "extra")));
-
-        assertEqualityCoveringKey(MatchType.NO_MATCH,
-                queryField("p").matches(
+                                queryField("c").equalsValue(3),
+                                queryField("DoesNotExist").lessThan(4)),
+                        concatenateFields("c", "b", "a"),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("a").isNull(),
+                                queryField("b").equalsValue(2)),
+                        concatenateFields("a", "b"),
+                        MatchType.EQUALITY,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(queryField("c").equalsValue(1)),
+                                queryField("b").equalsValue(2)),
+                        concat(
+                                keyField("p").nest(keyField("c")),
+                                keyField("b")),
+                        MatchType.EQUALITY,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(queryField("c").equalsValue(1)),
+                                queryField("b").equalsValue(2),
+                                queryField("a").equalsValue(1)),
+                        concat(
+                                keyField("p").nest(keyField("c")),
+                                keyField("b")),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(queryField("d").equalsValue(1)),
+                                queryField("b").equalsValue(2)),
+                        concat(
+                                keyField("p").nest(keyField("c")),
+                                keyField("b")),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("q").matches(queryField("c").equalsValue(1)),
+                                queryField("b").equalsValue(2)),
+                        concat(
+                                keyField("p").nest(keyField("c")),
+                                keyField("b")),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(queryField("c").equalsValue(1)),
+                                queryField("b").lessThanOrEquals(2)),
+                        concat(
+                                keyField("p").nest(keyField("c")),
+                                keyField("b")),
+                        MatchType.INEQUALITY,
+                        MatchType.INEQUALITY
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(queryField("c").lessThanOrEquals(1)),
+                                queryField("b").equalsValue(2)),
+                        concat(
+                                keyField("p").nest(keyField("c")),
+                                keyField("b")),
+                        MatchType.NO_MATCH,
+                        MatchType.NO_MATCH
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(queryField("c1").equalsValue(1)),
+                                queryField("p").matches(queryField("c2").equalsValue(2))),
+                        concat(
+                                keyField("p").nest(keyField("c1")),
+                                keyField("p").nest(keyField("c2"))),
+                        MatchType.EQUALITY,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
                         Query.and(
                                 queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2),
-                                queryField("c").equalsValue(3))),
-                keyField("p").nest(concatenateFields("c", "b", "a", "extra")));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                queryField("p").matches(
+                                queryField("b").equalsValue(2)
+                        ),
+                        keyField("a"),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
                         Query.and(
                                 queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2),
-                                queryField("c").equalsValue(3))),
-                keyField("p").nest(concatenateFields("c", "b")));
-
-        assertEquality(MatchType.INEQUALITY,
-                Query.and(
-                        queryField("a").lessThanOrEquals(1),
-                        queryField("b").equalsValue(2),
-                        queryField("c").equalsValue(3)),
-                concatenateFields("c", "b", "a"));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("a").lessThanOrEquals(1),
-                        queryField("b").equalsValue(2)),
-                concatenateFields("a", "b", "c", "d"));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        queryField("b").equalsValue(2),
-                        queryField("c").equalsValue(3),
-                        queryField("DoesNotExist").lessThan(4)),
-                concatenateFields("c", "b", "a"));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        queryField("b").equalsValue(2),
-                        queryField("c").equalsValue(3),
-                        queryField("DoesNotExist").lessThan(4)),
-                concatenateFields("c", "b", "a"));
-
-        assertEquality(MatchType.EQUALITY,
-                Query.and(
-                        queryField("a").isNull(),
-                        queryField("b").equalsValue(2)),
-                concatenateFields("a", "b"));
-
-        assertEquality(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(queryField("c").equalsValue(1)),
-                        queryField("b").equalsValue(2)),
-                concat(
-                        keyField("p").nest(keyField("c")),
-                        keyField("b")));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(queryField("c").equalsValue(1)),
-                        queryField("b").equalsValue(2),
-                        queryField("a").equalsValue(1)),
-                concat(
-                        keyField("p").nest(keyField("c")),
-                        keyField("b")));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("p").matches(queryField("d").equalsValue(1)),
-                        queryField("b").equalsValue(2)),
-                concat(
-                        keyField("p").nest(keyField("c")),
-                        keyField("b")));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("q").matches(queryField("c").equalsValue(1)),
-                        queryField("b").equalsValue(2)),
-                concat(
-                        keyField("p").nest(keyField("c")),
-                        keyField("b")));
-
-        assertEquality(MatchType.INEQUALITY,
-                Query.and(
-                        queryField("p").matches(queryField("c").equalsValue(1)),
-                        queryField("b").lessThanOrEquals(2)),
-                concat(
-                        keyField("p").nest(keyField("c")),
-                        keyField("b")));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("p").matches(queryField("c").lessThanOrEquals(1)),
-                        queryField("b").equalsValue(2)),
-                concat(
-                        keyField("p").nest(keyField("c")),
-                        keyField("b")));
-
-        assertEquality(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(queryField("c1").equalsValue(1)),
-                        queryField("p").matches(queryField("c2").equalsValue(2))),
-                concat(
-                        keyField("p").nest(keyField("c1")),
-                        keyField("p").nest(keyField("c2"))));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        queryField("b").equalsValue(2)
+                                queryField("b").equalsValue(2)
+                        ),
+                        keyField("b"),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
                 ),
-                keyField("a"));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        queryField("b").equalsValue(2)
+                Arguments.of(
+                        Query.and(
+                                queryField("a").equalsValue(1),
+                                new RecordTypeKeyComparison("ErsatzRecordType")
+                        ),
+                        concat(recordType(), keyField("a")),
+                        MatchType.EQUALITY,
+                        MatchType.EQUALITY
                 ),
-                keyField("a"));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        queryField("b").equalsValue(2)
+                Arguments.of(
+                        Query.and(
+                                queryField("a").equalsValue(1),
+                                new RecordTypeKeyComparison("ErsatzRecordType")
+                        ),
+                        recordType(),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
                 ),
-                keyField("b"));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        queryField("b").equalsValue(2)
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2)
+                                )),
+                                queryField("c").equalsValue(3)
+                        ),
+                        keyField("p").nest(concatenateFields("a", "b")),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
                 ),
-                keyField("b"));
-
-        assertEquality(MatchType.EQUALITY,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        new RecordTypeKeyComparison("ErsatzRecordType")
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").greaterThan(2)
+                                )),
+                                queryField("c").equalsValue(3)
+                        ),
+                        keyField("p").nest(concatenateFields("a", "b")),
+                        MatchType.NO_MATCH,
+                        MatchType.INEQUALITY
                 ),
-                concat(recordType(), keyField("a")));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        new RecordTypeKeyComparison("ErsatzRecordType")
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").equalsValue(2)
+                                )),
+                                queryField("c").equalsValue(3)
+                        ),
+                        concat(
+                                keyField("p").nest(
+                                        concatenateFields("a", "b")),
+                                keyField("c")),
+                        MatchType.EQUALITY,
+                        MatchType.EQUALITY
                 ),
-                recordType());
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("a").equalsValue(1),
-                        new RecordTypeKeyComparison("ErsatzRecordType")
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").matches(Query.and(
+                                                queryField("c").equalsValue(2),
+                                                queryField("d").equalsValue(3)
+                                        ))
+                                )),
+                                queryField("e").equalsValue(4)),
+                        concat(
+                                keyField("e"),
+                                keyField("p").nest("a")),
+                        MatchType.NO_MATCH,
+                        MatchType.EQUALITY
                 ),
-                recordType());
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(Query.and(
+                                        queryField("a").equalsValue(1),
+                                        queryField("b").matches(Query.and(
+                                                queryField("c").equalsValue(2),
+                                                queryField("d").equalsValue(3)
+                                        ))
+                                )),
+                                queryField("e").equalsValue(4)
+                        ),
+                        concat(
+                                keyField("e"),
+                                keyField("p").nest(concat(
+                                        keyField("b").nest(concatenateFields(
+                                                "c", "d")),
+                                        keyField("a")))),
+                        MatchType.EQUALITY,
+                        MatchType.EQUALITY
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(Query.and(
+                                        queryField("a").lessThan(1),
+                                        queryField("b").matches(Query.and(
+                                                queryField("c").equalsValue(2),
+                                                queryField("d").equalsValue(3)
+                                        ))
+                                )),
+                                queryField("e").equalsValue(4)
+                        ),
+                        concat(
+                                keyField("e"),
+                                keyField("p").nest(concat(
+                                        keyField("b").nest(concatenateFields(
+                                                "c", "d")),
+                                        keyField("a")))),
+                        MatchType.INEQUALITY,
+                        MatchType.INEQUALITY
+                )
+        );
     }
 
-    @Test
-    public void testNestedAnd() {
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2)
-                        )),
-                        queryField("c").equalsValue(3)
-                ),
-                keyField("p").nest(concatenateFields("a", "b")));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2)
-                        )),
-                        queryField("c").equalsValue(3)
-                ),
-                keyField("p").nest(concatenateFields("a", "b")));
-
-        assertEqualityCoveringKey(MatchType.INEQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").greaterThan(2)
-                        )),
-                        queryField("c").equalsValue(3)
-                ),
-                keyField("p").nest(concatenateFields("a", "b")));
-
-        assertEquality(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2)
-                        )),
-                        queryField("c").equalsValue(3)
-                ),
-                concat(keyField("p").nest(concatenateFields("a", "b")), keyField("c")));
-
-        assertEquality(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").equalsValue(2)
-                        )),
-                        queryField("c").equalsValue(3)
-                ),
-                concat(keyField("c"), keyField("p").nest(concatenateFields("a", "b")), keyField("c")));
-
-        assertEquality(MatchType.NO_MATCH,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").matches(Query.and(
-                                        queryField("c").equalsValue(2),
-                                        queryField("d").equalsValue(3)
-                                ))
-                        )),
-                        queryField("e").equalsValue(4)
-                ),
-                concat(keyField("e"), keyField("p").nest("a")));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").matches(Query.and(
-                                        queryField("c").equalsValue(2),
-                                        queryField("d").equalsValue(3)
-                                ))
-                        )),
-                        queryField("e").equalsValue(4)
-                ),
-                concat(keyField("e"), keyField("p").nest("a")));
-
-        assertEquality(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").matches(Query.and(
-                                        queryField("c").equalsValue(2),
-                                        queryField("d").equalsValue(3)
-                                ))
-                        )),
-                        queryField("e").equalsValue(4)
-                ),
-                concat(keyField("e"), keyField("p").nest(concat(keyField("b").nest(concatenateFields("c", "d")), keyField("a")))));
-
-        assertEquality(MatchType.INEQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").lessThan(1),
-                                queryField("b").matches(Query.and(
-                                        queryField("c").equalsValue(2),
-                                        queryField("d").equalsValue(3)
-                                ))
-                        )),
-                        queryField("e").equalsValue(4)
-                ),
-                concat(keyField("e"), keyField("p").nest(concat(keyField("b").nest(concatenateFields("c", "d")), keyField("a")))));
-
-        assertEqualityCoveringKey(MatchType.EQUALITY,
-                Query.and(
-                        queryField("p").matches(Query.and(
-                                queryField("a").equalsValue(1),
-                                queryField("b").matches(Query.and(
-                                        queryField("c").equalsValue(2),
-                                        queryField("d").equalsValue(3)
-                                ))
-                        )),
-                        queryField("e").equalsValue(4)
-                ),
-                concat(keyField("e"), keyField("p").nest(concat(keyField("b").nest(concatenateFields("c", "d")), keyField("a")))));
+    @ParameterizedTest(name = "testQueryAndPatterns[query = {0}, key = {1}]")
+    @MethodSource
+    void testQueryAndPatterns(QueryComponent query, KeyExpression key, MatchType matchTypeSatisfiesQuery, MatchType matchTypeCoveringKey) {
+        assertEquality(matchTypeSatisfiesQuery, query, key);
+        assertEqualityCoveringKey(matchTypeCoveringKey, query, key);
     }
 
-
-    @Test
-    public void testOneOfThem() {
-        QueryToKeyMatcher matcher = new QueryToKeyMatcher(queryField("a").oneOfThem().equalsValue(7));
-        Match match = matcher.matchesSatisfyingQuery(keyField("a", FanType.FanOut));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(7), match.getEquality());
-
-        matcher = new QueryToKeyMatcher(queryField("p").matches(queryField("a").oneOfThem().equalsValue(7)));
-        match = matcher.matchesSatisfyingQuery(keyField("p").nest(keyField("a", FanType.FanOut)));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(7), match.getEquality());
-
-        matcher = new QueryToKeyMatcher(queryField("g").matches(queryField("p").oneOfThem().matches(queryField("a").equalsValue(7))));
-        match = matcher.matchesSatisfyingQuery(keyField("g").nest(keyField("p", FanType.FanOut).nest(keyField("a"))));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar(7), match.getEquality());
-
-        matcher = new QueryToKeyMatcher(Query.and(
-                queryField("a").equalsValue(10),
-                queryField("g").matches(queryField("p").oneOfThem().matches(queryField("a").equalsValue(7)))));
-        match = matcher.matchesSatisfyingQuery(concat(
-                keyField("a"),
-                keyField("g").nest(keyField("p", FanType.FanOut).nest(keyField("a"))),
-                keyField("b")));
-        assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.concatenate(10, 7), match.getEquality());
-
-        assertNoMatch(queryField("a").oneOfThem().matches(queryField("ax").greaterThan(8)),
-                keyField("a", FanType.FanOut));
-
-        assertNoMatch(queryField("p").matches(queryField("a").oneOfThem().matches(queryField("ax").greaterThan(8))),
-                keyField("p").nest(keyField("a", FanType.FanOut)));
+    @SuppressWarnings("unused") // used as arguments for parameterized test
+    static Stream<Arguments> testEqualityMatches() {
+        return Stream.of(
+                Arguments.of(
+                        queryField("a").equalsValue(7),
+                        keyField("a"),
+                        scalar(7)
+                ),
+                Arguments.of(
+                        queryField("a").equalsValue(7),
+                        concatenateFields("a", "b"),
+                        scalar(7)
+                ),
+                Arguments.of(
+                        queryField("a").matches(queryField("ax").equalsValue(10)),
+                        keyField("a").nest("ax"),
+                        scalar(10)
+                ),
+                Arguments.of(
+                        queryField("a").matches(queryField("ax").equalsValue(10)),
+                        concat(keyField("a").nest("ax"), keyField("b")),
+                        scalar(10)
+                ),
+                Arguments.of(
+                        queryField("a").matches(queryField("ax").equalsValue(10)),
+                        keyField("a").nest(concat(keyField("ax"), keyField("b"))),
+                        scalar(10)
+                ),
+                Arguments.of(
+                        queryField("a").oneOfThem().equalsValue(7),
+                        keyField("a", FanType.FanOut),
+                        scalar(7)
+                ),
+                Arguments.of(
+                        queryField("p").matches(queryField("a").oneOfThem().equalsValue(7)),
+                        keyField("p").nest(keyField("a", FanType.FanOut)),
+                        scalar(7)
+                ),
+                Arguments.of(
+                        queryField("g").matches(queryField("p").matches(queryField("a").oneOfThem().equalsValue(7))),
+                        keyField("g").nest(keyField("p").nest(keyField("a", FanType.FanOut))),
+                        scalar(7)
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("a").equalsValue(10),
+                                queryField("g").matches(queryField("p").matches(queryField("a").oneOfThem().equalsValue(7)))),
+                        concat(keyField("a"), keyField("g").nest(keyField("p").nest(keyField("a", FanType.FanOut)))),
+                        Key.Evaluated.concatenate(10, 7)
+                ),
+                Arguments.of(
+                        Query.and(
+                                queryField("f1").equalsValue(7),
+                                queryField("f2").equalsValue(11)),
+                        keyWithValue(concatenateFields("f1", "f2", "f3", "f4"), 2),
+                        Key.Evaluated.concatenate(7, 11)
+                ),
+                Arguments.of(
+                        Query.keyExpression(function("nada", concatenateFields("f1", "f2", "f3"))).equalsValue("hello!"),
+                        function("nada", concatenateFields("f1", "f2", "f3")),
+                        scalar("hello!")
+                )
+        );
     }
 
-    @Test
-    public void testMatchWithQueryableExpression() {
-        final QueryableKeyExpression key = (QueryableKeyExpression)function("nada", concatenateFields("f1", "f2", "f3"));
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(Query.keyExpression(key).equalsValue("hello!"));
+    @ParameterizedTest(name = "testEqualityMatches[query = {0}, key = {1}")
+    @MethodSource
+    void testEqualityMatches(QueryComponent query, KeyExpression key, Key.Evaluated evaluated) {
+        QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
         Match match = matcher.matchesSatisfyingQuery(key);
         assertEquals(MatchType.EQUALITY, match.getType());
-        assertEquals(Key.Evaluated.scalar("hello!"), match.getEquality());
+        assertEquals(evaluated, match.getEquality());
     }
 
-    @Test
-    public void testTemporarilyNoMatch() {
-        // This is a holder test to make sure we don't forget to test things when we add support for them, and
-        // to make sure they return no match for now
-        // Ideally these match correctly once implemented
-        assertNoMatch(Query.and(queryField("a").equalsValue(3), queryField("b").isEmpty()), concatenateFields("a", "b"));
-        assertNoMatch(
-                Query.and(
-                        queryField("a").lessThan(3),
-                        queryField("a").greaterThan(0)
+    @SuppressWarnings("unused") // used as arguments for parameterized test
+    static Stream<Arguments> testNoMatch() {
+        Stream<Arguments> singleFieldQueryArgs = Stream.of(
+                keyField("b"),
+                keyField("a", FanType.FanOut),
+                keyField("a", FanType.Concatenate),
+                keyField("b").nest("a"),
+                keyField("a").nest("b"),
+                concatenateFields("b", "a")
+        ).map(key ->
+                Arguments.of(queryField("a").equalsValue(7), key)
+        );
+        Stream<Arguments> singleNestedQueryArgs = Stream.of(
+                keyField("a"),
+                keyField("a", FanType.FanOut),
+                keyField("a", FanType.Concatenate),
+                keyField("a", FanType.FanOut).nest("ax"),
+                keyField("a").nest("ax", FanType.FanOut),
+                keyField("a").nest("ax", FanType.Concatenate),
+                keyField("b").nest("ax"),
+                keyField("a").nest("bx"),
+
+                concat(keyField("b").nest("ax"), keyField("a").nest("ax")),
+                keyField("a").nest(concat(keyField("bx"), keyField("ax")))
+        ).map(key ->
+                Arguments.of(queryField("a").matches(queryField("ax").equalsValue(10)), key)
+        );
+        return Stream.of(singleFieldQueryArgs, singleNestedQueryArgs, Stream.of(
+                Arguments.of(
+                        queryField("a").oneOfThem().matches(queryField("ax").greaterThan(8)),
+                        keyField("a", FanType.FanOut)
                 ),
-                concatenateFields("a", "b"));
-
-        assertNoMatch(Query.not(queryField("a").equalsValue(3)), keyField("a"));
-        assertNoMatch(Query.or(queryField("a").equalsValue(3), queryField("b").equalsValue(4)), concatenateFields("a", "b"));
-        assertNoMatch(Query.rank("a").equalsValue(5), keyField("a"));
-
-        assertNoMatch(
-                queryField("p").matches(Query.or(queryField("a").equalsValue(3), queryField("b").equalsValue(4))),
-                keyField("p").nest(concatenateFields("a", "b")));
-        assertNoMatch(
-                queryField("p").matches(Query.rank("a").equalsValue(5)),
-                keyField("p").nest(keyField("a")));
-        assertNoMatch(
-                queryField("p").matches(Query.not(queryField("a").equalsValue(3))),
-                keyField("p").nest(keyField("a")));
-        assertNoMatch(
-                queryField("p").matches(Query.and(queryField("a").greaterThan(3),
-                        Query.or(queryField("b").lessThan(4), queryField("b").greaterThan(5)))),
-                keyField("p").nest(concatenateFields("a", "b")));
-        assertNoMatch(
-                queryField("p").matches(Query.and(
-                        queryField("c1").equalsValue(1),
-                        queryField("c2").equalsValue(2))),
-                concat(
-                        keyField("p").nest(keyField("c1")),
-                        keyField("p").nest(keyField("c2"))));
-        assertNoMatch(
-                Query.and(
-                        queryField("p").matches(queryField("c1").equalsValue(1)),
-                        queryField("p").matches(queryField("c2").equalsValue(2))),
-                keyField("p").nest(concatenateFields("c1", "c2")));
+                Arguments.of(
+                        queryField("p").matches(queryField("a").oneOfThem().matches(queryField("ax").greaterThan(8))),
+                        keyField("p").nest(keyField("a", FanType.FanOut))
+                ),
+                Arguments.of(
+                        queryField("f1").equalsValue("hello!"),
+                        keyWithValue(function("nada", concatenateFields("f1", "f2", "f3")), 1)
+                ),
+                Arguments.of(
+                        queryField("f1").equalsValue("hello!"),
+                        value(4)
+                ),
+                Arguments.of(
+                        // Note the different arguments in the query and key expression
+                        Query.keyExpression(function("nada", concatenateFields("f1", "f2", "f3"))).equalsValue("hello!"),
+                        function("nada", concatenateFields("f1", "f2", "f3", "f4"))
+                )
+        )).flatMap(Function.identity());
     }
 
-    @Test
-    public void testUnexpected() {
+    @ParameterizedTest(name = "testNoMatch[query = {0}, key = {1}")
+    @MethodSource
+    void testNoMatch(QueryComponent query, KeyExpression key) {
+        assertNoMatch(query, key);
+        assertEqualityCoveringKey(MatchType.NO_MATCH, query, key);
+    }
+
+    @SuppressWarnings("unused") // used as arguments for parameterized test
+    static Stream<Arguments> testTemporarilyNoMatch() {
+        return Stream.of(
+                Arguments.of(
+                        Query.and(queryField("a").equalsValue(3), queryField("b").isEmpty()),
+                        concatenateFields("a", "b")),
+                Arguments.of(
+                        Query.and(
+                                queryField("a").lessThan(3),
+                                queryField("a").greaterThan(0)
+                        ),
+                        concatenateFields("a", "b")),
+                Arguments.of(
+                        Query.not(queryField("a").equalsValue(3)),
+                        keyField("a")),
+                Arguments.of(
+                        Query.or(queryField("a").equalsValue(3), queryField("b").equalsValue(4)),
+                        concatenateFields("a", "b")),
+                Arguments.of(
+                        Query.rank("a").equalsValue(5),
+                        keyField("a")),
+                Arguments.of(
+                        queryField("p").matches(Query.or(queryField("a").equalsValue(3), queryField("b").equalsValue(4))),
+                        keyField("p").nest(concatenateFields("a", "b"))),
+                Arguments.of(
+                        queryField("p").matches(Query.rank("a").equalsValue(5)),
+                        keyField("p").nest(keyField("a"))),
+                Arguments.of(
+                        queryField("p").matches(Query.not(queryField("a").equalsValue(3))),
+                        keyField("p").nest(keyField("a"))),
+                Arguments.of(
+                        queryField("p").matches(Query.and(queryField("a").greaterThan(3),
+                                Query.or(queryField("b").lessThan(4), queryField("b").greaterThan(5)))),
+                        keyField("p").nest(concatenateFields("a", "b"))),
+                Arguments.of(
+                        queryField("p").matches(Query.and(
+                                queryField("c1").equalsValue(1),
+                                queryField("c2").equalsValue(2))),
+                        concat(
+                                keyField("p").nest(keyField("c1")),
+                                keyField("p").nest(keyField("c2")))),
+                Arguments.of(
+                        Query.and(
+                                queryField("p").matches(queryField("c1").equalsValue(1)),
+                                queryField("p").matches(queryField("c2").equalsValue(2))),
+                        keyField("p").nest(concatenateFields("c1", "c2")))
+        );
+    }
+
+    /**
+     * This is a holder test to make sure we don't forget to test things when we add support for them, and
+     * to make sure they return no match for now. Ideally these match correctly once implemented.
+     *
+     * @param query the query to match to match with
+     * @param key the key expression to match with
+     */
+    @ParameterizedTest(name = "testTemporarilyNoMatch[query = {0}, key = {1}")
+    @MethodSource
+    void testTemporarilyNoMatch(@Nonnull QueryComponent query, @Nonnull KeyExpression key) {
+        assertNoMatch(query, key);
+    }
+
+    @SuppressWarnings("unused") // used as arguments for parameterized test
+    static Stream<Arguments> testUnexpected() {
+        return Stream.of(
+                Arguments.of(queryField("a").equalsValue(1), UnknownKeyExpression.UNKNOWN),
+                Arguments.of(queryField("a").oneOfThem().equalsValue(1), UnknownKeyExpression.UNKNOWN),
+                Arguments.of(
+                        queryField("p").matches(queryField("b").equalsValue(1)),
+                        UnknownKeyExpression.UNKNOWN),
+                Arguments.of(
+                        queryField("p").oneOfThem().matches(queryField("b").equalsValue(1)),
+                        UnknownKeyExpression.UNKNOWN),
+                Arguments.of(
+                        queryField("p").matches(queryField("b").equalsValue(1)),
+                        keyField("p").nest(UnknownKeyExpression.UNKNOWN)),
+                Arguments.of(
+                        queryField("p").oneOfThem().matches(queryField("b").equalsValue(1)),
+                        keyField("p", FanType.FanOut).nest(UnknownKeyExpression.UNKNOWN)),
+                Arguments.of(
+                        Query.and(queryField("a").equalsValue(1), queryField("b").equalsValue(2)),
+                        concat(keyField("a"), UnknownKeyExpression.UNKNOWN)),
+                Arguments.of(
+                        new RecordTypeKeyComparison("DummyRecordType"),
+                        UnknownKeyExpression.UNKNOWN)
+        );
+    }
+
+    @ParameterizedTest(name = "testUnexpected[query = {0}, key = {1}]")
+    @MethodSource
+    void testUnexpected(QueryComponent query, KeyExpression key) {
         // Make sure the places that throw an error when given an unknown expression all do so.
-        assertUnexpected(queryField("a").equalsValue(1), UnknownKeyExpression.UNKNOWN);
-        assertUnexpected(queryField("a").oneOfThem().equalsValue(1), UnknownKeyExpression.UNKNOWN);
-        assertUnexpected(
-                queryField("p").matches(queryField("b").equalsValue(1)),
-                UnknownKeyExpression.UNKNOWN);
-        assertUnexpected(
-                queryField("p").oneOfThem().matches(queryField("b").equalsValue(1)),
-                UnknownKeyExpression.UNKNOWN);
-        assertUnexpected(
-                queryField("p").matches(queryField("b").equalsValue(1)),
-                keyField("p").nest(UnknownKeyExpression.UNKNOWN));
-        assertUnexpected(
-                queryField("p").oneOfThem().matches(queryField("b").equalsValue(1)),
-                keyField("p", FanType.FanOut).nest(UnknownKeyExpression.UNKNOWN));
-        assertUnexpected(
-                Query.and(Query.field("a").equalsValue(1), Query.field("b").equalsValue(2)),
-                concat(keyField("a"), UnknownKeyExpression.UNKNOWN));
-        assertUnexpected(
-                new RecordTypeKeyComparison("DummyRecordType"),
-                UnknownKeyExpression.UNKNOWN);
-    }
-
-    private void assertEquality(MatchType type, QueryComponent query, KeyExpression key) {
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
-        assertEquals(type, matcher.matchesSatisfyingQuery(key).getType());
-    }
-
-    private void assertEqualityCoveringKey(MatchType type, QueryComponent query, KeyExpression key) {
-        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
-        assertEquals(type, matcher.matchesCoveringKey(key).getType());
-    }
-
-    private void assertInvalid(QueryComponent query, KeyExpression key) {
-        assertThrows(Query.InvalidExpressionException.class, () -> {
-            final QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
-            matcher.matchesSatisfyingQuery(key);
-        });
-    }
-
-    private void assertUnexpected(QueryComponent query, KeyExpression key) {
         assertThrows(KeyExpression.InvalidExpressionException.class, () -> {
             final QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
             matcher.matchesSatisfyingQuery(key);
         });
     }
 
-    private void assertNoMatch(QueryComponent query, KeyExpression key) {
+    private static void assertEquality(MatchType type, QueryComponent query, KeyExpression key) {
+        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
+        assertEquals(type, matcher.matchesSatisfyingQuery(key).getType());
+    }
+
+    private static void assertEqualityCoveringKey(MatchType type, QueryComponent query, KeyExpression key) {
+        final QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
+        assertEquals(type, matcher.matchesCoveringKey(key).getType());
+    }
+
+    private static void assertNoMatch(QueryComponent query, KeyExpression key) {
         final QueryToKeyMatcher matcher = new QueryToKeyMatcher(query);
         assertNoMatch(matcher.matchesSatisfyingQuery(key));
     }
 
-    private void assertNoMatch(Match match) {
+    private static void assertNoMatch(Match match) {
         assertEquals(MatchType.NO_MATCH, match.getType());
     }
 
-    private FieldKeyExpression keyField(String name) {
+    private static FieldKeyExpression keyField(String name) {
         return Key.Expressions.field(name);
     }
 
-    private FieldKeyExpression keyField(String name, FanType fanType) {
+    private static FieldKeyExpression keyField(String name, FanType fanType) {
         return Key.Expressions.field(name, fanType);
     }
 
-    private Field queryField(String name) {
+    private static Field queryField(String name) {
         return Query.field(name);
     }
 


### PR DESCRIPTION
This adjusts the methods used by `canDeleteWhere` on indexes defined on a `GroupingKeyExpression` so that it tries to satisfy the query from the grouping sub key rather than the whole key to limit the number of accepted `deleteRecordsWhere` predicates to more closely align with that is actually possible to safely delete. This includes some regression tests that hit the error, as well as a small amount of refactoring that is to set up #1580.

This fixes #1583.