### PR TITLE
Fixes #1657: build error on Apple silicon with PB 2.6

### DIFF
--- a/gradle/proto.gradle
+++ b/gradle/proto.gradle
@@ -43,6 +43,14 @@ protobuf {
     }
     protoc {
         artifact = "com.google.protobuf:protoc:${protobufVersion}"
+        def osName = providers.systemProperty("os.name").forUseAtConfigurationTime().getOrElse("")
+        def osArch = providers.systemProperty("os.arch").forUseAtConfigurationTime().getOrElse("")
+        if ((osName == "macOS" || osName == "Mac OS X") && osArch == "aarch64" && protobufVersion == protobuf2Version) {
+            // There is not a macOS aarch64 build of the proto2 compiler. Download the x86_64 version instead, which
+            // will be run in emulation on that architecture. This is fine because this is used only to generate Java
+            // code; it is not directly linked against.
+            artifact = "com.google.protobuf:protoc:${protobufVersion}:osx-x86_64"
+        }
     }
     generateProtoTasks {
         all().each { task ->


### PR DESCRIPTION
As suggested in the issue, on macOS Apple Silicon architectures, this reverts to an x86_64 version of the proto2 compiler for compatibility reasons. This will run in emulation on machines with that architecture. Note also that we do not ship protoc with our binaries, nor do we link against it, so there is not a concern that this would cause problems at link time for software compiled for Apple Silicon. The protoc binary is only used during our own compilation to generate Java files from our `.proto` files.

This fixes #1657.