### PR TITLE
Resolve #1730: Fix double count

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix double counting of limits in remote fetch [(Issue #1730)](https://github.com/FoundationDB/fdb-record-layer/issues/1730)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
@@ -69,6 +69,8 @@ public class CursorLimitManager {
     private static final Optional<RecordCursor.NoNextReason> BYTE_LIMIT_REACHED = Optional.of(RecordCursor.NoNextReason.BYTE_LIMIT_REACHED);
     private static final Optional<RecordCursor.NoNextReason> TIME_LIMIT_REACHED = Optional.of(RecordCursor.NoNextReason.TIME_LIMIT_REACHED);
 
+    public static final CursorLimitManager UNTRACKED = new CursorLimitManager(null, false, null, null);
+
     @VisibleForTesting
     public CursorLimitManager(@Nullable RecordScanLimiter recordScanLimiter, boolean failOnScanLimitReached,
                               @Nullable ByteScanLimiter byteScanLimiter,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1347,8 +1347,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         final RecordCursor<FDBRawRecord> rawRecords;
         if (metaData.isSplitLongRecords()) {
             // Note that we always set "reverse" to false since regardless of the index scan direction, the MappedKeyValue is in non-reverse order
+            // Setting the limit manager to UNTRACKED since the KeyValueCursor already counts records, and we don't want the unsplitter to double-count
             rawRecords = new SplitHelper.KeyValueUnsplitter(context, recordSubspace, rangeCursor, oldVersionFormat,
-                    sizeInfo, false, new CursorLimitManager(scanProperties));
+                    sizeInfo, false, CursorLimitManager.UNTRACKED);
         } else {
             if (omitUnsplitRecordSuffix) {
                 rawRecords = rangeCursor.map(kv -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1359,8 +1359,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 });
             } else {
                 // Note that we always set "reverse" to false since regardless of the index scan direction, the MappedKeyValue is in non-reverse order
+                // Setting the limit manager to UNTRACKED since the KeyValueCursor already counts records, and we don't want the unsplitter to double-count
                 rawRecords = new SplitHelper.KeyValueUnsplitter(context, recordSubspace, rangeCursor, oldVersionFormat,
-                        sizeInfo, false, new CursorLimitManager(scanProperties));
+                        sizeInfo, false, CursorLimitManager.UNTRACKED);
             }
         }
         // Everything is synchronous, just get the only value from the cursor

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1276,7 +1276,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
         RecordCursor<FDBIndexedRecord<M>> indexedRecordCursor = indexEntries.mapPipelined(indexedRawRecord -> {
             // Use the raw record entries to reconstruct the original raw record (include all splits and version, if applicable)
-            FDBRawRecord fdbRawRecord = reconstructSingleRecord(recordSubspace, sizeInfo, indexedRawRecord.getRawRecord(), scanProperties, useOldVersionFormat());
+            FDBRawRecord fdbRawRecord = reconstructSingleRecord(recordSubspace, sizeInfo, indexedRawRecord.getRawRecord(), useOldVersionFormat());
             if (fdbRawRecord == null) {
                 return handleOrphanEntry(indexedRawRecord.getIndexEntry(), orphanBehavior);
             } else {
@@ -1335,8 +1335,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @Nullable
     @SuppressWarnings("PMD.CloseResource")
     private FDBRawRecord reconstructSingleRecord(final Subspace recordSubspace, final SplitHelper.SizeInfo sizeInfo,
-                                                 final MappedKeyValue mappedResult, final ScanProperties scanProperties,
-                                                 final boolean oldVersionFormat) {
+                                                 final MappedKeyValue mappedResult, final boolean oldVersionFormat) {
         List<KeyValue> scannedRange = mappedResult.getRangeResult();
         if ((scannedRange == null) || scannedRange.isEmpty()) {
             return null;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
@@ -501,7 +501,11 @@ class RemoteFetchTest extends RemoteFetchTestBase {
     }
 
     public boolean isUseSplitRecords() {
-        return true;
+        return useSplitRecords;
+    }
+
+    public void setUseSplitRecords(final boolean useSplitRecords) {
+        this.useSplitRecords = useSplitRecords;
     }
 
     private KeyExpression primaryKey() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
@@ -501,11 +501,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
     }
 
     public boolean isUseSplitRecords() {
-        return useSplitRecords;
-    }
-
-    public void setUseSplitRecords(final boolean useSplitRecords) {
-        this.useSplitRecords = useSplitRecords;
+        return true;
     }
 
     private KeyExpression primaryKey() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
@@ -26,11 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
  * Extends {@link RemoteFetchTest} and change the configurartion to run all tests with split=false.
  */
 public class RemoteFetchWithoutSplitRecordsTest extends RemoteFetchTest {
-    @BeforeEach
     @Override
-    void setup() throws Exception {
-        this.setUseSplitRecords(false);
-        super.setup();
+    public boolean isUseSplitRecords() {
+        return false;
     }
-
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
@@ -26,8 +26,10 @@ import org.junit.jupiter.api.BeforeEach;
  * Extends {@link RemoteFetchTest} and change the configurartion to run all tests with split=false.
  */
 public class RemoteFetchWithoutSplitRecordsTest extends RemoteFetchTest {
+    @BeforeEach
     @Override
-    public boolean isUseSplitRecords() {
-        return false;
+    void setup() throws Exception {
+        this.setUseSplitRecords(false);
+        super.setup();
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
@@ -32,4 +32,5 @@ public class RemoteFetchWithoutSplitRecordsTest extends RemoteFetchTest {
         this.setUseSplitRecords(false);
         super.setup();
     }
+
 }


### PR DESCRIPTION
Remote fetch was double counting bytes and scanned records in the limit manager.
Fix by giving KeyValueUnsplitter an unlimited limit manager.