### PR TITLE
Resolves #1665: Set default timeout for unit tests

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -73,6 +73,9 @@ def configureTestTask = { propertyPrefix, task ->
     task.systemProperties['log4j2.configurationFile'] = rootProject.file('gradle/scripts/log4j-test.properties').toURI()
     task.systemProperties['mme.app.useLog4jPropertyConfigurator'] = 'false'
 
+    // JUnit configuration parameters
+    task.systemProperties['junit.jupiter.execution.timeout.default'] = '5 m'
+
     task.maxParallelForks = Integer.getInteger(propertyPrefix + '.maxParallelForks', 1)
     task.forkEvery = Integer.getInteger(propertyPrefix + '.forkEvery', 0)
 


### PR DESCRIPTION
This sets a default timeout for JUnit tests in the project. The value that was chosen was supposed to be fairly high, but individual tests could still set their own.

It may be worth it to have a lower timeout (maybe 1 minute or 30 seconds), and then use the `Slow` and `Performance` tags to increase the timeout on some tests. I didn't do that here (yet, at least), because it looked unclear to me whether there was a way to do that with the existing `Tag`s, or if we'd need to do something like switch to using a custom test annotation.

This resolves #1665.