### PR TITLE
Fixing bug with KeyWithValueExpression.getValueExpression()

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyWithValueExpression.java
@@ -115,6 +115,8 @@ public class KeyWithValueExpression extends BaseKeyExpression implements KeyExpr
             List<KeyExpression> allKeys = normalizeKeyForPositions();
             if (splitPoint == allKeys.size()) {
                 valueExpression = EmptyKeyExpression.EMPTY;
+            } else if ((allKeys.size() - splitPoint) == 1) {
+                valueExpression = allKeys.get(splitPoint);
             } else {
                 valueExpression = new ThenKeyExpression(allKeys, splitPoint, allKeys.size());
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression.FanType;
+import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.metadata.expressions.ListKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.QueryableKeyExpression;
@@ -55,6 +56,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -764,6 +766,21 @@ public class KeyExpressionTest {
                 concatenate("numbers", "four", "five", "six"),
                 concatenate("numbers", "seven", "eight", "nine")),
                 evaluate(splitConcat, numbers));
+    }
+
+    @Test
+    void testCanProperlyGetValueExpressionFromKeyWithValue() {
+        /*
+         * Tests for a degenerate case of KeyWithValueExpressions
+         */
+        List<KeyExpression> fields = new ArrayList<>();
+        fields.add(recordType());
+        fields.add(Key.Expressions.field("col0"));
+        fields.add(Key.Expressions.field("col1"));
+        KeyWithValueExpression kwve = new KeyWithValueExpression(Key.Expressions.concat(fields),2);
+
+        assertEquals(concat(recordType(),field("col0")),kwve.getKeyExpression(),"Incorrect key expression!");
+        assertEquals(field("col1"),kwve.getValueExpression(),"Incorrect value expression!");
     }
 
     public static Stream<Arguments> getPrefixKeyComparisons() {


### PR DESCRIPTION
This fixes a minor issue where `KeyWithValueExpression.getValueExpression()` could break if there were less than 2 elements in the value portion of the expression, and adds a test to verify the fix.