### PR TITLE
Resolves #1714: LocatableResolver::reverseLookup should support borrowing read versions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,7 +30,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Reverse directory lookups can now borrow a read version from another transaction to avoid GRV costs [(Issue #1714)](https://github.com/FoundationDB/fdb-record-layer/issues/1714)
 * **Feature** Query returns null for unset non-repeated fields [(Issue #1718)](https://github.com/FoundationDB/fdb-record-layer/issues/1718)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayer.java
@@ -147,6 +147,22 @@ public class ExtendedDirectoryLayer extends LocatableResolver {
     }
 
     @Override
+    protected CompletableFuture<Optional<String>> readReverse(@Nonnull FDBRecordContext context, Long value) {
+        FDBReverseDirectoryCache reverseCache = database.getReverseDirectoryCache();
+        return reverseCache.get(context, wrap(value));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param timer a timer to use to instrument this operation
+     * @param value the value returned by this resolver
+     * @return a future returning an optional set to the key associated with the given value or {@link Optional#empty()}
+     *     if there is no such value in the map
+     * @deprecated implementors should switch to using {@link #readReverse(FDBRecordContext, Long)} instead
+     */
+    @Deprecated
+    @Override
     protected CompletableFuture<Optional<String>> readReverse(FDBStoreTimer timer, Long value) {
         FDBReverseDirectoryCache reverseCache = database.getReverseDirectoryCache();
         return reverseCache.get(timer, wrap(value));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverValidator.java
@@ -31,7 +31,9 @@ import com.apple.foundationdb.record.cursors.AutoContinuingCursor;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBReverseDirectoryCache;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
@@ -75,18 +77,22 @@ public class ResolverValidator {
                                 final int reverseLookupPipelineSize,
                                 final boolean badEntriesOnly,
                                 @Nonnull final Consumer<ValidatedEntry> entryListener) {
-        try (RecordCursor<ValidatedEntry> cursor = new AutoContinuingCursor<>(
-                resolver.getDatabase().newRunner(),
-                (context, continuation) ->
-                    validate(resolver, context, continuation, reverseLookupPipelineSize, false,
-                            new ScanProperties(executeProperties.build())),
-                3)) {
-            resolver.getDatabase().asyncToSync(timer, FDBStoreTimer.Waits.WAIT_VALIDATE_RESOLVER,
-                    cursor.forEach(validatedEntry -> {
-                        if (!badEntriesOnly || validatedEntry.getValidationResult() != ValidationResult.OK) {
-                            entryListener.accept(validatedEntry);
-                        }
-                    }));
+        try (FDBDatabaseRunner runner = resolver.database.newRunner()) {
+            runner.setContextConfigBuilder(FDBRecordContextConfig.newBuilder()
+                    .setSaveOpenStackTrace(true));
+            try (RecordCursor<ValidatedEntry> cursor = new AutoContinuingCursor<>(
+                    runner,
+                    (context, continuation) ->
+                            validate(resolver, context, continuation, reverseLookupPipelineSize, false,
+                                    new ScanProperties(executeProperties.build())),
+                    3)) {
+                resolver.getDatabase().asyncToSync(timer, FDBStoreTimer.Waits.WAIT_VALIDATE_RESOLVER,
+                        cursor.forEach(validatedEntry -> {
+                            if (!badEntriesOnly || validatedEntry.getValidationResult() != ValidationResult.OK) {
+                                entryListener.accept(validatedEntry);
+                            }
+                        }));
+            }
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverValidator.java
@@ -33,7 +33,6 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBReverseDirectoryCache;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
@@ -78,8 +77,6 @@ public class ResolverValidator {
                                 final boolean badEntriesOnly,
                                 @Nonnull final Consumer<ValidatedEntry> entryListener) {
         try (FDBDatabaseRunner runner = resolver.database.newRunner()) {
-            runner.setContextConfigBuilder(FDBRecordContextConfig.newBuilder()
-                    .setSaveOpenStackTrace(true));
             try (RecordCursor<ValidatedEntry> cursor = new AutoContinuingCursor<>(
                     runner,
                     (context, continuation) ->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ScopedDirectoryLayer.java
@@ -150,6 +150,22 @@ public class ScopedDirectoryLayer extends LocatableResolver {
     }
 
     @Override
+    protected CompletableFuture<Optional<String>> readReverse(@Nonnull FDBRecordContext context, Long value) {
+        FDBReverseDirectoryCache reverseCache = database.getReverseDirectoryCache();
+        return reverseCache.get(context, wrap(value));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param timer a timer to use to instrument this operation
+     * @param value the value returned by this resolver
+     * @return a future returning an optional set to the key associated with the given value or {@link Optional#empty()}
+     *     if there is no such value in the map
+     * @deprecated implementors should switch to using {@link #readReverse(FDBRecordContext, Long)} instead
+     */
+    @Deprecated
+    @Override
     protected CompletableFuture<Optional<String>> readReverse(FDBStoreTimer timer, Long value) {
         FDBReverseDirectoryCache reverseCache = database.getReverseDirectoryCache();
         return reverseCache.get(timer, wrap(value));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/ScopedInterningLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/ScopedInterningLayer.java
@@ -119,12 +119,26 @@ public class ScopedInterningLayer extends LocatableResolver {
     }
 
     @Override
+    protected CompletableFuture<Optional<String>> readReverse(@Nonnull final FDBRecordContext context, final Long value) {
+        return interningLayerFuture.thenCompose(layer -> layer.readReverse(context, value));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param timer a timer to use to instrument this operation
+     * @param value the value returned by this resolver
+     * @return a future returning an optional set to the key associated with the given value or {@link Optional#empty()}
+     *     if there is no such value in the map
+     * @deprecated implementors should switch to using {@link #readReverse(FDBRecordContext, Long)} instead
+     */
+    @Deprecated
+    @Override
     @SuppressWarnings("PMD.CloseResource")
     protected CompletableFuture<Optional<String>> readReverse(FDBStoreTimer timer, Long value) {
         FDBRecordContext context = database.openContext();
         context.setTimer(timer);
-        return interningLayerFuture
-                .thenCompose(layer -> layer.readReverse(context, value))
+        return readReverse(context, value)
                 .whenComplete((ignored, th) -> context.close());
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
@@ -104,7 +104,7 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
 
         for (Map.Entry<String, Long> entry : allocations.entrySet()) {
             Long value = reader.resolve(entry.getKey()).join();
-            String reverseLookup = reader.reverseLookup(null, entry.getValue()).join();
+            String reverseLookup = reader.reverseLookup((FDBStoreTimer)null, entry.getValue()).join();
             assertEquals(value, entry.getValue());
             assertEquals(reverseLookup, entry.getKey());
         }
@@ -249,7 +249,7 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
         resolver.getDatabase().clearCaches();
         resolver.getDatabase().getReverseDirectoryCache().clearStats();
         assertThat(resolver.getClass().getName() + " sees the reverse mapping",
-                resolver.reverseLookup(null, value).join(), is(key));
+                resolver.reverseLookup((FDBStoreTimer)null, value).join(), is(key));
         assertThat("we find the value in the reverse cache key space",
                 resolver.getDatabase().getReverseDirectoryCache().getPersistentCacheHitCount(), is(1L));
         assertThat("we don't get a hard cache miss",

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ResolverMappingReplicatorTest.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpaceDirectory.KeyType;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.MetadataHook;
@@ -255,7 +256,7 @@ public abstract class ResolverMappingReplicatorTest extends FDBTestBase {
         try (FDBRecordContext context = database.openContext()) {
             for (Map.Entry<String, ResolverResult> entry : mappings.entrySet()) {
                 ResolverResult resolved = scope.resolveWithMetadata(context.getTimer(), entry.getKey(), ResolverCreateHooks.getDefault()).join();
-                String keyFromReverseDirectoryCache = scope.reverseLookup(null, entry.getValue().getValue()).join();
+                String keyFromReverseDirectoryCache = scope.reverseLookup((FDBStoreTimer)null, entry.getValue().getValue()).join();
                 assertThat("mapping is in the directory layer", entry.getValue(), is(resolved));
                 assertThat("reverse mapping is in the reverse directory cache", entry.getKey(), is(keyFromReverseDirectoryCache));
             }


### PR DESCRIPTION
This adds arguments to `reverseLookup` to allow a transaction to be included that can be used to get a read version, much like the `resolve` methods.

This resolves #1714.