### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
@@ -45,6 +45,7 @@ import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -260,8 +261,14 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
         // Need to allow immediate rebuild of new count index.
         final FDBRecordStoreBase.UserVersionChecker alwaysEnabled = new FDBRecordStoreBase.UserVersionChecker() {
             @Override
-            public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
+            public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
                 return CompletableFuture.completedFuture(1);
+            }
+
+            @Deprecated
+            @Override
+            public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
+                throw new RecordCoreException("deprecated checkUserVersion called");
             }
 
             @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -37,6 +37,7 @@ import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.ScanProperties;
@@ -1937,8 +1938,14 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
             FDBRecordStoreBase.UserVersionChecker userVersionChecker = new FDBRecordStoreBase.UserVersionChecker() {
                 @Override
+                public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
+                    return CompletableFuture.completedFuture(1);
+                }
+
+                @Deprecated
+                @Override
                 public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
-                    return CompletableFuture.completedFuture(Integer.valueOf(1));
+                    throw new RecordCoreException("deprecated checkUserVersion called");
                 }
 
                 @Override
@@ -1982,8 +1989,14 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         final FDBRecordStoreBase.UserVersionChecker alwaysDisabled = new FDBRecordStoreBase.UserVersionChecker() {
             @Override
+            public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
+                return CompletableFuture.completedFuture(1);
+            }
+
+            @Deprecated
+            @Override
             public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
-                return CompletableFuture.completedFuture(Integer.valueOf(1));
+                throw new RecordCoreException("deprecated checkUserVersion called");
             }
 
             @Override
@@ -1994,8 +2007,14 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         final FDBRecordStoreBase.UserVersionChecker alwaysEnabled = new FDBRecordStoreBase.UserVersionChecker() {
             @Override
+            public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
+                return CompletableFuture.completedFuture(1);
+            }
+
+            @Deprecated
+            @Override
             public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
-                return CompletableFuture.completedFuture(Integer.valueOf(1));
+                throw new RecordCoreException("deprecated checkUserVersion called");
             }
 
             @Override
@@ -2130,8 +2149,14 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
     public void testSelectiveIndexDisable() throws Exception {
         final FDBRecordStoreBase.UserVersionChecker selectiveEnable = new FDBRecordStoreBase.UserVersionChecker() {
             @Override
+            public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
+                return CompletableFuture.completedFuture(1);
+            }
+
+            @Deprecated
+            @Override
             public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
-                return CompletableFuture.completedFuture(Integer.valueOf(1));
+                throw new RecordCoreException("deprecated checkUserVersion called");
             }
 
             @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
+import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.TestNoIndexesProto;
@@ -727,8 +728,14 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
         }
 
         @Override
+        public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
+            return CompletableFuture.completedFuture(storeHeader.getUserVersion());
+        }
+
+        @Deprecated
+        @Override
         public CompletableFuture<Integer> checkUserVersion(final int oldUserVersion, final int oldMetaDataVersion, final RecordMetaDataProvider metaData) {
-            return CompletableFuture.completedFuture(oldUserVersion);
+            throw new RecordCoreException("deprecated checkUserVersion called");
         }
 
         @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSplitRecordsTest.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestHelpers;
@@ -316,8 +317,14 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
         // We want to test that a conflict comes from the clearing itself.
         final FDBRecordStoreBase.UserVersionChecker dontBuild = new FDBRecordStoreBase.UserVersionChecker() {
             @Override
-            public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
+            public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
                 return CompletableFuture.completedFuture(0);
+            }
+
+            @Deprecated
+            @Override
+            public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
+                throw new RecordCoreException("deprecated checkUserVersion called");
             }
 
             @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTest.java
@@ -866,14 +866,21 @@ public class FDBRecordStoreTest extends FDBRecordStoreTestBase {
         }
 
         @Override
-        public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
-            if (oldUserVersion < 0) {
+        public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
+            if (storeHeader.getFormatVersion() == 0) {
                 return CompletableFuture.completedFuture(defaultVersion);
             }
+            int oldUserVersion = storeHeader.getUserVersion();
             if (oldUserVersion == 101) {
                 needOld = true;
             }
             return CompletableFuture.completedFuture(oldUserVersion);
+        }
+
+        @Deprecated
+        @Override
+        public CompletableFuture<Integer> checkUserVersion(int oldUserVersion, int oldMetaDataVersion, RecordMetaDataProvider metaData) {
+            throw new RecordCoreException("deprecated checkUserVersion called");
         }
     }
 


### PR DESCRIPTION
After #1711, there are some deprecation warnings that are breaking the build. This resolves the deprecation warnings by using the new API and marking the old one as deprecated in test code.