### PR TITLE
Resolves #1743: Update FDB dependency to 7.1.10

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -51,12 +51,32 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/ed28ded51a8b1c6b112568def5f4b455e6809019/j2objc-annotations-1.1.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.codehaus.mojo/animal-sniffer-annotations/1.17/f97ce6decaea32b36101e37979f8b647f00681fb/animal-sniffer-annotations-1.17.jar" />
         </processorPath>
-        <module name="fdb-record-layer.fdb-record-layer-core.main" />
+        <module name="fdb-record-layer.fdb-extensions.main" />
         <module name="fdb-record-layer.fdb-record-layer-lucene.test" />
         <module name="fdb-record-layer.fdb-record-layer-spatial.main" />
         <module name="fdb-record-layer.fdb-record-layer-lucene.main" />
         <module name="fdb-record-layer.fdb-record-layer-core.test" />
         <module name="fdb-record-layer.fdb-record-layer-icu.main" />
+      </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$PROJECT_DIR$/fdb-extensions/.out/libs/fdb-extensions-3.2-SNAPSHOT.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0-rc6/4586e4191111b24135ffac93d3e1a91e91bf71d3/auto-service-1.0-rc6.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.foundationdb/fdb-java/7.1.10/5b63e331d6eb1758e9eacd946fb4dfd0d4ad03ca/fdb-java-7.1.10.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/0.10/c8f153ebe04a17183480ab4016098055fb474364/auto-common-0.10.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/30.1-jre/d0c3ce2311c9e36e73228da25a6e99b2ab826f/guava-30.1-jre.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.36/6c62681a2f655b49963a5983b8b0950a6120ae14/slf4j-api-1.7.36.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup/javapoet/1.12.0/459ae6c796db7dcbc723f9536af2ce49d86c1a80/javapoet-1.12.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service-annotations/1.0-rc6/32c6a6313217c949396376d9caddb6b8c8f4e7c3/auto-service-annotations-1.0-rc6.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/b421526c5f297295adef1c886e5246c39d4ac629/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-qual/3.5.0/2f50520c8abea66fbd8d26e481d3aef5c673b510/checker-qual-3.5.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.3.4/dac170e4594de319655ffb62f41cbd6dbb5e601e/error_prone_annotations-2.3.4.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.3/ba035118bc8bac37d7eff77700720999acd9986d/j2objc-annotations-1.3.jar" />
+        </processorPath>
+        <module name="fdb-record-layer.fdb-record-layer-core.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="11" />

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,7 +1,7 @@
 FROM centos:7
-LABEL version=0.0.18
+LABEL version=0.0.19
 
-ARG FDBVERSION=7.1.3
+ARG FDBVERSION=7.1.10
 
 RUN yum install -y \
     git \

--- a/build/Dockerfile.fdbserver
+++ b/build/Dockerfile.fdbserver
@@ -1,5 +1,5 @@
 FROM centos:7
-ARG FDBVERSION=7.1.3
+ARG FDBVERSION=7.1.10
 LABEL version=${FDBVERSION}-1
 
 RUN yum install -y \

--- a/build/Dockerfile.standalone-tests
+++ b/build/Dockerfile.standalone-tests
@@ -1,9 +1,9 @@
 # EKS (amazonlinux) version:
-# --build-arg FDBVERSION=7.1.3-${OKTETO_USER}-debug \
+# --build-arg FDBVERSION=7.1.10-${OKTETO_USER}-debug \
 # --build-arg FDBREPO=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/foundationdb \
 # --build-arg JDKPKG=java-11-amazon-corretto-11.0.13+8-1.amzn2
 
-ARG FDBVERSION=7.1.3
+ARG FDBVERSION=7.1.10
 ARG FDBREPO=foundationdb
 
 FROM ${FDBREPO}/foundationdb-base:${FDBVERSION} AS java

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: fdb-record-layer-build:0.0.18
+    image: fdb-record-layer-build:0.0.19
     build:
       context: .
       dockerfile: Dockerfile.build
@@ -17,7 +17,7 @@ services:
       - FDBHOSTNAME=fdbserver
 
   fdbserver:
-    image: foundationdb-server:7.1.3-1
+    image: foundationdb-server:7.1.10-1
     environment:
       - FDBSTARTOPT=2
       - HOST_IP=0.0.0.0

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** FDB Java dependency version updated to 7.1.10 to incorporate fixes over older 7.1 versions [(Issue #1743)](https://github.com/FoundationDB/fdb-record-layer/issues/1743)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ group=org.foundationdb
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation
 
-fdbVersion=7.1.3
+fdbVersion=7.1.10
 # Set the api version used by build and CI tests. The default api version used by consumers is not impacted and is determined
 # by ApiVersion.getDefault()
 apiVersion=710


### PR DESCRIPTION
The FDB Java version has been updated to 7.1.10 in this PR. The more important thing is actually that the client (and server) versions be updated to 7.1.10 or 7.1.11 (depending on whether the environments support AVX instructions) to get the recent bug fixes, but this seems like a good signal to send to let our downstream adopters know they should upgrade.

This resolves #1743.