### PR TITLE
LuceneOptimizedCompoundFormat: Fetch Initial References and Blocks in parallel vs. Sequentially #1621

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.lucene.codec;
 
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
 import org.apache.lucene.codecs.CompoundDirectory;
 import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.lucene50.Lucene50CompoundFormat;
@@ -61,6 +63,15 @@ public class LuceneOptimizedCompoundFormat extends CompoundFormat {
 
     @Override
     public void write(Directory dir, final SegmentInfo si, final IOContext context) throws IOException {
+        // Make sure all fetches are initiated in advance of the compoundFormat sequentially stepping through them.
+        si.files().stream().forEach(file -> {
+            try {
+                dir.openInput(file, IOContext.READONCE);
+            } catch (IOException ioe) {
+                throw new RecordCoreArgumentException("Cannot open input for file", ioe)
+                        .addLogInfo(LogMessageKeys.SOURCE_FILE, file);
+            }
+        });
         compoundFormat.write(new LuceneOptimizedWrappedDirectory(dir), si, context);
         final String fileName = IndexFileNames.segmentFileName(si.name, "", DATA_EXTENSION);
         si.setFiles(si.files().stream().filter(file -> !file.equals(fileName)).collect(Collectors.toSet()));


### PR DESCRIPTION
Adds a prefetch before sequentially loading references and data blocks during the merge process for creating Compound Segment Files.