### PR TITLE
Resolves #1639: Support a configurable FDB API version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ allprojects {
     }
     project.tasks.withType(Test) {
         systemProperty "file.encoding", "utf-8"
+        if (project.hasProperty("apiVersion")) {
+            systemProperty "com.apple.foundationdb.apiVersion", project.getProperty("apiVersion")
+        }
     }
 
     buildDir = ".out"

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,6 +6,10 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ## 3.2
 
+### Features
+
+This version of the Record Layer allows the FDB API version to be configured through the `FDBDatabaseFactory`. This means that while this version allows the client to be configured to use 7.1 features, it also supports connecting to 6.3 FDB clusters if the API version is set appropriately. Note that setting the API version does restrict the set of potential FDB server versions that can be connected to, so this configuration change should only be made if the FDB server has already been updated.
+
 ### Breaking Changes
 
 The FoundationDB Java binding dependency has been updated to 7.1 with this release. This means that clients also need to update their main FDB C client to a 7.1 version. Adopters that still wish to connect to an FDB cluster running a 6.3 or 7.0 server version can do so by packaging additional FDB C clients at the appropriate version(s) using the [FDB multi-version client feature](https://apple.github.io/foundationdb/api-general.html#multi-version-client).
@@ -26,7 +30,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The FDB API version can now be configured through the `FDBDatabaseFactory` [(Issue #1639)](https://github.com/FoundationDB/fdb-record-layer/issues/1639)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/FDBTestBase.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/FDBTestBase.java
@@ -26,9 +26,22 @@ import org.junit.jupiter.api.BeforeAll;
  * Base class that all tests touching FoundationDB should inherit from.
  */
 public abstract class FDBTestBase {
+    private static final int MIN_API_VERSION = 630;
+    private static final int MAX_API_VERSION = 710;
+    private static final String API_VERSION_PROPERTY = "com.apple.foundationdb.apiVersion";
+
+    private static int getAPIVersion() {
+        int apiVersion = Integer.parseInt(System.getProperty(API_VERSION_PROPERTY, "630"));
+        if (apiVersion < MIN_API_VERSION || apiVersion > MAX_API_VERSION) {
+            throw new IllegalStateException(String.format("unsupported API version %d (must be between %d and %d)",
+                    apiVersion, MIN_API_VERSION, MAX_API_VERSION));
+        }
+        return apiVersion;
+    }
+
     @BeforeAll
     public static void setupFDB() {
-        FDB fdb = FDB.selectAPIVersion(630);
+        FDB fdb = FDB.selectAPIVersion(getAPIVersion());
         fdb.setUnclosedWarning(true);
     }
 }

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -81,8 +81,8 @@ test {
 
         // Configure whether or not tests will validate that asyncToSync isn't being called in async
         // context.  See BlockingInAsyncDetection class for details on values.
-        systemProperties = [ "com.apple.foundationdb.record.blockingInAsyncDetection": 
-            System.getenv('BLOCKING_DETECTION') ?: "IGNORE_COMPLETE_EXCEPTION_BLOCKING" ]
+        systemProperty "com.apple.foundationdb.record.blockingInAsyncDetection",
+                System.getenv('BLOCKING_DETECTION') ?: "IGNORE_COMPLETE_EXCEPTION_BLOCKING"
 
         // We need the destructive tests to be available in the 'test' task, so that IntelliJ's gradle test runner can
         // find them. However, we _only_ want to run them as part of the 'test' task if we're running from IntelliJ.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -165,6 +165,15 @@ public enum LogMessageKeys {
     INDEXING_POLICY,
     INDEXING_POLICY_DESIRED_ACTION,
 
+    // FDB client configuration
+    API_VERSION,
+    RUN_LOOP_PROFILING,
+    THREADS_PER_CLIENT_VERSION,
+    TRACE_DIRECTORY,
+    TRACE_FORMAT,
+    TRACE_LOG_GROUP,
+    UNCLOSED_WARNING,
+
     // comparisons
     COMPARISON_VALUE,
     EXPECTED,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
@@ -44,12 +44,14 @@ import javax.annotation.Nonnull;
  * <p>
  * A note on Record Layer API stability: the elements of this enum are expected to shift as support
  * for FDB versions are deprecated and removed. As a result, the elements of this enum will be added
- * and removed as support for old FDB versions is dropped and new FDB versions is added.
+ * and removed as support for old FDB versions is dropped and new FDB versions is added. Setting the
+ * API version to a non-default value is also currently an experimental feature as additional testing
+ * and validation work to evaluate the library at various FDB API versions is developed.
  * </p>
  *
  * @see FDBDatabaseFactory#setAPIVersion(APIVersion)
  */
-@API(API.Status.MAINTAINED)
+@API(API.Status.EXPERIMENTAL)
 public enum APIVersion {
     /**
      * API version corresponding to FoundationDB 6.3.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
@@ -1,0 +1,108 @@
+/*
+ * APIVersion.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+
+/**
+ * An enum representing the different supported FDB API versions. The
+ * <a href="https://apple.github.io/foundationdb/api-general.html#api-versions">FDB API version</a>
+ * controls the minimum FDB server version that can be successfully connected to, as well as
+ * what features are supported by the FDB client. It is therefore important that in scenarios where
+ * there are FDB servers on different versions that the API version be configured to not exceed the
+ * smallest FDB server version. If the API version is set too high, the FDB client may hang when
+ * trying to connect to the server.
+ *
+ * <p>
+ * Because FDB API versions also control which features are guaranteed to be supported, there may
+ * be Record Layer features that are gated on specific FDB API versions. For that reason, if there
+ * is a new feature that relies on specific FDB server features being available, the client may
+ * need to be configured with the appropriate API version before that feature can be used.
+ * </p>
+ *
+ * <p>
+ * A note on Record Layer API stability: the elements of this enum are expected to shift as support
+ * for FDB versions are deprecated and removed. As a result, the elements of this enum will be added
+ * and removed as support for old FDB versions is dropped and new FDB versions is added.
+ * </p>
+ *
+ * @see FDBDatabaseFactory#setAPIVersion(APIVersion)
+ */
+@API(API.Status.MAINTAINED)
+public enum APIVersion {
+    /**
+     * API version corresponding to FoundationDB 6.3.
+     */
+    API_VERSION_6_3(630),
+    /**
+     * API version corresponding to FoundationDB 7.0.
+     */
+    API_VERSION_7_0(700),
+    /**
+     * API version corresponding to FoundationDB 7.1.
+     */
+    API_VERSION_7_1(710),
+    ;
+
+    private final int versionNumber;
+
+    APIVersion(int versionNumber) {
+        this.versionNumber = versionNumber;
+    }
+
+    /**
+     * Get the API version number. This is the value passed to FDB during client initialization.
+     * @return the version number associated with this version of the API
+     */
+    public int getVersionNumber() {
+        return versionNumber;
+    }
+
+    /**
+     * Get the default API version. Unless the adopter overrides this value by calling
+     * {@link FDBDatabaseFactory#setAPIVersion(APIVersion)}, this is the API version that will
+     * be used to initialize the FDB client connection.
+     *
+     * <p>
+     * This is currently {@link #API_VERSION_6_3}.
+     * </p>
+     *
+     * @return the default API version
+     */
+    public static APIVersion getDefault() {
+        return API_VERSION_6_3;
+    }
+
+    /**
+     * Get the {@code APIVersion} enum from the version number.
+     * @param versionNumber the FDB API version number
+     * @return the corresponding enum value
+     */
+    public static APIVersion fromVersionNumber(int versionNumber) {
+        for (APIVersion version : values()) {
+            if (version.getVersionNumber() == versionNumber) {
+                return version;
+            }
+        }
+        throw new RecordCoreArgumentException("api version not supported");
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
  * controls the minimum FDB server version that can be successfully connected to, as well as
  * what features are supported by the FDB client. It is therefore important that in scenarios where
  * there are FDB servers on different versions that the API version be configured to not exceed the
- * smallest FDB server version. If the API version is set too high, the FDB client may hang when
+ * lowest FDB server version. If the API version is set too high, the FDB client may hang when
  * trying to connect to the server.
  *
  * <p>

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/APIVersion.java
@@ -23,6 +23,8 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 
+import javax.annotation.Nonnull;
+
 /**
  * An enum representing the different supported FDB API versions. The
  * <a href="https://apple.github.io/foundationdb/api-general.html#api-versions">FDB API version</a>
@@ -75,6 +77,17 @@ public enum APIVersion {
      */
     public int getVersionNumber() {
         return versionNumber;
+    }
+
+    /**
+     * Whether this API version is at least as new as another API version. This is
+     * useful for determining if a feature added at a certain API version is available.
+     *
+     * @param other the API version to compare against
+     * @return whether this API version is at least the provided API version
+     */
+    public boolean isAtLeast(@Nonnull APIVersion other) {
+        return versionNumber >= other.getVersionNumber();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -153,7 +153,10 @@ public class FDBDatabase {
     private String datacenterId;
 
     @Nonnull
-    private FDBLocalityProvider localityProvider;
+    private final FDBLocalityProvider localityProvider;
+
+    @Nonnull
+    private final APIVersion apiVersion;
 
     @Nonnull
     private static ImmutablePair<Long, Long> initialVersionPair = new ImmutablePair<>(null, null);
@@ -184,6 +187,7 @@ public class FDBDatabase {
         this.latencyInjector = factory.getLatencyInjector();
         this.datacenterId = factory.getDatacenterId();
         this.localityProvider = factory.getLocalityProvider();
+        this.apiVersion = factory.getAPIVersion();
     }
 
     /**
@@ -236,6 +240,23 @@ public class FDBDatabase {
     @Nonnull
     public synchronized FDBLocalityProvider getLocalityProvider() {
         return localityProvider;
+    }
+
+    /**
+     * Get the FDB API version that this database was created with. This can be used by calling
+     * code to determine what methods are safe to call, and for compatibility code to know how to
+     * properly execute operations that may require differently depending on the API. This is an
+     * internal method that should only be called by internal modules, as higher level Record
+     * Layer APIs should shield adopters from needing to know this configuration value except
+     * possibly during application initialization.
+     *
+     * @return the API version of this database
+     * @see APIVersion
+     * @see FDBDatabaseFactory#setAPIVersion(APIVersion)
+     */
+    @API(API.Status.INTERNAL)
+    public APIVersion getAPIVersion() {
+        return apiVersion;
     }
 
     public synchronized void setTrackLastSeenVersionOnRead(boolean trackLastSeenVersion) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -1287,7 +1287,7 @@ public class FDBDatabase {
                                            boolean isComplete,
                                            @Nonnull StackTraceElement stackElement,
                                            @Nonnull String title) {
-        final RuntimeException exception = new BlockingInAsyncException(title)
+        final RecordCoreException exception = new BlockingInAsyncException(title)
                 .addLogInfo(
                         LogMessageKeys.FUTURE_COMPLETED, isComplete,
                         LogMessageKeys.CALLING_CLASS, stackElement.getClassName(),
@@ -1297,12 +1297,9 @@ public class FDBDatabase {
         if (!isComplete && behavior.throwExceptionOnBlocking()) {
             throw exception;
         } else {
-            LOGGER.warn(KeyValueLogMessage.of(title,
-                    LogMessageKeys.FUTURE_COMPLETED, isComplete,
-                    LogMessageKeys.CALLING_CLASS, stackElement.getClassName(),
-                    LogMessageKeys.CALLING_METHOD, stackElement.getMethodName(),
-                    LogMessageKeys.CALLING_LINE, stackElement.getLineNumber()),
-                    exception);
+            KeyValueLogMessage logMessage = KeyValueLogMessage.build(title)
+                    .addKeysAndValues(exception.getLogInfo());
+            LOGGER.warn(logMessage.toString(), exception);
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -680,12 +680,15 @@ public abstract class FDBDatabaseFactory {
      * </p>
      *
      * <p>
-     * By default, this will be set to {@link APIVersion#getDefault()}.
+     * By default, this will be set to {@link APIVersion#getDefault()}. Note that setting the API version
+     * to a non-default value is currently experimental as additional testing and validation of various
+     * API versions is developed.
      * </p>
      *
      * @param apiVersion the API version to use when initializing the FDB client
      * @see APIVersion
      */
+    @API(API.Status.EXPERIMENTAL)
     public abstract void setAPIVersion(@Nonnull APIVersion apiVersion);
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -666,6 +666,39 @@ public abstract class FDBDatabaseFactory {
 
     public abstract Supplier<Boolean> getTransactionIsTracedSupplier();
 
+    /**
+     * Set the API version for this database factory. This value will be used to determine what FDB APIs are
+     * available.
+     *
+     * <p>
+     * Note that once an API version has been set, the client will not be able to talk to any FDB cluster
+     * that is running an older associated server version. It is therefore important that the adopter sets
+     * this value so that it does not exceed the smallest FDB server version that this client will be
+     * expected to connect to. However, if there are features that are only available on a subset of
+     * supported FDB API versions, the Record Layer will attempt to guard those features so that they are
+     * only used if the configured API version supports it.
+     * </p>
+     *
+     * <p>
+     * By default, this will be set to {@link APIVersion#getDefault()}.
+     * </p>
+     *
+     * @param apiVersion the API version to use when initializing the FDB client
+     * @see APIVersion
+     */
+    public abstract void setAPIVersion(@Nonnull APIVersion apiVersion);
+
+    /**
+     * Get the configured FDB API version. This is an internal method to indicate what value was configured
+     * on this database factory, as other Record Layer APIs should hide API-version compatibility code so
+     * that adopters do not need to worry about setting this value except possibly during client initialization.
+     *
+     * @return the configured FDB API version
+     * @see #setAPIVersion(APIVersion)
+     */
+    @API(API.Status.INTERNAL)
+    public abstract APIVersion getAPIVersion();
+
     @Nonnull
     public abstract FDBDatabase getDatabase(@Nullable String clusterFile);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -195,7 +195,7 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
     }
 
     @Override
-    public APIVersion getAPIVersion() {
+    public synchronized APIVersion getAPIVersion() {
         return apiVersion;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,8 +100,16 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
 
     protected synchronized FDB initFDB() {
         if (!inited) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(KeyValueLogMessage.of("Starting FDB"));
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(KeyValueLogMessage.build("Staring FDB")
+                        .addKeyAndValue(LogMessageKeys.API_VERSION, apiVersion.getVersionNumber())
+                        .addKeyAndValue(LogMessageKeys.UNCLOSED_WARNING, unclosedWarning)
+                        .addKeyAndValue(LogMessageKeys.TRACE_FORMAT, traceFormat)
+                        .addKeyAndValue(LogMessageKeys.TRACE_DIRECTORY, traceDirectory)
+                        .addKeyAndValue(LogMessageKeys.TRACE_LOG_GROUP, traceLogGroup)
+                        .addKeyAndValue(LogMessageKeys.RUN_LOOP_PROFILING, runLoopProfilingEnabled)
+                        .addKeyAndValue(LogMessageKeys.THREADS_PER_CLIENT_VERSION, threadsPerClientVersion)
+                        .getMessageWithKeys());
             }
             fdb = FDB.selectAPIVersion(apiVersion.getVersionNumber());
             fdb.setUnclosedWarning(unclosedWarning);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -81,6 +81,8 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
     private String traceLogGroup = null;
     @Nonnull
     private FDBTraceFormat traceFormat = FDBTraceFormat.DEFAULT;
+    @Nonnull
+    private APIVersion apiVersion = APIVersion.getDefault();
 
     private boolean runLoopProfilingEnabled = false;
 
@@ -101,7 +103,7 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(KeyValueLogMessage.of("Starting FDB"));
             }
-            fdb = FDB.selectAPIVersion(API_VERSION);
+            fdb = FDB.selectAPIVersion(apiVersion.getVersionNumber());
             fdb.setUnclosedWarning(unclosedWarning);
             setStaticOptions(fdb);
             NetworkOptions options = fdb.options();
@@ -171,6 +173,19 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
     @Override
     public void setTraceFormat(@Nonnull FDBTraceFormat traceFormat) {
         this.traceFormat = traceFormat;
+    }
+
+    @Override
+    public synchronized void setAPIVersion(@Nonnull APIVersion apiVersion) {
+        if (inited) {
+            throw new RecordCoreException("API version cannot be changed after client has already started");
+        }
+        this.apiVersion = apiVersion;
+    }
+
+    @Override
+    public APIVersion getAPIVersion() {
+        return apiVersion;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -41,7 +41,6 @@ import java.util.function.Supplier;
 public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabaseFactory.class);
-    private static final int API_VERSION = 630;
 
     @Nonnull
     private static final FDBDatabaseFactoryImpl INSTANCE = new FDBDatabaseFactoryImpl();
@@ -177,6 +176,9 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
 
     @Override
     public synchronized void setAPIVersion(@Nonnull APIVersion apiVersion) {
+        if (this.apiVersion == apiVersion) {
+            return;
+        }
         if (inited) {
             throw new RecordCoreException("API version cannot be changed after client has already started");
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
@@ -78,6 +78,34 @@ public class FDBTransactionContext {
         return transaction.getApproximateSize();
     }
 
+    /**
+     * Get the FDB API version associated with this transaction. This is an internal
+     * method that should be used within the Record Layer to accommodate changes in
+     * underlying FDB behavior that are dictated by the API version.
+     *
+     * @return the transaction's associated FDB API version
+     * @see APIVersion
+     */
+    @API(API.Status.INTERNAL)
+    public APIVersion getAPIVersion() {
+        return database.getAPIVersion();
+    }
+
+    /**
+     * Determine whether the API version of this transaction is at least as new as
+     * the provided API version. This is an internal method that should be used
+     * to gate features requiring certain FDB API versions for support from the database.
+     *
+     * @param apiVersion the FDB API version to compare against
+     * @return whether the transaction's API version is at least as new as the provided API version
+     * @see #getAPIVersion()
+     * @see APIVersion
+     */
+    @API(API.Status.INTERNAL)
+    public boolean isAPIVersionAtLeast(@Nonnull APIVersion apiVersion) {
+        return getAPIVersion().isAtLeast(apiVersion);
+    }
+
     @Nullable
     public FDBStoreTimer getTimer() {
         return timer;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/APIVersionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/APIVersionTest.java
@@ -1,0 +1,48 @@
+/*
+ * APIVersionTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class APIVersionTest {
+
+    @SuppressWarnings("unused") // used as argument source for parameterized test
+    static Stream<Arguments> isAtLeast() {
+        return Arrays.stream(APIVersion.values())
+                .flatMap(version1 -> Arrays.stream(APIVersion.values())
+                        .map(version2 -> Arguments.of(version1, version2))
+                );
+    }
+
+    @ParameterizedTest(name = "isAtLeast[{arguments}]")
+    @MethodSource
+    void isAtLeast(@Nonnull APIVersion version1, @Nonnull APIVersion version2) {
+        assertEquals(version1.getVersionNumber() >= version2.getVersionNumber(), version1.isAtLeast(version2));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
@@ -518,5 +519,12 @@ public class FDBDatabaseTest extends FDBTestBase {
                 FDBRecordContextConfig.newBuilder().setEnableAssertions(true).build())) {
             assertThrows(exception, () -> consumer.accept(context));
         }
+    }
+
+    @Test
+    public void getAPIVersion() {
+        final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
+        assertEquals(APIVersion.getDefault(), database.getAPIVersion());
+        assertEquals(FDB.instance().getAPIVersion(), database.getAPIVersion().getVersionNumber());
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -36,6 +36,7 @@ import com.google.protobuf.Message;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
@@ -56,6 +57,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -67,12 +69,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBDatabase}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBDatabaseTest extends FDBTestBase {
+class FDBDatabaseTest extends FDBTestBase {
     @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabaseTest.class);
 
     @Test
-    public void cachedVersionMaintenanceOnReadsTest() throws Exception {
+    void cachedVersionMaintenanceOnReadsTest() throws Exception {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setTrackLastSeenVersion(true);
         FDBDatabase database = factory.getDatabase();
@@ -119,7 +121,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void cachedVersionMaintenanceOnCommitTest() {
+    void cachedVersionMaintenanceOnCommitTest() {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setTrackLastSeenVersion(true);
         FDBDatabase database = factory.getDatabase();
@@ -141,7 +143,7 @@ public class FDBDatabaseTest extends FDBTestBase {
 
     @ParameterizedTest(name = "cachedReadVersionWithRetryLoops [async = {0}]")
     @BooleanSource
-    public void cachedReadVersionWithRetryLoops(boolean async) throws InterruptedException, ExecutionException {
+    void cachedReadVersionWithRetryLoops(boolean async) throws InterruptedException, ExecutionException {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setTrackLastSeenVersion(true);
         FDBDatabase database = factory.getDatabase();
@@ -178,7 +180,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testBlockingInAsyncException() {
+    void testBlockingInAsyncException() {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setBlockingInAsyncDetection(BlockingInAsyncDetection.IGNORE_COMPLETE_EXCEPTION_BLOCKING);
 
@@ -191,7 +193,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testBlockingInAsyncWarning() {
+    void testBlockingInAsyncWarning() {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setBlockingInAsyncDetection(BlockingInAsyncDetection.IGNORE_COMPLETE_WARN_BLOCKING);
         factory.clear();
@@ -205,7 +207,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testCompletedBlockingInAsyncWarning() {
+    void testCompletedBlockingInAsyncWarning() {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setBlockingInAsyncDetection(BlockingInAsyncDetection.WARN_COMPLETE_EXCEPTION_BLOCKING);
         factory.clear();
@@ -218,7 +220,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testBlockingCreatingAsyncDetection() throws Exception {
+    void testBlockingCreatingAsyncDetection() throws Exception {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setBlockingInAsyncDetection(BlockingInAsyncDetection.WARN_COMPLETE_EXCEPTION_BLOCKING);
         factory.clear();
@@ -229,7 +231,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testCompletedBlockingCreatingAsyncDetection() {
+    void testCompletedBlockingCreatingAsyncDetection() {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setBlockingInAsyncDetection(BlockingInAsyncDetection.WARN_COMPLETE_EXCEPTION_BLOCKING);
         factory.clear();
@@ -241,7 +243,7 @@ public class FDBDatabaseTest extends FDBTestBase {
 
     @ParameterizedTest(name = "testJoinNowOnCompletedFuture (behavior = {0})")
     @EnumSource(BlockingInAsyncDetection.class)
-    public void testJoinNowOnCompletedFuture(BlockingInAsyncDetection behavior) {
+    void testJoinNowOnCompletedFuture(BlockingInAsyncDetection behavior) {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setBlockingInAsyncDetection(behavior);
         factory.clear();
@@ -256,7 +258,7 @@ public class FDBDatabaseTest extends FDBTestBase {
 
     @ParameterizedTest(name = "testJoinNowOnNonCompletedFuture (behavior = {0})")
     @EnumSource(BlockingInAsyncDetection.class)
-    public void testJoinNowOnNonCompletedFuture(BlockingInAsyncDetection behavior) {
+    void testJoinNowOnNonCompletedFuture(BlockingInAsyncDetection behavior) {
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setBlockingInAsyncDetection(behavior);
         factory.clear();
@@ -276,7 +278,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void loggableTimeoutException() {
+    void loggableTimeoutException() {
         CompletableFuture<Void> delayed = new CompletableFuture<Void>();
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         FDBDatabase database = factory.getDatabase();
@@ -298,12 +300,12 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testGetReadVersionLatencyInjection() throws Exception {
+    void testGetReadVersionLatencyInjection() throws Exception {
         testLatencyInjection(FDBLatencySource.GET_READ_VERSION, 300L, FDBRecordContext::getReadVersion);
     }
 
     @Test
-    public void testCommitLatencyInjection() throws Exception {
+    void testCommitLatencyInjection() throws Exception {
         testLatencyInjection(FDBLatencySource.COMMIT_ASYNC, 300L, context -> {
             final Transaction tr = context.ensureActive();
             tr.clear(new byte[] { (byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef });
@@ -311,7 +313,7 @@ public class FDBDatabaseTest extends FDBTestBase {
         });
     }
 
-    public void testLatencyInjection(FDBLatencySource latencySource, long expectedLatency, Consumer<FDBRecordContext> thingToDo) throws Exception {
+    private void testLatencyInjection(FDBLatencySource latencySource, long expectedLatency, Consumer<FDBRecordContext> thingToDo) throws Exception {
         final FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
 
         // Databases only pick up the latency injector upon creation, so clear out any cached database
@@ -340,7 +342,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testPostCommitHooks() throws Exception {
+    void testPostCommitHooks() throws Exception {
         final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
         final AtomicInteger counter = new AtomicInteger(0);
 
@@ -410,7 +412,7 @@ public class FDBDatabaseTest extends FDBTestBase {
         }
     }
 
-    public static void testStoreAndRetrieveSimpleRecord(FDBDatabase database, RecordMetaData metaData) {
+    static void testStoreAndRetrieveSimpleRecord(FDBDatabase database, RecordMetaData metaData) {
         TestRecords1Proto.MySimpleRecord simpleRecord = storeSimpleRecord(database, metaData, 1066L);
         TestRecords1Proto.MySimpleRecord retrieved = retrieveSimpleRecord(database, metaData, 1066L);
         assertNotNull(retrieved);
@@ -452,7 +454,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void performNoOp() {
+    void performNoOp() {
         final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
         FDBStoreTimer timer = new FDBStoreTimer();
         database.performNoOp(timer);
@@ -467,7 +469,7 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void performNoOpAgainstFakeCluster() throws IOException {
+    void performNoOpAgainstFakeCluster() throws IOException {
         final String clusterFile = FDBTestBase.createFakeClusterFile("perform_no_op_");
         final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase(clusterFile);
 
@@ -492,14 +494,14 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void testAssertionsOnKeySize() {
+    void testAssertionsOnKeySize() {
         testSizeAssertion(context ->
                         context.ensureActive().set(Tuple.from(1, new byte[InstrumentedTransaction.MAX_KEY_LENGTH]).pack(), Tuple.from(1).pack()),
                 FDBExceptions.FDBStoreKeySizeException.class);
     }
 
     @Test
-    public void testAssertionsOnValueSize() {
+    void testAssertionsOnValueSize() {
         testSizeAssertion(context ->
                         context.ensureActive().set(Tuple.from(1).pack(), Tuple.from(2, new byte[InstrumentedTransaction.MAX_VALUE_LENGTH]).pack()),
                 FDBExceptions.FDBStoreValueSizeException.class);
@@ -522,9 +524,32 @@ public class FDBDatabaseTest extends FDBTestBase {
     }
 
     @Test
-    public void getAPIVersion() {
+    void apiVersionIsSet() {
         final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
-        assertEquals(APIVersion.getDefault(), database.getAPIVersion());
+        assertEquals(FDBTestBase.getAPIVersion(), database.getAPIVersion());
         assertEquals(FDB.instance().getAPIVersion(), database.getAPIVersion().getVersionNumber());
+        try (FDBRecordContext context = database.openContext()) {
+            assertEquals(database.getAPIVersion(), context.getAPIVersion());
+            assertTrue(context.isAPIVersionAtLeast(context.getAPIVersion()));
+            assertTrue(context.isAPIVersionAtLeast(APIVersion.API_VERSION_6_3));
+        }
+    }
+
+    @Test
+    void cannotChangeAPIVersionAfterInit() {
+        final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase();
+        final APIVersion initApiVersion = database.getAPIVersion();
+
+        for (APIVersion newApiVersion : APIVersion.values()) {
+            Executable setVersion = () -> database.getFactory().setAPIVersion(newApiVersion);
+            if (newApiVersion == initApiVersion) {
+                assertDoesNotThrow(setVersion,
+                        "should be able to set the API version to the same value it was already set to");
+            } else {
+                assertThrows(RecordCoreException.class, setVersion, "should not be able to change the API version after it has been set");
+            }
+            assertEquals(initApiVersion, database.getFactory().getAPIVersion());
+            assertEquals(initApiVersion, database.getAPIVersion());
+        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBTestBase.java
@@ -37,10 +37,20 @@ public abstract class FDBTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBTestBase.class);
 
     public static final String BLOCKING_IN_ASYNC_PROPERTY = "com.apple.foundationdb.record.blockingInAsyncDetection";
+    public static final String API_VERSION_PROPERTY = "com.apple.foundationdb.apiVersion";
+
+    public static APIVersion getAPIVersion() {
+        String apiVersionStr = System.getProperty(API_VERSION_PROPERTY);
+        if (apiVersionStr == null) {
+            return APIVersion.getDefault();
+        }
+        return APIVersion.fromVersionNumber(Integer.parseInt(apiVersionStr));
+    }
 
     @BeforeAll
     public static void initFDB() {
         FDBDatabaseFactoryImpl factory = FDBDatabaseFactory.instance();
+        factory.setAPIVersion(getAPIVersion());
         factory.setUnclosedWarning(true);
         factory.initFDB();
     }

--- a/gradle/scripts/log4j-test.properties
+++ b/gradle/scripts/log4j-test.properties
@@ -18,14 +18,14 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=INFO, CONSOLE
-log4j.logger.mme=DEBUG
-log4j.logger.com.apple=DEBUG
-log4j.logger.dispatch=DEBUG
+name = TestConfig
+appenders = console
 
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d [%level] %logger{1.} - %m%n%ex{full}
 
-log4j.appender.CONSOLE.Target=System.out
-logj4.appender.CONSOLE.Follow=true
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d %-5p %c - %m%n
+rootLogger.level = debug
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -70,7 +70,7 @@ def configureTestTask = { propertyPrefix, task ->
     task.systemProperties['java.io.tmpdir'] = tmpdir.absolutePath
 
     // configure test logging
-    task.systemProperties['log4j.configuration'] = rootProject.file('gradle/scripts/log4j-test.properties').toURI()
+    task.systemProperties['log4j2.configurationFile'] = rootProject.file('gradle/scripts/log4j-test.properties').toURI()
     task.systemProperties['mme.app.useLog4jPropertyConfigurator'] = 'false'
 
     task.maxParallelForks = Integer.getInteger(propertyPrefix + '.maxParallelForks', 1)


### PR DESCRIPTION
This makes the FDB API version configurable through the `FDBDatabaseFactory`.

We'll need some better way of testing this, I think. I've tried running the tests at both the 6.3 and 7.1 API versions, and it passed, but this value cannot be changed after the client has been initiated, which makes this somewhat complex to test with our normal approach. We might be able to use a test-only implementation of `FDBDatabaseFactory` if we wanted to, say, test future work that had feature flags on the API version. Another approach might be to run the tests multiple times, once per API version

This resolves https://github.com/FoundationDB/fdb-record-layer/issues/1639.