### PR TITLE
Improve performance of ChooseK algorithm

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Performance** The Lucene directory implementation now caches the complete list of files in a directory [(Issue #1575)](https://github.com/FoundationDB/fdb-record-layer/issues/1575)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Improve performance of chooseK algorithm by using integer counters for state management instead of Iterator heap objects [(Issue #1590)](https://github.com/FoundationDB/fdb-record-layer/issues/1590)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/ChooseKTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/temp/ChooseKTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.temp;
 
 import com.apple.foundationdb.record.query.combinatorics.ChooseK;
 import com.apple.foundationdb.record.query.combinatorics.EnumeratingIterable;
+import com.apple.foundationdb.record.query.combinatorics.EnumeratingIterator;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
@@ -151,5 +152,29 @@ public class ChooseKTest {
                         .add(ImmutableSet.of("a", "b", "c", "d", "e"))
                         .build(),
                 combinations);
+    }
+
+    @Test
+    void testChooseK3() {
+        final Set<String> elements = ImmutableSet.of("a", "b", "c", "d", "e");
+
+        final EnumeratingIterable<String> combinationsIterable = ChooseK.chooseK(elements, 4);
+        final EnumeratingIterator<String> iterator = combinationsIterable.iterator();
+
+        final var actualSetBuilder = ImmutableSet.builder();
+
+        actualSetBuilder.add(ImmutableSet.copyOf(iterator.next())); // a,b,c,d
+        iterator.skip(1);                                     // skip subtree a,[b,...] combinations.
+        actualSetBuilder.add(ImmutableSet.copyOf(iterator.next())); // a,c,d,e
+        actualSetBuilder.add(ImmutableSet.copyOf(iterator.next())); // b,c,d,e
+
+        assertEquals(ImmutableSet.<Set<String>>builder()
+                        .add(ImmutableSet.of("a", "b", "c", "d"))
+                        // .add(ImmutableSet.of("a", "b", "c", "e")) // skipped
+                        // .add(ImmutableSet.of("a", "b", "d", "e")) // skipped
+                        .add(ImmutableSet.of("a", "c", "d", "e"))
+                        .add(ImmutableSet.of("b", "c", "d", "e"))
+                        .build(),
+                actualSetBuilder.build());
     }
 }


### PR DESCRIPTION
This Improves performance of chooseK algorithm by using integer counters for state management instead of Iterator heap objects.

This resolves https://github.com/FoundationDB/fdb-record-layer/issues/1590.