### PR TITLE
Fixes #1643: Remove JCenter from build repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,22 +25,21 @@ buildscript {
             logger.warn 'Warning: you have enabled maven local repository. This should only be used on local workstations to test undeployed library dependencies.'
         }
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.38.0'
         classpath 'org.jboss.tattletale:tattletale:1.2.0.Beta2'
-        classpath 'de.undercouch:gradle-download-task:4.1.1'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.15'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 
 plugins {
+    id 'com.google.protobuf' version '0.8.15'
+    id 'com.github.ben-manes.versions' version '0.38.0'
     id 'com.github.spotbugs' version '4.6.1'
-    id 'org.sonarqube' version '3.3'
     id 'com.jfrog.artifactory' version '4.21.0'
+    id 'de.undercouch.download' version '4.1.1'
+    id 'org.sonarqube' version '3.3'
 }
 
 ext {
@@ -164,7 +163,6 @@ allprojects {
             logger.warn 'Warning: you have enabled maven local repository. This should only be used on local workstations to test undeployed library dependencies.'
         }
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
This removes the references to `jcenter()` from our gradle configuration. There was one dependency, one of the plugins, that didn't seem to have an up-to-date version on `mavenCentral()` (which was potentially why we were using `jcenter()` for anything), but they are now in the `gradlePluginsPortal()`, and so I switched those over to using the new gradle plugins format. The two remaining plugins did not seem to have entries in the `gradlePluginsPortal()`, so I left them as is for now.

I was able to redownload the dependencies locally, but a CI run would be good to know to double check that there wasn't accidentally some cache that made the build possible.

This fixes #1643.