### PR TITLE
Lucene Scoring Weighting Phase: Sequential Database Activity #1697

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteResultCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteResultCursor.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.cursors.BaseCursor;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager;
+import com.apple.foundationdb.record.lucene.search.LuceneOptimizedIndexSearcher;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -311,7 +312,7 @@ public class LuceneAutoCompleteResultCursor implements BaseCursor<IndexEntry> {
                     .toString());
         }
 
-        IndexSearcher searcher = new IndexSearcher(indexReader, executor);
+        IndexSearcher searcher = new LuceneOptimizedIndexSearcher(indexReader, executor);
         TopDocs topDocs = searcher.search(finalQuery, limit);
         if (timer != null) {
             timer.increment(LuceneEvents.Counts.LUCENE_SCAN_MATCHED_AUTO_COMPLETE_SUGGESTIONS, topDocs.scoreDocs.length);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.cursors.BaseCursor;
 import com.apple.foundationdb.record.cursors.CursorLimitManager;
 import com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager;
+import com.apple.foundationdb.record.lucene.search.LuceneOptimizedIndexSearcher;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -290,7 +291,7 @@ class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     private void performScan() throws IOException {
         long startTime = System.nanoTime();
         indexReader = getIndexReader();
-        searcher = new IndexSearcher(indexReader, executorService);
+        searcher = new LuceneOptimizedIndexSearcher(indexReader, executorService);
         int limit = Math.min(limitRemaining, MAX_PAGE_SIZE);
         TopDocs newTopDocs;
         if (searchAfter != null && sort != null) {
@@ -314,4 +315,5 @@ class LuceneRecordCursor implements BaseCursor<IndexEntry> {
             timer.increment(LuceneEvents.Counts.LUCENE_SCAN_MATCHED_DOCUMENTS, topDocs.scoreDocs.length);
         }
     }
+
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -1,0 +1,114 @@
+/*
+ * LuceneOptimizedIndexSearcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.search;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+/**
+ * This class optimizes the current IndexSearcher and attempts to perform operations in parallel in places where
+ * data access can occur.
+ *
+ *
+ */
+public class LuceneOptimizedIndexSearcher extends IndexSearcher {
+
+    public LuceneOptimizedIndexSearcher(final IndexReader r) {
+        super(r);
+    }
+
+    public LuceneOptimizedIndexSearcher(final IndexReader r, final Executor executor) {
+        super(r, executor);
+    }
+
+    /**
+     * Lower-level search API.
+     *
+     * This is optimized into an attempt to parallelize database access in FDB
+     *
+     * <p>
+     * {@link LeafCollector#collect(int)} is called for every document. <br>
+     *
+     * <p>
+     * NOTE: this method executes the searches on all given leaves exclusively.
+     * To search across all the searchers leaves use {@link #leafContexts}.
+     *
+     * @param leaves
+     *          the searchers leaves to execute the searches on
+     * @param weight
+     *          to match documents
+     * @param collector
+     *          to receive hits
+     * @throws BooleanQuery.TooManyClauses If a query would exceed
+     *         {@link BooleanQuery#getMaxClauseCount()} clauses.
+     */
+    @Override
+    @SuppressWarnings("PMD")
+    protected void search(List<LeafReaderContext> leaves, Weight weight, Collector collector)
+            throws IOException {
+        Executor executor = getExecutor();
+        if (executor == null) {
+            super.search(leaves, weight, collector);
+        } else {
+            // Used to parallelize weight.bulkScorer database access
+            Map<LeafReaderContext, CompletableFuture<Pair<LeafCollector, BulkScorer>>> leafScorers =
+                    new ConcurrentHashMap<>();
+            leaves.forEach(ctx -> leafScorers.put(ctx, CompletableFuture.supplyAsync(() -> {
+                try {
+                    return Pair.of(collector.getLeafCollector(ctx), weight.bulkScorer(ctx));
+                } catch (IOException e) {
+                    return null;
+                }
+            }, getExecutor())));
+
+            // Need to be able to throw IOExceptions out of this stack.
+            // For example, attempting to perform phrase search without pos/freqs throws out of this
+            // piece of code.
+            for (LeafReaderContext ctx : leaves) {
+                try {
+                    Pair<LeafCollector, BulkScorer> scorer = leafScorers.get(ctx).join();
+                    if (scorer != null && scorer.getLeft() != null && scorer.getRight() != null) {
+                        scorer.getRight().score(scorer.getLeft(), ctx.reader().getLiveDocs());
+                    }
+                } catch (CollectionTerminatedException ioe) {
+                    // No Op
+                }
+            }
+        }
+    }
+
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common classes for parallel execution of search.
+ */
+package com.apple.foundationdb.record.lucene.search;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCodec;
+import com.apple.foundationdb.record.lucene.search.LuceneOptimizedIndexSearcher;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -88,7 +89,7 @@ public class FDBLuceneTestIndex {
     public List<Document> searchIndex(String inField, String queryString) throws ParseException, IOException {
         Query query = new QueryParser(inField, analyzer).parse(queryString);
         try (IndexReader indexReader = DirectoryReader.open(directory)) {
-            IndexSearcher searcher = new IndexSearcher(indexReader);
+            IndexSearcher searcher = new LuceneOptimizedIndexSearcher(indexReader);
             TopDocs topDocs = searcher.search(query, 10);
             List<Document> documents = new ArrayList<>();
             for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
@@ -100,7 +101,7 @@ public class FDBLuceneTestIndex {
 
     public List<Document> searchIndex(Query query) throws IOException {
         try (IndexReader indexReader = DirectoryReader.open(directory)) {
-            IndexSearcher searcher = new IndexSearcher(indexReader);
+            IndexSearcher searcher = new LuceneOptimizedIndexSearcher(indexReader);
             TopDocs topDocs = searcher.search(query, 10);
             List<Document> documents = new ArrayList<>();
             for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
@@ -112,7 +113,7 @@ public class FDBLuceneTestIndex {
 
     public List<Document> searchIndex(Query query, Sort sort) throws IOException {
         try (IndexReader indexReader = DirectoryReader.open(directory)) {
-            IndexSearcher searcher = new IndexSearcher(indexReader);
+            IndexSearcher searcher = new LuceneOptimizedIndexSearcher(indexReader);
             TopDocs topDocs = searcher.search(query, 10, sort);
             List<Document> documents = new ArrayList<>();
             for (ScoreDoc scoreDoc : topDocs.scoreDocs) {


### PR DESCRIPTION
Major phases of Lucene Query for data access:

1. IndexSearcher Open
2. Term Weights
3. IndexSearcher Probe
4. Scoring Weighting***


1 Sequential call per Leaf

`com.apple.foundationdb.record.lucene.directory.FDBDirectory.readBlock(FDBDirectory.java:357)
	at com.apple.foundationdb.record.lucene.directory.FDBIndexInput.readBlock(FDBIndexInput.java:130)
	at com.apple.foundationdb.record.lucene.directory.FDBIndexInput.seek(FDBIndexInput.java:184)
	at org.apache.lucene.codecs.lucene84.LuceneOptimizedPostingsReader$BlockDocsEnum.reset(LuceneOptimizedPostingsReader.java:365)
	at org.apache.lucene.codecs.lucene84.LuceneOptimizedPostingsReader.postings(LuceneOptimizedPostingsReader.java:250)
	at org.apache.lucene.codecs.lucene84.LuceneOptimizedPostingsReader.impacts(LuceneOptimizedPostingsReader.java:269)
	at org.apache.lucene.codecs.blocktree.LuceneOptimizedSegmentTermsEnum.impacts(LuceneOptimizedSegmentTermsEnum.java:1019)
	at org.apache.lucene.search.SynonymQuery$SynonymWeight.scorer(SynonymQuery.java:313)
	at org.apache.lucene.search.Weight.bulkScorer(Weight.java:182)
	at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:656)`