### PR TITLE
Resolve #1725: Reconstruct KeyWithValue expression correctly.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Cascades does not reconstruct a KeyWithValue correctly [(Issue #1725)](https://github.com/FoundationDB/fdb-record-layer/issues/1725)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
@@ -156,13 +156,16 @@ public class ValueIndexExpansionVisitor extends KeyExpressionExpansionVisitor im
      */
     @Nonnull
     public static KeyExpression fullKey(@Nonnull Index index, @Nullable final KeyExpression primaryKey) {
+        final KeyExpression rootExpression = index.getRootExpression() instanceof KeyWithValueExpression
+                                             ? ((KeyWithValueExpression)index.getRootExpression()).getKeyExpression()
+                                             : index.getRootExpression();
         if (primaryKey == null) {
-            return index.getRootExpression();
+            return rootExpression;
         }
         final var trimmedPrimaryKeyComponents = new ArrayList<>(primaryKey.normalizeKeyForPositions());
         index.trimPrimaryKey(trimmedPrimaryKeyComponents);
         final var fullKeyListBuilder = ImmutableList.<KeyExpression>builder();
-        fullKeyListBuilder.add(index.getRootExpression());
+        fullKeyListBuilder.add(rootExpression);
         fullKeyListBuilder.addAll(trimmedPrimaryKeyComponents);
         return concat(fullKeyListBuilder.build());
     }


### PR DESCRIPTION
When Cascades expands a `Index` into a `KeyExpression`, there is some logic that examines the index's root expression keys and appends any missing primary keys to the end via `concat`. This works as expected for `ThenKeyExpression`.

However if the root expression is `KeyWithValue` such as e.g. (`KeyWithValue({RecordType, A, B} 2)`, where `A` is a primary key), then it will pass the `KeyWithValue` as-is to `concat` causing it to fail, because `concat` thinks there is only a single key to be concatenated (but in our example above, we have two keys: `RecordType` and `A`).

To fix this problem, we check first if the root expression is a `KeyWithValue`, if so, we get its key expression, and proceed with the same logic.