### PR TITLE
resolves #1671: match index hints in a query

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Create a transactional runner that does not retry [(Issue #1615)](https://github.com/FoundationDB/fdb-record-layer/issues/1615)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Match index hints in a query [(Issue #1671)](https://github.com/FoundationDB/fdb-record-layer/issues/1671)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,7 +30,6 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Create a transactional runner that does not retry [(Issue #1615)](https://github.com/FoundationDB/fdb-record-layer/issues/1615)
 * **Feature** The FDB API version can now be configured through the `FDBDatabaseFactory` [(Issue #1639)](https://github.com/FoundationDB/fdb-record-layer/issues/1639)
 * **Feature** Match index hints in a query [(Issue #1671)](https://github.com/FoundationDB/fdb-record-layer/issues/1671)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 /**
  * Interface to represent an access hint. An access hint can be of type INDEX and PRIMARY_KEY.
  */
-public abstract class AccessHint {
+public class AccessHint {
 
     /**
      * Gets the type of the access hint.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
@@ -25,13 +25,15 @@ import javax.annotation.Nonnull;
 /**
  * Interface to represent an access hint. An access hint can be of type INDEX and PRIMARY_KEY.
  */
-public interface AccessHint {
+public abstract class AccessHint {
 
     /**
      * Gets the type of the access hint.
      * @return the type of the access hint
      */
     @Nonnull
-    String getAccessHintType();
+    public String getAccessHintType() {
+        return getClass().getSimpleName();
+    }
 }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
@@ -1,0 +1,37 @@
+/*
+ * AccessHint.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Interface to represent an access hint. An access hint can be of type INDEX and PRIMARY_KEY.
+ */
+public interface AccessHint {
+
+    /**
+     * Gets the type of the access hint.
+     * @return the type of the access hint
+     */
+    @Nonnull
+    String getAccessHintType();
+}
+

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHint.java
@@ -23,17 +23,15 @@ package com.apple.foundationdb.record.query.plan.cascades;
 import javax.annotation.Nonnull;
 
 /**
- * Interface to represent an access hint. An access hint can be of type INDEX and PRIMARY_KEY.
+ * Interface to represent an access hint. An access hint can be of type INDEX and PRIMARY.
  */
-public class AccessHint {
+public interface AccessHint {
 
     /**
      * Gets the type of the access hint.
      * @return the type of the access hint
      */
     @Nonnull
-    public String getAccessHintType() {
-        return getClass().getSimpleName();
-    }
+    String getAccessHintType();
 }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
@@ -31,11 +31,9 @@ import java.util.Set;
 public class AccessHints {
     @Nonnull
     private final Set<AccessHint> accessHintSet = new HashSet<>();
-    private final boolean noAccessHint;
 
     public AccessHints(AccessHint... accessHints) {
         this.accessHintSet.addAll(Arrays.asList(accessHints));
-        this.noAccessHint = this.accessHintSet.isEmpty();
     }
 
     @Nonnull
@@ -43,10 +41,18 @@ public class AccessHints {
         return accessHintSet;
     }
 
+    public int size() {
+        return accessHintSet.size();
+    }
+
     public boolean containsAll(AccessHints other) {
-        // if accessHint is not set, it's considered to include all possible hints
-        if (noAccessHint) {
+        // if no hint is set, it's considered to include all possible hints
+        if (size() == 0) {
             return true;
+        }
+        // if other is empty, this does not include other
+        if (other.size() == 0) {
+            return false;
         }
         // check that all hints in other exist in this
         for (AccessHint hint: other.accessHintSet) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
@@ -45,7 +45,7 @@ public class AccessHints {
         return accessHintSet.size();
     }
 
-    public boolean containsAll(AccessHints other) {
+    public boolean containsAll(@Nonnull AccessHints other) {
         // if no hint is set, it's considered to include all possible hints
         if (size() == 0) {
             return true;
@@ -54,21 +54,6 @@ public class AccessHints {
         if (other.size() == 0) {
             return false;
         }
-        // check that all hints in other exist in this
-        for (AccessHint hint: other.accessHintSet) {
-            if (!contains(hint)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean contains(AccessHint hint) {
-        for (AccessHint accessHint: accessHintSet) {
-            if (accessHint.equals(hint)) {
-                return true;
-            }
-        }
-        return false;
+        return accessHintSet.containsAll(other.getAccessHintSet());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
@@ -43,21 +43,21 @@ public class AccessHints {
         return accessHintSet;
     }
 
-    public boolean contains(AccessHints other) {
+    public boolean containsAll(AccessHints other) {
         // if accessHint is not set, it's considered to include all possible hints
         if (noAccessHint) {
             return true;
         }
         // check that all hints in other exist in this
         for (AccessHint hint: other.accessHintSet) {
-            if (!containsOneHint(hint)) {
+            if (!contains(hint)) {
                 return false;
             }
         }
         return true;
     }
 
-    private boolean containsOneHint(AccessHint hint) {
+    private boolean contains(AccessHint hint) {
         for (AccessHint accessHint: accessHintSet) {
             if (accessHint.equals(hint)) {
                 return true;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
@@ -1,0 +1,68 @@
+/*
+ * AccessHints.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents a set of AccessHint a query or a match candidate has.
+ */
+public class AccessHints {
+    @Nonnull
+    private final Set<AccessHint> accessHintSet = new HashSet<>();
+    private final boolean noAccessHint;
+
+    public AccessHints(AccessHint... accessHints) {
+        this.accessHintSet.addAll(Arrays.asList(accessHints));
+        this.noAccessHint = this.accessHintSet.isEmpty();
+    }
+
+    @Nonnull
+    public Set<AccessHint> getAccessHintSet() {
+        return accessHintSet;
+    }
+
+    public boolean contains(AccessHints other) {
+        // if accessHint is not set, it's considered to include all possible hints
+        if (noAccessHint) {
+            return true;
+        }
+        // check that all hints in other exist in this
+        for (AccessHint hint: other.accessHintSet) {
+            if (!containsOneHint(hint)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean containsOneHint(AccessHint hint) {
+        for (AccessHint accessHint: accessHintSet) {
+            if (accessHint.equals(hint)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AccessHints.java
@@ -45,7 +45,7 @@ public class AccessHints {
         return accessHintSet.size();
     }
 
-    public boolean containsAll(@Nonnull AccessHints other) {
+    public boolean satisfies(@Nonnull AccessHints other) {
         // if no hint is set, it's considered to include all possible hints
         if (size() == 0) {
             return true;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
@@ -26,12 +26,18 @@ import java.util.Objects;
 /**
  * Represents an index hint.
  */
-public class IndexAccessHint extends AccessHint {
+public class IndexAccessHint implements AccessHint {
     @Nonnull
     private final String indexName;
 
     public IndexAccessHint(@Nonnull final String indexName) {
         this.indexName = indexName;
+    }
+
+    @Override
+    @Nonnull
+    public String getAccessHintType() {
+        return "INDEX";
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
@@ -30,7 +30,7 @@ public class IndexAccessHint implements AccessHint {
     @Nonnull
     private final String indexName;
 
-    public IndexAccessHint(@Nonnull String indexName) {
+    public IndexAccessHint(@Nonnull final String indexName) {
         this.indexName = indexName;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
@@ -1,0 +1,64 @@
+/*
+ * IndexAccessHint.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Represents an index hint.
+ */
+public class IndexAccessHint implements AccessHint {
+    @Nonnull
+    private final String indexName;
+
+    public IndexAccessHint(@Nonnull String indexName) {
+        this.indexName = indexName;
+    }
+
+    @Override
+    @Nonnull
+    public String getAccessHintType() {
+        return "INDEX";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        return indexName.equals(((IndexAccessHint)other).getIndexName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexName);
+    }
+
+    @Nonnull
+    public String getIndexName() {
+        return indexName;
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexAccessHint.java
@@ -26,18 +26,12 @@ import java.util.Objects;
 /**
  * Represents an index hint.
  */
-public class IndexAccessHint implements AccessHint {
+public class IndexAccessHint extends AccessHint {
     @Nonnull
     private final String indexName;
 
     public IndexAccessHint(@Nonnull final String indexName) {
         this.indexName = indexName;
-    }
-
-    @Override
-    @Nonnull
-    public String getAccessHintType() {
-        return "INDEX";
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -155,11 +155,9 @@ public interface MatchCandidate {
     /**
      * Compute a list of {@link BoundKeyPart}s which forms a bridge to relate {@link KeyExpression}s and
      * {@link QueryPredicate}s.
-     *
      * @param matchInfo a pre-existing match info structure
      * @param sortParameterIds the query should be ordered by
      * @param isReverse reversed-ness of the order
-     *
      * @return a list of bound key parts that express the order of the outgoing data stream and their respective mappings
      *         between query and match candidate
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -55,7 +55,6 @@ import java.util.Set;
  * that can be matched against a query graph. The match candidate does not keep the root to the graph to be matched but
  * rather an instance of {@link ExpressionRefTraversal} to allow for navigation of references within the candidate.
  *
- * <p>
  * Match candidates also allow for creation of scans over the materialized data, e.g. the index for an
  * {@link ValueIndexScanMatchCandidate} or the primary range for a {@link PrimaryScanMatchCandidate}, given appropriate
  * {@link ComparisonRange}s which usually are the direct result of graph matching.
@@ -114,15 +113,12 @@ public interface MatchCandidate {
      * would be the scan over the index.
      * As matching progresses it finds mappings from parameters to corresponding comparison ranges. Matching, however,
      * is not sensitive to whether such a binding could actually be used in an index scan. In fact, in a different maybe
-     * future record layer with improved physical operators this method should be revised to account for those
-     * improvements.
+     * future record layer with improved physical operators this method should be revised to account for those improvements.
      * For now, we only consider a prefix of said mappings that consist of n equality-bound mappings and stops either
      * at an inequality bound parameter or before a unbound parameter.
-     *
      * @param matchInfo match info
-     *
      * @return a map containing parameter to comparison range mappings for a prefix of parameters that is compatible
-     * with a physical scan over the materialized view (of the candidate)
+     *         with a physical scan over the materialized view (of the candidate)
      */
     default Map<CorrelationIdentifier, ComparisonRange> computeBoundParameterPrefixMap(@Nonnull final MatchInfo matchInfo) {
         final var prefixMap = Maps.<CorrelationIdentifier, ComparisonRange>newHashMap();
@@ -165,7 +161,7 @@ public interface MatchCandidate {
      * @param isReverse reversed-ness of the order
      *
      * @return a list of bound key parts that express the order of the outgoing data stream and their respective mappings
-     * between query and match candidate
+     *         between query and match candidate
      */
     @Nonnull
     List<BoundKeyPart> computeBoundKeyParts(@Nonnull MatchInfo matchInfo,
@@ -209,11 +205,9 @@ public interface MatchCandidate {
     /**
      * Creates a logical expression that represents a scan over the materialized candidate data. This method is expected
      * to be implemented by specific implementations of {@link MatchCandidate}.
-     *
      * @param recordMetaData the metadata available to the planner
      * @param partialMatch the {@link PartialMatch} that matched th query and the candidate
      * @param comparisonRanges a {@link List} of {@link ComparisonRange}s to be applied
-     *
      * @return a new {@link RelationalExpression}
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -315,7 +315,7 @@ public interface MatchCandidate {
                                                           final boolean isReverse) {
         if (commonPrimaryKey != null) {
             final var availableRecordTypes = metaData.getRecordTypes().keySet();
-            final var baseRef = createBaseRef(metaData, availableRecordTypes, recordTypes, new PrimaryAccessHint(commonPrimaryKey));
+            final var baseRef = createBaseRef(metaData, availableRecordTypes, recordTypes, new PrimaryAccessHint());
             final var expansionVisitor = new PrimaryAccessExpansionVisitor(availableRecordTypes, recordTypes);
             return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), commonPrimaryKey, isReverse));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -146,15 +146,15 @@ public interface MatchCandidate {
             }
 
             switch (comparisonRange.getRangeType()) {
-            case EQUALITY:
-                prefixMap.put(parameter, comparisonRange);
-                break;
-            case INEQUALITY:
-                prefixMap.put(parameter, comparisonRange);
-                return ImmutableMap.copyOf(prefixMap);
-            case EMPTY:
-            default:
-                return ImmutableMap.copyOf(prefixMap);
+                case EQUALITY:
+                    prefixMap.put(parameter, comparisonRange);
+                    break;
+                case INEQUALITY:
+                    prefixMap.put(parameter, comparisonRange);
+                    return ImmutableMap.copyOf(prefixMap);
+                case EMPTY:
+                default:
+                    return ImmutableMap.copyOf(prefixMap);
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -293,7 +292,7 @@ public interface MatchCandidate {
                                                                       final boolean isReverse,
                                                                       @Nullable final KeyExpression commonPrimaryKeyForIndex,
                                                                       @Nonnull final ExpansionVisitor<?> expansionVisitor) {
-        final var baseRef = createBaseRef(recordMetaData, availableRecordTypes, recordTypeNamesForIndex, index.getName());
+        final var baseRef = createBaseRef(recordMetaData, availableRecordTypes, recordTypeNamesForIndex, new IndexAccessHint(index.getName()));
         try {
             return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), commonPrimaryKeyForIndex, isReverse));
         } catch (final UnsupportedOperationException uOE) {
@@ -316,7 +315,7 @@ public interface MatchCandidate {
                                                           final boolean isReverse) {
         if (commonPrimaryKey != null) {
             final var availableRecordTypes = metaData.getRecordTypes().keySet();
-            final var baseRef = createBaseRef(metaData, availableRecordTypes, recordTypes, "");
+            final var baseRef = createBaseRef(metaData, availableRecordTypes, recordTypes, new PrimaryAccessHint(commonPrimaryKey));
             final var expansionVisitor = new PrimaryAccessExpansionVisitor(availableRecordTypes, recordTypes);
             return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), commonPrimaryKey, isReverse));
         }
@@ -325,9 +324,9 @@ public interface MatchCandidate {
     }
 
     @Nonnull
-    static GroupExpressionRef<RelationalExpression> createBaseRef(@Nonnull RecordMetaData metaData, @Nonnull final Set<String> allAvailableRecordTypes, @Nonnull final Set<String> recordTypesForIndex, @Nonnull String indexName) {
+    static GroupExpressionRef<RelationalExpression> createBaseRef(@Nonnull RecordMetaData metaData, @Nonnull final Set<String> allAvailableRecordTypes, @Nonnull final Set<String> recordTypesForIndex, @Nonnull AccessHint accessHint) {
         final var quantifier =
-                Quantifier.forEach(GroupExpressionRef.of(new FullUnorderedScanExpression(allAvailableRecordTypes, Collections.singleton(indexName))));
+                Quantifier.forEach(GroupExpressionRef.of(new FullUnorderedScanExpression(allAvailableRecordTypes, new AccessHints(accessHint))));
         return GroupExpressionRef.of(
                 new LogicalTypeFilterExpression(recordTypesForIndex,
                         quantifier,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Interface to represent a match candidate. A match candidate on code level is just a name and a data flow graph
@@ -325,7 +326,9 @@ public interface MatchCandidate {
     @Nonnull
     static GroupExpressionRef<RelationalExpression> createBaseRef(@Nonnull RecordMetaData metaData, @Nonnull final Set<String> allAvailableRecordTypes, @Nonnull final Set<String> recordTypesForIndex) {
         final var quantifier =
-                Quantifier.forEach(GroupExpressionRef.of(new FullUnorderedScanExpression(allAvailableRecordTypes)));
+                Quantifier.forEach(GroupExpressionRef.of(new FullUnorderedScanExpression(allAvailableRecordTypes, metaData.getAllIndexes().stream()
+                        .map(Index::getName)
+                        .collect(Collectors.toSet()))));
         return GroupExpressionRef.of(
                 new LogicalTypeFilterExpression(recordTypesForIndex,
                         quantifier,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -54,6 +54,7 @@ import java.util.Set;
  * Interface to represent a match candidate. A match candidate on code level is just a name and a data flow graph
  * that can be matched against a query graph. The match candidate does not keep the root to the graph to be matched but
  * rather an instance of {@link ExpressionRefTraversal} to allow for navigation of references within the candidate.
+ *
  * <p>
  * Match candidates also allow for creation of scans over the materialized data, e.g. the index for an
  * {@link ValueIndexScanMatchCandidate} or the primary range for a {@link PrimaryScanMatchCandidate}, given appropriate
@@ -77,7 +78,6 @@ public interface MatchCandidate {
      * the candidate is created or lazily when this method is invoked. It is, however, necessary that the traversal
      * once computed is stable, meaning the object returned by implementors of this method must always return the
      * same object.
-     *
      * @return the traversal associated for this match candidate
      */
     @Nonnull
@@ -85,7 +85,6 @@ public interface MatchCandidate {
 
     /**
      * Returns a list of parameter names for sargable parameters that can to be bound during matching.
-     *
      * @return a list of {@link CorrelationIdentifier}s for all sargable parameters in this match candidate
      */
     @Nonnull
@@ -94,7 +93,6 @@ public interface MatchCandidate {
     /**
      * Returns the parameter names for the resulting order for parameters that can be bound during matching
      * (sargable and residual).
-     *
      * @return a list of {@link CorrelationIdentifier}s describing the ordering of the result set of this match candidate
      */
     @Nonnull
@@ -105,7 +103,6 @@ public interface MatchCandidate {
      * given record.
      * The current expression hierarchy cannot be evaluated at runtime (in general). This key expression helps
      * representing compensation or part of compensation if needed.
-     *
      * @return a key expression that can be evaluated based on a base record
      */
     @Nonnull
@@ -113,12 +110,10 @@ public interface MatchCandidate {
 
     /**
      * Computes a map from {@link CorrelationIdentifier} to {@link ComparisonRange} that is physically compatible with
-     * a scan over the materialized version of the match candidate, so e.g. for an {@link ValueIndexScanMatchCandidate}
-     * that
+     * a scan over the materialized version of the match candidate, so e.g. for an {@link ValueIndexScanMatchCandidate} that
      * would be the scan over the index.
      * As matching progresses it finds mappings from parameters to corresponding comparison ranges. Matching, however,
-     * is not sensitive to whether such a binding could actually be used in an index scan. In fact, in a different
-     * maybe
+     * is not sensitive to whether such a binding could actually be used in an index scan. In fact, in a different maybe
      * future record layer with improved physical operators this method should be revised to account for those
      * improvements.
      * For now, we only consider a prefix of said mappings that consist of n equality-bound mappings and stops either
@@ -184,10 +179,8 @@ public interface MatchCandidate {
 
     /**
      * Creates a logical expression that represents a scan over the materialized candidate data.
-     *
      * @param recordMetaData the metadata used by the planner
      * @param partialMatch the match to be used
-     *
      * @return a new {@link RelationalExpression}
      */
     @SuppressWarnings("java:S135")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -316,7 +316,7 @@ public interface MatchCandidate {
                                                           final boolean isReverse) {
         if (commonPrimaryKey != null) {
             final var availableRecordTypes = metaData.getRecordTypes().keySet();
-            final var baseRef = createBaseRef(metaData, availableRecordTypes, recordTypes, commonPrimaryKey.toString());
+            final var baseRef = createBaseRef(metaData, availableRecordTypes, recordTypes, "");
             final var expansionVisitor = new PrimaryAccessExpansionVisitor(availableRecordTypes, recordTypes);
             return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), commonPrimaryKey, isReverse));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
@@ -26,11 +26,6 @@ import javax.annotation.Nonnull;
  * Represents reading a table directly without using an index plus fetch.
  */
 public class PrimaryAccessHint implements AccessHint {
-
-    public PrimaryAccessHint() {
-
-    }
-
     @Override
     @Nonnull
     public String getAccessHintType() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
@@ -1,0 +1,65 @@
+/*
+ * PrimaryAccessHint.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Represents a primary key hint.
+ */
+public class PrimaryAccessHint implements AccessHint {
+    @Nonnull
+    private final KeyExpression primaryKey;
+
+    public PrimaryAccessHint(@Nonnull KeyExpression primaryKey) {
+        this.primaryKey = primaryKey;
+    }
+
+    @Override
+    @Nonnull
+    public String getAccessHintType() {
+        return "PRIMARY_KEY";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        return primaryKey.equals(((PrimaryAccessHint)other).getPrimaryKey());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(primaryKey);
+    }
+
+    @Nonnull
+    public KeyExpression getPrimaryKey() {
+        return primaryKey;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
@@ -32,7 +32,7 @@ public class PrimaryAccessHint implements AccessHint {
     @Nonnull
     private final KeyExpression primaryKey;
 
-    public PrimaryAccessHint(@Nonnull KeyExpression primaryKey) {
+    public PrimaryAccessHint(@Nonnull final KeyExpression primaryKey) {
         this.primaryKey = primaryKey;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
@@ -20,40 +20,20 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
-import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
-
 import javax.annotation.Nonnull;
-import java.util.Objects;
 
 /**
- * Represents a primary key hint.
+ * Represents reading a table directly without using an index plus fetch.
  */
-public class PrimaryAccessHint extends AccessHint {
-    @Nonnull
-    private final KeyExpression primaryKey;
+public class PrimaryAccessHint implements AccessHint {
 
-    public PrimaryAccessHint(@Nonnull final KeyExpression primaryKey) {
-        this.primaryKey = primaryKey;
+    public PrimaryAccessHint() {
+
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-        return primaryKey.equals(((PrimaryAccessHint)other).getPrimaryKey());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(primaryKey);
-    }
-
     @Nonnull
-    public KeyExpression getPrimaryKey() {
-        return primaryKey;
+    public String getAccessHintType() {
+        return "PRIMARY";
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryAccessHint.java
@@ -28,18 +28,12 @@ import java.util.Objects;
 /**
  * Represents a primary key hint.
  */
-public class PrimaryAccessHint implements AccessHint {
+public class PrimaryAccessHint extends AccessHint {
     @Nonnull
     private final KeyExpression primaryKey;
 
     public PrimaryAccessHint(@Nonnull final KeyExpression primaryKey) {
         this.primaryKey = primaryKey;
-    }
-
-    @Override
-    @Nonnull
-    public String getAccessHintType() {
-        return "PRIMARY_KEY";
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
-import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.combinatorics.EnumeratingIterable;
 import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraphProperty;
@@ -51,6 +50,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -59,7 +59,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
@@ -114,14 +113,10 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
         final GroupExpressionRef<? extends RelationalExpression> baseRef;
         Quantifier.ForEach quantifier;
         if (recordTypes.isEmpty()) {
-            baseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), context.getMetaData().getAllIndexes().stream()
-                    .map(Index::getName)
-                    .collect(Collectors.toSet())));
+            baseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), Collections.emptySet()));
             quantifier = Quantifier.forEach(baseRef);
         } else {
-            final var fuseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), context.getMetaData().getAllIndexes().stream()
-                    .map(Index::getName)
-                    .collect(Collectors.toSet())));
+            final var fuseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), Collections.emptySet()));
             baseRef = GroupExpressionRef.of(
                     new LogicalTypeFilterExpression(
                             new HashSet<>(recordTypes),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
@@ -50,7 +50,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -108,10 +107,10 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
         final GroupExpressionRef<? extends RelationalExpression> baseRef;
         Quantifier.ForEach quantifier;
         if (recordTypes.isEmpty()) {
-            baseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), Collections.emptySet()));
+            baseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), new AccessHints()));
             quantifier = Quantifier.forEach(baseRef);
         } else {
-            final var fuseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), Collections.emptySet()));
+            final var fuseRef = GroupExpressionRef.of(new FullUnorderedScanExpression(context.getMetaData().getRecordTypes().keySet(), new AccessHints()));
             baseRef = GroupExpressionRef.of(
                     new LogicalTypeFilterExpression(
                             new HashSet<>(recordTypes),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
@@ -229,9 +229,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
 
     /**
      * Overloaded method to call {@link #semanticEquals} with an empty alias map.
-     *
      * @param other object to compare to this expression
-     *
      * @return {@code true} if this object is semantically equal to {@code other} that is {@code this} and {@code other}
      *         produce the same result when invoked with no bindings, {@code false} otherwise.
      */
@@ -242,7 +240,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * Method to establish whether this relational expression is equal to another object under the bindings
      * given by the {@link AliasMap} passed in.
-     *
      * @param other the other object to establish equality with
      * @param aliasMap a map of {@link CorrelationIdentifier}s {@code ids} to {@code ids'}. A correlation
      *        identifier {@code id} used in {@code this} should be considered equal to another correlation identifier
@@ -361,10 +358,9 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * @param constraintsFunction function constraining the number of permutations to enumerate
      * @param matchFunction function producing a match result as iterable of type {@code M}
      * @param combineFunction function to produce an iterable of type {@code S} by combining on bound matches of type
-     * {@code M}
+     *        {@code M}
      * @param <M> intermediate type to represent match results
      * @param <S> final type to represent match results
-     *
      * @return an {@link Iterable} of type {@code S} of matches of {@code this} expression with {@code otherExpression}.
      */
     @Nonnull
@@ -393,21 +389,17 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * themselves under a bijective association (mapping between the quantifiers of this expression and
      * the quantifier of the candidate expression). To this end, the {@code matchFunction} passed in to this method is
      * used to determine the matches between two quantifiers: one from this graph and one from the candidate graph.
-     * The {@code matchFunction} can produce zero, one or many matches which are returned as an {@link Iterable} of
-     * type
+     * The {@code matchFunction} can produce zero, one or many matches which are returned as an {@link Iterable} of type
      * {@code M}.
      *
      * This method attempts to find that bijective mapping between the quantifiers contained by their respective
-     * expressions. Naturally, if the expressions that are being matched own a different number of quantifiers we
-     * cannot
+     * expressions. Naturally, if the expressions that are being matched own a different number of quantifiers we cannot
      * ever find a bijective mapping. In that case, the two expressions do not match at all. If, on the other hand the
      * expressions that are being matched do have the same number of quantifiers, we need to enumerate all possible
      * associations in order to potentially find matches. In a naive implementation, and not considering any other
-     * constraints, such an enumeration produces a number of mappings that is equal to the enumeration of all
-     * permutations
+     * constraints, such an enumeration produces a number of mappings that is equal to the enumeration of all permutations
      * of sets of size {@code n} which is {@code n!}. Fortunately, it is possible for most cases to impose strict
-     * constraints on the enumeration of mappings and therefore reduce the degrees of freedom we seemingly have at
-     * first
+     * constraints on the enumeration of mappings and therefore reduce the degrees of freedom we seemingly have at first
      * considerably. For instance, if this expression can be the anchor of a correlation, there might be an implied
      * necessary order imposed by a correlation between two quantifiers {@code q1} and {@code q2} where {@code q2}
      * depends on {@code q1}, denoted by {@code q1 -> q2}.
@@ -428,7 +420,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      *        {@code M}
      * @param <M> intermediate type to represent match results
      * @param <S> final type to represent match results
-     *
      * @return an {@link Iterable} of type {@code S} of matches of {@code this} expression with {@code otherExpression}.
      */
     @Nonnull
@@ -640,7 +631,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      *         all the records that the query may produce.
      *     </li>
      * </ul>
-     *
      * @param candidateExpression the candidate expression
      * @param aliasMap a map of alias defining the equivalence between aliases and therefore quantifiers
      * @param partialMatchMap a map from quantifier to a {@link PartialMatch} that pulled up along that quantifier
@@ -738,7 +728,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * Apply the given property visitor to this planner expression and its children. Returns {@code null} if
      * {@link PlannerProperty#shouldVisit(RelationalExpression)} called on this expression returns {@code false}.
-     *
      * @param visitor a {@link PlannerProperty} visitor to evaluate
      * @param <U> the type of the evaluated property
      * @return the result of evaluating the property on the subtree rooted at this expression
@@ -761,7 +750,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * This is needed for graph integration into IntelliJ as IntelliJ only ever evaluates selfish methods. Add this
      * method as a custom renderer for the type {@link RelationalExpression}. During debugging you can then for instance
      * click show() on an instance and enjoy the query graph it represents rendered in your standard browser.
-     *
      * @param renderSingleGroups whether to render group references with just one member
      * @return the String "done"
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
@@ -62,24 +62,19 @@ import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 /**
- * A relational expression is a {@link RelationalExpression} that represents a stream of records. At all times, the
- * root
+ * A relational expression is a {@link RelationalExpression} that represents a stream of records. At all times, the root
  * expression being planned must be relational. This interface acts as a common tag interface for
- * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan}s, which can actually produce a stream of
- * records,
- * and various logical relational expressions (not yet introduced), which represent an abstract stream of records but
- * can't
+ * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan}s, which can actually produce a stream of records,
+ * and various logical relational expressions (not yet introduced), which represent an abstract stream of records but can't
  * be executed directly (such as an unimplemented sort). Other planner expressions such as {@link
  * com.apple.foundationdb.record.query.expressions.QueryComponent}
  * and {@link com.apple.foundationdb.record.metadata.expressions.KeyExpression} do not represent streams of records.
- * <p>
  * The basic type that represents a part of the planner expression tree. An expression is generally an immutable
  * object with two different kinds of fields: regular Java fields and reference fields. The regular fields represent
  * "node information", which pertains only to this specific node in the tree. In contrast, the reference fields
  * represent
  * this expression's children in the tree, such as its inputs and filter/sort expressions, and are always hidden behind
  * an {@link ExpressionRef}.
- * <p>
  * Deciding whether certain fields constitute "node information" (and should therefore be a regular field) or
  * "hierarchical information" (and therefore should not be) is subtle and more of an art than a science. There are two
  * reasonable tests that can help make this decision:
@@ -88,13 +83,11 @@ import java.util.stream.StreamSupport;
  *     or access it as a getter on the matched operator? Will you ever want to match to just this field?</li>
  *     <li>Should the planner memoize (and therefore optimize) this field separately from its parent?</li>
  * </ol>
- * <p>
  * For example, {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan} has only regular fields, including the
  * index name and the comparisons to use when scanning it.
  * Applying the first rule, it wouldn't really make sense to match the index name or the comparisons being performed on
  * their own: they're what define an index scan, after all!
  * Applying the second rule, they're relatively small immutable objects that don't need to be memoized.
- * <p>
  * In contrast, {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan} has no regular fields.
  * A filter plan has two important fields: the <code>Query.Component</code> used for the filter and a child plan that
  * provides input. Both of these might be matched by rules directly, in order to optimize them without regard for the
@@ -196,27 +189,22 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
 
     /**
      * Returns if this expression can be the anchor of a correlation.
-     * <p>
      * A correlation is always formed between three entities:
      * <ol>
      * <li>the {@link Quantifier} that flows data</li>
      * <li>2. the anchor (which is a {@link RelationalExpression}) that ranges directly over the source</li>
      * <li>3. the consumers (or dependents) of the correlation which must be a descendant of the anchor.</li>
      * </ol>
-     * <p>
      * In order for a correlation to be meaningful, the anchor must define how data is bound and used by all
      * dependents. For most expressions it is not meaningful or even possible to define correlation in such a way.
-     * <p>
      * For instance, a {@link LogicalUnionExpression}
      * cannot correlate (this method returns {@code false}) because it is not meaningful to bind a record from one child
      * of the union while providing bound values to another.
-     * <p>
      * In another example, a logical select expression can correlate which means that one child of the SELECT expression
      * can be evaluated and the resulting records can bound individually one after another. For each bound record
      * flowing along that quantifier the other children of the SELECT expression can be evaluated, potentially causing
      * more correlation values to be bound, etc. These concepts follow closely to the mechanics of what SQL calls a query
      * block.
-     * <p>
      * The existence of a correlation between source, anchor, and dependents may adversely affect planning because
      * a correlation always imposes order between the evaluated of children of an expression. This may or may
      * not tie the hands of the planner to produce an optimal plan. In certain cases, queries written in a correlated

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RelationalExpression.java
@@ -66,15 +66,15 @@ import java.util.stream.StreamSupport;
  * expression being planned must be relational. This interface acts as a common tag interface for
  * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan}s, which can actually produce a stream of records,
  * and various logical relational expressions (not yet introduced), which represent an abstract stream of records but can't
- * be executed directly (such as an unimplemented sort). Other planner expressions such as {@link
- * com.apple.foundationdb.record.query.expressions.QueryComponent}
+ * be executed directly (such as an unimplemented sort). Other planner expressions such as {@link com.apple.foundationdb.record.query.expressions.QueryComponent}
  * and {@link com.apple.foundationdb.record.metadata.expressions.KeyExpression} do not represent streams of records.
+ *
  * The basic type that represents a part of the planner expression tree. An expression is generally an immutable
  * object with two different kinds of fields: regular Java fields and reference fields. The regular fields represent
- * "node information", which pertains only to this specific node in the tree. In contrast, the reference fields
- * represent
+ * "node information", which pertains only to this specific node in the tree. In contrast, the reference fields represent
  * this expression's children in the tree, such as its inputs and filter/sort expressions, and are always hidden behind
  * an {@link ExpressionRef}.
+ *
  * Deciding whether certain fields constitute "node information" (and should therefore be a regular field) or
  * "hierarchical information" (and therefore should not be) is subtle and more of an art than a science. There are two
  * reasonable tests that can help make this decision:
@@ -83,11 +83,13 @@ import java.util.stream.StreamSupport;
  *     or access it as a getter on the matched operator? Will you ever want to match to just this field?</li>
  *     <li>Should the planner memoize (and therefore optimize) this field separately from its parent?</li>
  * </ol>
+ *
  * For example, {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan} has only regular fields, including the
  * index name and the comparisons to use when scanning it.
  * Applying the first rule, it wouldn't really make sense to match the index name or the comparisons being performed on
  * their own: they're what define an index scan, after all!
  * Applying the second rule, they're relatively small immutable objects that don't need to be memoized.
+ *
  * In contrast, {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan} has no regular fields.
  * A filter plan has two important fields: the <code>Query.Component</code> used for the filter and a child plan that
  * provides input. Both of these might be matched by rules directly, in order to optimize them without regard for the
@@ -181,7 +183,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * to the same object, as when <code>Collections.emptyIterator()</code> is returned. The returned iterator should
      * be treated as an immutable object and may throw an exception if {@link Iterator#remove} is called.
      * The iterator must return its elements in a consistent order.
-     *
      * @return an iterator of references to the children of this planner expression
      */
     @Nonnull
@@ -189,22 +190,27 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
 
     /**
      * Returns if this expression can be the anchor of a correlation.
+     *
      * A correlation is always formed between three entities:
      * <ol>
      * <li>the {@link Quantifier} that flows data</li>
      * <li>2. the anchor (which is a {@link RelationalExpression}) that ranges directly over the source</li>
      * <li>3. the consumers (or dependents) of the correlation which must be a descendant of the anchor.</li>
      * </ol>
+     *
      * In order for a correlation to be meaningful, the anchor must define how data is bound and used by all
      * dependents. For most expressions it is not meaningful or even possible to define correlation in such a way.
+     *
      * For instance, a {@link LogicalUnionExpression}
      * cannot correlate (this method returns {@code false}) because it is not meaningful to bind a record from one child
      * of the union while providing bound values to another.
+     *
      * In another example, a logical select expression can correlate which means that one child of the SELECT expression
      * can be evaluated and the resulting records can bound individually one after another. For each bound record
      * flowing along that quantifier the other children of the SELECT expression can be evaluated, potentially causing
      * more correlation values to be bound, etc. These concepts follow closely to the mechanics of what SQL calls a query
      * block.
+     *
      * The existence of a correlation between source, anchor, and dependents may adversely affect planning because
      * a correlation always imposes order between the evaluated of children of an expression. This may or may
      * not tie the hands of the planner to produce an optimal plan. In certain cases, queries written in a correlated
@@ -227,7 +233,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * @param other object to compare to this expression
      *
      * @return {@code true} if this object is semantically equal to {@code other} that is {@code this} and {@code other}
-     * produce the same result when invoked with no bindings, {@code false} otherwise.
+     *         produce the same result when invoked with no bindings, {@code false} otherwise.
      */
     default boolean semanticEquals(@Nullable final Object other) {
         return semanticEquals(other, AliasMap.emptyMap());
@@ -239,10 +245,9 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      *
      * @param other the other object to establish equality with
      * @param aliasMap a map of {@link CorrelationIdentifier}s {@code ids} to {@code ids'}. A correlation
-     * identifier {@code id} used in {@code this} should be considered equal to another correlation identifier
-     * {@code id'} used in {@code other} if either they are the same by {@link Object#equals}
-     * of if there is a mapping from {@code id} to {@code id'}.
-     *
+     *        identifier {@code id} used in {@code this} should be considered equal to another correlation identifier
+     *        {@code id'} used in {@code other} if either they are the same by {@link Object#equals}
+     *        of if there is a mapping from {@code id} to {@code id'}.
      * @return {@code true} if this is considered equal to {@code other}, false otherwise
      */
     @Override
@@ -293,7 +298,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * @param aliasMap alias map with external bindings
      * @param matchPredicate a predicate uses for matching a pair of {@link Quantifier}s
      * @param combinePredicate a predicate to accept or reject a match
-     *
      * @return an {@link Iterable} of {@link AliasMap}s where each alias map is a match.
      */
     @Nonnull
@@ -335,11 +339,9 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     interface CombinePredicate {
         /**
          * Combine the results of a {@link Quantifiers#findMatches} into a boolean result.
-         *
          * @param boundCorrelatedToMap the bound correlated to map
          * @param boundMapIterable an iterable of {@link AliasMap} for all the matches for a given
-         * {@code boundCorrelatedToMap}
-         *
+         *        {@code boundCorrelatedToMap}
          * @return {@code false} if the match should be dropped or {@code true} if it should be kept.
          */
         boolean combine(@Nonnull final AliasMap boundCorrelatedToMap,
@@ -349,7 +351,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * Attempt to match this expression (this graph) with another expression (from another graph called the candidate
      * graph) to produce matches of some kind.
-     * <p>
+     *
      * This overload matches over all quantifiers owned by this expression respectively the {@code otherExpression}.
      * See {@link #match(RelationalExpression, AliasMap, List, List, Function, MatchFunction, CombineFunction)} for
      * more information about the matching process.
@@ -386,7 +388,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * Attempt to match this expression (this graph) with another expression (from another graph called the candidate
      * graph) to produce matches of some kind.
-     * <p>
+     *
      * Two relational expressions can only match if the sub-graphs of the quantifiers they range over match
      * themselves under a bijective association (mapping between the quantifiers of this expression and
      * the quantifier of the candidate expression). To this end, the {@code matchFunction} passed in to this method is
@@ -394,7 +396,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * The {@code matchFunction} can produce zero, one or many matches which are returned as an {@link Iterable} of
      * type
      * {@code M}.
-     * <p>
+     *
      * This method attempts to find that bijective mapping between the quantifiers contained by their respective
      * expressions. Naturally, if the expressions that are being matched own a different number of quantifiers we
      * cannot
@@ -411,7 +413,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * depends on {@code q1}, denoted by {@code q1 -> q2}.
      * This implies that every enumerated mapping must contain {@code q1} before {@code q2} which therefore decreases
      * the number of all mappings that need to be enumerated.
-     * <p>
+     *
      * One complicating factor are correlations to parts of the graph that are not contained in the sub-graphs
      * underneath {@code this} respectively the candidate expression. These correlations are enumerated and bound
      * prior to matching the quantifiers.
@@ -423,7 +425,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * @param constraintsFunction function constraining the number of permutations to enumerate
      * @param matchFunction function producing a match result as iterable of type {@code M}
      * @param combineFunction function to produce an iterable of type {@code S} by combining on bound matches of type
-     * {@code M}
+     *        {@code M}
      * @param <M> intermediate type to represent match results
      * @param <S> final type to represent match results
      *
@@ -492,24 +494,23 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * A functional interface to combine the matches computed over pairs of quantifiers during matching into a
      * result (for the bound correlatedTo set handed into {@link #combine}).
-     * <p>
+     *
      * Let's assume we have multiple bindings during matching on the deep correlations (.getCorrelatedTo() of this).
      * Let's call that the sets of outer bindings. We also attempt to match the quantifiers owned by this to the
      * quantifiers of other.
-     * <p>
+     *
      * For each set of outer bindings we enumerate bindings among the owned quantifiers of the respective expressions.
      * Let's call those sets the inner bindings. For each set out outer bindings there are many sets of inner bindings.
-     * <p>
+     *
      * At the end of matching we want to establish a match between this expression and some other expression and the
      * quantifiers owned by the respective expressions and their bindings among each other do not matter anymore in
      * terms of matching logic. Those bindings only matter for the result of the match under a set of outer bindings.
-     * <p>
+     *
      * The matching algorithm returns an iterable of some type {@code S} which is computed by a lambda passed in by
      * the caller. It is up to the caller what to do with the outer and inner bindings and how to compute a useful
      * result out of it. The signature of that lambda is defined by this interface.
-     * <p>
-     * During matching the matching logic calls {@link #combine} for each set of outer bindings with and {@link
-     * Iterable}
+     *
+     * During matching the matching logic calls {@link #combine} for each set of outer bindings with and {@link Iterable}
      * over sets of inner bindings (and their match results).
      *
      * @param <R> type of the match result computed while matching quantifiers
@@ -520,10 +521,8 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
         /**
          * Combine the sets of bindings (and their results) under the given set of outer bindings to an iterable of
          * combined results.
-         *
          * @param boundCorrelatedToMap set of outer bindings encoded in an {@link AliasMap}
          * @param boundMatches iterable of {@link BoundMatch}es
-         *
          * @return an iterable of type {@code S}
          */
         @Nonnull
@@ -533,7 +532,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
 
     /**
      * Method to enumerate all bindings of unbound correlations of this and some other expression.
-     * <p>
+     *
      * Example:
      *
      * <pre>
@@ -572,7 +571,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      *
      * @param boundAliasMap alias map of bindings that should be considered pre-bound
      * @param otherExpression the other expression
-     *
      * @return an iterable of sets of bindings
      */
     @Nonnull
@@ -599,13 +597,11 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * Given the correlatedTo sets {@code c1} and {@code c2} of this expression and some other expression compute a set
      * of bindings that contains identity bindings ({@code a -> a}) for the intersection of {@code c1} and {@code c2}.
-     *
      * @param otherExpression other expression
      * @param boundAliasMap alias map of bindings that should be considered pre-bound meaning that this method does
-     * not include aliases participating in this map into the identities bindings.
-     *
+     *        not include aliases participating in this map into the identities bindings.
      * @return an {@link AliasMap} for containing only identity bindings for the intersection of the correlatedTo set
-     * of this expression and the other expression
+     *         of this expression and the other expression
      */
     @Nonnull
     default AliasMap bindIdentities(@Nonnull final RelationalExpression otherExpression,
@@ -648,10 +644,9 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * @param candidateExpression the candidate expression
      * @param aliasMap a map of alias defining the equivalence between aliases and therefore quantifiers
      * @param partialMatchMap a map from quantifier to a {@link PartialMatch} that pulled up along that quantifier
-     * from one of the expressions below that quantifier
-     *
+     *        from one of the expressions below that quantifier
      * @return an iterable of {@link MatchInfo}s if subsumption between this expression and the candidate expression
-     * can be established
+     *         can be established
      */
     @Nonnull
     default Iterable<MatchInfo> subsumedBy(@Nonnull final RelationalExpression candidateExpression,
@@ -664,14 +659,12 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * Helper method that can be called by sub classes to defer subsumption in a way that the particular expression
      * only matches if it is semantically equivalent.
-     *
      * @param candidateExpression the candidate expression
      * @param aliasMap a map of alias defining the equivalence between aliases and therefore quantifiers
      * @param partialMatchMap a map from quantifier to a {@link PartialMatch} that pulled up along that quantifier
-     * from one of the expressions below that quantifier
-     *
+     *        from one of the expressions below that quantifier
      * @return an iterable of {@link MatchInfo}s if semantic equivalence between this expression and the candidate
-     * expression can be established
+     *         expression can be established
      */
     @Nonnull
     default Iterable<MatchInfo> exactlySubsumedBy(@Nonnull final RelationalExpression candidateExpression,
@@ -692,11 +685,9 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
 
     /**
      * Override that is called by {@link AdjustMatchRule} to improve an already existing {@link PartialMatch}.
-     *
      * @param partialMatch the partial match already existing between {@code expression} and {@code this}
-     *
      * @return {@code Optional.empty()} if the match could not be adjusted, Optional.of(matchInfo) for a new adjusted
-     * match, otherwise.
+     *         match, otherwise.
      */
     @Nonnull
     default Optional<MatchInfo> adjustMatch(@Nonnull final PartialMatch partialMatch) {
@@ -733,7 +724,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     /**
      * Compute the semantic hash code of this expression. The logic computing the hash code is agnostic to the order
      * of owned quantifiers.
-     *
      * @return the semantic hash code
      */
     @Override
@@ -751,7 +741,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      *
      * @param visitor a {@link PlannerProperty} visitor to evaluate
      * @param <U> the type of the evaluated property
-     *
      * @return the result of evaluating the property on the subtree rooted at this expression
      */
     @Nullable
@@ -774,7 +763,6 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      * click show() on an instance and enjoy the query graph it represents rendered in your standard browser.
      *
      * @param renderSingleGroups whether to render group references with just one member
-     *
      * @return the String "done"
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
@@ -148,7 +148,7 @@ public class FullUnorderedScanExpression implements RelationalExpression, Planne
             return ImmutableList.of();
         }
         // if query doesnot contain candidate's indexes, the query cannot be subsumed by the candidate
-        if (getAccessHints().containsAll(((FullUnorderedScanExpression)candidateExpression).getAccessHints())) {
+        if (getAccessHints().satisfies(((FullUnorderedScanExpression)candidateExpression).getAccessHints())) {
             return exactlySubsumedBy(candidateExpression, aliasMap, partialMatchMap);
         } else {
             return ImmutableList.of();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.expressions;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.apple.foundationdb.record.query.plan.cascades.Compensation;
@@ -55,10 +56,10 @@ import java.util.Set;
  * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan}, a {@code FullUnorderedScanExpression}
  * is not implicitly ordered by the primary key.
  *
- * <p>
+ *
  * This expression is useful as the source of records for the initial planner expression produced from a
  * {@link com.apple.foundationdb.record.query.RecordQuery}.
- * </p>
+ *
  */
 @API(API.Status.EXPERIMENTAL)
 public class FullUnorderedScanExpression implements RelationalExpression, PlannerGraphRewritable {
@@ -66,11 +67,11 @@ public class FullUnorderedScanExpression implements RelationalExpression, Planne
     private final Set<String> recordTypes;
 
     @Nonnull
-    private final Set<String> indexSet;
+    final AccessHints accessHints;
 
-    public FullUnorderedScanExpression(final Set<String> recordTypes, final Set<String> indexSet) {
+    public FullUnorderedScanExpression(final Set<String> recordTypes, @Nonnull final AccessHints accessHints) {
         this.recordTypes = ImmutableSet.copyOf(recordTypes);
-        this.indexSet = ImmutableSet.copyOf(indexSet);
+        this.accessHints = accessHints;
     }
 
     @Nonnull
@@ -79,8 +80,8 @@ public class FullUnorderedScanExpression implements RelationalExpression, Planne
     }
 
     @Nonnull
-    public Set<String> getIndexSet() {
-        return indexSet;
+    public AccessHints getAccessHints() {
+        return accessHints;
     }
 
     @Nonnull
@@ -146,8 +147,8 @@ public class FullUnorderedScanExpression implements RelationalExpression, Planne
         if (getClass() != candidateExpression.getClass()) {
             return ImmutableList.of();
         }
-        // if 1) query contains candidate's indexes; AND 2) the query can be exactly subsumed by the candidate, the query can be subsumed by the candidate
-        if (getIndexSet().isEmpty() || getIndexSet().containsAll(((FullUnorderedScanExpression)candidateExpression).getIndexSet())) {
+        // if query doesnot contain candidate's indexes, the query cannot be subsumed by the candidate
+        if (getAccessHints().contains(((FullUnorderedScanExpression)candidateExpression).getAccessHints())) {
             return exactlySubsumedBy(candidateExpression, aliasMap, partialMatchMap);
         } else {
             return ImmutableList.of();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
@@ -148,7 +148,7 @@ public class FullUnorderedScanExpression implements RelationalExpression, Planne
             return ImmutableList.of();
         }
         // if query doesnot contain candidate's indexes, the query cannot be subsumed by the candidate
-        if (getAccessHints().contains(((FullUnorderedScanExpression)candidateExpression).getAccessHints())) {
+        if (getAccessHints().containsAll(((FullUnorderedScanExpression)candidateExpression).getAccessHints())) {
             return exactlySubsumedBy(candidateExpression, aliasMap, partialMatchMap);
         } else {
             return ImmutableList.of();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
@@ -146,8 +146,8 @@ public class FullUnorderedScanExpression implements RelationalExpression, Planne
         if (getClass() != candidateExpression.getClass()) {
             return ImmutableList.of();
         }
-        // if query doesn't contain any index, or contains candidate's index, the query should be exactly subsumed by the candidate
-        if (getIndexSet().size() == 0 || getIndexSet().containsAll(((FullUnorderedScanExpression)candidateExpression).getIndexSet())) {
+        // if 1) query contains candidate's indexes; AND 2) the query can be exactly subsumed by the candidate, the query can be subsumed by the candidate
+        if (getIndexSet().isEmpty() || getIndexSet().containsAll(((FullUnorderedScanExpression)candidateExpression).getIndexSet())) {
             return exactlySubsumedBy(candidateExpression, aliasMap, partialMatchMap);
         } else {
             return ImmutableList.of();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
@@ -50,8 +50,8 @@ public class AccessHintsTest {
         Assertions.assertNotEquals(indexHint1, primaryHint1);
 
         // test get type
-        Assertions.assertEquals("INDEX", indexHint1.getAccessHintType());
-        Assertions.assertEquals("PRIMARY_KEY", primaryHint1.getAccessHintType());
+        Assertions.assertEquals("IndexAccessHint", indexHint1.getAccessHintType());
+        Assertions.assertEquals("PrimaryAccessHint", primaryHint1.getAccessHintType());
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test the class AccessHints and interface AccessHint.
  */
-public class AccessHintsTest {
+class AccessHintsTest {
 
     @Test
     void testAccessHint() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
@@ -1,0 +1,70 @@
+/*
+ * AccessHintsTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.query;
+
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.query.plan.cascades.AccessHint;
+import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
+import com.apple.foundationdb.record.query.plan.cascades.IndexAccessHint;
+import com.apple.foundationdb.record.query.plan.cascades.PrimaryAccessHint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test the class AccessHints and interface AccessHint.
+ */
+public class AccessHintsTest {
+
+    @Test
+    void testAccessHint() {
+        AccessHint indexHint1 = new IndexAccessHint("index1");
+        AccessHint indexHint2 = new IndexAccessHint("index1");
+        AccessHint indexHint3 = new IndexAccessHint("index2");
+        AccessHint primaryHint1 = new PrimaryAccessHint(Key.Expressions.field("name1"));
+        AccessHint primaryHint2 = new PrimaryAccessHint(Key.Expressions.field("name1"));
+        AccessHint primaryHint3 = new PrimaryAccessHint(Key.Expressions.field("name2"));
+
+        // test equals method
+        Assertions.assertEquals(indexHint1, indexHint2);
+        Assertions.assertEquals(primaryHint1, primaryHint2);
+        Assertions.assertNotEquals(indexHint1, indexHint3);
+        Assertions.assertNotEquals(primaryHint1, primaryHint3);
+        Assertions.assertNotEquals(indexHint1, primaryHint1);
+
+        // test get type
+        Assertions.assertEquals("INDEX", indexHint1.getAccessHintType());
+        Assertions.assertEquals("PRIMARY_KEY", primaryHint1.getAccessHintType());
+    }
+
+    @Test
+    void testContainsAll() {
+        AccessHint indexHint1 = new IndexAccessHint("index1");
+        AccessHint indexHint2 = new IndexAccessHint("index2");
+
+        AccessHints hints1 = new AccessHints();
+        AccessHints hints2 = new AccessHints(indexHint1, indexHint2);
+        AccessHints hints3 = new AccessHints(indexHint1);
+
+        Assertions.assertTrue(hints1.containsAll(hints2));
+        Assertions.assertTrue(hints2.containsAll(hints3));
+        Assertions.assertFalse(hints3.containsAll(hints2));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
-import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.query.plan.cascades.AccessHint;
 import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
 import com.apple.foundationdb.record.query.plan.cascades.IndexAccessHint;
@@ -38,20 +37,16 @@ class AccessHintsTest {
         AccessHint indexHint1 = new IndexAccessHint("index1");
         AccessHint indexHint2 = new IndexAccessHint("index1");
         AccessHint indexHint3 = new IndexAccessHint("index2");
-        AccessHint primaryHint1 = new PrimaryAccessHint(Key.Expressions.field("name1"));
-        AccessHint primaryHint2 = new PrimaryAccessHint(Key.Expressions.field("name1"));
-        AccessHint primaryHint3 = new PrimaryAccessHint(Key.Expressions.field("name2"));
+        AccessHint primaryHint = new PrimaryAccessHint();
 
         // test equals method
         Assertions.assertEquals(indexHint1, indexHint2);
-        Assertions.assertEquals(primaryHint1, primaryHint2);
         Assertions.assertNotEquals(indexHint1, indexHint3);
-        Assertions.assertNotEquals(primaryHint1, primaryHint3);
-        Assertions.assertNotEquals(indexHint1, primaryHint1);
+        Assertions.assertNotEquals(indexHint1, primaryHint);
 
         // test get type
-        Assertions.assertEquals("IndexAccessHint", indexHint1.getAccessHintType());
-        Assertions.assertEquals("PrimaryAccessHint", primaryHint1.getAccessHintType());
+        Assertions.assertEquals("INDEX", indexHint1.getAccessHintType());
+        Assertions.assertEquals("PRIMARY", primaryHint.getAccessHintType());
     }
 
     @Test
@@ -63,9 +58,9 @@ class AccessHintsTest {
         AccessHints hints2 = new AccessHints(indexHint1, indexHint2);
         AccessHints hints3 = new AccessHints(indexHint1);
 
-        Assertions.assertTrue(hints1.containsAll(hints2));
-        Assertions.assertTrue(hints2.containsAll(hints3));
-        Assertions.assertFalse(hints3.containsAll(hints2));
-        Assertions.assertFalse(hints3.containsAll(hints1));
+        Assertions.assertTrue(hints1.satisfies(hints2));
+        Assertions.assertTrue(hints2.satisfies(hints3));
+        Assertions.assertFalse(hints3.satisfies(hints2));
+        Assertions.assertFalse(hints3.satisfies(hints1));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/AccessHintsTest.java
@@ -66,5 +66,6 @@ public class AccessHintsTest {
         Assertions.assertTrue(hints1.containsAll(hints2));
         Assertions.assertTrue(hints2.containsAll(hints3));
         Assertions.assertFalse(hints3.containsAll(hints2));
+        Assertions.assertFalse(hints3.containsAll(hints1));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
@@ -351,7 +351,6 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
         // Covering(Index(multi_index ([null],[1])) -> [num_value_2: KEY[1], num_value_3_indexed: KEY[0], rec_no: KEY[2]]) | num_value_2 LESS_THAN 2
         RecordQueryPlan plan = planner.plan(query);
         if (planner instanceof RecordQueryPlanner) {
-            // plan.show(true);
             final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                     filterPlan(
                             coveringIndexPlan()
@@ -363,7 +362,6 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
             assertEquals(1359983418, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
             assertEquals(-1492450855, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         } else {
-           // plan.show(true);
             final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                     predicatesFilterPlan(
                             coveringIndexPlan()
@@ -409,7 +407,6 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 assertEquals(1350035332, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
                 assertEquals(-1843652335, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
             } else {
-                plan.show(true);
                 final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                         fetchFromPartialRecordPlan(
                                 predicatesFilterPlan(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
@@ -351,6 +351,7 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
         // Covering(Index(multi_index ([null],[1])) -> [num_value_2: KEY[1], num_value_3_indexed: KEY[0], rec_no: KEY[2]]) | num_value_2 LESS_THAN 2
         RecordQueryPlan plan = planner.plan(query);
         if (planner instanceof RecordQueryPlanner) {
+            // plan.show(true);
             final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                     filterPlan(
                             coveringIndexPlan()
@@ -362,6 +363,7 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
             assertEquals(1359983418, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
             assertEquals(-1492450855, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         } else {
+           // plan.show(true);
             final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                     predicatesFilterPlan(
                             coveringIndexPlan()
@@ -407,6 +409,7 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
                 assertEquals(1350035332, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
                 assertEquals(-1843652335, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
             } else {
+                plan.show(true);
                 final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                         fetchFromPartialRecordPlan(
                                 predicatesFilterPlan(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -30,12 +30,12 @@ import com.apple.foundationdb.record.query.plan.cascades.Column;
 import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
-import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
-import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.test.Tags;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -155,7 +155,7 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                     var qun =
                             Quantifier.forEach(GroupExpressionRef.of(
                                     new FullUnorderedScanExpression(ImmutableSet.of("RestaurantRecord",
-                                            "RestaurantReviewer"))));
+                                            "RestaurantReviewer"), ImmutableSet.of())));
 
                     qun = Quantifier.forEach(GroupExpressionRef.of(
                             new LogicalTypeFilterExpression(ImmutableSet.of("RestaurantRecord"),

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -259,12 +259,10 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 false,
                 ParameterRelationshipGraph.empty());
 
-        assertMatchesExactly(plan2,
-                mapPlan(
-                        typeFilterPlan(
-                                scanPlan()
-                                        .where(scanComparisons(range("([1],>")))))
-                        .where(result(recordConstructorValue(exactly(fieldValue("name"), fieldValue("rest_no"))))));
-
+        Assertions.assertFalse(mapPlan(
+                typeFilterPlan(
+                        scanPlan()
+                                .where(scanComparisons(range("([1],>")))))
+                .where(result(recordConstructorValue(exactly(fieldValue("name"), fieldValue("rest_no"))))).matchesExactly(plan2));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -26,10 +26,12 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.Column;
 import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.IndexAccessHint;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
@@ -82,7 +84,7 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                     var qun =
                             Quantifier.forEach(GroupExpressionRef.of(
                                     new FullUnorderedScanExpression(ImmutableSet.of("RestaurantRecord",
-                                            "RestaurantReviewer"), ImmutableSet.of())));
+                                            "RestaurantReviewer"), new AccessHints())));
 
                     qun = Quantifier.forEach(GroupExpressionRef.of(
                             new LogicalTypeFilterExpression(ImmutableSet.of("RestaurantRecord"),
@@ -131,7 +133,7 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                     var qun =
                             Quantifier.forEach(GroupExpressionRef.of(
                                     new FullUnorderedScanExpression(ImmutableSet.of("RestaurantRecord",
-                                            "RestaurantReviewer"), ImmutableSet.of("review_rating"))));
+                                            "RestaurantReviewer"), new AccessHints(new IndexAccessHint("review_rating")))));
 
                     qun = Quantifier.forEach(GroupExpressionRef.of(
                             new LogicalTypeFilterExpression(ImmutableSet.of("RestaurantRecord"),
@@ -170,7 +172,7 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                     var qun =
                             Quantifier.forEach(GroupExpressionRef.of(
                                     new FullUnorderedScanExpression(ImmutableSet.of("RestaurantRecord",
-                                            "RestaurantReviewer"), ImmutableSet.of("RestaurantRecord$name"))));
+                                            "RestaurantReviewer"), new AccessHints(new IndexAccessHint("RestaurantRecord$name")))));
 
                     qun = Quantifier.forEach(GroupExpressionRef.of(
                             new LogicalTypeFilterExpression(ImmutableSet.of("RestaurantRecord"),

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
@@ -119,6 +120,11 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
     @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
     public void testCannotPlanWithIndexHintGraph() throws Exception {
         CascadesPlanner cascadesPlanner = setUp();
+
+        final Optional<Collection<String>> recordTypeNamesOptional = Optional.of(ImmutableSet.of("RestaurantRecord"));
+        final Optional<Collection<String>> allowedIndexesOptional = Optional.empty();
+        final ParameterRelationshipGraph parameterRelationshipGraph = ParameterRelationshipGraph.empty();
+
         // with index hints ("review_rating"), cannot plan a query
         Exception exception = Assertions.assertThrows(RecordCoreException.class, () -> cascadesPlanner.planGraph(
                 () -> {
@@ -146,11 +152,11 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                     qun = Quantifier.forEach(GroupExpressionRef.of(graphExpansionBuilder.build().buildSelect()));
                     return GroupExpressionRef.of(new LogicalSortExpression(null, false, qun));
                 },
-                Optional.of(ImmutableSet.of("RestaurantRecord")),
-                Optional.empty(),
+                recordTypeNamesOptional,
+                allowedIndexesOptional,
                 IndexQueryabilityFilter.TRUE,
                 false,
-                ParameterRelationshipGraph.empty()));
+                parameterRelationshipGraph));
         Assertions.assertEquals("Cascades planner could not plan query", exception.getMessage());
     }
 


### PR DESCRIPTION
* This PR is to support index hint in a query
* Add index info to FullUnorderedScanExpression, then when match candidates, the query can be subsumed by a candidate only when the index is included in the hint indexes.