### PR TITLE
Fix the covering index plan for Lucene spell-check not include primar…

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
@@ -80,7 +80,7 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan {
             final RecordCursor<IndexEntry> entryRecordCursor = executeEntries(store, context, continuation, executeProperties);
             return entryRecordCursor
                     .map(QueryPlanUtils.getCoveringIndexEntryToPartialRecordFunction(store, recordType.getName(), indexName,
-                            getToPartialRecord(index, recordType, scanType), true))
+                            getToPartialRecord(index, recordType, scanType), scanType.equals(LuceneScanTypes.BY_LUCENE_AUTO_COMPLETE)))
                     .map(QueryResult::fromQueriedRecord);
         }
         return super.executePlan(store, context, continuation, executeProperties);


### PR DESCRIPTION
…y key