### PR TITLE
Resolve #1721: Remote fetch counters

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -2010,6 +2010,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         }).thenCompose(this::removeReplacedIndexesIfChanged);
     }
 
+    @SuppressWarnings("java:S3776")
     private CompletableFuture<Void> checkUserVersion(@Nullable UserVersionChecker userVersionChecker,
                                                      @Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader,
                                                      @Nonnull RecordMetaDataProto.DataStoreInfo.Builder info, @Nonnull boolean[] dirty) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1260,7 +1260,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         // Parse the index entries and payload and build records
         RecordCursor<FDBIndexedRecord<M>> indexedRecordCursor = indexEntriesToIndexRecords(scanProperties, orphanBehavior, recordSubspace, indexEntries, typedSerializer);
 
-        return context.instrument(FDBStoreTimer.Events.SCAN_INDEX_REMOTE_FETCH, indexedRecordCursor);
+        return context.instrument(FDBStoreTimer.Events.SCAN_REMOTE_FETCH_ENTRY, indexedRecordCursor);
     }
 
     @VisibleForTesting

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -130,7 +130,7 @@ public class FDBStoreTimer extends StoreTimer {
          * The amount of time taken performing an index prefetch operation.
          * Index prefetch operation is an index scan followed by record fetches, all done at the FDB level.
          */
-        SCAN_INDEX_REMOTE_FETCH("index remote fetch"),
+        SCAN_REMOTE_FETCH_ENTRY("remote fetch index entry"),
         /**
          * The amount of time taken deleting records.
          * This time includes secondary index maintenance as well as writing to the current transaction
@@ -642,6 +642,8 @@ public class FDBStoreTimer extends StoreTimer {
         READS("reads", false),
         /** Total number of range read (get) operations. */
         RANGE_READS("range reads", false),
+        /** Total number of remote fetch (get) operations. */
+        REMOTE_FETCH("remote fetch reads", false),
         /** Total number of write operations. */
         WRITES("writes", false),
         /** Total number of delete (clear) operations. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
@@ -196,8 +196,7 @@ abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements
 
     @Override
     public AsyncIterable<MappedKeyValue> getMappedRange(final KeySelector begin, final KeySelector end, final byte[] mapper, final int limit, final boolean reverse, final StreamingMode mode) {
-        increment(FDBStoreTimer.Counts.READS);
-        increment(FDBStoreTimer.Counts.RANGE_READS);
+        increment(FDBStoreTimer.Counts.REMOTE_FETCH);
         return underlying.getMappedRange(begin, end, mapper, limit, reverse, mode);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
@@ -154,7 +154,7 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
 
     protected void assertCounters(final RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch, final int expectedRemoteFetches, final int expectedRemoteFetchEntries) {
         if ((useIndexPrefetch != RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) &&
-            (recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1))) {
+                (recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1))) {
 
             StoreTimer.Counter numRemoteFetches = recordStore.getTimer().getCounter(REMOTE_FETCH);
             StoreTimer.Counter numRemoteFetchEntries = recordStore.getTimer().getCounter(SCAN_REMOTE_FETCH_ENTRY);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
@@ -153,7 +153,9 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
     }
 
     protected void assertCounters(final RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch, final int expectedRemoteFetches, final int expectedRemoteFetchEntries) {
-        if (useIndexPrefetch != RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) {
+        if ((useIndexPrefetch != RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) &&
+            (recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1))) {
+
             StoreTimer.Counter numRemoteFetches = recordStore.getTimer().getCounter(REMOTE_FETCH);
             StoreTimer.Counter numRemoteFetchEntries = recordStore.getTimer().getCounter(SCAN_REMOTE_FETCH_ENTRY);
             assertEquals(expectedRemoteFetches, numRemoteFetches.getCount());


### PR DESCRIPTION
Improve remote fetch store timer counters: Rename SCAN_INDEX_REMOTE_FETCH to SCAN_REMOTE_FETCH_ENTRY and add REMOTE_FETCH.

Modify tests.