### PR TITLE
Resolve #1733 MatchCandidate type fields are generated with nondeterministic order

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** OrdinalFieldValue eval does not use ordinal index [(Issue #1733)](https://github.com/FoundationDB/fdb-record-layer/issues/1733)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -650,6 +651,7 @@ public class RecordMetaData implements RecordMetaDataProvider {
         return recordTypeStream
                 .flatMap(recordType -> recordType.getDescriptor().getFields().stream())
                 .collect(Collectors.groupingBy(Descriptors.FieldDescriptor::getName,
+                        LinkedHashMap::new,
                         Collectors.reducing(null,
                                 (fieldDescriptor, fieldDescriptor2) -> {
                                     Verify.verify(fieldDescriptor != null || fieldDescriptor2 != null);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OrdinalFieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OrdinalFieldValue.java
@@ -100,8 +100,7 @@ public class OrdinalFieldValue implements ValueWithChild {
             return null;
         }
         final Descriptors.Descriptor descriptorForType = childMessage.getDescriptorForType();
-        // ordinalPosition is 0-based, protobuf field numbers are 1-based -> compensate.
-        final Descriptors.FieldDescriptor fieldDescriptor = descriptorForType.findFieldByNumber(ordinalPosition + 1);
+        final Descriptors.FieldDescriptor fieldDescriptor = descriptorForType.findFieldByNumber(field.getFieldIndex());
         return childMessage.getField(fieldDescriptor);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OrdinalFieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OrdinalFieldValue.java
@@ -100,7 +100,8 @@ public class OrdinalFieldValue implements ValueWithChild {
             return null;
         }
         final Descriptors.Descriptor descriptorForType = childMessage.getDescriptorForType();
-        final Descriptors.FieldDescriptor fieldDescriptor = descriptorForType.findFieldByNumber(field.getFieldIndex());
+        // ordinalPosition is 0-based, protobuf field numbers are 1-based -> compensate.
+        final Descriptors.FieldDescriptor fieldDescriptor = descriptorForType.findFieldByNumber(ordinalPosition + 1);
         return childMessage.getField(fieldDescriptor);
     }
 


### PR DESCRIPTION
When generating the `Type` information for a `MatchCandidate` we use this `RecordMetaData::getFieldDescriptorMap` which returns a `HashMap` of fields that is translated later to a `Record` type.

This could cause a problem when attempting to reference some of these fields by ordinal (`OrdinalFieldValue`) as fields could be enlisted differently between a `MatchCandidate` and a flown type of another operator.