### PR TITLE
Fixes #1672: Merge skew causing compilation failure in RecordQueryIndexPlan

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -198,7 +198,7 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
         // CommonPrimaryKey is nullable but is protected by the constructor in the case pf index prefetch
         return store.scanIndexRemoteFetch(index, scanBounds, Objects.requireNonNull(getCommonPrimaryKey()), continuation, executeProperties.asScanProperties(isReverse()), IndexOrphanBehavior.ERROR)
                 .map(store::queriedRecord)
-                .map(QueryResult::of);
+                .map(QueryResult::fromQueriedRecord);
     }
 
     @Nonnull


### PR DESCRIPTION
This fixes the merge skew error caused by #1561 relying on a method that #1629 removed.

This fixes #1672.