### PR TITLE
Resolves #1674: Lucene scans without queries

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -100,6 +100,10 @@ public class LucenePlanner extends RecordQueryPlanner {
             if (!groupingMatch.getType().equals((QueryToKeyMatcher.MatchType.EQUALITY))) {
                 return null;
             }
+            if (filterMask.allSatisfied()) {
+                // If filter is only group predicates, can skip trying to find non-trivial Lucene scan.
+                return null;
+            }
             groupingComparisons = new ScanComparisons(groupingMatch.getEqualityComparisons(), Collections.emptySet());
         } else {
             groupingComparisons = ScanComparisons.EMPTY;
@@ -257,6 +261,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         if (filterMask != null && filterMask.getUnsatisfiedFilters().isEmpty()) {
             filterMask.setSatisfied(true);
         }
+        // Don't do Lucene scan if none are satisfied, though.
         if (childClauses.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
Note that this does not change any generated plans. It just tries to make the logic for excluding vacuous queries more clear and better commented. And adds a couple tests.