### PR TITLE
Make the type system more extensible

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
@@ -750,20 +750,17 @@ public interface Type extends Narrowable<Type> {
          * @param isNullable True if the record type is nullable, otherwise false.
          * @param fields The list of {@link Record} {@link Field}s.
          */
-        protected Record(final boolean isNullable,
-                       @Nullable final List<Field> fields) {
+        protected Record(final boolean isNullable, @Nullable final List<Field> fields) {
             this(null, isNullable, fields);
         }
 
         /**
          * Constructs a new {@link Record} using a list of {@link Field}s and an explicit name.
-         * @param name The name of the record, used only for pretty-printing purposes.
+         * @param name The name of the record.
          * @param isNullable True if the record type is nullable, otherwise false.
          * @param fields The list of {@link Record} {@link Field}s.
          */
-        protected Record(@Nonnull String name,
-                       final boolean isNullable,
-                       @Nullable final List<Field> fields) {
+        protected Record(@Nullable final String name, final boolean isNullable, @Nullable final List<Field> fields) {
             this.name = name;
             this.isNullable = isNullable;
             this.fields = fields == null ? null : normalizeFields(fields);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,16 +70,16 @@ public class TypeRepository {
     private final FileDescriptorSet fileDescSet;
 
     @Nonnull
-    private final Map<String, Descriptor> msgDescriptorMapFull = new HashMap<>();
+    private final Map<String, Descriptor> msgDescriptorMapFull = new LinkedHashMap<>();
 
     @Nonnull
-    private final Map<String, Descriptor> msgDescriptorMapShort = new HashMap<>();
+    private final Map<String, Descriptor> msgDescriptorMapShort = new LinkedHashMap<>();
 
     @Nonnull
-    private final Map<String, EnumDescriptor> enumDescriptorMapFull = new HashMap<>();
+    private final Map<String, EnumDescriptor> enumDescriptorMapFull = new LinkedHashMap<>();
 
     @Nonnull
-    private final Map<String, EnumDescriptor> enumDescriptorMapShort = new HashMap<>();
+    private final Map<String, EnumDescriptor> enumDescriptorMapShort = new LinkedHashMap<>();
 
     @Nonnull
     private final Map<Type, String> typeToNameMap;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
@@ -21,6 +21,8 @@
 package com.apple.foundationdb.record.query.plan.cascades.typing;
 
 import com.google.common.base.Verify;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.protobuf.DescriptorProtos;
@@ -396,12 +398,12 @@ public class TypeRepository {
     public static class Builder {
         private @Nonnull final FileDescriptorProto.Builder fileDescProtoBuilder;
         private @Nonnull final FileDescriptorSet.Builder fileDescSetBuilder;
-        private @Nonnull final Map<Type, String> typeToNameMap;
+        private @Nonnull final BiMap<Type, String> typeToNameMap;
 
         private Builder() {
             fileDescProtoBuilder = FileDescriptorProto.newBuilder();
             fileDescSetBuilder = FileDescriptorSet.newBuilder();
-            typeToNameMap = Maps.newHashMap();
+            typeToNameMap = HashBiMap.create();
         }
 
         @Nonnull
@@ -439,6 +441,11 @@ public class TypeRepository {
         @Nonnull
         public Optional<String> getTypeName(@Nonnull final Type type) {
             return Optional.ofNullable(typeToNameMap.get(type));
+        }
+
+        @Nonnull
+        public Optional<Type> getTypeByName(@Nonnull final String name) {
+            return Optional.ofNullable(typeToNameMap.inverse().get(name));
         }
 
         @Nonnull


### PR DESCRIPTION
In this PR we expose some constructors to make it to extend the type system, we also expose a `Type.Record` builder that accepts an explicit record name, and use `LinkedHashMap` instead of `HashMap` in `TypeRepository` for a stable traversal order (insertion order).