### PR TITLE
Resolves #1756: Remote fetch index scan wrapper

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,3 +1,4 @@
+
 # Release Notes
 
 This document contains a log of changes to the FoundationDB Record Layer. It aims to include mostly user-visible changes or improvements. Within each minor release, larger or more involved changes are highlighted first before detailing the changes that were included in each build or patch version. Users should especially take note of any breaking changes or special upgrade instructions which should always be included as a preface to the minor version as a whole before looking at changes at a version-by-version level.
@@ -30,7 +31,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Index Remote Fetch for index scan methods [(Issue #1751)](https://github.com/FoundationDB/fdb-record-layer/issues/1751)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexFetchMethod.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexFetchMethod.java
@@ -34,4 +34,4 @@ import com.apple.foundationdb.annotation.API;
  * </UL>
  */
 @API(API.Status.EXPERIMENTAL)
-public enum IndexFetchMethod {SCAN_AND_FETCH, USE_REMOTE_FETCH, USE_REMOTE_FETCH_WITH_FALLBACK}
+public enum IndexFetchMethod { SCAN_AND_FETCH, USE_REMOTE_FETCH, USE_REMOTE_FETCH_WITH_FALLBACK }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexFetchMethod.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexFetchMethod.java
@@ -1,0 +1,37 @@
+/*
+ * IndexFetchMethod.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.annotation.API;
+
+/**
+ * An indicator for the index fetch method to use for a query or an index scan.
+ * Possible values are:
+ * <UL>
+ * <LI>{@link IndexFetchMethod#SCAN_AND_FETCH} use regular index scan followed by fetch</LI>
+ * <LI>{@link IndexFetchMethod#USE_REMOTE_FETCH} use remote fetch feature from FDB</LI>
+ * <LI>{@link IndexFetchMethod#USE_REMOTE_FETCH_WITH_FALLBACK} use remote fetch ability with fallback to regular
+ * scan and fetch in case of failure. This is a safety measure meant to be used while the
+ * remote fetch mechanism is being tested</LI>
+ * </UL>
+ */
+@API(API.Status.EXPERIMENTAL)
+public enum IndexFetchMethod {SCAN_AND_FETCH, USE_REMOTE_FETCH, USE_REMOTE_FETCH_WITH_FALLBACK}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -60,8 +60,8 @@ import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
 import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.subspace.Subspace;
@@ -953,7 +953,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
 
     /**
      * Scan the records pointed to by an index. This version of the method can choose between various scan options as
-     * determined by the {@link RecordQueryPlannerConfiguration.IndexFetchMethod} parameter:
+     * determined by the {@link IndexFetchMethod} parameter:
      * <UL>
      *     <LI>SCAN_AND_FETCH: Scan the index and fetch each record individually</LI>
      *     <LI>USE_REMOTE_FETCH: Use FDB's remote fetch feature to scan the index and fetch the records in one call</LI>
@@ -973,13 +973,13 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
     @API(API.Status.EXPERIMENTAL)
     @Nonnull
     default RecordCursor<FDBIndexedRecord<M>> scanIndexRecords(@Nonnull final String indexName,
-                                                               @Nonnull final RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod,
+                                                               @Nonnull final IndexFetchMethod fetchMethod,
                                                                @Nonnull final IndexScanBounds scanBounds,
                                                                @Nullable final KeyExpression commonPrimaryKey,
                                                                @Nullable byte[] continuation,
                                                                @Nonnull IndexOrphanBehavior orphanBehavior,
                                                                @Nonnull ScanProperties scanProperties) {
-        if ((fetchMethod != RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) && (commonPrimaryKey == null)) {
+        if ((fetchMethod != IndexFetchMethod.SCAN_AND_FETCH) && (commonPrimaryKey == null)) {
             throw new RecordCoreArgumentException("scanIndexRecords with remote fetch requires a commonPrimaryKey", LogMessageKeys.INDEX_NAME, indexName);
         }
         if (!(scanBounds instanceof IndexScanRange)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -43,6 +43,7 @@ import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.cursors.FallbackCursor;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
@@ -67,6 +68,8 @@ import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
 import com.google.protobuf.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -120,6 +123,8 @@ import java.util.function.Supplier;
  */
 @API(API.Status.MAINTAINED)
 public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataProvider {
+
+    Logger LOGGER = LoggerFactory.getLogger(FDBRecordStoreBase.class);
 
     /**
      * Get the untyped record store associated with this possibly typed store.
@@ -995,10 +1000,10 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                     return new FallbackCursor<>(remoteFetchCursor,
                             lastSuccessfulResult -> remoteFetchFallbackFrom(indexName, scanRange.getScanType(), scanRange.getScanRange(), continuation, orphanBehavior, scanProperties, lastSuccessfulResult));
                 } catch (Exception ex) {
-                    //                    if (LOGGER.isWarnEnabled()) {
-                    //                        LOGGER.warn(KeyValueLogMessage.of("Remote Fetch execution failed, falling back to Index scan",
-                    //                                LogMessageKeys.PLAN_HASH, planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS)), ex);
-                    //                    }
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER.warn(KeyValueLogMessage.of("scanIndexRecords: Remote Fetch execution failed, falling back to Index scan",
+                                LogMessageKeys.INDEX_NAME, indexName, ex));
+                    }
                     return scanIndexRecords(indexName, scanRange.getScanType(), scanRange.getScanRange(), continuation, orphanBehavior, scanProperties);
                 }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryPlannerSortConfiguration;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule;
@@ -39,18 +40,6 @@ import java.util.stream.Stream;
  */
 @API(API.Status.MAINTAINED)
 public class RecordQueryPlannerConfiguration {
-    /**
-     * An indicator for the index fetch method to use for a query.
-     * Possible values are:
-     * <UL>
-     *     <LI>{@link IndexFetchMethod#SCAN_AND_FETCH} use regular index scan followed by fetch</LI>
-     *     <LI>{@link IndexFetchMethod#USE_REMOTE_FETCH} use remote fetch feature from FDB</LI>
-     *     <LI>{@link IndexFetchMethod#USE_REMOTE_FETCH_WITH_FALLBACK} use remote fetch ability with fallback to regular
-     *     scan and fetch in case of failure. This is a safety measure meant to be used while the
-     *     remote fetch mechanism is being tested</LI>
-     * </UL>
-     */
-    public enum IndexFetchMethod { SCAN_AND_FETCH, USE_REMOTE_FETCH, USE_REMOTE_FETCH_WITH_FALLBACK }
 
     @Nonnull
     private final QueryPlanner.IndexScanPreference indexScanPreference;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -159,7 +159,7 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
         IndexFetchMethod fetchMethod = indexFetchMethod;
         // Check here to allow for the store API_VERSION to change
         if ((indexFetchMethod != IndexFetchMethod.SCAN_AND_FETCH) &&
-            !store.getContext().getAPIVersion().isAtLeast(APIVersion.API_VERSION_7_1)) {
+                !store.getContext().getAPIVersion().isAtLeast(APIVersion.API_VERSION_7_1)) {
             if (LOGGER.isWarnEnabled()) {
                 LOGGER.warn(KeyValueLogMessage.of("Index remote fetch can only be used with API_VERSION of at least 7.1. Falling back to regular scan.",
                         LogMessageKeys.PLAN_HASH, planHash(PlanHashKind.STRUCTURAL_WITHOUT_LITERALS)));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
@@ -30,7 +30,7 @@ import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
@@ -85,7 +85,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchSimpleIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchSimpleIndexTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void indexPrefetchSimpleIndexTest(IndexFetchMethod fetchMethod) throws Exception {
         scanAndVerifyData("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN,
                 primaryKey(), null, 100,
                 (rec, i) -> {
@@ -99,7 +99,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchSimpleIndexReverseTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchSimpleIndexReverseTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void indexPrefetchSimpleIndexReverseTest(IndexFetchMethod fetchMethod) throws Exception {
         scanAndVerifyData("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.REVERSE_SCAN,
                 primaryKey(), null, 100,
                 (rec, i) -> {
@@ -113,7 +113,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchComplexIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchComplexIndexTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void indexPrefetchComplexIndexTest(IndexFetchMethod fetchMethod) throws Exception {
         scanAndVerifyData("MySimpleRecord$str_value_indexed", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN,
                 primaryKey(), null, 100,
                 (rec, i) -> {
@@ -127,7 +127,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchWithContinuationTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchWithContinuationTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void indexPrefetchWithContinuationTest(IndexFetchMethod fetchMethod) throws Exception {
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
                 .setReturnedRowLimit(5)
                 .build();
@@ -177,7 +177,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
         ScanProperties scanProperties = new ScanProperties(executeProperties, false);
 
         // First iteration - first 4 records
-        byte[] continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+        byte[] continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", IndexFetchMethod.USE_REMOTE_FETCH,
                 scanBounds(), scanProperties, primaryKey(), null, 4,
                 (rec, i) -> {
                     int primaryKey = 99 - i;
@@ -187,7 +187,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
                 }, splitRecordsHook);
 
         // Second iteration - second 4 records
-        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH,
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", IndexFetchMethod.SCAN_AND_FETCH,
                 scanBounds(), scanProperties, primaryKey(), continuation, 4,
                 (rec, i) -> {
                     int primaryKey = 95 - i;
@@ -197,7 +197,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
                 }, splitRecordsHook);
 
         // Third iteration - last 92 records
-        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", IndexFetchMethod.USE_REMOTE_FETCH,
                 scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), continuation, 92,
                 (rec, i) -> {
                     int primaryKey = 91 - i;
@@ -207,18 +207,18 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
                 }, splitRecordsHook);
 
         assertNull(continuation);
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 2, 98);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 2, 98);
     }
 
     @ParameterizedTest(name = "testScanLimit(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void testScanLimit(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void testScanLimit(IndexFetchMethod useIndexPrefetch) throws Exception {
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
                 .setScannedRecordsLimit(3)
                 .build();
         ScanProperties scanProperties = new ScanProperties(executeProperties, false);
 
-        byte[] continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+        byte[] continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", IndexFetchMethod.USE_REMOTE_FETCH,
                 scanBounds(), scanProperties, primaryKey(), null, 3,
                 (rec, i) -> {
                     int primaryKey = 99 - i;
@@ -232,7 +232,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
                 .build();
         scanProperties = new ScanProperties(executeProperties, false);
 
-        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", IndexFetchMethod.USE_REMOTE_FETCH,
                 scanBounds(), scanProperties, primaryKey(), continuation, 1,
                 (rec, i) -> {
                     int primaryKey = 96 - i;
@@ -246,7 +246,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
                 .build();
         scanProperties = new ScanProperties(executeProperties, false);
 
-        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", IndexFetchMethod.USE_REMOTE_FETCH,
                 scanBounds(), scanProperties, primaryKey(), continuation, 96,
                 (rec, i) -> {
                     int primaryKey = 95 - i;
@@ -263,7 +263,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "testReadYourWriteInRange(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void testReadYourWriteInRange(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void testReadYourWriteInRange(IndexFetchMethod fetchMethod) throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
         try (FDBRecordContext context = openContext()) {
@@ -275,7 +275,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
             recBuilder.setStrValueIndexed("blah");
             recordStore.saveRecord(recBuilder.build());
 
-            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+            if (fetchMethod == IndexFetchMethod.USE_REMOTE_FETCH) {
                 assertThrows(ExecutionException.class, () -> scanToList(context, "MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), null));
             } else {
                 scanAndVerifyData(context, "MySimpleRecord$num_value_unique", fetchMethod,
@@ -301,7 +301,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "failAfterRecordsReturnedTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void failAfterRecordsReturnedTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void failAfterRecordsReturnedTest(IndexFetchMethod fetchMethod) throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
         List<TestRecords1Proto.MySimpleRecord> created = saveManyRecords();
@@ -321,7 +321,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
             // data (essentially the first few pages of data from scanning the index), but once it
             // gets to the final page, it should fail because it sees a modified range when trying to look
             // up the record
-            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+            if (fetchMethod == IndexFetchMethod.USE_REMOTE_FETCH) {
                 assertThrows(ExecutionException.class, () -> scanToList(context, "MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), null));
             } else {
                 scanAndVerifyData(context, "MySimpleRecord$num_value_unique", fetchMethod,
@@ -338,7 +338,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "failAfterRecordsReturnedReverseTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void failAfterRecordsReturnedReverseTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void failAfterRecordsReturnedReverseTest(IndexFetchMethod fetchMethod) throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
         List<TestRecords1Proto.MySimpleRecord> created = saveManyRecords();
@@ -358,7 +358,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
             // data (essentially the first few pages of data from scanning the index), but once it
             // gets to the final page, it should fail because it sees a modified range when trying to look
             // up the record
-            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+            if (fetchMethod == IndexFetchMethod.USE_REMOTE_FETCH) {
                 assertThrows(ExecutionException.class, () -> scanToList(context, "MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.REVERSE_SCAN, primaryKey(), null));
             } else {
                 scanAndVerifyData(context, "MySimpleRecord$num_value_unique", fetchMethod,
@@ -381,7 +381,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
 
         try (FDBRecordContext context = openContext()) {
             uncheckedOpenSimpleRecordStore(context, splitRecordsHook);
-            Exception ex = assertThrows(ExecutionException.class, () -> scanIndex(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.ERROR, ScanProperties.FORWARD_SCAN));
+            Exception ex = assertThrows(ExecutionException.class, () -> scanIndex(IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.ERROR, ScanProperties.FORWARD_SCAN));
             assertTrue(ex.getCause() instanceof RecordCoreStorageException);
         }
     }
@@ -395,7 +395,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
         List<FDBIndexedRecord<Message>> records;
         try (FDBRecordContext context = openContext()) {
             uncheckedOpenSimpleRecordStore(context, splitRecordsHook);
-            records = scanIndex(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.SKIP, ScanProperties.FORWARD_SCAN);
+            records = scanIndex(IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.SKIP, ScanProperties.FORWARD_SCAN);
         }
         assertEquals(99, records.size());
         long c = 99;
@@ -408,7 +408,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
             }
             c--;
         }
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 100);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 1, 100);
     }
 
     @Test
@@ -420,7 +420,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
         List<FDBIndexedRecord<Message>> records;
         try (FDBRecordContext context = openContext()) {
             uncheckedOpenSimpleRecordStore(context, splitRecordsHook);
-            records = scanIndex(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.RETURN, ScanProperties.FORWARD_SCAN);
+            records = scanIndex(IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.RETURN, ScanProperties.FORWARD_SCAN);
         }
         assertEquals(100, records.size());
         long c = 99;
@@ -432,10 +432,10 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
             }
             c--;
         }
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 101);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 1, 101);
     }
 
-    private List<FDBIndexedRecord<Message>> scanIndex(final RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod,
+    private List<FDBIndexedRecord<Message>> scanIndex(final IndexFetchMethod fetchMethod,
                                                       final IndexOrphanBehavior orphanBehavior, final ScanProperties scanProperties) throws InterruptedException, ExecutionException {
         return recordStore.scanIndexRecords("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(),
                 primaryKey(), null, orphanBehavior, scanProperties).asList().get();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
@@ -51,7 +51,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -289,7 +288,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
                             }
                             int numValue = 1000 - primaryKey;
                             assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue);
-                });
+                        });
                 assertCounters(fetchMethod, 1, 60);
             }
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
@@ -1,0 +1,530 @@
+/*
+ * FDBRecordStoreIndexPrefetchTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.RecordCoreStorageException;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.ParameterizedTest.ARGUMENTS_WITH_NAMES_PLACEHOLDER;
+
+/**
+ * A test for the remote fetch index scan wrapper.
+ */
+@Tag(Tags.RequiresFDB)
+class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
+    protected static final RecordQuery IN_VALUE = RecordQuery.newBuilder()
+            .setRecordType("MySimpleRecord")
+            .setFilter(Query.field("num_value_unique").in(List.of(1000, 990, 980, 970, 960)))
+            .build();
+
+    protected static final RecordQuery OR_AND_VALUE = RecordQuery.newBuilder()
+            .setRecordType("MySimpleRecord")
+            .setFilter(Query.or(
+                    Query.field("num_value_unique").equalsValue(1000),
+                    Query.and(
+                            Query.field("num_value_unique").greaterThanOrEquals(900),
+                            Query.field("num_value_unique").lessThan(910))))
+            .build();
+
+    private boolean useSplitRecords = true;
+
+    @BeforeEach
+    void setup() throws Exception {
+        complexQuerySetup(splitRecordsHook);
+    }
+
+    @ParameterizedTest(name = "indexPrefetchSimpleIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void indexPrefetchSimpleIndexTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+        scanAndVerifyData("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN,
+                primaryKey(), null, 100,
+                (rec, i) -> {
+                    int primaryKey = 99 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+        assertCounters(fetchMethod, 1, 101);
+    }
+
+    @ParameterizedTest(name = "indexPrefetchSimpleIndexReverseTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void indexPrefetchSimpleIndexReverseTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+        scanAndVerifyData("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.REVERSE_SCAN,
+                primaryKey(), null, 100,
+                (rec, i) -> {
+                    int primaryKey = i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+        assertCounters(fetchMethod, 1, 101);
+    }
+
+    @ParameterizedTest(name = "indexPrefetchComplexIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void indexPrefetchComplexIndexTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+        scanAndVerifyData("MySimpleRecord$str_value_indexed", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN,
+                primaryKey(), null, 100,
+                (rec, i) -> {
+                    int primaryKey = (i < 50) ? (i * 2) : ((i - 50) * 2) + 1;
+                    String strValue = (i < 50) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$str_value_indexed", strValue, primaryKey);
+                }, splitRecordsHook);
+        assertCounters(fetchMethod, 1, 101);
+    }
+
+    @ParameterizedTest(name = "indexPrefetchWithContinuationTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void indexPrefetchWithContinuationTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+        ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                .setReturnedRowLimit(5)
+                .build();
+        ScanProperties scanProperties = new ScanProperties(executeProperties, false);
+
+        // First iteration - first 5 records
+        byte[] continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), scanProperties,
+                primaryKey(), null, 5,
+                (rec, i) -> {
+                    int primaryKey = 99 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+        assertCounters(fetchMethod, 1, 6);
+        // Second iteration - next 5 records
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), scanProperties,
+                primaryKey(), continuation, 5,
+                (rec, i) -> {
+                    int primaryKey = 94 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+        // Third iteration - final 90 records
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN,
+                primaryKey(), continuation, 90,
+                (rec, i) -> {
+                    int primaryKey = 89 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+
+        assertNull(continuation);
+        assertCounters(fetchMethod, 3, 103);
+    }
+
+    /*
+     * Test continuation where the continued plan uses a different prefetch mode than the original plan.
+     */
+    @Test
+    void indexPrefetchWithMixedContinuationTest() throws Exception {
+        ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                .setReturnedRowLimit(4)
+                .build();
+        ScanProperties scanProperties = new ScanProperties(executeProperties, false);
+
+        // First iteration - first 4 records
+        byte[] continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+                scanBounds(), scanProperties, primaryKey(), null, 4,
+                (rec, i) -> {
+                    int primaryKey = 99 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+
+        // Second iteration - second 4 records
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH,
+                scanBounds(), scanProperties, primaryKey(), continuation, 4,
+                (rec, i) -> {
+                    int primaryKey = 95 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+
+        // Third iteration - last 92 records
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+                scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), continuation, 92,
+                (rec, i) -> {
+                    int primaryKey = 91 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+
+        assertNull(continuation);
+        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 2, 98);
+    }
+
+    @ParameterizedTest(name = "testScanLimit(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void testScanLimit(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+        ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                .setScannedRecordsLimit(3)
+                .build();
+        ScanProperties scanProperties = new ScanProperties(executeProperties, false);
+
+        byte[] continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+                scanBounds(), scanProperties, primaryKey(), null, 3,
+                (rec, i) -> {
+                    int primaryKey = 99 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+
+        executeProperties = ExecuteProperties.newBuilder()
+                .setScannedRecordsLimit(1)
+                .build();
+        scanProperties = new ScanProperties(executeProperties, false);
+
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+                scanBounds(), scanProperties, primaryKey(), continuation, 1,
+                (rec, i) -> {
+                    int primaryKey = 96 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+
+        executeProperties = ExecuteProperties.newBuilder()
+                .setScannedRecordsLimit(100)
+                .build();
+        scanProperties = new ScanProperties(executeProperties, false);
+
+        continuation = scanAndVerifyData("MySimpleRecord$num_value_unique", RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH,
+                scanBounds(), scanProperties, primaryKey(), continuation, 96,
+                (rec, i) -> {
+                    int primaryKey = 95 - i;
+                    String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                    int numValue = 1000 - primaryKey;
+                    assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
+                }, splitRecordsHook);
+
+        assertNull(continuation);
+    }
+
+    /**
+     * This test writes a value to the store within the range of the scan.
+     */
+    @ParameterizedTest(name = "testReadYourWriteInRange(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void testReadYourWriteInRange(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+        assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, splitRecordsHook);
+            // Save record in range (don't commit)
+            TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
+            recBuilder.setRecNo(1);
+            recBuilder.setNumValueUnique(999);
+            recBuilder.setStrValueIndexed("blah");
+            recordStore.saveRecord(recBuilder.build());
+
+            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+                assertThrows(ExecutionException.class, () -> scanToList(context, "MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), null));
+            } else {
+                scanAndVerifyData(context, "MySimpleRecord$num_value_unique", fetchMethod,
+                        scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), null, 100,
+                        (rec, i) -> {
+                            int primaryKey = 99 - i;
+                            String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
+                            if (primaryKey == 1) {
+                                strValue = "blah";
+                            }
+                            int numValue = 1000 - primaryKey;
+                            assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue);
+                });
+                assertCounters(fetchMethod, 1, 60);
+            }
+        }
+    }
+
+    /**
+     * This test captures the case that FDB fails the scan after it has already returned several records. A record gets
+     * modified in the transaction at a point that would allow FDB to fetch a few pages of payload before encountering
+     * the modified range conflict. This should be recovered by the fallback mode.
+     */
+    @ParameterizedTest(name = "failAfterRecordsReturnedTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void failAfterRecordsReturnedTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+        assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
+
+        List<TestRecords1Proto.MySimpleRecord> created = saveManyRecords();
+
+        // Modify record and then scan unmodified index
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, splitRecordsHook);
+
+            // Update a record. This record will eventually be returned in a query, but we do *not* modify
+            // a field in the index being scanned, so that FDB does not detect the range conflict until later
+            TestRecords1Proto.MySimpleRecord lastRecord = created.get(created.size() - 1);
+            recordStore.saveRecord(lastRecord.toBuilder()
+                    .setStrValueIndexed("foo")
+                    .build());
+
+            // Use remote fetch to scan the num_value_unique index. The first few results should return
+            // data (essentially the first few pages of data from scanning the index), but once it
+            // gets to the final page, it should fail because it sees a modified range when trying to look
+            // up the record
+            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+                assertThrows(ExecutionException.class, () -> scanToList(context, "MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), null));
+            } else {
+                scanAndVerifyData(context, "MySimpleRecord$num_value_unique", fetchMethod,
+                        scanBounds(), ScanProperties.FORWARD_SCAN, primaryKey(), null, 500,
+                        (rec, i) -> {
+                            int primaryKey = i;
+                            int numValue = i;
+                            String strValue = (i == created.size() - 1) ? "foo" : "";
+                            assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue);
+                        });
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "failAfterRecordsReturnedReverseTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
+    @EnumSource()
+    void failAfterRecordsReturnedReverseTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+        assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
+
+        List<TestRecords1Proto.MySimpleRecord> created = saveManyRecords();
+
+        // Modify record and then scan unmodified index
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, splitRecordsHook);
+
+            // Update a record. This record will eventually be returned in a query, but we do *not* modify
+            // a field in the index being scanned, so that FDB does not detect the range conflict until later
+            TestRecords1Proto.MySimpleRecord lastRecord = created.get(0);
+            recordStore.saveRecord(lastRecord.toBuilder()
+                    .setStrValueIndexed("foo")
+                    .build());
+
+            // Use remote fetch to scan the num_value_unique index. The first few results should return
+            // data (essentially the first few pages of data from scanning the index), but once it
+            // gets to the final page, it should fail because it sees a modified range when trying to look
+            // up the record
+            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+                assertThrows(ExecutionException.class, () -> scanToList(context, "MySimpleRecord$num_value_unique", fetchMethod, scanBounds(), ScanProperties.REVERSE_SCAN, primaryKey(), null));
+            } else {
+                scanAndVerifyData(context, "MySimpleRecord$num_value_unique", fetchMethod,
+                        scanBounds(), ScanProperties.REVERSE_SCAN, primaryKey(), null, 500,
+                        (rec, i) -> {
+                            int primaryKey = 499 - i;
+                            int numValue = primaryKey;
+                            String strValue = (i == (created.size() - 1)) ? "foo" : "";
+                            assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue);
+                        });
+            }
+        }
+    }
+
+    @Test
+    void testOrphanPolicyError() throws Exception {
+        assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
+
+        createOrphanEntry();
+
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, splitRecordsHook);
+            Exception ex = assertThrows(ExecutionException.class, () -> scanIndex(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.ERROR, ScanProperties.FORWARD_SCAN));
+            assertTrue(ex.getCause() instanceof RecordCoreStorageException);
+        }
+    }
+
+    @Test
+    void testOrphanPolicySkip() throws Exception {
+        assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
+
+        createOrphanEntry();
+
+        List<FDBIndexedRecord<Message>> records;
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, splitRecordsHook);
+            records = scanIndex(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.SKIP, ScanProperties.FORWARD_SCAN);
+        }
+        assertEquals(99, records.size());
+        long c = 99;
+        for (FDBIndexedRecord<Message> rec : records) {
+            if (c != 2) {
+                assertEquals(c, rec.getStoredRecord().getPrimaryKey().get(0));
+            } else {
+                // skip the missing record
+                c--;
+            }
+            c--;
+        }
+        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 100);
+    }
+
+    @Test
+    void testOrphanPolicyReturn() throws Exception {
+        assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
+
+        createOrphanEntry();
+
+        List<FDBIndexedRecord<Message>> records;
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, splitRecordsHook);
+            records = scanIndex(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, IndexOrphanBehavior.RETURN, ScanProperties.FORWARD_SCAN);
+        }
+        assertEquals(100, records.size());
+        long c = 99;
+        for (FDBIndexedRecord<Message> rec : records) {
+            if (c != 2) {
+                assertEquals(c, rec.getStoredRecord().getPrimaryKey().get(0));
+            } else {
+                assertFalse(rec.hasStoredRecord());
+            }
+            c--;
+        }
+        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 101);
+    }
+
+    private List<FDBIndexedRecord<Message>> scanIndex(final RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod,
+                                                      final IndexOrphanBehavior orphanBehavior, final ScanProperties scanProperties) throws InterruptedException, ExecutionException {
+        return recordStore.scanIndexRecords("MySimpleRecord$num_value_unique", fetchMethod, scanBounds(),
+                primaryKey(), null, orphanBehavior, scanProperties).asList().get();
+    }
+
+    private void createOrphanEntry() throws Exception {
+        // Unchecked open the store, remove the index and then delete a record. This will create an orphan entry in the index.
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, builder -> {
+                builder.removeIndex("MySimpleRecord$num_value_unique");
+            });
+            recordStore.deleteRecord(Tuple.from(2L));
+            commit(context);
+        }
+    }
+
+    public boolean isUseSplitRecords() {
+        return useSplitRecords;
+    }
+
+    public void setUseSplitRecords(final boolean useSplitRecords) {
+        this.useSplitRecords = useSplitRecords;
+    }
+
+    private KeyExpression primaryKey() {
+        return recordStore.getRecordMetaData().getRecordType("MySimpleRecord").getPrimaryKey();
+    }
+
+    @Nonnull
+    private IndexScanRange scanBounds() {
+        return new IndexScanRange(IndexScanType.BY_VALUE, TupleRange.ALL);
+    }
+
+    @Nonnull
+    private final RecordMetaDataHook splitRecordsHook = metaDataBuilder -> {
+        // UseSplitRecords can be set to different values to impact the way the store is opened
+        metaDataBuilder.setSplitLongRecords(isUseSplitRecords());
+        metaDataBuilder.addIndex("MySimpleRecord", "PrimaryKeyIndex", "rec_no");
+    };
+
+    private void assertRecordWithPrimaryKeyIndex(final FDBQueriedRecord<Message> rec, final long primaryKey, final String strValue, final int numValue, final String indexName, final Object indexedValue) {
+        IndexEntry indexEntry = rec.getIndexEntry();
+        assertThat(indexEntry.getIndex().getName(), equalTo(indexName));
+        List<Object> indexElements = indexEntry.getKey().getItems();
+        assertThat(indexElements.size(), equalTo(1));
+        assertThat(indexElements.get(0), equalTo(primaryKey));
+        List<Object> indexPrimaryKey = indexEntry.getPrimaryKey().getItems();
+        assertThat(indexPrimaryKey.size(), equalTo(1));
+        assertThat(indexPrimaryKey.get(0), equalTo(primaryKey));
+
+        FDBStoredRecord<Message> storedRecord = rec.getStoredRecord();
+        assertThat(storedRecord.getPrimaryKey().get(0), equalTo(primaryKey));
+        assertThat(storedRecord.getRecordType().getName(), equalTo("MySimpleRecord"));
+
+        TestRecords1Proto.MySimpleRecord.Builder myrec = TestRecords1Proto.MySimpleRecord.newBuilder();
+        myrec.mergeFrom(Objects.requireNonNull(rec).getRecord());
+        assertThat(myrec.getRecNo(), equalTo(primaryKey));
+        assertThat(myrec.getStrValueIndexed(), equalTo(strValue));
+        assertThat(myrec.getNumValueUnique(), equalTo(numValue));
+    }
+
+    private List<TestRecords1Proto.MySimpleRecord> saveManyRecords() {
+        List<TestRecords1Proto.MySimpleRecord> created = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            created.add(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(i)
+                    .setNumValue3Indexed(i % 3)
+                    .setNumValueUnique(i)
+                    .build());
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, splitRecordsHook);
+            recordStore.deleteAllRecords();
+            commit(context);
+        }
+        Iterator<TestRecords1Proto.MySimpleRecord> createdIterator = created.iterator();
+        while (createdIterator.hasNext()) {
+            try (FDBRecordContext context = openContext()) {
+                openSimpleRecordStore(context, splitRecordsHook);
+                int i = 0;
+                while (i < 50 && createdIterator.hasNext()) {
+                    recordStore.saveRecord(createdIterator.next());
+                    i++;
+                }
+                commit(context);
+            }
+        }
+
+        return created;
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchMultiColumnKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchMultiColumnKeyTest.java
@@ -27,7 +27,7 @@ import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestRecordsWithHeaderProto;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
@@ -73,7 +73,7 @@ class RemoteFetchMultiColumnKeyTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "testMultiColumnPrimaryKeyNoKeyInIndex(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    public void testMultiColumnPrimaryKeyNoKeyInIndex(RecordQueryPlannerConfiguration.IndexFetchMethod indexFetchMethod) throws Exception {
+    public void testMultiColumnPrimaryKeyNoKeyInIndex(IndexFetchMethod indexFetchMethod) throws Exception {
         List<FDBQueriedRecord<Message>> records = executeQuery(indexFetchMethod, recordMetadataStrValueIndex(), STR_HELLO);
         assertRecordStrIndex(records.get(0), "aaa", 1, "hello");
     }
@@ -84,7 +84,7 @@ class RemoteFetchMultiColumnKeyTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "testMultiColumnPrimaryKeyRecnoInIndex(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    public void testMultiColumnPrimaryKeyRecnoInIndex(RecordQueryPlannerConfiguration.IndexFetchMethod indexFetchMethod) throws Exception {
+    public void testMultiColumnPrimaryKeyRecnoInIndex(IndexFetchMethod indexFetchMethod) throws Exception {
         List<FDBQueriedRecord<Message>> records = executeQuery(indexFetchMethod, recordMetadataRecnoIndex(), REC_NO_1);
         assertRecordRecnoIndex(records.get(0), "aaa", 1, "hello");
     }
@@ -96,12 +96,12 @@ class RemoteFetchMultiColumnKeyTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "testMultiColumnPrimaryKeyPathInIndex(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    public void testMultiColumnPrimaryKeyPathInIndex(RecordQueryPlannerConfiguration.IndexFetchMethod indexFetchMethod) throws Exception {
+    public void testMultiColumnPrimaryKeyPathInIndex(IndexFetchMethod indexFetchMethod) throws Exception {
         List<FDBQueriedRecord<Message>> records = executeQuery(indexFetchMethod, recordMetadataPathIndex(), PATH_AAA);
         assertRecordPathIndex(records.get(0), "aaa", 1, "hello");
     }
 
-    private List<FDBQueriedRecord<Message>> executeQuery(final RecordQueryPlannerConfiguration.IndexFetchMethod indexFetchMethod, final RecordMetaData metaData, final RecordQuery query) throws InterruptedException, ExecutionException {
+    private List<FDBQueriedRecord<Message>> executeQuery(final IndexFetchMethod indexFetchMethod, final RecordMetaData metaData, final RecordQuery query) throws InterruptedException, ExecutionException {
         populateRecords(metaData);
         List<FDBQueriedRecord<Message>> records;
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchOldVersionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchOldVersionTest.java
@@ -30,8 +30,8 @@ import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
@@ -61,7 +61,7 @@ public class RemoteFetchOldVersionTest extends RemoteFetchTestBase {
 
     @ParameterizedTest
     @EnumSource()
-    void oldVersionFormatTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void oldVersionFormatTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990, useIndexPrefetch);
 
         int count = 0;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.record.TestRecords1Proto;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +46,7 @@ class RemoteFetchSplitRecordsTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchSplitRecordTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchSplitRecordTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchSplitRecordTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         saveLargeRecord(1, 200, 2000);
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990, useIndexPrefetch);
 
@@ -65,7 +65,7 @@ class RemoteFetchSplitRecordsTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchSplitRecordReverseTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchSplitRecordReverseTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchSplitRecordReverseTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         saveLargeRecord(1, 200, 2000);
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990_REVERSE, useIndexPrefetch);
 
@@ -84,7 +84,7 @@ class RemoteFetchSplitRecordsTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchManySplitRecordTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchManySplitRecordTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchManySplitRecordTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         // TODO: This test actually runs the API in a way that returns results that are too large: Over 50MB
         // FDB will fix the issue to limit the bytes returned and then this test would need to adjust accordingly.
         int numTransactions = 8;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
@@ -33,7 +33,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
@@ -92,7 +92,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchSimpleIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchSimpleIndexTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchSimpleIndexTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990, useIndexPrefetch);
         executeAndVerifyData(plan, 10, (rec, i) -> {
             int primaryKey = 9 - i;
@@ -105,7 +105,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchSimpleIndexReverseTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchSimpleIndexReverseTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchSimpleIndexReverseTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990_REVERSE, useIndexPrefetch);
         executeAndVerifyData(plan, 10, (rec, i) -> {
             int primaryKey = i;
@@ -125,7 +125,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "indexPrefetchPrimaryKeyIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchPrimaryKeyIndexTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchPrimaryKeyIndexTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(PRIMARY_KEY_EQUAL, useIndexPrefetch);
         executeAndVerifyData(plan, 1, (rec, i) -> {
             int primaryKey = 1;
@@ -138,7 +138,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchComplexIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchComplexIndexTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchComplexIndexTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(STR_VALUE_EVEN, useIndexPrefetch);
         executeAndVerifyData(plan, 50, (rec, i) -> {
             int primaryKey = i * 2;
@@ -150,7 +150,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchInQueryTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchInQueryTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchInQueryTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(IN_VALUE, useIndexPrefetch);
         executeAndVerifyData(plan, 5, (rec, i) -> {
             int primaryKey = i * 10;
@@ -161,7 +161,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchAndOrQueryTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchAndOrQueryTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchAndOrQueryTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(OR_AND_VALUE, useIndexPrefetch);
         executeAndVerifyData(plan, 10, (rec, i) -> {
             int primaryKey = (i == 9) ? 0 : (99 - i);
@@ -173,7 +173,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "indexPrefetchWithContinuationTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void indexPrefetchWithContinuationTest(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchWithContinuationTest(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990, useIndexPrefetch);
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
                 .setReturnedRowLimit(5)
@@ -207,8 +207,8 @@ class RemoteFetchTest extends RemoteFetchTestBase {
      */
     @Test
     void indexPrefetchWithMixedContinuationTest() throws Exception {
-        RecordQueryPlan planWithPrefetch = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH);
-        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH);
+        RecordQueryPlan planWithPrefetch = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.USE_REMOTE_FETCH);
+        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.SCAN_AND_FETCH);
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
                 .setReturnedRowLimit(4)
                 .build();
@@ -235,16 +235,16 @@ class RemoteFetchTest extends RemoteFetchTestBase {
             assertRecord(rec, primaryKey, strValue, numValue, "MySimpleRecord$num_value_unique", (long)numValue, primaryKey);
         }, splitRecordsHook);
         assertNull(continuation);
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 2, 8);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 2, 8);
     }
 
     @ParameterizedTest(name = "indexPrefetchByteLimitContinuation(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
     @Disabled("This test is inconsistently failing when running as part of the larger suite")
-    void indexPrefetchByteLimitContinuation(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void indexPrefetchByteLimitContinuation(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990, useIndexPrefetch);
         // TODO: Why should the index prefetch take so many more bytes to scan the same number of records? Maybe the index scan counts the records and the fetch does not?
-        int scanBytesLimit = (useIndexPrefetch == RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) ? 350 : 1300;
+        int scanBytesLimit = (useIndexPrefetch == IndexFetchMethod.SCAN_AND_FETCH) ? 350 : 1300;
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
                 .setScannedBytesLimit(scanBytesLimit)
                 .build();
@@ -270,7 +270,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "testScanLimit(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void testScanLimit(RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) throws Exception {
+    void testScanLimit(IndexFetchMethod useIndexPrefetch) throws Exception {
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990, useIndexPrefetch);
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
                 .setScannedRecordsLimit(3)
@@ -310,8 +310,8 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @Test
     void testIndexPrefetchWithComparatorPlan() throws Exception {
-        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH);
-        RecordQueryPlan planWithPrefetch = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH);
+        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.SCAN_AND_FETCH);
+        RecordQueryPlan planWithPrefetch = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.USE_REMOTE_FETCH);
         ExecuteProperties executeProperties = ExecuteProperties.SERIAL_EXECUTE;
         RecordQueryPlan plan = RecordQueryComparatorPlan.from(List.of(planWithScan, planWithPrefetch), primaryKey(), 0, true);
 
@@ -323,13 +323,13 @@ class RemoteFetchTest extends RemoteFetchTestBase {
                 assertNotNull(cursor.asList().get());
             }
         }
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 11);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 1, 11);
     }
 
     @Test
     void testIndexPrefetchWithComparatorPlanFails() throws Exception {
-        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH);
-        RecordQueryPlan planWithPrefetch = plan(STR_VALUE_EVEN, RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH);
+        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.SCAN_AND_FETCH);
+        RecordQueryPlan planWithPrefetch = plan(STR_VALUE_EVEN, IndexFetchMethod.USE_REMOTE_FETCH);
         ExecuteProperties executeProperties = ExecuteProperties.SERIAL_EXECUTE;
         RecordQueryPlan plan = RecordQueryComparatorPlan.from(List.of(planWithScan, planWithPrefetch), primaryKey(), 0, true);
 
@@ -339,7 +339,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
                 assertThrows(ExecutionException.class, () -> cursor.asList().get());
             }
         }
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 1);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 1, 1);
     }
 
     /**
@@ -347,7 +347,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "testReadYourWriteInRange(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void testReadYourWriteInRange(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void testReadYourWriteInRange(IndexFetchMethod fetchMethod) throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
         try (FDBRecordContext context = openContext()) {
@@ -361,7 +361,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
             RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_990, fetchMethod);
 
-            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+            if (fetchMethod == IndexFetchMethod.USE_REMOTE_FETCH) {
                 assertThrows(ExecutionException.class, () -> executeToList(context, plan, null, ExecuteProperties.SERIAL_EXECUTE));
             } else {
                 executeAndVerifyData(context, plan, null, ExecuteProperties.SERIAL_EXECUTE, 10, (rec, i) -> {
@@ -383,7 +383,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "testReadYourWriteOutOfRangeSucceeds(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void testReadYourWriteOutOfRangeSucceeds(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void testReadYourWriteOutOfRangeSucceeds(IndexFetchMethod fetchMethod) throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
         try (FDBRecordContext context = openContext()) {
@@ -415,7 +415,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
      */
     @ParameterizedTest(name = "failAfterRecordsReturnedTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void failAfterRecordsReturnedTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void failAfterRecordsReturnedTest(IndexFetchMethod fetchMethod) throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
         List<TestRecords1Proto.MySimpleRecord> created = saveManyRecords();
@@ -436,7 +436,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
             // gets to the final page, it should fail because it sees a modified range when trying to look
             // up the record
             RecordQueryPlan plan = plan(NUM_VALUES_LARGER_EQUAL_0, fetchMethod);
-            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+            if (fetchMethod == IndexFetchMethod.USE_REMOTE_FETCH) {
                 assertThrows(ExecutionException.class, () -> executeToList(context, plan, null, ExecuteProperties.SERIAL_EXECUTE));
             } else {
                 executeAndVerifyData(context, plan, null, ExecuteProperties.SERIAL_EXECUTE, 500, (rec, i) -> {
@@ -451,7 +451,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
 
     @ParameterizedTest(name = "failAfterRecordsReturnedReverseTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()
-    void failAfterRecordsReturnedReverseTest(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    void failAfterRecordsReturnedReverseTest(IndexFetchMethod fetchMethod) throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
         List<TestRecords1Proto.MySimpleRecord> created = saveManyRecords();
@@ -472,7 +472,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
             // gets to the final page, it should fail because it sees a modified range when trying to look
             // up the record
             RecordQueryPlan plan = plan(NUM_VALUES_LARGER_EQUAL_0_REVERSE, fetchMethod);
-            if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH) {
+            if (fetchMethod == IndexFetchMethod.USE_REMOTE_FETCH) {
                 assertThrows(ExecutionException.class, () -> executeToList(context, plan, null, ExecuteProperties.SERIAL_EXECUTE));
             } else {
                 executeAndVerifyData(context, plan, null, ExecuteProperties.SERIAL_EXECUTE, 500, (rec, i) -> {
@@ -489,9 +489,9 @@ class RemoteFetchTest extends RemoteFetchTestBase {
     void indexPrefetchSimpleIndexFallbackTest() throws Exception {
         assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
 
-        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH);
-        RecordQueryPlan planWithPrefetch = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH);
-        RecordQueryPlan planWithFallback = plan(NUM_VALUES_LARGER_THAN_990, RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH_WITH_FALLBACK);
+        RecordQueryPlan planWithScan = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.SCAN_AND_FETCH);
+        RecordQueryPlan planWithPrefetch = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.USE_REMOTE_FETCH);
+        RecordQueryPlan planWithFallback = plan(NUM_VALUES_LARGER_THAN_990, IndexFetchMethod.USE_REMOTE_FETCH_WITH_FALLBACK);
         RecordQueryPlan comparatorPlan = RecordQueryComparatorPlan.from(List.of(planWithScan, planWithFallback), primaryKey(), 0, true);
 
         ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
@@ -546,7 +546,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
             }
             c--;
         }
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 100);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 1, 100);
     }
 
     @Test
@@ -570,7 +570,7 @@ class RemoteFetchTest extends RemoteFetchTestBase {
             }
             c--;
         }
-        assertCounters(RecordQueryPlannerConfiguration.IndexFetchMethod.USE_REMOTE_FETCH, 1, 101);
+        assertCounters(IndexFetchMethod.USE_REMOTE_FETCH, 1, 101);
     }
 
     private List<FDBIndexedRecord<Message>> scanIndex(final IndexOrphanBehavior orphanBehavior) throws InterruptedException, ExecutionException {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
@@ -32,7 +32,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.query.FDBRecordStoreQueryTestBase;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
@@ -133,7 +133,7 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
     }
 
     @Nonnull
-    protected RecordQueryPlan plan(final RecordQuery query, final RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) {
+    protected RecordQueryPlan plan(final RecordQuery query, final IndexFetchMethod useIndexPrefetch) {
         planner.setConfiguration(planner.getConfiguration()
                 .asBuilder()
                 .setIndexFetchMethod(useIndexPrefetch)
@@ -168,7 +168,7 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
         return lastContinuation;
     }
 
-    protected byte[] scanAndVerifyData(String indexName, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod, IndexScanBounds scanBounds,
+    protected byte[] scanAndVerifyData(String indexName, IndexFetchMethod fetchMethod, IndexScanBounds scanBounds,
                                        final ScanProperties scanProperties, KeyExpression commonPrimaryKey, byte[] continuation,
                                        int expectedRecords, BiConsumer<FDBQueriedRecord<Message>, Integer> recordVerifier, RecordMetaDataHook metaDataHook) {
         byte[] lastContinuation;
@@ -181,7 +181,7 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
     }
 
     @Nullable
-    protected byte[] scanAndVerifyData(FDBRecordContext context, String indexName, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod,
+    protected byte[] scanAndVerifyData(FDBRecordContext context, String indexName, IndexFetchMethod fetchMethod,
                                      IndexScanBounds scanBounds, final ScanProperties scanProperties, final KeyExpression commonPrimaryKey, final byte[] continuation,
                                      int expectedRecords, BiConsumer<FDBQueriedRecord<Message>, Integer> recordVerifier) {
         byte[] lastContinuation;
@@ -209,9 +209,9 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
         return iterator.getContinuation();
     }
 
-    protected void assertCounters(final RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch, final int expectedRemoteFetches, final int expectedRemoteFetchEntries) {
-        if ((useIndexPrefetch != RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) &&
-                (recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1))) {
+    protected void assertCounters(final IndexFetchMethod useIndexPrefetch, final int expectedRemoteFetches, final int expectedRemoteFetchEntries) {
+        if ((useIndexPrefetch != IndexFetchMethod.SCAN_AND_FETCH) &&
+            (recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1))) {
 
             StoreTimer.Counter numRemoteFetches = recordStore.getTimer().getCounter(REMOTE_FETCH);
             StoreTimer.Counter numRemoteFetchEntries = recordStore.getTimer().getCounter(SCAN_REMOTE_FETCH_ENTRY);
@@ -229,7 +229,7 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
         return results;
     }
 
-    protected List<FDBQueriedRecord<Message>> scanToList(FDBRecordContext context, String indexName, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod,
+    protected List<FDBQueriedRecord<Message>> scanToList(FDBRecordContext context, String indexName, IndexFetchMethod fetchMethod,
                                                          IndexScanBounds scanBounds, final ScanProperties scanProperties, final KeyExpression commonPrimaryKey,
                                                          final byte[] continuation) throws Exception {
         final List<FDBQueriedRecord<Message>> results;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
@@ -211,7 +211,7 @@ public class RemoteFetchTestBase extends FDBRecordStoreQueryTestBase {
 
     protected void assertCounters(final IndexFetchMethod useIndexPrefetch, final int expectedRemoteFetches, final int expectedRemoteFetchEntries) {
         if ((useIndexPrefetch != IndexFetchMethod.SCAN_AND_FETCH) &&
-            (recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1))) {
+                (recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1))) {
 
             StoreTimer.Counter numRemoteFetches = recordStore.getTimer().getCounter(REMOTE_FETCH);
             StoreTimer.Counter numRemoteFetchEntries = recordStore.getTimer().getCounter(SCAN_REMOTE_FETCH_ENTRY);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
@@ -68,8 +68,8 @@ import com.apple.foundationdb.record.provider.foundationdb.KeyValueCursor;
 import com.apple.foundationdb.record.provider.foundationdb.TestKeySpace;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
-import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
@@ -244,7 +244,7 @@ public class VersionIndexTest extends FDBTestBase {
     // Provide a combination of format versions, split and a remote fetch option
     private static Stream<Arguments> formatVersionArgumentsWithRemoteFetch() {
         return formatVersionArguments()
-                .flatMap(arg -> Arrays.stream(RecordQueryPlannerConfiguration.IndexFetchMethod.values())
+                .flatMap(arg -> Arrays.stream(IndexFetchMethod.values())
                         .map(indexFetchMethod -> Arguments.of(arg.get()[0], arg.get()[1], indexFetchMethod)));
     }
 
@@ -600,7 +600,7 @@ public class VersionIndexTest extends FDBTestBase {
     @ParameterizedTest(name = "saveLoadWithFunctionVersion [" + ARGUMENTS_PLACEHOLDER + "]")
     @MethodSource("formatVersionArgumentsWithRemoteFetch")
     @SuppressWarnings("try")
-    public void saveLoadWithFunctionVersion(int testFormatVersion, boolean testSplitLongRecords, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    public void saveLoadWithFunctionVersion(int testFormatVersion, boolean testSplitLongRecords, IndexFetchMethod fetchMethod) throws Exception {
         formatVersion = testFormatVersion;
         splitLongRecords = testSplitLongRecords;
 
@@ -859,7 +859,7 @@ public class VersionIndexTest extends FDBTestBase {
     @ParameterizedTest(name = "saveLoadWithRepeatedVersion [formatVersion = {0}, splitLongRecords = {1}]")
     @MethodSource("formatVersionArgumentsWithRemoteFetch")
     @SuppressWarnings("try")
-    public void scanWithIncompleteVersion(int testFormatVersion, boolean testSplitLongRecords, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    public void scanWithIncompleteVersion(int testFormatVersion, boolean testSplitLongRecords, IndexFetchMethod fetchMethod) throws Exception {
         formatVersion = testFormatVersion;
         splitLongRecords = testSplitLongRecords;
 
@@ -1005,7 +1005,7 @@ public class VersionIndexTest extends FDBTestBase {
     @ParameterizedTest(name = "updateWithinContext [" + ARGUMENTS_PLACEHOLDER + "]")
     @MethodSource("formatVersionArgumentsWithRemoteFetch")
     @SuppressWarnings("try")
-    public void updateWithinContext(int testFormatVersion, boolean testSplitLongRecords, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    public void updateWithinContext(int testFormatVersion, boolean testSplitLongRecords, IndexFetchMethod fetchMethod) throws Exception {
         formatVersion = testFormatVersion;
         splitLongRecords = testSplitLongRecords;
 
@@ -1721,7 +1721,7 @@ public class VersionIndexTest extends FDBTestBase {
     @ParameterizedTest(name = "queryOnVersion [" + ARGUMENTS_PLACEHOLDER + "]")
     @MethodSource("formatVersionArgumentsWithRemoteFetch")
     @SuppressWarnings("try")
-    public void queryOnVersion(int testFormatVersion, boolean testSplitLongRecords, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) {
+    public void queryOnVersion(int testFormatVersion, boolean testSplitLongRecords, IndexFetchMethod fetchMethod) {
         formatVersion = testFormatVersion;
         splitLongRecords = testSplitLongRecords;
 
@@ -1951,7 +1951,7 @@ public class VersionIndexTest extends FDBTestBase {
     @ParameterizedTest(name = "queryOnRepeatedVersions [" + ARGUMENTS_PLACEHOLDER + "]")
     @MethodSource("formatVersionArgumentsWithRemoteFetch")
     @SuppressWarnings("try")
-    public void queryOnRepeatedVersion(int testFormatVersion, boolean testSplitLongRecords, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) {
+    public void queryOnRepeatedVersion(int testFormatVersion, boolean testSplitLongRecords, IndexFetchMethod fetchMethod) {
         formatVersion = testFormatVersion;
         splitLongRecords = testSplitLongRecords;
 
@@ -2040,7 +2040,7 @@ public class VersionIndexTest extends FDBTestBase {
     @SuppressWarnings("try")
     @ParameterizedTest(name = "withMetaDataRebuilds [" + ARGUMENTS_PLACEHOLDER + "]")
     @MethodSource("formatVersionArgumentsWithRemoteFetch")
-    public void withMetaDataRebuilds(int testFormatVersion, boolean testSplitLongRecords, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) {
+    public void withMetaDataRebuilds(int testFormatVersion, boolean testSplitLongRecords, IndexFetchMethod fetchMethod) {
         formatVersion = testFormatVersion;
         splitLongRecords = testSplitLongRecords;
 
@@ -2196,7 +2196,7 @@ public class VersionIndexTest extends FDBTestBase {
     @SuppressWarnings("try")
     @ParameterizedTest(name = "upgradeFormatVersions [" + ARGUMENTS_PLACEHOLDER + "]")
     @MethodSource("formatVersionArgumentsWithRemoteFetch")
-    public void upgradeFormatVersions(int testFormatVersion, boolean splitLongRecords, RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) {
+    public void upgradeFormatVersions(int testFormatVersion, boolean splitLongRecords, IndexFetchMethod fetchMethod) {
         formatVersion = testFormatVersion;
         final RecordMetaDataHook hook = metaDataBuilder -> {
             simpleVersionHook.apply(metaDataBuilder);
@@ -2333,8 +2333,8 @@ public class VersionIndexTest extends FDBTestBase {
     }
 
     @ParameterizedTest(name = "testScanVersionIndex [" + ARGUMENTS_PLACEHOLDER + "]")
-    @EnumSource(RecordQueryPlannerConfiguration.IndexFetchMethod.class)
-    void testScanVersionIndex(RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod) throws Exception {
+    @EnumSource(IndexFetchMethod.class)
+    void testScanVersionIndex(IndexFetchMethod fetchMethod) throws Exception {
         MySimpleRecord record1 = MySimpleRecord.newBuilder().setRecNo(1066L).setNumValue2(42).setNumValue3Indexed(1).build();
         MySimpleRecord record2 = MySimpleRecord.newBuilder().setRecNo(1067L).setNumValue2(42).setNumValue3Indexed(2).build();
         MySimpleRecord record3 = MySimpleRecord.newBuilder().setRecNo(1068L).setNumValue2(43).setNumValue3Indexed(2).build();
@@ -2433,8 +2433,8 @@ public class VersionIndexTest extends FDBTestBase {
     }
 
     @Nonnull
-    private List<Tuple> scanIndexToKeys(final RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod, final String indexName, final ScanProperties direction) throws Exception {
-        if (fetchMethod == RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) {
+    private List<Tuple> scanIndexToKeys(final IndexFetchMethod fetchMethod, final String indexName, final ScanProperties direction) throws Exception {
+        if (fetchMethod == IndexFetchMethod.SCAN_AND_FETCH) {
             return recordStore.scanIndex(metaData.getIndex(indexName), IndexScanType.BY_VALUE, TupleRange.ALL, null, direction)
                     .map(IndexEntry::getKey)
                     .asList().get();
@@ -2452,10 +2452,10 @@ public class VersionIndexTest extends FDBTestBase {
     }
 
     @Nonnull
-    private List<FDBIndexedRecord<Message>> scanIndexToRecords(final RecordQueryPlannerConfiguration.IndexFetchMethod fetchMethod,
+    private List<FDBIndexedRecord<Message>> scanIndexToRecords(final IndexFetchMethod fetchMethod,
                                                                final String indexName,
                                                                final ScanProperties direction) throws Exception {
-        if (fetchMethod != RecordQueryPlannerConfiguration.IndexFetchMethod.SCAN_AND_FETCH) {
+        if (fetchMethod != IndexFetchMethod.SCAN_AND_FETCH) {
             assumeTrue(recordStore.getContext().isAPIVersionAtLeast(APIVersion.API_VERSION_7_1));
         }
 
@@ -2465,7 +2465,7 @@ public class VersionIndexTest extends FDBTestBase {
     }
 
     @Nonnull
-    protected RecordQueryPlan plan(final RecordQuery query, final RecordQueryPlannerConfiguration.IndexFetchMethod useIndexPrefetch) {
+    protected RecordQueryPlan plan(final RecordQuery query, final IndexFetchMethod useIndexPrefetch) {
         planner.setConfiguration(planner.getConfiguration()
                 .asBuilder()
                 .setIndexFetchMethod(useIndexPrefetch)


### PR DESCRIPTION
This PR creates a wrapper around index scan method: A new overload of `scanIndexRecords` that takes in an `IndexScanMethod` and delegates to the appropriate method. This is very similar to the work done in the `RecordQueryIndexPlan` (except that in the plan, the regular scan and fallback methods are managed by the plan and are not plain ValueIndex scans).
Added tests are a subset of the `RemoteFetchTests` adjusted for the new method instead of a plan execution.