### PR TITLE
Making the StoreTimer.Counter class have a couple public constructors

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -392,15 +392,15 @@ public class StoreTimer {
             this(counter.getCount(), counter.getTimeNanos(), immutable);
         }
 
-        private Counter(boolean immutable) {
+        public Counter(boolean immutable) {
             this(0, 0L, immutable);
         }
 
-        private Counter(int count, long timeNanos) {
+        public Counter(int count, long timeNanos) {
             this(count, timeNanos, false);
         }
 
-        private Counter(int count, long timeNanos, boolean immutable) {
+        public Counter(int count, long timeNanos, boolean immutable) {
             this.count = new AtomicInteger(count);
             this.timeNanos = new AtomicLong(timeNanos);
             this.immutable = immutable;


### PR DESCRIPTION
To interface out StoreTimer, but still make use of it, it would be useful if we could create a Subclass of `StoreTimer` that can create and manage it's own `Counter` instances; this PR makes a few of the constructors in `StoreTimer.Counter` public so that they can be instantiated outside the `StoreTimer` class