### PR TITLE
Allow writes to pipeline compression in Lucene #1625

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -314,21 +314,23 @@ public class FDBDirectory extends Directory {
      * @param value the data to be stored
      * @return the actual data size written to database with potential compression and encryption applied
      */
-    public int writeData(long id, int block, @Nonnull byte[] value) {
-        final byte[] encodedBytes = Objects.requireNonNull(LuceneSerializer.encode(value, compressionEnabled, encryptionEnabled));
-        //This may not be correct transactionally
-        context.increment(LuceneEvents.Counts.LUCENE_WRITE_SIZE, encodedBytes.length);
-        context.increment(LuceneEvents.Counts.LUCENE_WRITE_CALL);
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace(getLogMessage("Write lucene data",
-                    LuceneLogMessageKeys.FILE_ID, id,
-                    LuceneLogMessageKeys.BLOCK_NUMBER, block,
-                    LuceneLogMessageKeys.DATA_SIZE, value.length,
-                    LuceneLogMessageKeys.ENCODED_DATA_SIZE, encodedBytes.length));
-        }
-        Verify.verify(value.length <= blockSize);
-        context.ensureActive().set(dataSubspace.pack(Tuple.from(id, block)), encodedBytes);
-        return encodedBytes.length;
+    public CompletableFuture<Integer> writeData(final long id, final int block, @Nonnull final byte[] value) {
+        return CompletableFuture.supplyAsync( () -> {
+            final byte[] encodedBytes = Objects.requireNonNull(LuceneSerializer.encode(value, compressionEnabled, encryptionEnabled));
+            //This may not be correct transactionally
+            context.increment(LuceneEvents.Counts.LUCENE_WRITE_SIZE, encodedBytes.length);
+            context.increment(LuceneEvents.Counts.LUCENE_WRITE_CALL);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace(getLogMessage("Write lucene data",
+                        LuceneLogMessageKeys.FILE_ID, id,
+                        LuceneLogMessageKeys.BLOCK_NUMBER, block,
+                        LuceneLogMessageKeys.DATA_SIZE, value.length,
+                        LuceneLogMessageKeys.ENCODED_DATA_SIZE, encodedBytes.length));
+            }
+            Verify.verify(value.length <= blockSize);
+            context.ensureActive().set(dataSubspace.pack(Tuple.from(id, block)), encodedBytes);
+            return encodedBytes.length;
+        });
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -141,7 +141,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         assertNull(directory.readBlock("testReference1", directory.getFDBLuceneFileReferenceAsync("testReference1"), 1).get());
         directory.writeFDBLuceneFileReference("testReference2", new FDBLuceneFileReference(2, 1, 1, 200));
         byte[] data = "test string for write".getBytes();
-        directory.writeData(2, 1, data);
+        directory.writeData(2, 1, data).join();
         assertNotNull(directory.readBlock("testReference2",
                 directory.getFDBLuceneFileReferenceAsync("testReference2"), 1).get(), "seek data should exist");
 


### PR DESCRIPTION
This reduces the time for the merging of segments after commit by pipelining the writes.  On a local machine attempting to write 10K records and committing every 50 records, it reduced the total processing time ~ 20%.