### PR TITLE
Fixes #1601: Make EvaluationContextBuilder API backwards compatible

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Delete records where limits indexes on grouping key expressions to predicates that can be satisfied by only the grouping columns [(Issue #1583)](https://github.com/FoundationDB/fdb-record-layer/issues/1583)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Backwards incompatible API changes on `EvaluationContext.Builder` have been reverted to 3.1.247.0 state, and a new parameter on `EvaluationContext` has been exposed as a builder method [(Issue #1601)](https://github.com/FoundationDB/fdb-record-layer/issues/1601)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContext.java
@@ -71,12 +71,13 @@ public class EvaluationContext {
     }
 
     /**
-     * Create a new {@link EvaluationContext} around a given set of {@link Bindings} and a {@link TypeRepository}.
-     * from parameter names to values.
+     * Create a new {@link EvaluationContext} around a given set of {@link Bindings}
+     * from parameter names to values and the given {@link TypeRepository}.
      * @param bindings a mapping from parameter name to values
      * @param typeRepository a type repository
      * @return a new evaluation context with the bindings and the schema.
      */
+    @API(API.Status.INTERNAL)
     @Nonnull
     public static EvaluationContext forBindingsAndTypeRepository(@Nonnull Bindings bindings, @Nonnull TypeRepository typeRepository) {
         return new EvaluationContext(bindings, typeRepository);
@@ -132,6 +133,12 @@ public class EvaluationContext {
         return bindings.get(Bindings.Internal.CORRELATION.bindingName(alias.getId()));
     }
 
+    /**
+     * Get the type repository for this query evaluation. This is an internal method used during
+     * query execution.
+     * @return the {@link TypeRepository} evaluating a query
+     */
+    @API(API.Status.INTERNAL)
     @Nonnull
     public TypeRepository getTypeRepository() {
         return typeRepository;
@@ -172,7 +179,7 @@ public class EvaluationContext {
      */
     @Nonnull
     public EvaluationContext withBinding(@Nonnull String bindingName, @Nullable Object value) {
-        return childBuilder().setBinding(bindingName, value).build(typeRepository);
+        return childBuilder().setBinding(bindingName, value).build();
     }
 
     /**
@@ -186,6 +193,6 @@ public class EvaluationContext {
      * @return a new <code>EvaluationContext</code> with the new binding
      */
     public EvaluationContext withBinding(@Nonnull CorrelationIdentifier alias, @Nullable Object value) {
-        return childBuilder().setBinding(Bindings.Internal.CORRELATION.bindingName(alias.getId()), value).build(typeRepository);
+        return childBuilder().setBinding(Bindings.Internal.CORRELATION.bindingName(alias.getId()), value).build();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContextBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContextBuilder.java
@@ -37,12 +37,15 @@ import javax.annotation.Nullable;
 public class EvaluationContextBuilder {
     @Nonnull
     protected final Bindings.Builder bindings;
+    @Nonnull
+    private TypeRepository typeRepository;
 
     /**
      * Create an empty builder.
      */
     protected EvaluationContextBuilder() {
         this.bindings = Bindings.newBuilder();
+        this.typeRepository = TypeRepository.EMPTY_SCHEMA;
     }
 
     /**
@@ -54,6 +57,7 @@ public class EvaluationContextBuilder {
      */
     protected EvaluationContextBuilder(@Nonnull EvaluationContext original) {
         this.bindings = original.getBindings().childBuilder();
+        this.typeRepository = original.getTypeRepository();
     }
 
     /**
@@ -74,11 +78,11 @@ public class EvaluationContextBuilder {
     /**
      * Bind a name to a value. This mutation will be
      * reflected in the {@link EvaluationContext} returned by
-     * calling {@link #build(TypeRepository)}.
+     * calling {@link #build()}.
      *
      * @param name the name of the binding
      * @param value the value to associate with the name
-     * @return this <code>EvaluationContextBuilder</code>
+     * @return this {@code EvaluationContextBuilder}
      */
     @Nonnull
     public EvaluationContextBuilder setBinding(@Nonnull String name, @Nullable Object value) {
@@ -89,14 +93,27 @@ public class EvaluationContextBuilder {
     /**
      * Bind an alias to a value. This mutation will be
      * reflected in the {@link EvaluationContext} returned by
-     * calling {@link #build(TypeRepository)}.
+     * calling {@link #build()}.
      *
      * @param alias the alias of the binding
      * @param value the value to associate with the name
-     * @return this <code>EvaluationContextBuilder</code>
+     * @return this {@code EvaluationContextBuilder}
      */
     public EvaluationContextBuilder setBinding(@Nonnull CorrelationIdentifier alias, @Nullable Object value) {
         return setBinding(Bindings.Internal.CORRELATION.bindingName(alias.getId()), value);
+    }
+
+    /**
+     * Set the {@link TypeRepository} for this evaluation context. This is an internal method that
+     * should only be used to supply types during query execution.
+     * @param typeRepository the {@link TypeRepository} to associate with the built evaluation context
+     * @return this {@code EvaluationContextBuilder}
+     */
+    @API(API.Status.INTERNAL)
+    @Nonnull
+    public EvaluationContextBuilder setTypeRepository(TypeRepository typeRepository) {
+        this.typeRepository = typeRepository;
+        return this;
     }
 
     /**
@@ -107,11 +124,10 @@ public class EvaluationContextBuilder {
      * {@link #setBinding(String, Object)}. All other state included
      * in the context should remain the same.
      *
-     * @param typeRepository a type repository to be used in the new context
      * @return an {@link EvaluationContext} with updated bindings
      */
     @Nonnull
-    public EvaluationContext build(@Nonnull final TypeRepository typeRepository) {
+    public EvaluationContext build() {
         return EvaluationContext.forBindingsAndTypeRepository(bindings.build(), typeRepository);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
@@ -93,6 +93,7 @@ public class StreamGrouping<M extends Message> {
      * @param context evaluation context containing parameter bindings
      * @param alias the quantifier alias for the value evaluation
      */
+    @SuppressWarnings({"squid:S107"}) // too many constructor parameters
     public StreamGrouping(@Nullable final Value groupingKeyValue,
                           @Nonnull final AggregateValue aggregateValue,
                           @Nonnull final Value completeResultValue,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
@@ -172,7 +172,7 @@ public class StreamGrouping<M extends Message> {
         final EvaluationContext nestedContext = context.childBuilder()
                 .setBinding(groupingKeyAlias, currentGroup)
                 .setBinding(aggregateAlias, accumulator.finish())
-                .build(context.getTypeRepository());
+                .build();
         previousCompleteResult = completeResultValue.eval(store, nestedContext, null, null);
 
         currentGroup = nextGroup;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -113,7 +113,7 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
                 }
                 builder.setBinding(rank.bindingName, binding);
             }
-            return builder.build(context.getTypeRepository());
+            return builder.build();
         });
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/JoinedRecordPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/JoinedRecordPlan.java
@@ -85,7 +85,7 @@ class JoinedRecordPlan implements SyntheticRecordFromStoredRecordPlan  {
             for (BindingPlan bindingPlan : bindingPlans) {
                 builder.setBinding(bindingPlan.name, bindingPlan.evaluate(record));
             }
-            return builder.build(context.getTypeRepository());
+            return builder.build();
         }
 
         @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/EvaluationContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/EvaluationContextTest.java
@@ -1,0 +1,132 @@
+/*
+ * EvaluationContextTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.record.query.plan.temp.Type;
+import com.apple.foundationdb.record.query.plan.temp.dynamic.TypeRepository;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for the {@link EvaluationContext} class.
+ */
+class EvaluationContextTest {
+    @Test
+    void emptyContext() {
+        EvaluationContext evaluationContext = EvaluationContext.empty();
+        assertMissingBinding(evaluationContext, "foo");
+        assertSame(TypeRepository.EMPTY_SCHEMA, evaluationContext.getTypeRepository());
+    }
+
+    @Test
+    void withBinding() {
+        EvaluationContext evaluationContext = EvaluationContext.forBinding("foo", "bar");
+        assertEquals("bar", evaluationContext.getBinding("foo"));
+        assertMissingBinding(evaluationContext, "unknown");
+        assertSame(TypeRepository.EMPTY_SCHEMA, evaluationContext.getTypeRepository());
+    }
+
+    @Test
+    void builderPreservesBindings() {
+        Bindings bindings = Bindings.newBuilder()
+                .set("key_a", "value_a")
+                .set("key_b", "value_b")
+                .build();
+        EvaluationContext evaluationContext = EvaluationContext.forBindings(bindings);
+        EvaluationContext newContext = evaluationContext.childBuilder().build();
+        assertBindingsMatch(bindings, newContext);
+    }
+
+    @Test
+    void builderBindingsDoNotAffectParent() {
+        Bindings bindings = Bindings.newBuilder()
+                .set("a", 'a')
+                .set("b", 'b')
+                .set("c", 'c')
+                .build();
+        EvaluationContext evaluationContext = EvaluationContext.forBindings(bindings);
+        EvaluationContext newContext = evaluationContext.childBuilder()
+                .setBinding("d", 'd')
+                .build();
+        // New key "d" should be in only the new context, not the original one
+        assertEquals('d', newContext.getBinding("d"));
+        assertMissingBinding(evaluationContext, "d");
+        assertMissingBinding(bindings, "d");
+    }
+
+    @Test
+    void builderPreservesTypeRepository() {
+        TypeRepository typeRepository = TypeRepository.newBuilder()
+                .addTypeIfNeeded(Type.primitiveType(Type.TypeCode.BYTES))
+                .build();
+        EvaluationContext context = EvaluationContext.forTypeRepository(typeRepository);
+        assertSame(typeRepository, context.getTypeRepository());
+        EvaluationContext newContext = context.childBuilder().build();
+        assertSame(typeRepository, newContext.getTypeRepository());
+    }
+
+    @Test
+    void builderCanChangeTypeRepository() {
+        TypeRepository repo1 = TypeRepository.newBuilder()
+                .addTypeIfNeeded(Type.primitiveType(Type.TypeCode.BOOLEAN))
+                .build();
+        TypeRepository repo2 = TypeRepository.newBuilder()
+                .addTypeIfNeeded(Type.primitiveType(Type.TypeCode.INT))
+                .build();
+        Bindings bindings = Bindings.newBuilder()
+                .set("foo", 0)
+                .set("bar", 1)
+                .build();
+        EvaluationContext context1 = EvaluationContext.forBindingsAndTypeRepository(bindings, repo1);
+        assertSame(repo1, context1.getTypeRepository());
+        assertBindingsMatch(bindings, context1);
+
+        EvaluationContext context2 = context1.childBuilder()
+                .setTypeRepository(repo2)
+                .build();
+        assertSame(repo2, context2.getTypeRepository());
+        assertBindingsMatch(bindings, context2);
+    }
+
+    private static void assertBindingsMatch(Bindings expectedBindings, EvaluationContext evaluationContext) {
+        assertThat(evaluationContext.getBindings().asMappingList(),
+                containsInAnyOrder(expectedBindings.asMappingList().stream().map(Matchers::equalTo).collect(Collectors.toList())));
+    }
+
+    private static void assertMissingBinding(EvaluationContext evaluationContext, String key) {
+        RecordCoreException err = assertThrows(RecordCoreException.class, () -> evaluationContext.getBinding(key));
+        assertThat(err.getMessage(), containsString(String.format("Missing binding for %s", key)));
+    }
+
+    private static void assertMissingBinding(Bindings bindings, String key) {
+        RecordCoreException err = assertThrows(RecordCoreException.class, () -> bindings.get(key));
+        assertThat(err.getMessage(), containsString(String.format("Missing binding for %s", key)));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -181,6 +181,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -190,7 +191,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Tests for {@code TEXT} type indexes.
  */
 @Tag(Tags.RequiresFDB)
-@SuppressWarnings({"squid:S1192", "squid:S00112"}) // constant definition, throwing "Exception"
+@SuppressWarnings({"squid:S1192", "squid:S00112", "squid:S5961"}) // constant definition, throwing "Exception", too many assertions
 public class TextIndexTest extends FDBRecordStoreTestBase {
     private static final TextTokenizerFactory FILTERING_TOKENIZER = FilteringTextTokenizer.create(
             "filter_by_length$" + TextIndexTest.class.getCanonicalName(),
@@ -541,8 +542,10 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         }
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, metaDataBuilder -> metaDataBuilder.setSplitLongRecords(true));
-            recordStore.deleteRecord(Tuple.from(bigDocument.getDocId()));
-            recordStore.saveRecord(bigDocument);
+            assertDoesNotThrow(() -> {
+                recordStore.deleteRecord(Tuple.from(bigDocument.getDocId()));
+                recordStore.saveRecord(bigDocument);
+            });
             // do not commit
         } catch (RuntimeException e) {
             Throwable err = e;
@@ -3138,6 +3141,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         }
     }
 
+    @SuppressWarnings({"squid:S2699"}) // Performance test does not have assertions
     @Tag(Tags.Performance)
     @Test
     void textIndexPerf1000SerialInsert() throws Exception {
@@ -3162,6 +3166,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         printUsage();
     }
 
+    @SuppressWarnings({"squid:S2699"}) // Performance test does not have assertions
     @Tag(Tags.Performance)
     @Test
     void textIndexPerf100InsertOneBatch() throws Exception {
@@ -3184,6 +3189,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         printUsage();
     }
 
+    @SuppressWarnings({"squid:S2699"}) // Performance test does not have assertions
     @Tag(Tags.Performance)
     @Test
     void textIndexPerf1000SerialInsertNoBatching() throws Exception {
@@ -3206,6 +3212,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         printUsage();
     }
 
+    @SuppressWarnings({"squid:S2699"}) // Performance test does not have assertions
     @Tag(Tags.Performance)
     @Test
     void textIndexPerf1000ParallelInsert() throws Exception {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -89,7 +89,6 @@ import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
 import com.apple.foundationdb.record.query.plan.match.PlanMatchers;
 import com.apple.foundationdb.record.query.plan.planning.BooleanNormalizer;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
-import com.apple.foundationdb.record.query.plan.temp.dynamic.TypeRepository;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
@@ -1152,7 +1151,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         EvaluationContext evaluationContext = EvaluationContext.newBuilder()
                 .setBinding("group_value", group)
                 .setBinding("key_value", mapKey)
-                .build(TypeRepository.empty());
+                .build();
         return plan.execute(recordStore, evaluationContext)
                 .map(FDBRecord::getRecord)
                 .map(message -> MapDocument.newBuilder().mergeFrom(message).build())

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -59,7 +59,6 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryRecordFunction;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
-import com.apple.foundationdb.record.query.plan.temp.dynamic.TypeRepository;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.common.primitives.Longs;
@@ -662,14 +661,14 @@ public class LeaderboardIndexTest extends FDBTestBase {
             final EvaluationContext evaluationContext1 = EvaluationContext.newBuilder()
                     .setBinding("l1", FIVE_UNITS)
                     .setBinding("l2", 10103)
-                    .build(TypeRepository.empty());
+                    .build();
             assertEquals(Arrays.asList("hector", "achilles"),
                     leaderboards.executeQuery(plan2, evaluationContext1).map(leaderboards::getName).asList().join());
 
             final EvaluationContext evaluationContext2 = EvaluationContext.newBuilder()
                     .setBinding("l1", FIVE_UNITS)
                     .setBinding("l2", 10105)
-                    .build(TypeRepository.empty());
+                    .build();
             assertEquals(Arrays.asList("achilles", "hector"),
                     leaderboards.executeQuery(plan2, evaluationContext2).map(leaderboards::getName).asList().join());
         }


### PR DESCRIPTION
This makes the `TypeRepository` handling in the `EvaluationContext` API more-buildery, with a default value of `TypeRepository.EMPTY_SCHEMA`. This also simplifies some logic that was creating a child builder off of a parent context and then had to remember to pass in the parent's `TypeRepository` to the new child, as that's now handled by the `Builder` itself, though it is still possible for the child to override the `TypeRepository` if it wishes. This is a breaking API change of of 3.1.248.0, though it reverts it back to something that is backwards compatible with 3.1.247.0.

This fixes #1601.