### PR TITLE
Resolves #1636: Increase FDB Java version to FDB 7.1 

### DIFF
--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,5 +1,5 @@
 FROM centos:7
-LABEL version=0.0.17
+LABEL version=0.0.18
 
 RUN yum install -y \
     git \
@@ -10,8 +10,8 @@ RUN yum install -y \
     unzip \
     wget \
     which \
-    https://github.com/apple/foundationdb/releases/download/6.3.16/foundationdb-clients-6.3.16-1.el7.x86_64.rpm \
-    https://github.com/apple/foundationdb/releases/download/6.3.16/foundationdb-server-6.3.16-1.el7.x86_64.rpm && \
+    https://github.com/apple/foundationdb/releases/download/7.1.3/foundationdb-clients-7.1.3-1.el7.x86_64.rpm \
+    https://github.com/apple/foundationdb/releases/download/7.1.3/foundationdb-server-7.1.3-1.el7.x86_64.rpm && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/build/Dockerfile.fdbserver
+++ b/build/Dockerfile.fdbserver
@@ -1,5 +1,5 @@
 FROM centos:7
-LABEL version=6.3.16-1
+LABEL version=7.1.3-1
 
 RUN yum install -y \
     which \
@@ -7,8 +7,8 @@ RUN yum install -y \
     rsync \
     net-tools \
     passwd \
-    https://github.com/apple/foundationdb/releases/download/6.3.16/foundationdb-clients-6.3.16-1.el7.x86_64.rpm \
-    https://github.com/apple/foundationdb/releases/download/6.3.16/foundationdb-server-6.3.16-1.el7.x86_64.rpm && \
+    https://github.com/apple/foundationdb/releases/download/7.1.3/foundationdb-clients-7.1.3-1.el7.x86_64.rpm \
+    https://github.com/apple/foundationdb/releases/download/7.1.3/foundationdb-server-7.1.3-1.el7.x86_64.rpm && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: fdb-record-layer-build:0.0.16
+    image: fdb-record-layer-build:0.0.18
     build:
       context: .
       dockerfile: Dockerfile.build
@@ -17,7 +17,7 @@ services:
       - FDBHOSTNAME=fdbserver
 
   fdbserver:
-    image: foundationdb-server:6.3.12-1
+    image: foundationdb-server:7.1.3-1
     environment:
       - FDBSTARTOPT=2
       - HOST_IP=0.0.0.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,11 +4,11 @@ This document contains a log of changes to the FoundationDB Record Layer. It aim
 
 As the [versioning guide](Versioning.md) details, it cannot always be determined solely by looking at the version numbers whether one Record Layer version contains all changes included in another. In particular, bug fixes and backwards-compatible changes might be back-ported to or introduced as patches against older versions. To track when a patch version has been included in the main release train, some releases will say as a note that they contain all changes from a specific patch.
 
-## 3.1
+## 3.2
 
-### Breaking Changes
+### Breaking changes
 
-This version of the Record Layer changes the Java source and target compatibility to version 11.  Downstream projects need to be aware that the byte code produced is of class file version `55.0` going forward.
+The FoundationDB Java binding dependency has been updated to 7.1 with this release. This means that clients also need to update their main FDB C client to a 7.1 version. Adopters that still wish to connect to an FDB cluster running a 6.3 or 7.0 server version can do so by packaging additional FDB C clients at the appropriate version(s) using the [FDB multi-version client feature](https://apple.github.io/foundationdb/api-general.html#multi-version-client).
 
 <!--
 // begin next release
@@ -29,7 +29,7 @@ This version of the Record Layer changes the Java source and target compatibilit
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** The FDB dependency has been updated to require version 7.1 [(Issue #1636)](https://github.com/FoundationDB/fdb-record-layer/issues/1636)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
@@ -37,6 +37,12 @@ This version of the Record Layer changes the Java source and target compatibilit
 
 // end next release
 -->
+
+## 3.1
+
+### Breaking Changes
+
+This version of the Record Layer changes the Java source and target compatibility to version 11.  Downstream projects need to be aware that the byte code produced is of class file version `55.0` going forward.
 
 ### 3.1.256.0
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,7 +6,7 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ## 3.2
 
-### Breaking changes
+### Breaking Changes
 
 The FoundationDB Java binding dependency has been updated to 7.1 with this release. This means that clients also need to update their main FDB C client to a 7.1 version. Adopters that still wish to connect to an FDB cluster running a 6.3 or 7.0 server version can do so by packaging additional FDB C clients at the appropriate version(s) using the [FDB multi-version client feature](https://apple.github.io/foundationdb/api-general.html#multi-version-client).
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,8 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 The FoundationDB Java binding dependency has been updated to 7.1 with this release. This means that clients also need to update their main FDB C client to a 7.1 version. Adopters that still wish to connect to an FDB cluster running a 6.3 or 7.0 server version can do so by packaging additional FDB C clients at the appropriate version(s) using the [FDB multi-version client feature](https://apple.github.io/foundationdb/api-general.html#multi-version-client).
 
+This release also updates downstream dependency versions. Most notably, the proto3 artifacts now require Protobuf version 3.20.1.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -30,7 +32,7 @@ The FoundationDB Java binding dependency has been updated to 7.1 with this relea
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** The FDB dependency has been updated to require version 7.1 [(Issue #1636)](https://github.com/FoundationDB/fdb-record-layer/issues/1636)
-* **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Additional downstream dependency versions have been upgraded, including Protobuf [(Issue #1640)](https://github.com/FoundationDB/fdb-record-layer/issues/1640)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -32,7 +32,7 @@ Then the following dependency can be added:
 ```
   <groupId>org.foundationdb</groupId>
   <artifactId>fdb-record-layer-core</artifactId>
-  <version>3.1.+</version>
+  <version>3.2.+</version>
 ```
 
 Older builds are also available in the maven central repository, and newer builds will be published there upon the resolution of [Issue #1288](https://github.com/FoundationDB/fdb-record-layer/issues/1288).
@@ -53,7 +53,7 @@ repositories {
 Then the following dependency can be added:
 
 ```
-"org.foundationdb:fdb-record-layer-core:3.1.+"
+"org.foundationdb:fdb-record-layer-core:3.2.+"
 ```
 
 Older builds are also available in the `mavenCentral()` repository, and newer builds will be published there upon the resolution of [Issue #1288](https://github.com/FoundationDB/fdb-record-layer/issues/1288).

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
@@ -20,8 +20,10 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.KeyArrayResult;
 import com.apple.foundationdb.KeySelector;
 import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.MappedKeyValue;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.StreamingMode;
@@ -190,6 +192,23 @@ abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements
         increment(FDBStoreTimer.Counts.READS);
         increment(FDBStoreTimer.Counts.RANGE_READS);
         return new ByteCountingAsyncIterable(underlying.getRange(checkKey(range), limit, reverse, streamingMode));
+    }
+
+    @Override
+    public AsyncIterable<MappedKeyValue> getMappedRange(final KeySelector begin, final KeySelector end, final byte[] mapper, final int limit, final boolean reverse, final StreamingMode mode) {
+        increment(FDBStoreTimer.Counts.READS);
+        increment(FDBStoreTimer.Counts.RANGE_READS);
+        return underlying.getMappedRange(begin, end, mapper, limit, reverse, mode);
+    }
+
+    @Override
+    public CompletableFuture<KeyArrayResult> getRangeSplitPoints(final Range range, final long chunkSize) {
+        return underlying.getRangeSplitPoints(range, chunkSize);
+    }
+
+    @Override
+    public CompletableFuture<KeyArrayResult> getRangeSplitPoints(final byte[] begin, final byte[] end, final long chunkSize) {
+        return underlying.getRangeSplitPoints(begin, end, chunkSize);
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,10 +31,10 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 
 fdbVersion=7.1.3
 jsr305Version=3.0.2
-slf4jVersion=1.7.30
+slf4jVersion=1.7.36
 commonsLang3Version=3.12.0
 commonsMath3Version=3.6.1
-log4jVersion=2.17.1
+log4jVersion=2.17.2
 guavaVersion=30.1-jre
 hamcrestVersion=2.2
 # AutoService kept on 1.0-rc6 to avoid annotation being retained in CLASS. See: https://github.com/FoundationDB/fdb-record-layer/issues/1281
@@ -46,7 +46,7 @@ junitVersion=5.7.1
 jacocoVersion=0.8.5
 
 protobuf2Version=2.6.1
-protobuf3Version=3.15.6
+protobuf3Version=3.20.1
 
 mavenLocalEnabled=false
 org.gradle.daemon=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=3.1
+version=3.2
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)
@@ -29,7 +29,7 @@ group=org.foundationdb
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation
 
-fdbVersion=6.3.12
+fdbVersion=7.1.3
 jsr305Version=3.0.2
 slf4jVersion=1.7.30
 commonsLang3Version=3.12.0


### PR DESCRIPTION
This increases the FDB Java dependency to FDB 7.1. This keeps the API version at 630 so that the library can still be used to connect to FDB 6.3 and FDB 7.0 clusters, though it would now require using a 7.1 FDB C client as the primary client with the other clients as external clients.

This will allow for additional features to be built on top of FDB 7.1, though we probably want to also complete #1639 so that we can responsibly guard features reliant on 7.1 in environments where the cluster may still be running older FDB server versions.

This also updates the proto3 version to 3.20.1 and along with a few other dependencies. It leaves the guava version at 30.1-jre instead of updating it to 31.1-jre because that causes spotbugs violations regarding nullability problems. I think those errors are because of a possible change in the way Guava handles nullability annotations, but it seems like something we should fix later.

This resolves #1636, and it resolves #1640.