### PR TITLE
Create perf tests for potential scan optimizations during nested loop joins

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -51,12 +51,32 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/ed28ded51a8b1c6b112568def5f4b455e6809019/j2objc-annotations-1.1.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.17/f97ce6decaea32b36101e37979f8b647f00681fb/animal-sniffer-annotations-1.17.jar" />
         </processorPath>
-        <module name="fdb-record-layer.fdb-record-layer-core.main" />
+        <module name="fdb-record-layer.fdb-extensions.main" />
         <module name="fdb-record-layer.fdb-record-layer-lucene.test" />
         <module name="fdb-record-layer.fdb-record-layer-spatial.main" />
         <module name="fdb-record-layer.fdb-record-layer-lucene.main" />
         <module name="fdb-record-layer.fdb-record-layer-core.test" />
         <module name="fdb-record-layer.fdb-record-layer-icu.main" />
+      </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$PROJECT_DIR$/fdb-extensions/.out/libs/fdb-extensions-3.2-SNAPSHOT.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0-rc6/4586e4191111b24135ffac93d3e1a91e91bf71d3/auto-service-1.0-rc6.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.foundationdb/fdb-java/7.1.3/40d9492ed36777fa91ea0f2d5d3a39e7801f5901/fdb-java-7.1.3.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/0.10/c8f153ebe04a17183480ab4016098055fb474364/auto-common-0.10.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/30.1-jre/d0c3ce2311c9e36e73228da25a6e99b2ab826f/guava-30.1-jre.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.36/6c62681a2f655b49963a5983b8b0950a6120ae14/slf4j-api-1.7.36.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup/javapoet/1.12.0/459ae6c796db7dcbc723f9536af2ce49d86c1a80/javapoet-1.12.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service-annotations/1.0-rc6/32c6a6313217c949396376d9caddb6b8c8f4e7c3/auto-service-annotations-1.0-rc6.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/b421526c5f297295adef1c886e5246c39d4ac629/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-qual/3.5.0/2f50520c8abea66fbd8d26e481d3aef5c673b510/checker-qual-3.5.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.3.4/dac170e4594de319655ffb62f41cbd6dbb5e601e/error_prone_annotations-2.3.4.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.3/ba035118bc8bac37d7eff77700720999acd9986d/j2objc-annotations-1.3.jar" />
+        </processorPath>
+        <module name="fdb-record-layer.fdb-record-layer-core.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="11" />

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ExecuteProperties.java
@@ -74,8 +74,11 @@ public class ExecuteProperties {
 
     private final CursorStreamingMode defaultCursorStreamingMode;
 
+    private final boolean overScanForCache;
+
     private ExecuteProperties(int skip, int rowLimit, @Nonnull IsolationLevel isolationLevel, long timeLimit,
-                              @Nonnull ExecuteState state, boolean failOnScanLimitReached, @Nonnull CursorStreamingMode defaultCursorStreamingMode) {
+                              @Nonnull ExecuteState state, boolean failOnScanLimitReached, @Nonnull CursorStreamingMode defaultCursorStreamingMode,
+                              boolean overScanForCache) {
         this.skip = skip;
         this.rowLimit = rowLimit;
         this.isolationLevel = isolationLevel;
@@ -83,6 +86,7 @@ public class ExecuteProperties {
         this.state = state;
         this.failOnScanLimitReached = failOnScanLimitReached;
         this.defaultCursorStreamingMode = defaultCursorStreamingMode;
+        this.overScanForCache = overScanForCache;
     }
 
     @Nonnull
@@ -99,7 +103,7 @@ public class ExecuteProperties {
         if (skip == this.skip) {
             return this;
         }
-        return copy(skip, rowLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, rowLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -121,7 +125,7 @@ public class ExecuteProperties {
         if (newLimit == this.rowLimit) {
             return this;
         }
-        return copy(skip, newLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, newLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -168,7 +172,7 @@ public class ExecuteProperties {
      */
     @Nonnull
     public ExecuteProperties setState(@Nonnull ExecuteState newState) {
-        return copy(skip, rowLimit, timeLimit, isolationLevel, newState, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, rowLimit, timeLimit, isolationLevel, newState, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -177,7 +181,7 @@ public class ExecuteProperties {
      */
     @Nonnull
     public ExecuteProperties clearState() {
-        return copy(skip, rowLimit, timeLimit, isolationLevel, new ExecuteState(), failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, rowLimit, timeLimit, isolationLevel, new ExecuteState(), failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -193,7 +197,7 @@ public class ExecuteProperties {
         if (failOnScanLimitReached == this.failOnScanLimitReached) {
             return this;
         }
-        return copy(skip, rowLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, rowLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     @Nonnull
@@ -201,7 +205,7 @@ public class ExecuteProperties {
         if (getReturnedRowLimit() == ReadTransaction.ROW_LIMIT_UNLIMITED) {
             return this;
         }
-        return copy(skip, ReadTransaction.ROW_LIMIT_UNLIMITED, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, ReadTransaction.ROW_LIMIT_UNLIMITED, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -213,7 +217,7 @@ public class ExecuteProperties {
         if (getTimeLimit() == UNLIMITED_TIME && getReturnedRowLimit() == ReadTransaction.ROW_LIMIT_UNLIMITED ) {
             return this;
         }
-        return copy(skip, ReadTransaction.ROW_LIMIT_UNLIMITED, UNLIMITED_TIME, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, ReadTransaction.ROW_LIMIT_UNLIMITED, UNLIMITED_TIME, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -225,7 +229,7 @@ public class ExecuteProperties {
         if (skip == 0 && rowLimit == ReadTransaction.ROW_LIMIT_UNLIMITED) {
             return this;
         }
-        return copy(0, ReadTransaction.ROW_LIMIT_UNLIMITED, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(0, ReadTransaction.ROW_LIMIT_UNLIMITED, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -238,7 +242,7 @@ public class ExecuteProperties {
             return this;
         }
         return copy(0, rowLimit == ReadTransaction.ROW_LIMIT_UNLIMITED ? ReadTransaction.ROW_LIMIT_UNLIMITED : rowLimit + skip,
-                timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+                timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -289,7 +293,18 @@ public class ExecuteProperties {
         if (defaultCursorStreamingMode == this.defaultCursorStreamingMode) {
             return this;
         }
-        return copy(skip, rowLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, rowLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
+    }
+
+    public boolean isOverScanForCache() {
+        return overScanForCache;
+    }
+
+    public ExecuteProperties setOverScanForCache(boolean overScanForCache) {
+        if (overScanForCache == this.overScanForCache) {
+            return this;
+        }
+        return copy(skip, rowLimit, timeLimit, isolationLevel, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -299,7 +314,7 @@ public class ExecuteProperties {
      */
     @Nonnull
     public ExecuteProperties resetState() {
-        return copy(skip, rowLimit, timeLimit, isolationLevel, state.reset(), failOnScanLimitReached, defaultCursorStreamingMode);
+        return copy(skip, rowLimit, timeLimit, isolationLevel, state.reset(), failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     /**
@@ -315,8 +330,9 @@ public class ExecuteProperties {
      */
     @Nonnull
     protected ExecuteProperties copy(int skip, int rowLimit, long timeLimit, @Nonnull IsolationLevel isolationLevel,
-                                     @Nonnull ExecuteState state, boolean failOnScanLimitReached, CursorStreamingMode defaultCursorStreamingMode) {
-        return new ExecuteProperties(skip, rowLimit, isolationLevel, timeLimit, state, failOnScanLimitReached, defaultCursorStreamingMode);
+                                     @Nonnull ExecuteState state, boolean failOnScanLimitReached, CursorStreamingMode defaultCursorStreamingMode,
+                                     boolean overScanForCache) {
+        return new ExecuteProperties(skip, rowLimit, isolationLevel, timeLimit, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
     }
 
     @Nonnull
@@ -390,6 +406,7 @@ public class ExecuteProperties {
         private ExecuteState executeState = null;
         private boolean failOnScanLimitReached = false;
         private CursorStreamingMode defaultCursorStreamingMode = CursorStreamingMode.ITERATOR;
+        private boolean overScanForCache = false;
 
         private Builder() {
         }
@@ -402,6 +419,7 @@ public class ExecuteProperties {
             this.executeState = executeProperties.state;
             this.failOnScanLimitReached = executeProperties.failOnScanLimitReached;
             this.defaultCursorStreamingMode = executeProperties.defaultCursorStreamingMode;
+            this.overScanForCache = executeProperties.overScanForCache;
         }
 
         @Nonnull
@@ -562,6 +580,15 @@ public class ExecuteProperties {
             return this;
         }
 
+        public boolean isOverScanForCache() {
+            return overScanForCache;
+        }
+
+        public Builder setOverScanForCache(boolean overScanForCache) {
+            this.overScanForCache = overScanForCache;
+            return this;
+        }
+
         @Nonnull
         public ExecuteProperties build() {
             final ExecuteState state;
@@ -576,7 +603,7 @@ public class ExecuteProperties {
             } else {
                 state = new ExecuteState(RecordScanLimiterFactory.enforce(scannedRecordsLimit), ByteScanLimiterFactory.enforce(scannedBytesLimit));
             }
-            return new ExecuteProperties(skip, rowLimit, isolationLevel, timeLimit, state, failOnScanLimitReached, defaultCursorStreamingMode);
+            return new ExecuteProperties(skip, rowLimit, isolationLevel, timeLimit, state, failOnScanLimitReached, defaultCursorStreamingMode, overScanForCache);
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -3150,7 +3150,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @SuppressWarnings("PMD.CloseResource")
     private CompletableFuture<Map<String, IndexState>> loadIndexStatesAsync(@Nonnull IsolationLevel isolationLevel) {
         Subspace isSubspace = getSubspace().subspace(Tuple.from(INDEX_STATE_SPACE_KEY));
-        KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(isSubspace)
+        RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(isSubspace)
                 .setContext(getContext())
                 .setRange(TupleRange.ALL)
                 .setContinuation(null)
@@ -3945,7 +3945,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         // Read all of the keys in the old record version location. For each
         // record, copy its version to the new location within the primary record
         // subspace. Then once they are all copied, delete the old subspace.
-        KeyValueCursor kvCursor = KeyValueCursor.Builder.withSubspace(legacyVersionSubspace)
+        RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(legacyVersionSubspace)
                 .setContext(getRecordContext())
                 .setScanProperties(ScanProperties.FORWARD_SCAN)
                 .build();
@@ -4263,7 +4263,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         }
 
         final Subspace recordSubspace = recordsSubspace();
-        KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(recordSubspace)
+        RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(recordSubspace)
                 .setContext(getRecordContext())
                 .setContinuation(continuation)
                 .setScanProperties(scanProperties)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SizeStatisticsCollectorCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SizeStatisticsCollectorCursor.java
@@ -128,7 +128,7 @@ public class SizeStatisticsCollectorCursor implements RecordCursor<SizeStatistic
         }
 
         return subspaceProvider.getSubspaceAsync(context).thenCompose(subspace -> {
-            KeyValueCursor kvCursor = KeyValueCursor.Builder.withSubspace(subspace).setContext(context).setContinuation(kvCursorContinuation).setScanProperties(scanProperties).build();
+            RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace).setContext(context).setContinuation(kvCursorContinuation).setScanProperties(scanProperties).build();
             return kvCursor.forEachResult(nextKv -> {
                 sizeStatisticsResults.updateStatistics(nextKv.get());
             }).thenApply(resultKv -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
@@ -555,7 +555,7 @@ public class KeySpaceDirectory {
                                                          @Nonnull KeyRange range,
                                                          @Nonnull Optional<Tuple> lastTuple,
                                                          @Nonnull ScanProperties scanProperties) {
-        final KeyValueCursor cursor;
+        final RecordCursor<KeyValue> cursor;
         if (!lastTuple.isPresent()) {
             cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSparseJoinPerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSparseJoinPerformanceTest.java
@@ -20,9 +20,14 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.PipelineOperation;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -30,6 +35,7 @@ import com.apple.foundationdb.record.RecordCursorStartContinuation;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestSparseJoinPerfProto;
+import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.Key;
@@ -37,24 +43,35 @@ import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
 import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.coveringIndexScan;
@@ -152,7 +169,361 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
                 .build();
     }
 
-    private RecordCursor<Integer> executeJoin(FDBRecordStore store, int group, String text, @Nullable byte[] continuation, ExecuteProperties executeProperties) {
+    private Map<Long, List<TestSparseJoinPerfProto.InnerRecord>> getInnerByOuterForGroup(int group) {
+        Map<Long, List<TestSparseJoinPerfProto.InnerRecord>> innerRecordsByOuter = new HashMap<>();
+        RecordCursorContinuation continuation = RecordCursorStartContinuation.START;
+
+        RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType(INNER_RECORD)
+                .setFilter(Query.field(GROUP_FIELD).equalsValue((long)group))
+                .build();
+
+        do {
+            try (FDBRecordContext context = database.openContext()) {
+                ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                        .setTimeLimit(3000L)
+                        .build();
+                FDBRecordStore recordStore = openStore(context);
+                try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(query, continuation.toBytes(), executeProperties)) {
+                    RecordCursorResult<FDBQueriedRecord<Message>> result;
+                    while ((result = cursor.getNext()).hasNext()) {
+                        TestSparseJoinPerfProto.InnerRecord innerRecord = TestSparseJoinPerfProto.InnerRecord.newBuilder()
+                                .mergeFrom(result.get().getRecord())
+                                .build();
+                        long outerId = innerRecord.getOuterId();
+                        innerRecordsByOuter.compute(outerId, (ignore, existing) -> {
+                            List<TestSparseJoinPerfProto.InnerRecord> newList = existing == null ? new ArrayList<>() : existing;
+                            newList.add(innerRecord);
+                            return newList;
+                        });
+                    }
+                    continuation = result.getContinuation();
+                }
+            }
+        } while (!continuation.isEnd());
+
+        return innerRecordsByOuter;
+    }
+
+    private Set<Long> getOuterRecordIdsByGroup(int group) {
+        return getInnerByOuterForGroup(group).keySet();
+    }
+
+    private BitSet getOuterRecordBitSetByGroup(int group) {
+        Set<Long> outerIdsByGroup = getOuterRecordIdsByGroup(group);
+        BitSet bitSet = new BitSet();
+        for (Long outerId : outerIdsByGroup) {
+            bitSet.set(outerId.intValue());
+        }
+        return bitSet;
+    }
+
+    private BloomFilter<Long> getOuterRecordBloomFilterByGroup(int group) {
+        Set<Long> outerIdsByGroup = getOuterRecordIdsByGroup(group);
+        BloomFilter<Long> filter = BloomFilter.create(Funnels.longFunnel(), outerIdsByGroup.size());
+        for (Long outerId : outerIdsByGroup) {
+            filter.put(outerId);
+        }
+        return filter;
+    }
+
+    public enum JoinTechniqueType {
+        STANDARD,
+        PREFETCH,
+        OVERSCAN,
+        IN_MEMORY_HASH_JOIN,
+        SET_FILTER,
+        BIT_SET_FILTER,
+        BLOOM_FILTER,
+    }
+
+    public JoinTechnique getJoinTechnique(JoinTechniqueType type, int group) {
+        switch (type) {
+        case STANDARD:
+            return new StandardIndexProbeJoinTechnique();
+        case PREFETCH:
+            return new PreFetchedIndexProbeJoinTechnique(group, 100);
+        case OVERSCAN:
+            return new OverScanIndexProbeJoinTechnique();
+        case IN_MEMORY_HASH_JOIN:
+            return new InMemoryHashJoinTechnique(getInnerByOuterForGroup(group));
+        case SET_FILTER:
+            return new IdSetHashJoinTechnique(getOuterRecordIdsByGroup(group));
+        case BIT_SET_FILTER:
+            return new BitSetHashJoinTechnique(getOuterRecordBitSetByGroup(group));
+        case BLOOM_FILTER:
+            return new BloomFilterHashJoinTechnique(getOuterRecordBloomFilterByGroup(group));
+        default:
+            throw new RecordCoreArgumentException("Unrecognized join technique type", "type", type);
+        }
+    }
+
+    public interface JoinTechnique {
+        JoinTechniqueType getType();
+        Joiner createJoiner(FDBRecordStore store);
+    }
+
+    public interface Joiner {
+        RecordCursor<QueryResult> executeInner(EvaluationContext innerContext, @Nullable byte[] continuation, ExecuteProperties executeProperties);
+    }
+
+    /**
+     * Join technique that executes the inner loop of a nested loop join via an index probe. This is the "standard" way
+     * of attempting to do the operation.
+     */
+    private static class StandardIndexProbeJoinTechnique implements JoinTechnique {
+        @Override
+        public JoinTechniqueType getType() {
+            return JoinTechniqueType.STANDARD;
+        }
+
+        @Override
+        public Joiner createJoiner(final FDBRecordStore store) {
+            final RecordQuery inner = innerQuery();
+            final RecordQueryPlan innerPlan = store.planQuery(inner);
+            assertThat(innerPlan, coveringIndexScan(indexScan(allOf(indexName(GROUP_OUTER_VALUE_INDEX), bounds(hasTupleString("[EQUALS $" + GROUP_PARAM + ", EQUALS $" + OUTER_PARAM + "]"))))));
+            return new StandardIndexProbeJoiner(store, innerPlan);
+        }
+
+        public static class StandardIndexProbeJoiner implements Joiner {
+            private final FDBRecordStore store;
+            private final RecordQueryPlan plan;
+
+            public StandardIndexProbeJoiner(FDBRecordStore store, RecordQueryPlan plan) {
+                this.store = store;
+                this.plan = plan;
+            }
+
+            @Override
+            public RecordCursor<QueryResult> executeInner(EvaluationContext innerContext, @Nullable byte[] continuation, ExecuteProperties executeProperties) {
+                return store.executeQuery(plan, continuation, innerContext, executeProperties);
+            }
+        }
+    }
+
+    private static class PreFetchedIndexProbeJoinTechnique implements JoinTechnique {
+        private final int group;
+        private final int prefetchLimit;
+
+        public PreFetchedIndexProbeJoinTechnique(int group, int prefetchLimit) {
+            this.group = group;
+            this.prefetchLimit = prefetchLimit;
+        }
+
+        @Override
+        public JoinTechniqueType getType() {
+            return JoinTechniqueType.PREFETCH;
+        }
+
+        @Override
+        public Joiner createJoiner(final FDBRecordStore store) {
+            // Fire-and-forget a limited index scan of the group to try and get the values for the group into
+            // the RYW cache
+            Index index = store.getRecordMetaData().getIndex(GROUP_OUTER_VALUE_INDEX);
+            ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                    .setReturnedRowLimit(prefetchLimit)
+                    .setFailOnScanLimitReached(false)
+                    .build();
+            try (RecordCursor<IndexEntry> indexPrefetchCursor = store.scanIndex(index, IndexScanType.BY_VALUE, TupleRange.allOf(Tuple.from(group)), null, executeProperties.asScanProperties(false))) {
+                AsyncUtil.whileTrue(() -> {
+                    if (store.getRecordContext().isClosed()) {
+                        return AsyncUtil.READY_FALSE;
+                    }
+                    // Consume results until we run out
+                    return indexPrefetchCursor.onNext().thenApply(RecordCursorResult::hasNext);
+                }, store.getExecutor());
+            }
+
+            // Return the same join strategy as if we didn't have prefetch enabled.
+            final RecordQueryPlan innerPlan = store.planQuery(innerQuery());
+            return new StandardIndexProbeJoinTechnique.StandardIndexProbeJoiner(store, innerPlan);
+        }
+    }
+
+    private static class OverScanIndexProbeJoinTechnique implements JoinTechnique {
+        @Override
+        public JoinTechniqueType getType() {
+            return JoinTechniqueType.OVERSCAN;
+        }
+
+        @Override
+        public Joiner createJoiner(final FDBRecordStore store) {
+            return new OverScanIndexProbeJoiner(store);
+        }
+
+        public static class OverScanIndexProbeJoiner implements Joiner {
+            private final FDBRecordStore store;
+            private final Index index;
+
+            public OverScanIndexProbeJoiner(FDBRecordStore store) {
+                this.store = store;
+                this.index = store.getRecordMetaData().getIndex(GROUP_OUTER_VALUE_INDEX);
+            }
+
+            @Override
+            public RecordCursor<QueryResult> executeInner(final EvaluationContext innerContext, @Nullable final byte[] continuation, final ExecuteProperties executeProperties) {
+                Object group = innerContext.getBinding(GROUP_PARAM);
+                Long outerId = (Long) innerContext.getBinding(OUTER_PARAM);
+                TupleRange range = new TupleRange(Tuple.from(group, outerId), Tuple.from(group), EndpointType.RANGE_INCLUSIVE, EndpointType.RANGE_INCLUSIVE);
+                ExecuteProperties limited = executeProperties.setReturnedRowLimit(1);
+                return store.scanIndex(index, IndexScanType.BY_VALUE, range, continuation, limited.asScanProperties(false))
+                        .filter(entry -> entry.getKey().getLong(1) == outerId)
+                        .mapResult(result -> {
+                            if (result.hasNext()) {
+                                IndexEntry entry = result.get();
+                                TestSparseJoinPerfProto.InnerRecord innerRecord = TestSparseJoinPerfProto.InnerRecord.newBuilder()
+                                        .setGroup(entry.getKey().getLong(0))
+                                        .setOuterId(entry.getKey().getLong(1))
+                                        .setVal((int)entry.getKey().getLong(2))
+                                        .setRecNo(entry.getKey().getLong(3))
+                                        .build();
+                                QueryResult queryResult = QueryResult.ofComputed(innerRecord);
+                                return RecordCursorResult.withNextValue(queryResult, result.getContinuation());
+                            } else {
+                                return RecordCursorResult.exhausted();
+                            }
+                        });
+            }
+        }
+    }
+
+    /**
+     * Simulate an entirely in-memory hash join. This is in some sense for getting a baseline measurement, as this
+     * assumes we'd be able to get the full
+     */
+    private static class InMemoryHashJoinTechnique implements JoinTechnique {
+        private final Map<Long, List<TestSparseJoinPerfProto.InnerRecord>> innerRecordsByOuter;
+
+        public InMemoryHashJoinTechnique(Map<Long, List<TestSparseJoinPerfProto.InnerRecord>> innerRecordsByOuter) {
+            this.innerRecordsByOuter = innerRecordsByOuter;
+        }
+
+        @Override
+        public JoinTechniqueType getType() {
+            return JoinTechniqueType.IN_MEMORY_HASH_JOIN;
+        }
+
+        @Override
+        public Joiner createJoiner(final FDBRecordStore store) {
+            return new InMemoryHashJoiner(store.getExecutor());
+        }
+
+        private class InMemoryHashJoiner implements Joiner {
+            private final Executor executor;
+
+            private InMemoryHashJoiner(Executor executor) {
+                this.executor = executor;
+            }
+
+            @Override
+            public RecordCursor<QueryResult> executeInner(final EvaluationContext innerContext, @Nullable final byte[] continuation, final ExecuteProperties executeProperties) {
+                Long outerId = (Long) innerContext.getBinding(OUTER_PARAM);
+                List<TestSparseJoinPerfProto.InnerRecord> innerRecords = innerRecordsByOuter.get(outerId);
+                if (innerRecords == null) {
+                    return RecordCursor.empty();
+                } else {
+                    return RecordCursor.fromList(executor, innerRecords, continuation)
+                            .map(QueryResult::ofComputed);
+                }
+            }
+        }
+    }
+
+    /**
+     * Abstract join technique for join strategies that attempt to optimize execution by filtering out some
+     * of the values before executing the
+     */
+    private static abstract class AbstractPreFilterHashJoinTechnique implements JoinTechnique {
+        abstract Predicate<EvaluationContext> getFilter();
+
+        @Override
+        public Joiner createJoiner(final FDBRecordStore store) {
+            return new AbstractPreFilterHashJoiner(store, store.planQuery(innerQuery()), getFilter());
+        }
+
+        private static class AbstractPreFilterHashJoiner extends StandardIndexProbeJoinTechnique.StandardIndexProbeJoiner {
+            private final Predicate<EvaluationContext> filter;
+
+            public AbstractPreFilterHashJoiner(final FDBRecordStore store, final RecordQueryPlan plan, Predicate<EvaluationContext> filter) {
+                super(store, plan);
+                this.filter = filter;
+            }
+
+            @Override
+            public RecordCursor<QueryResult> executeInner(final EvaluationContext innerContext, @Nullable final byte[] continuation, final ExecuteProperties executeProperties) {
+                if (filter.test(innerContext)) {
+                    return super.executeInner(innerContext, continuation, executeProperties);
+                } else {
+                    return RecordCursor.empty();
+                }
+            }
+        }
+    }
+
+    private static class IdSetHashJoinTechnique extends AbstractPreFilterHashJoinTechnique {
+        private final Set<Long> outerIdsInGroup;
+
+        public IdSetHashJoinTechnique(Set<Long> outerIdsInGroup) {
+            this.outerIdsInGroup = outerIdsInGroup;
+        }
+
+        @Override
+        public JoinTechniqueType getType() {
+            return JoinTechniqueType.SET_FILTER;
+        }
+
+        @Override
+        Predicate<EvaluationContext> getFilter() {
+            return evaluationContext -> {
+                Long outerId = (Long) evaluationContext.getBinding(OUTER_PARAM);
+                return outerIdsInGroup.contains(outerId);
+            };
+        }
+    }
+
+    private static class BitSetHashJoinTechnique extends AbstractPreFilterHashJoinTechnique {
+        private final BitSet outerIdsInGroup;
+
+        public BitSetHashJoinTechnique(BitSet outerIdsInGroup) {
+            this.outerIdsInGroup = outerIdsInGroup;
+        }
+
+        @Override
+        public JoinTechniqueType getType() {
+            return JoinTechniqueType.BIT_SET_FILTER;
+        }
+
+        @Override
+        Predicate<EvaluationContext> getFilter() {
+            return evaluationContext -> {
+                Long outerId = (Long) evaluationContext.getBinding(OUTER_PARAM);
+                return outerIdsInGroup.get(outerId.intValue());
+            };
+        }
+    }
+
+    private static class BloomFilterHashJoinTechnique extends AbstractPreFilterHashJoinTechnique {
+        private final BloomFilter<Long> bloomFilter;
+
+        public BloomFilterHashJoinTechnique(BloomFilter<Long> bloomFilter) {
+            this.bloomFilter = bloomFilter;
+        }
+
+        @Override
+        public JoinTechniqueType getType() {
+            return JoinTechniqueType.BLOOM_FILTER;
+        }
+
+        @Override
+        Predicate<EvaluationContext> getFilter() {
+            return evaluationContext -> {
+                Long outerId = (Long) evaluationContext.getBinding(OUTER_PARAM);
+                return bloomFilter.mightContain(outerId);
+            };
+        }
+    }
+
+    private RecordCursor<Integer> executeJoin(FDBRecordStore store, int group, String text, @Nullable byte[] continuation, ExecuteProperties executeProperties, JoinTechnique joinTechnique) {
         // Combine the outer and inner queries to produce roughly this join:
         //   SELECT InnerRecord.val FROM OuterRecord JOIN InnerRecord
         //   WHERE OuterRecord.text = $text AND InnerRecord.group = $group AND InnerRecord.outer_id = OuterRecord.rec_no
@@ -160,9 +531,7 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
         final RecordQuery outer = outerQuery();
         final RecordQueryPlan outerPlan = store.planQuery(outer);
         assertThat(outerPlan, coveringIndexScan(indexScan(allOf(indexName(TEXT_INDEX_NAME), bounds(hasTupleString("[EQUALS $" + TEXT_PARAM + "]"))))));
-        final RecordQuery inner = innerQuery();
-        final RecordQueryPlan innerPlan = store.planQuery(inner);
-        assertThat(innerPlan, coveringIndexScan(indexScan(allOf(indexName(GROUP_OUTER_VALUE_INDEX), bounds(hasTupleString("[EQUALS $" + GROUP_PARAM + ", EQUALS $" + OUTER_PARAM + "]"))))));
+        Joiner joiner = joinTechnique.createJoiner(store);
 
         final EvaluationContext evalContext = EvaluationContext.newBuilder()
                 .setBinding(GROUP_PARAM, group)
@@ -176,7 +545,7 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
                 (outerRecord, innerContinuation) -> {
                     Message outerMessage = outerRecord.getMessage();
                     final EvaluationContext innerEvalContext = evalContext.withBinding(OUTER_PARAM, outerMessage.getField(recNoDescriptor));
-                    return store.executeQuery(innerPlan, innerContinuation, innerEvalContext, executeProperties.clearSkipAndLimit())
+                    return joiner.executeInner(innerEvalContext, innerContinuation, executeProperties.clearSkipAndLimit())
                             .map(innerRecord -> (Integer) innerRecord.getMessage().getField(valDescriptor));
                 },
                 outerRecord -> outerRecord.getQueriedRecord().getPrimaryKey().pack(),
@@ -185,7 +554,7 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
         ).skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
     }
 
-    private List<Integer> executeMultiTransactionJoin(FDBRecordContextConfig contextConfig, int group, String text) {
+    private List<Integer> executeMultiTransactionJoin(FDBRecordContextConfig contextConfig, int group, String text, JoinTechnique joinTechnique) {
         long startNanos = System.nanoTime();
         List<Integer> values = new ArrayList<>();
         RecordCursorContinuation continuation = RecordCursorStartContinuation.START;
@@ -199,7 +568,7 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
                     .build();
             try (FDBRecordContext context = database.openContext(contextConfig)) {
                 FDBRecordStore store = openStore(context);
-                try (RecordCursor<Integer> cursor = executeJoin(store, group, text, continuation.toBytes(), executeProperties)) {
+                try (RecordCursor<Integer> cursor = executeJoin(store, group, text, continuation.toBytes(), executeProperties, joinTechnique)) {
                     RecordCursorResult<Integer> result;
                     while ((result = cursor.getNext()).hasNext()) {
                         values.add(result.get());
@@ -216,6 +585,7 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
                     "group", group,
                     "text", text,
                     "result_count", values.size(),
+                    "join_technique_type", joinTechnique.getType(),
                     "execute_micros", TimeUnit.NANOSECONDS.toMicros(endNanos - startNanos));
             FDBStoreTimer timer = contextConfig.getTimer();
             if (timer != null) {
@@ -235,10 +605,12 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
         message.addKeyAndValue(prefix + "_avg", data.stream().mapToLong(Long::longValue).sum() / data.size());
     }
 
-    private void profileQuery(int group, String text) {
+    private void profileQuery(int group, String text, JoinTechniqueType joinTechniqueType) {
+        JoinTechnique joinTechnique = getJoinTechnique(joinTechniqueType, group);
+
         // Run some initial tests without profiling to warm up the JVM
         for (int i = 0; i < 50; i++) {
-            executeMultiTransactionJoin(FDBRecordContextConfig.newBuilder().setTimer(new FDBStoreTimer()).build(), group, text);
+            executeMultiTransactionJoin(FDBRecordContextConfig.newBuilder().setTimer(new FDBStoreTimer()).build(), group, text, joinTechnique);
         }
 
         List<Long> durations = new ArrayList<>();
@@ -247,7 +619,7 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
         for (int i = 0; i < 50; i++) {
             long startNanos = System.nanoTime();
             final FDBStoreTimer timer = new FDBStoreTimer();
-            resultCount = executeMultiTransactionJoin(FDBRecordContextConfig.newBuilder().setTimer(timer).build(), group, text).size();
+            resultCount = executeMultiTransactionJoin(FDBRecordContextConfig.newBuilder().setTimer(timer).build(), group, text, joinTechnique).size();
             readsCount = timer.getCount(FDBStoreTimer.Counts.READS);
             long endNanos = System.nanoTime();
             durations.add(TimeUnit.NANOSECONDS.toMicros(endNanos - startNanos));
@@ -258,7 +630,8 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
                     .addKeyAndValue("group", group)
                     .addKeyAndValue("text", text)
                     .addKeyAndValue("result_count", resultCount)
-                    .addKeyAndValue("reads_count", readsCount);
+                    .addKeyAndValue("reads_count", readsCount)
+                    .addKeyAndValue("join_technique_type", joinTechnique.getType());
 
             addStats(logMessage, durations, "latency_micros");
 
@@ -285,7 +658,7 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
 
             for (int i = 0; i < OUTER_RECORD_COUNT; i++) {
                 TestSparseJoinPerfProto.OuterRecord outerRecord = TestSparseJoinPerfProto.OuterRecord.newBuilder()
-                        .setRecNo(r.nextLong())
+                        .setRecNo(r.nextInt(50_000_000))
                         .setText(TEXTS.get(i % TEXTS.size()))
                         .build();
                 store.saveRecord(outerRecord);
@@ -353,19 +726,21 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
     void emptyJoin() {
         try (FDBRecordContext context = database.openContext()) {
             FDBRecordStore store = openStore(context);
-            RecordCursor<Integer> results = executeJoin(store, 42, "foo", null, ExecuteProperties.SERIAL_EXECUTE);
+            RecordCursor<Integer> results = executeJoin(store, 42, "foo", null, ExecuteProperties.SERIAL_EXECUTE, new StandardIndexProbeJoinTechnique());
             assertEquals(0, results.getCount().join());
             context.commit();
         }
     }
 
-    @Test
-    void middleGroupJoin() {
-        profileQuery(GROUP_COUNT / 2, "d");
+    @ParameterizedTest(name = "middleGroupJoin[joinTechniqueType={0}]")
+    @EnumSource(JoinTechniqueType.class)
+    void middleGroupJoin(JoinTechniqueType joinTechniqueType) {
+        profileQuery(GROUP_COUNT / 2, "d", joinTechniqueType);
     }
 
-    @Test
-    void zeroGroupJoin() {
-        profileQuery(0, "d");
+    @ParameterizedTest(name = "zeroGroupJoin[joinTechniqueType={0}]")
+    @EnumSource(JoinTechniqueType.class)
+    void zeroGroupJoin(JoinTechniqueType joinTechniqueType) {
+        profileQuery(0, "d", joinTechniqueType);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSparseJoinPerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSparseJoinPerformanceTest.java
@@ -239,22 +239,22 @@ public class FDBRecordStoreSparseJoinPerformanceTest {
 
     public JoinTechnique getJoinTechnique(JoinTechniqueType type, int group) {
         switch (type) {
-        case STANDARD:
-            return new StandardIndexProbeJoinTechnique();
-        case PREFETCH:
-            return new PreFetchedIndexProbeJoinTechnique(group, 100);
-        case OVERSCAN:
-            return new OverScanIndexProbeJoinTechnique();
-        case IN_MEMORY_HASH_JOIN:
-            return new InMemoryHashJoinTechnique(getInnerByOuterForGroup(group));
-        case SET_FILTER:
-            return new IdSetHashJoinTechnique(getOuterRecordIdsByGroup(group));
-        case BIT_SET_FILTER:
-            return new BitSetHashJoinTechnique(getOuterRecordBitSetByGroup(group));
-        case BLOOM_FILTER:
-            return new BloomFilterHashJoinTechnique(getOuterRecordBloomFilterByGroup(group));
-        default:
-            throw new RecordCoreArgumentException("Unrecognized join technique type", "type", type);
+            case STANDARD:
+                return new StandardIndexProbeJoinTechnique();
+            case PREFETCH:
+                return new PreFetchedIndexProbeJoinTechnique(group, 100);
+            case OVERSCAN:
+                return new OverScanIndexProbeJoinTechnique();
+            case IN_MEMORY_HASH_JOIN:
+                return new InMemoryHashJoinTechnique(getInnerByOuterForGroup(group));
+            case SET_FILTER:
+                return new IdSetHashJoinTechnique(getOuterRecordIdsByGroup(group));
+            case BIT_SET_FILTER:
+                return new BitSetHashJoinTechnique(getOuterRecordBitSetByGroup(group));
+            case BLOOM_FILTER:
+                return new BloomFilterHashJoinTechnique(getOuterRecordBloomFilterByGroup(group));
+            default:
+                throw new RecordCoreArgumentException("Unrecognized join technique type", "type", type);
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSparseJoinPerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSparseJoinPerformanceTest.java
@@ -1,0 +1,371 @@
+/*
+ * FDBRecordStoreSparseJoinPerformanceTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.PipelineOperation;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.TestSparseJoinPerfProto;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.test.Tags;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.coveringIndexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTupleString;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Performance tests of a "sparse join", that is, a nested loop join where many entries returned by the
+ * first half of the join require looking up another record in a second index which may or may not have
+ * any entries.
+ *
+ * <p>
+ * To run, do the following:
+ * </p>
+ *
+ * <ol>
+ *     <li>Run the {@link #repopulateForTest()} test to insert records.</li>
+ *     <li>The other tests can then be run to investigate certain scenarios, querying from that dataset.</li>
+ * </ol>
+ *
+ * <p>
+ * Certain testing parameters, like the number of {@code OuterRecord}s, can be adjusted, though the dataset
+ * will need to be repopulated in order to pick up those changes.
+ * </p>
+ */
+@Tag(Tags.RequiresFDB)
+@Tag(Tags.Performance)
+public class FDBRecordStoreSparseJoinPerformanceTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBRecordStoreSparseJoinPerformanceTest.class);
+
+    private static final Object[] PATH = { "record-test", "performance", "join"};
+
+    private static final String OUTER_RECORD = TestSparseJoinPerfProto.OuterRecord.getDescriptor().getName();
+    private static final String INNER_RECORD = TestSparseJoinPerfProto.InnerRecord.getDescriptor().getName();
+
+    private static final String TEXT_INDEX_NAME = "textIndex";
+    private static final Object TEXT_INDEX_SUBSPACE_KEY = 1L;
+    private static final String GROUP_OUTER_VALUE_INDEX = "groupOuterValueIndex";
+    private static final Object GROUP_OUTER_VALUE_SUBSPACE_KEY = 2L;
+
+    private static final String TEXT_FIELD = "text";
+    private static final String GROUP_FIELD = "group";
+    private static final String VAL_FIELD = "val";
+    private static final String OUTER_ID_FIELD = "outer_id";
+    private static final String REC_NO_FIELD = "rec_no";
+
+    private static final String TEXT_PARAM = "text_param";
+    private static final String GROUP_PARAM = "group_param";
+    private static final String OUTER_PARAM = "outer_param";
+
+    private static final PipelineOperation JOIN = new PipelineOperation("NESTED_LOOP_JOIN");
+
+    private static final List<String> TEXTS = List.of("a", "b", "c", "d", "e", "f", "g");
+    private static final int OUTER_RECORD_COUNT = 100_000;
+    private static final int GROUP_COUNT = 50;
+
+    private FDBDatabase database;
+
+    private static RecordMetaData createMetaData() {
+        RecordMetaDataBuilder builder = RecordMetaData.newBuilder()
+                .setRecords(TestSparseJoinPerfProto.getDescriptor());
+
+        Index textIndex = new Index(TEXT_INDEX_NAME, Key.Expressions.field(TEXT_FIELD));
+        textIndex.setSubspaceKey(TEXT_INDEX_SUBSPACE_KEY);
+        builder.addIndex(OUTER_RECORD, textIndex);
+
+        Index groupOuterValIndex = new Index(GROUP_OUTER_VALUE_INDEX, Key.Expressions.concatenateFields(GROUP_FIELD, OUTER_ID_FIELD, VAL_FIELD));
+        groupOuterValIndex.setSubspaceKey(GROUP_OUTER_VALUE_SUBSPACE_KEY);
+        builder.addIndex(INNER_RECORD, groupOuterValIndex);
+
+        return builder.build();
+    }
+
+    private static RecordQuery outerQuery() {
+        // Roughly:
+        //   SELECT rec_no FROM OuterRecord WHERE text = $text_param
+        return RecordQuery.newBuilder()
+                .setRecordType(OUTER_RECORD)
+                .setFilter(Query.field(TEXT_FIELD).equalsParameter(TEXT_PARAM))
+                .setRequiredResults(List.of(Key.Expressions.field(REC_NO_FIELD)))
+                .build();
+    }
+
+    private static RecordQuery innerQuery() {
+        // Roughly:
+        //   SELECT val FROM InnerRecord WHERE group = $group_param AND outer_id = $outer_param
+        return RecordQuery.newBuilder()
+                .setRecordType(INNER_RECORD)
+                .setFilter(Query.and(Query.field(GROUP_FIELD).equalsParameter(GROUP_PARAM), Query.field(OUTER_ID_FIELD).equalsParameter(OUTER_PARAM)))
+                .setRequiredResults(List.of(Key.Expressions.field(VAL_FIELD)))
+                .build();
+    }
+
+    private RecordCursor<Integer> executeJoin(FDBRecordStore store, int group, String text, @Nullable byte[] continuation, ExecuteProperties executeProperties) {
+        // Combine the outer and inner queries to produce roughly this join:
+        //   SELECT InnerRecord.val FROM OuterRecord JOIN InnerRecord
+        //   WHERE OuterRecord.text = $text AND InnerRecord.group = $group AND InnerRecord.outer_id = OuterRecord.rec_no
+
+        final RecordQuery outer = outerQuery();
+        final RecordQueryPlan outerPlan = store.planQuery(outer);
+        assertThat(outerPlan, coveringIndexScan(indexScan(allOf(indexName(TEXT_INDEX_NAME), bounds(hasTupleString("[EQUALS $" + TEXT_PARAM + "]"))))));
+        final RecordQuery inner = innerQuery();
+        final RecordQueryPlan innerPlan = store.planQuery(inner);
+        assertThat(innerPlan, coveringIndexScan(indexScan(allOf(indexName(GROUP_OUTER_VALUE_INDEX), bounds(hasTupleString("[EQUALS $" + GROUP_PARAM + ", EQUALS $" + OUTER_PARAM + "]"))))));
+
+        final EvaluationContext evalContext = EvaluationContext.newBuilder()
+                .setBinding(GROUP_PARAM, group)
+                .setBinding(TEXT_PARAM, text)
+                .build(TypeRepository.EMPTY_SCHEMA);
+
+        Descriptors.FieldDescriptor recNoDescriptor = TestSparseJoinPerfProto.OuterRecord.getDescriptor().findFieldByName(REC_NO_FIELD);
+        Descriptors.FieldDescriptor valDescriptor = TestSparseJoinPerfProto.InnerRecord.getDescriptor().findFieldByName(VAL_FIELD);
+        return RecordCursor.flatMapPipelined(
+                outerContinuation -> store.executeQuery(outerPlan, outerContinuation, evalContext, executeProperties.clearSkipAndLimit()),
+                (outerRecord, innerContinuation) -> {
+                    Message outerMessage = outerRecord.getMessage();
+                    final EvaluationContext innerEvalContext = evalContext.withBinding(OUTER_PARAM, outerMessage.getField(recNoDescriptor));
+                    return store.executeQuery(innerPlan, innerContinuation, innerEvalContext, executeProperties.clearSkipAndLimit())
+                            .map(innerRecord -> (Integer) innerRecord.getMessage().getField(valDescriptor));
+                },
+                outerRecord -> outerRecord.getQueriedRecord().getPrimaryKey().pack(),
+                continuation,
+                store.getPipelineSize(JOIN)
+        ).skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
+    }
+
+    private List<Integer> executeMultiTransactionJoin(FDBRecordContextConfig contextConfig, int group, String text) {
+        long startNanos = System.nanoTime();
+        List<Integer> values = new ArrayList<>();
+        RecordCursorContinuation continuation = RecordCursorStartContinuation.START;
+
+        do {
+            final ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                    .setReturnedRowLimit(100)
+                    .setScannedBytesLimit(50_000)
+                    .setScannedRecordsLimit(1000)
+                    .setTimeLimit(3_000L)
+                    .build();
+            try (FDBRecordContext context = database.openContext(contextConfig)) {
+                FDBRecordStore store = openStore(context);
+                try (RecordCursor<Integer> cursor = executeJoin(store, group, text, continuation.toBytes(), executeProperties)) {
+                    RecordCursorResult<Integer> result;
+                    while ((result = cursor.getNext()).hasNext()) {
+                        values.add(result.get());
+                    }
+                    continuation = result.getContinuation();
+                }
+            }
+
+        } while (!continuation.isEnd());
+        long endNanos = System.nanoTime();
+
+        if (LOGGER.isInfoEnabled()) {
+            KeyValueLogMessage msg = KeyValueLogMessage.build("multi-transaction join executed",
+                    "group", group,
+                    "text", text,
+                    "result_count", values.size(),
+                    "execute_micros", TimeUnit.NANOSECONDS.toMicros(endNanos - startNanos));
+            FDBStoreTimer timer = contextConfig.getTimer();
+            if (timer != null) {
+                msg.addKeysAndValues(timer.getKeysAndValues());
+            }
+            LOGGER.info(msg.toString());
+        }
+
+        return values;
+    }
+
+    private static void addStats(KeyValueLogMessage message, List<Long> data, String prefix) {
+        data.sort(Comparator.naturalOrder());
+        message.addKeyAndValue(prefix + "_min", data.get(0));
+        message.addKeyAndValue(prefix + "_max", data.get(data.size() - 1));
+        message.addKeyAndValue(prefix + "_median", data.get(data.size() / 2));
+        message.addKeyAndValue(prefix + "_avg", data.stream().mapToLong(Long::longValue).sum() / data.size());
+    }
+
+    private void profileQuery(int group, String text) {
+        // Run some initial tests without profiling to warm up the JVM
+        for (int i = 0; i < 50; i++) {
+            executeMultiTransactionJoin(FDBRecordContextConfig.newBuilder().setTimer(new FDBStoreTimer()).build(), group, text);
+        }
+
+        List<Long> durations = new ArrayList<>();
+        int resultCount = 0;
+        long readsCount = 0;
+        for (int i = 0; i < 50; i++) {
+            long startNanos = System.nanoTime();
+            final FDBStoreTimer timer = new FDBStoreTimer();
+            resultCount = executeMultiTransactionJoin(FDBRecordContextConfig.newBuilder().setTimer(timer).build(), group, text).size();
+            readsCount = timer.getCount(FDBStoreTimer.Counts.READS);
+            long endNanos = System.nanoTime();
+            durations.add(TimeUnit.NANOSECONDS.toMicros(endNanos - startNanos));
+        }
+
+        if (LOGGER.isInfoEnabled()) {
+            KeyValueLogMessage logMessage = KeyValueLogMessage.build("join query profiled")
+                    .addKeyAndValue("group", group)
+                    .addKeyAndValue("text", text)
+                    .addKeyAndValue("result_count", resultCount)
+                    .addKeyAndValue("reads_count", readsCount);
+
+            addStats(logMessage, durations, "latency_micros");
+
+            LOGGER.info(logMessage.toString());
+        }
+    }
+
+    private FDBRecordStore openStore(FDBRecordContext context) {
+        return FDBRecordStore.newBuilder()
+                .setContext(context)
+                .setMetaDataProvider(createMetaData())
+                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION)
+                .setKeySpacePath(TestKeySpace.getKeyspacePath(PATH))
+                .createOrOpen();
+    }
+
+    private void populate(Random r) {
+        long startNanos = System.nanoTime();
+        Map<Integer, Integer> countsByGroup = new TreeMap<>();
+
+        FDBRecordContext context = database.openContext();
+        try {
+            FDBRecordStore store = openStore(context);
+
+            for (int i = 0; i < OUTER_RECORD_COUNT; i++) {
+                TestSparseJoinPerfProto.OuterRecord outerRecord = TestSparseJoinPerfProto.OuterRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setText(TEXTS.get(i % TEXTS.size()))
+                        .build();
+                store.saveRecord(outerRecord);
+
+                // Create an inner record pointing to OuterRecord, choosing a group with a normal distribution
+                // centered around the middle group so that there are 3 z-values around the center
+                int group = (int)(r.nextGaussian() * (GROUP_COUNT / 6) + (GROUP_COUNT / 2));
+                group = Math.min(group, GROUP_COUNT - 1);
+                group = Math.max(group, 0);
+                TestSparseJoinPerfProto.InnerRecord innerRecord = TestSparseJoinPerfProto.InnerRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setGroup(group)
+                        .setOuterId(outerRecord.getRecNo())
+                        .setVal(i)
+                        .build();
+                store.saveRecord(innerRecord);
+                countsByGroup.compute(group, (ignore, current) -> current == null ? 1 : current + 1);
+
+                if (context.ensureActive().getApproximateSize().join() > 100_000) {
+                    context.commit();
+                    context.close();
+
+                    context = database.openContext();
+                    store = openStore(context);
+                }
+            }
+
+            context.commit();
+
+        } finally {
+            context.close();
+
+            long endNanos = System.nanoTime();
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(KeyValueLogMessage.of("data populated for sparse join test",
+                        "outer_record_count", OUTER_RECORD_COUNT,
+                        "inner_records_by_group", countsByGroup,
+                        "populate_time_micros", TimeUnit.NANOSECONDS.toMicros(endNanos - startNanos)));
+            }
+        }
+    }
+
+    private void repopulate() {
+        try (FDBRecordContext context = database.openContext()) {
+            KeySpacePath path = TestKeySpace.getKeyspacePath(PATH);
+            path.deleteAllData(context);
+            context.commit();
+        }
+
+        Random r = new Random();
+        populate(r);
+    }
+
+    @BeforeEach
+    void setUp() {
+        database = FDBDatabaseFactory.instance().getDatabase();
+    }
+
+    @Test
+    void repopulateForTest() {
+        repopulate();
+    }
+
+    @Test
+    void emptyJoin() {
+        try (FDBRecordContext context = database.openContext()) {
+            FDBRecordStore store = openStore(context);
+            RecordCursor<Integer> results = executeJoin(store, 42, "foo", null, ExecuteProperties.SERIAL_EXECUTE);
+            assertEquals(0, results.getCount().join());
+            context.commit();
+        }
+    }
+
+    @Test
+    void middleGroupJoin() {
+        profileQuery(GROUP_COUNT / 2, "d");
+    }
+
+    @Test
+    void zeroGroupJoin() {
+        profileQuery(0, "d");
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -85,7 +85,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void all() {
         fdb.run(context -> {
-            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setRange(TupleRange.ALL)
                     .setContinuation(null)
@@ -122,7 +122,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void beginsWith() {
         fdb.run(context -> {
-            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setRange(TupleRange.allOf(Tuple.from(3)))
                     .setContinuation(null)
@@ -157,7 +157,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void inclusiveRange() {
         fdb.run(context -> {
-            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_INCLUSIVE)
                     .setHigh(Tuple.from(4, 2), EndpointType.RANGE_INCLUSIVE)
@@ -193,7 +193,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void exclusiveRange() {
         fdb.run(context -> {
-            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_EXCLUSIVE)
                     .setHigh(Tuple.from(4, 2), EndpointType.RANGE_EXCLUSIVE)
@@ -268,7 +268,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     @Test
     public void noNextReasons() {
         fdb.run(context -> {
-            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setRange(TupleRange.allOf(Tuple.from(3)))
                     .setContinuation(null)
@@ -302,7 +302,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     public void simpleScanLimit() {
         fdb.run(context -> {
             RecordScanLimiter limiter = RecordScanLimiterFactory.enforce(2);
-            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setRange(TupleRange.ALL)
                     .setScanProperties(forwardScanWithLimiter(limiter))
@@ -320,7 +320,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     public void limitNotReached() {
         fdb.run(context -> {
             RecordScanLimiter limiter = RecordScanLimiterFactory.enforce(4);
-            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> cursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_EXCLUSIVE)
                     .setHigh(Tuple.from(4, 2), EndpointType.RANGE_EXCLUSIVE)
@@ -335,7 +335,7 @@ public class KeyValueCursorTest extends FDBTestBase {
         });
     }
 
-    private boolean hasNextAndAdvance(KeyValueCursor cursor) {
+    private boolean hasNextAndAdvance(RecordCursor<?> cursor) {
         return cursor.getNext().hasNext();
     }
 
@@ -348,8 +348,8 @@ public class KeyValueCursorTest extends FDBTestBase {
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_EXCLUSIVE)
                     .setHigh(Tuple.from(4, 2), EndpointType.RANGE_EXCLUSIVE)
                     .setScanProperties(forwardScanWithLimiter(limiter));
-            KeyValueCursor cursor1 = builder.build();
-            KeyValueCursor cursor2 = builder.build();
+            RecordCursor<KeyValue> cursor1 = builder.build();
+            RecordCursor<KeyValue> cursor2 = builder.build();
 
             assertThat(hasNextAndAdvance(cursor1), is(true));
             assertThat(hasNextAndAdvance(cursor2), is(true));
@@ -370,7 +370,7 @@ public class KeyValueCursorTest extends FDBTestBase {
     public void limiterWithLookahead() {
         fdb.run(context -> {
             RecordScanLimiter limiter = RecordScanLimiterFactory.enforce(1);
-            KeyValueCursor kvCursor =  KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> kvCursor =  KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setLow(Tuple.from(3, 3), EndpointType.RANGE_EXCLUSIVE)
                     .setHigh(Tuple.from(4, 2), EndpointType.RANGE_EXCLUSIVE)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
@@ -650,7 +650,7 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
 
     private FDBRawRecord scanSingleRecord(@Nonnull FDBRecordContext context, boolean reverse, @Nonnull Tuple key, @Nullable FDBStoredSizes expectedSizes, @Nullable byte[] expectedContents, @Nullable FDBRecordVersion version) {
         final ScanProperties scanProperties = reverse ? ScanProperties.REVERSE_SCAN : ScanProperties.FORWARD_SCAN;
-        KeyValueCursor kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
+        RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
                 .setContext(context)
                 .setRange(TupleRange.allOf(key))
                 .setScanProperties(scanProperties)
@@ -723,7 +723,7 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
         List<FDBRawRecord> rawRecords = writeDummyRecords();
 
         try (FDBRecordContext context = openContext()) {
-            KeyValueCursor kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
+            RecordCursor<KeyValue> kvCursor = KeyValueCursor.Builder.withSubspace(subspace)
                     .setContext(context)
                     .setRange(TupleRange.ALL)
                     .setScanProperties(scanProperties)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TestKeySpace.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TestKeySpace.java
@@ -55,6 +55,7 @@ public class TestKeySpace {
                     )
                     .addSubdirectory(new DirectoryLayerDirectory("performance", "performance")
                             .addSubdirectory(new DirectoryLayerDirectory("recordStore", "recordStore"))
+                            .addSubdirectory(new DirectoryLayerDirectory("join", "join"))
                     )
     );
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
+import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
@@ -2330,7 +2331,7 @@ public class VersionIndexTest extends FDBTestBase {
     private <M extends Message> void validateUsingNewerVersionFormat(@Nonnull List<FDBStoredRecord<M>> storedRecords) {
         // Make sure the old keyspace doesn't have anything in it
         final Subspace legacyVersionSubspace = recordStore.getLegacyVersionSubspace();
-        KeyValueCursor legacyKvs = KeyValueCursor.Builder.withSubspace(legacyVersionSubspace)
+        RecordCursor<KeyValue> legacyKvs = KeyValueCursor.Builder.withSubspace(legacyVersionSubspace)
                 .setContext(recordStore.getRecordContext())
                 .setScanProperties(ScanProperties.FORWARD_SCAN)
                 .build();

--- a/fdb-record-layer-core/src/test/proto/test_sparse_join_perf.proto
+++ b/fdb-record-layer-core/src/test/proto/test_sparse_join_perf.proto
@@ -1,0 +1,47 @@
+/*
+ * test_sparse_join_perf.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.test1;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestSparseJoinPerfProto";
+
+import "record_metadata_options.proto";
+
+option (schema).store_record_versions = true;
+
+message OuterRecord {
+    optional int64 rec_no = 1 [(field).primary_key = true];
+    optional string text = 2;
+}
+
+message InnerRecord {
+    optional int64 rec_no = 1 [(field).primary_key = true];
+    optional int64 group = 2;
+    optional int32 val = 3;
+    optional int64 outer_id = 4;
+}
+
+message SparseJoinUnion {
+    option (record).usage = UNION;
+    optional OuterRecord _OuterRecord = 1;
+    optional InnerRecord _InnerRecord = 2;
+}


### PR DESCRIPTION
This adds `FDBRecordStoreSparseJoinPerformanceTest` for profiling sparse joins. There are some instructions on how to run that test locally within the Javadoc for that test.