### PR TITLE
Transition SortedDocValuesField to BinaryPoint to support efficient deletes in Lucene #1595

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -315,6 +315,29 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         return field.getMessageType();
     }
 
+    /**
+     * Only supporting DOUBLE, INT64, INT32, and BOOL currently.
+     *
+     * @param descriptor Record Descriptor
+     * @return boolean
+     */
+    @Override
+    public boolean isFixedWidth(Descriptors.Descriptor descriptor) {
+        Descriptors.FieldDescriptor fieldDescriptor = descriptor.findFieldByName(fieldName);
+        if (fieldDescriptor.isRepeated() || (nullStandin != null && nullStandin.toProto().equals(RecordMetaDataProto.Field.NullInterpretation.UNIQUE))) {
+            return false;
+        }
+        switch (fieldDescriptor.getJavaType()) {
+            case DOUBLE:
+            case INT:
+            case LONG:
+            case BOOLEAN:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     @Nonnull
     public FanType getFanType() {
         return fanType;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -208,6 +208,18 @@ public interface KeyExpression extends PlanHashable, QueryHashable {
     }
 
     /**
+     * Method that indicates whether the keys can be stored in a fixed width.  For example, an integer or long can be
+     * stored as a fixed width byte[].
+     *
+     * This is utilized by Lucene to see if we can optimize the key lookup in the case of deletes.
+     *
+     */
+    @API(API.Status.INTERNAL)
+    default boolean isFixedWidth(Descriptors.Descriptor descriptor) {
+        return false;
+    }
+
+    /**
      * Expand this key expression into a data flow graph. The returned graph represents an adequate representation
      * of the key expression as composition of relational expressions and operators
      * ({@link com.apple.foundationdb.record.query.plan.temp.RelationalExpression}s). Note that implementors should

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTestUtils.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTestUtils.java
@@ -43,7 +43,8 @@ public class TextIndexTestUtils {
     public static final String COMPLEX_DOC = "ComplexDocument";
     public static final String MAP_DOC = "MapDocument";
     public static final String MULTI_DOC = "MultiDocument";
-    public static final List<String> ALL_DOC_TYPES = List.of(SIMPLE_DOC, COMPLEX_DOC, MAP_DOC, MULTI_DOC);
+    public static final String SIMPLE_DOCUMENT_WITH_TEXT_PRIMARY_KEY = "SimpleDocumentWithTextPrimaryKey";
+    public static final List<String> ALL_DOC_TYPES = List.of(SIMPLE_DOC, COMPLEX_DOC, MAP_DOC, MULTI_DOC, SIMPLE_DOCUMENT_WITH_TEXT_PRIMARY_KEY);
     public static final TransformedRecordSerializer<Message> COMPRESSING_SERIALIZER =
             TransformedRecordSerializer.newDefaultBuilder().setCompressWhenSerializing(true).build();
     public static final String SIMPLE_DEFAULT_NAME = "SimpleDocument$text";

--- a/fdb-record-layer-core/src/test/proto/test_records_text.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_text.proto
@@ -32,6 +32,12 @@ message SimpleDocument {
     optional int64 group = 3;
 }
 
+message SimpleDocumentWithTextPrimaryKey {
+    optional string doc_id = 1 [(field).primary_key = true];
+    optional string text = 2 [(field).index = { type: "text" }];
+    optional int64 group = 3;
+}
+
 // The primary key is set in the test.
 message ComplexDocument {
     message Header {
@@ -69,6 +75,7 @@ message RecordTypeUnion {
     optional ComplexDocument _ComplexDocument = 2;
     optional MapDocument _MapDocument = 3;
     optional MultiDocument _MultiDocument = 4;
+    optional SimpleDocumentWithTextPrimaryKey _SimpleDocumentWithTextPrimaryKey = 5;
 }
 
 message NestedMapDocument {


### PR DESCRIPTION
The SortedDocValuesField is known to have issues deleting large number of records and requires the index to read more data than needed during a delete.  The BinaryPoint implementation is known to be fast when deleting the records but has the requirement that the encodings have to be fixed width (yuck).