### PR TITLE
Lucene Term Weights Phase: Sequential Database Activity #1700

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/org/apache/lucene/search/QueryHelper.java
+++ b/fdb-record-layer-lucene/src/main/java/org/apache/lucene/search/QueryHelper.java
@@ -1,0 +1,56 @@
+/*
+ * QueryHelper.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import com.google.common.collect.Lists;
+import org.apache.lucene.index.Term;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The goal of this Helper class is to extract terms from queries.  It is located in the private package because some
+ * query implementations are private.
+ *
+ */
+public class QueryHelper {
+    /**
+     * Class to get optional terms for a query.
+     *
+     * @param query query implemenation
+     * @return List of terms
+     */
+    public static List<Term> getQueriesTerms(Query query) {
+        if (query instanceof PhraseQuery) {
+            return Lists.newArrayList(((PhraseQuery)query).getTerms());
+        } else if (query instanceof SynonymQuery) {
+            return ((SynonymQuery)query).getTerms();
+        } else if (query instanceof TermQuery) {
+            return Lists.newArrayList(((TermQuery)query).getTerm());
+        } else if (query instanceof BoostQuery) {
+            return getQueriesTerms(((BoostQuery)query).getQuery());
+        } else if (query instanceof MultiTermQueryConstantScoreWrapper) {
+            return getQueriesTerms(((MultiTermQueryConstantScoreWrapper)query).getQuery());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/fdb-record-layer-lucene/src/main/java/org/apache/lucene/search/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/org/apache/lucene/search/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Search optimizations mostly around pre-caching calls to make concurrent database access.
+ *
+ */
+package org.apache.lucene.search;


### PR DESCRIPTION
Major phases of Lucene Query for data access:

1. IndexSearcher Open
2. Term Weights***
3. IndexSearcher Probe
4. Scoring Weighting

Here is the call stack in the code…

`com.apple.foundationdb.record.lucene.directory.FDBIndexInput.readBlock(FDBIndexInput.java:130)
	at com.apple.foundationdb.record.lucene.directory.FDBIndexInput.seek(FDBIndexInput.java:184)
	at org.apache.lucene.codecs.blocktree.LuceneOptimizedSegmentTermsEnumFrame.loadBlock(LuceneOptimizedSegmentTermsEnumFrame.java:171)
	at org.apache.lucene.codecs.blocktree.LuceneOptimizedSegmentTermsEnum.seekExact(LuceneOptimizedSegmentTermsEnum.java:515)
	at org.apache.lucene.index.TermStates.loadTermsEnum(TermStates.java:124)
	at org.apache.lucene.index.TermStates.build(TermStates.java:109)
	at org.apache.lucene.search.SynonymQuery$SynonymWeight.<init>(SynonymQuery.java:237)
	at org.apache.lucene.search.SynonymQuery.createWeight(SynonymQuery.java:211)
	at org.apache.lucene.search.IndexSearcher.createWeight(IndexSearcher.java:724)
	at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:591)
	at org.apache.lucene.search.IndexSearcher.searchAfter(IndexSearcher.java:419)
	at org.apache.lucene.search.IndexSearcher.search(IndexSearcher.java:430)
	at com.apple.foundationdb.record.lucene.LuceneRecordCursor.performScan(LuceneRecordCursor.java:308)`