### PR TITLE
Resolves #1692: Remove ERROR level log on failed no-ops

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,7 +24,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Failed no-ops no longer log at `ERROR` [(Issue #1692)](https://github.com/FoundationDB/fdb-record-layer/issues/1692)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
This removes the `ERROR`-level log on no-op failure. The error was already getting propagated, and that, in practice, should be enough for adopters to detect errors and (if they so desire) log the error. I considered adding logic to include the `cluster` as logging details, but that ended up being a little bit delicate because it only works if the underlying failure is a `LoggableException`, which isn't necessarily the case because we haven't called the error-wrapping logic at that point. So, it was easier to just leave it without that information, and it didn't seem like a huge loss, as the caller should be able to determine that based on the fact that they need an `FDBDatabase` to call this on anyway.

This resolves #1692.