### PR TITLE
Fixes #1598: Build broken due to merge skew around EvaluationContext build

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -89,6 +89,7 @@ import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
 import com.apple.foundationdb.record.query.plan.match.PlanMatchers;
 import com.apple.foundationdb.record.query.plan.planning.BooleanNormalizer;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.temp.dynamic.TypeRepository;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
@@ -1151,7 +1152,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         EvaluationContext evaluationContext = EvaluationContext.newBuilder()
                 .setBinding("group_value", group)
                 .setBinding("key_value", mapKey)
-                .build();
+                .build(TypeRepository.empty());
         return plan.execute(recordStore, evaluationContext)
                 .map(FDBRecord::getRecord)
                 .map(message -> MapDocument.newBuilder().mergeFrom(message).build())


### PR DESCRIPTION
This resolves the merge skew between #1564 and #1584 to unblock outstanding PRs, though it's possible we'll need a different approach if we want to fix the API-breakage.

This fixes #1598.