### PR TITLE
Add missing Checkstyle WhitespaceAfter module.

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -123,14 +123,14 @@ public class MoreAsyncUtil {
      */
     @Nonnull
     public static <T> AsyncIterable<T> filterIterable(@Nonnull final AsyncIterable<T> iterable,
-                                                      @Nonnull final Function<T,Boolean> filter) {
+                                                      @Nonnull final Function<T, Boolean> filter) {
         return filterIterable(ForkJoinPool.commonPool(), iterable, filter);
     }
 
     @Nonnull
     public static <T> AsyncIterable<T> filterIterable(@Nonnull Executor executor,
                                                       @Nonnull final AsyncIterable<T> iterable,
-                                                      @Nonnull final Function<T,Boolean> filter) {
+                                                      @Nonnull final Function<T, Boolean> filter) {
         return new AsyncIterable<T>() {
             @Nonnull
             @Override
@@ -225,7 +225,7 @@ public class MoreAsyncUtil {
     public static <T> AsyncIterable<T> dedupIterable(@Nonnull Executor executor,
                                                      @Nonnull final AsyncIterable<T> iterable) {
         return filterIterable(executor, iterable,
-                new Function<T,Boolean>() {
+                new Function<T, Boolean>() {
                     private Object lastObj;
 
                     @Nonnull
@@ -384,17 +384,17 @@ public class MoreAsyncUtil {
      * @return the results of all the {@code AsyncIterable}s returned by func for each value of iterable, concatenated
      */
     @Nonnull
-    public static <T1,T2> AsyncIterable<T2> mapConcatIterable(@Nonnull final AsyncIterable<T1> iterable,
-                                                              @Nonnull final Function<T1,AsyncIterable<T2>> func,
-                                                              final int pipelineSize) {
+    public static <T1, T2> AsyncIterable<T2> mapConcatIterable(@Nonnull final AsyncIterable<T1> iterable,
+                                                               @Nonnull final Function<T1, AsyncIterable<T2>> func,
+                                                               final int pipelineSize) {
         return mapConcatIterable(ForkJoinPool.commonPool(), iterable, func, pipelineSize);
     }
 
     @Nonnull
-    public static <T1,T2> AsyncIterable<T2> mapConcatIterable(@Nonnull Executor executor,
-                                                              @Nonnull final AsyncIterable<T1> iterable,
-                                                              @Nonnull final Function<T1,AsyncIterable<T2>> func,
-                                                              final int pipelineSize) {
+    public static <T1, T2> AsyncIterable<T2> mapConcatIterable(@Nonnull Executor executor,
+                                                               @Nonnull final AsyncIterable<T1> iterable,
+                                                               @Nonnull final Function<T1, AsyncIterable<T2>> func,
+                                                               final int pipelineSize) {
         return new AsyncIterable<T2>() {
             @Nonnull
             @Override
@@ -540,7 +540,7 @@ public class MoreAsyncUtil {
      */
     @Nonnull
     static <T> AsyncIterable<T> filterToIterable(final T item,
-                                                 @Nonnull final Function<T,CompletableFuture<Boolean>> filter) {
+                                                 @Nonnull final Function<T, CompletableFuture<Boolean>> filter) {
         return new AsyncIterable<T>() {
             @Nullable
             @Override
@@ -620,7 +620,7 @@ public class MoreAsyncUtil {
      */
     @Nonnull
     public static <T> AsyncIterable<T> filterIterablePipelined(@Nonnull AsyncIterable<T> iterable,
-                                                               @Nonnull final Function<T,CompletableFuture<Boolean>> filter,
+                                                               @Nonnull final Function<T, CompletableFuture<Boolean>> filter,
                                                                int pipelineSize) {
         return filterIterablePipelined(ForkJoinPool.commonPool(), iterable, filter, pipelineSize);
     }
@@ -628,7 +628,7 @@ public class MoreAsyncUtil {
     @Nonnull
     public static <T> AsyncIterable<T> filterIterablePipelined(@Nonnull Executor executor,
                                                                @Nonnull AsyncIterable<T> iterable,
-                                                               @Nonnull final Function<T,CompletableFuture<Boolean>> filter,
+                                                               @Nonnull final Function<T, CompletableFuture<Boolean>> filter,
                                                                int pipelineSize) {
         return mapConcatIterable(iterable,
                 item -> filterToIterable(item, filter),
@@ -644,8 +644,8 @@ public class MoreAsyncUtil {
      * @return a new {@code AsyncIterable} containing the result of func(item)
      */
     @Nonnull
-    static <T1,T2> AsyncIterable<T2> mapToIterable(final T1 item,
-                                                   @Nonnull final Function<T1,CompletableFuture<T2>> func) {
+    static <T1, T2> AsyncIterable<T2> mapToIterable(final T1 item,
+                                                    @Nonnull final Function<T1, CompletableFuture<T2>> func) {
         return new AsyncIterable<T2>() {
             @Nullable
             @Override
@@ -726,9 +726,9 @@ public class MoreAsyncUtil {
      * @return a new {@code AsyncIterable} with the results of applying func to each of the elements of iterable
      */
     @Nonnull
-    public static <T1,T2> AsyncIterable<T2> mapIterablePipelined(@Nonnull AsyncIterable<T1> iterable,
-                                                                 @Nonnull final Function<T1,CompletableFuture<T2>> func,
-                                                                 int pipelineSize) {
+    public static <T1, T2> AsyncIterable<T2> mapIterablePipelined(@Nonnull AsyncIterable<T1> iterable,
+                                                                  @Nonnull final Function<T1, CompletableFuture<T2>> func,
+                                                                  int pipelineSize) {
         return mapConcatIterable(iterable,
                 item -> mapToIterable(item, func),
                 pipelineSize);
@@ -756,15 +756,15 @@ public class MoreAsyncUtil {
      * @return the reduced result
      */
     @Nullable
-    public static <U,T> CompletableFuture<U> reduce(@Nonnull AsyncIterator<T> iterator, U identity,
-                                                    BiFunction<U, ? super T, U> accumulator) {
+    public static <U, T> CompletableFuture<U> reduce(@Nonnull AsyncIterator<T> iterator, U identity,
+                                                     BiFunction<U, ? super T, U> accumulator) {
         return reduce(ForkJoinPool.commonPool(), iterator, identity, accumulator);
     }
 
     @Nullable
-    public static <U,T> CompletableFuture<U> reduce(@Nonnull Executor executor,
-                                                    @Nonnull AsyncIterator<T> iterator, U identity,
-                                                    BiFunction<U, ? super T, U> accumulator) {
+    public static <U, T> CompletableFuture<U> reduce(@Nonnull Executor executor,
+                                                     @Nonnull AsyncIterator<T> iterator, U identity,
+                                                     BiFunction<U, ? super T, U> accumulator) {
         Holder<U> holder = new Holder<>(identity);
         return whileTrue(() -> iterator.onHasNext().thenApply(hasNext -> {
             if (hasNext) {
@@ -869,8 +869,8 @@ public class MoreAsyncUtil {
      */
     public static <V> CompletableFuture<V> composeWhenComplete(
             @Nonnull CompletableFuture<V> future,
-            @Nonnull BiFunction<V,Throwable,CompletableFuture<Void>> handler,
-            @Nullable Function<Throwable,RuntimeException> exceptionMapper) {
+            @Nonnull BiFunction<V, Throwable, CompletableFuture<Void>> handler,
+            @Nullable Function<Throwable, RuntimeException> exceptionMapper) {
         return composeWhenCompleteAndHandle(
                 future,
                 (result, exception) -> handler.apply(result, exception).thenApply(vignore -> result),
@@ -892,8 +892,8 @@ public class MoreAsyncUtil {
      */
     public static <V, T> CompletableFuture<T> composeWhenCompleteAndHandle(
             @Nonnull CompletableFuture<V> future,
-            @Nonnull BiFunction<V,Throwable,? extends CompletableFuture<T>> handler,
-            @Nullable Function<Throwable,RuntimeException> exceptionMapper) {
+            @Nonnull BiFunction<V, Throwable, ? extends CompletableFuture<T>> handler,
+            @Nullable Function<Throwable, RuntimeException> exceptionMapper) {
         return AsyncUtil.composeHandle(future, (futureResult, futureException) -> {
             try {
                 return handler.apply(futureResult, futureException).handle((handlerResult, handlerAsyncException) -> {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapIterator.java
@@ -46,7 +46,7 @@ import java.util.concurrent.CompletableFuture;
  * @param <V> type of values in the map
  */
 @API(API.Status.EXPERIMENTAL)
-public class BunchedMapIterator<K,V> implements AsyncPeekIterator<Map.Entry<K,V>> {
+public class BunchedMapIterator<K, V> implements AsyncPeekIterator<Map.Entry<K, V>> {
     @Nonnull private final AsyncPeekIterator<KeyValue> underlying;
     @Nonnull private final Subspace subspace;
     @Nonnull private final ReadTransaction tr;
@@ -58,7 +58,7 @@ public class BunchedMapIterator<K,V> implements AsyncPeekIterator<Map.Entry<K,V>
 
     @Nullable private CompletableFuture<Boolean> hasNextFuture;
     private boolean continuationSatisfied;
-    @Nullable private List<Map.Entry<K,V>> currEntryList;
+    @Nullable private List<Map.Entry<K, V>> currEntryList;
     private int currEntryIndex;
     @Nullable private K lastKey;
     private int returned;
@@ -118,7 +118,7 @@ public class BunchedMapIterator<K,V> implements AsyncPeekIterator<Map.Entry<K,V>
                         }
                         underlying.next(); // Advance the underlying scan.
                         final K boundaryKey = bunchedMap.getSerializer().deserializeKey(underlyingNext.getKey(), subspaceKey.length);
-                        List<Map.Entry<K,V>> nextEntryList = bunchedMap.getSerializer().deserializeEntries(boundaryKey, underlyingNext.getValue());
+                        List<Map.Entry<K, V>> nextEntryList = bunchedMap.getSerializer().deserializeEntries(boundaryKey, underlyingNext.getValue());
                         if (nextEntryList.isEmpty()) {
                             // No entries in list. Try next key.
                             return underlying.onHasNext();
@@ -164,7 +164,7 @@ public class BunchedMapIterator<K,V> implements AsyncPeekIterator<Map.Entry<K,V>
 
     @Override
     @Nonnull
-    public Map.Entry<K,V> peek() {
+    public Map.Entry<K, V> peek() {
         if (hasNext()) {
             // The hasNext method should enforce that currEntryList is not null
             // and that currEntryIndex is in the right range.
@@ -179,8 +179,8 @@ public class BunchedMapIterator<K,V> implements AsyncPeekIterator<Map.Entry<K,V>
 
     @Override
     @Nonnull
-    public Map.Entry<K,V> next() {
-        Map.Entry<K,V> nextEntry = peek();
+    public Map.Entry<K, V> next() {
+        Map.Entry<K, V> nextEntry = peek();
         lastKey = nextEntry.getKey();
         hasNextFuture = null;
         currEntryIndex += reverse ? -1 : 1;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
@@ -51,7 +51,7 @@ import java.util.concurrent.CompletableFuture;
  * @param <T> type of tags associated with each subspace
  */
 @API(API.Status.EXPERIMENTAL)
-public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<BunchedMapScanEntry<K,V,T>> {
+public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<BunchedMapScanEntry<K, V, T>> {
     @Nonnull private final AsyncPeekIterator<KeyValue> underlying;
     @Nonnull private final ReadTransaction tr;
     @Nonnull private final Subspace subspace;
@@ -64,12 +64,12 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
 
     @Nullable private CompletableFuture<Boolean> hasNextFuture;
     private boolean continuationSatisfied;
-    @Nullable private BunchedMapIterator<K,V> mapIterator;
+    @Nullable private BunchedMapIterator<K, V> mapIterator;
     @Nullable private Subspace currentSubspace;
     @Nullable private byte[] currentSubspaceSuffix;
     @Nullable private byte[] currentSubspaceKey;
     @Nullable private T currentSubspaceTag;
-    @Nullable private BunchedMapScanEntry<K,V,T> nextEntry;
+    @Nullable private BunchedMapScanEntry<K, V, T> nextEntry;
     @Nullable private K lastKey;
     private boolean hasCurrent;
     private int returned;
@@ -155,7 +155,7 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
                         }, tr.getExecutor()).thenCompose(vignore -> getNextMapIterator());
                     }
                 }
-                BunchedMapIterator<K,V> nextMapIterator = new BunchedMapIterator<>(
+                BunchedMapIterator<K, V> nextMapIterator = new BunchedMapIterator<>(
                         underlying,
                         tr,
                         nextSubspace,
@@ -173,7 +173,7 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
                         currentSubspaceSuffix = nextSubspaceSuffix;
                         currentSubspaceTag = nextSubspaceTag;
                         mapIterator = nextMapIterator;
-                        Map.Entry<K,V> mapEntry = mapIterator.next();
+                        Map.Entry<K, V> mapEntry = mapIterator.next();
                         nextEntry = new BunchedMapScanEntry<>(currentSubspace, currentSubspaceTag, mapEntry.getKey(), mapEntry.getValue());
                         return AsyncUtil.READY_TRUE;
                     } else {
@@ -202,7 +202,7 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
             if (mapIterator != null) {
                 hasNextFuture = mapIterator.onHasNext().thenCompose(mapHasNext -> {
                     if (mapHasNext) {
-                        Map.Entry<K,V> entry = mapIterator.next();
+                        Map.Entry<K, V> entry = mapIterator.next();
                         assert currentSubspace != null;
                         assert currentSubspaceKey != null;
                         nextEntry = new BunchedMapScanEntry<>(currentSubspace, currentSubspaceTag, entry.getKey(), entry.getValue());
@@ -230,7 +230,7 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
 
     @Override
     @Nonnull
-    public BunchedMapScanEntry<K,V,T> peek() {
+    public BunchedMapScanEntry<K, V, T> peek() {
         if (hasNext() && nextEntry != null) {
             return nextEntry;
         } else {
@@ -240,8 +240,8 @@ public class BunchedMapMultiIterator<K,V,T> implements AsyncPeekIterator<Bunched
 
     @Override
     @Nonnull
-    public BunchedMapScanEntry<K,V,T> next() {
-        BunchedMapScanEntry<K,V,T> nextEntry = peek();
+    public BunchedMapScanEntry<K, V, T> next() {
+        BunchedMapScanEntry<K, V, T> nextEntry = peek();
         lastKey = nextEntry.getKey();
         hasCurrent = false;
         hasNextFuture = null;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapScanEntry.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapScanEntry.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
  * @param <T> type of the tag associated with each subspace
  */
 @API(API.Status.EXPERIMENTAL)
-public class BunchedMapScanEntry<K,V,T> {
+public class BunchedMapScanEntry<K, V, T> {
     @Nonnull private final Subspace subspace;
     @Nullable private final T subspaceTag;
     @Nonnull private final K key;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializer.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializer.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
  * @param <V> type of the values in the {@link BunchedMap}
  */
 @API(API.Status.EXPERIMENTAL)
-public interface BunchedSerializer<K,V> {
+public interface BunchedSerializer<K, V> {
 
     /**
      * Serialize a key to bytes. These bytes will be used by the {@link BunchedMap}
@@ -95,7 +95,7 @@ public interface BunchedSerializer<K,V> {
      * @throws BunchedSerializationException if serializing the entries fails
      */
     @Nonnull
-    byte[] serializeEntries(@Nonnull List<Map.Entry<K,V>> entries);
+    byte[] serializeEntries(@Nonnull List<Map.Entry<K, V>> entries);
 
     /**
      * Deserialize a byte array into a key. This assumes that the entire
@@ -156,7 +156,7 @@ public interface BunchedSerializer<K,V> {
      * @throws BunchedSerializationException if deserializing the entries fails
      */
     @Nonnull
-    List<Map.Entry<K,V>> deserializeEntries(@Nonnull K key, @Nonnull byte[] data);
+    List<Map.Entry<K, V>> deserializeEntries(@Nonnull K key, @Nonnull byte[] data);
 
     /**
      * Deserialize raw data to a list of keys. This expects that <code>data</code>

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -40,7 +40,7 @@ public class ByteArrayUtil2 {
     private static final int MAXIMUM_PRINTABLE_CHARACTER = 127;
 
     private static final char[] HEX_CHARS =
-            { '0','1','2','3','4','5','6','7','8','9','A','B','C','D', 'E', 'F' };
+            { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
     @Nullable
     public static String toHexString(@Nullable byte[] bytes) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValuesImpl.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValuesImpl.java
@@ -126,7 +126,7 @@ public class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Loggable
         }
         Object[] exportedInfo = new Object[2 * logInfo.size()];
         int i = 0;
-        for (Map.Entry<String,Object> entry : logInfo.entrySet()) {
+        for (Map.Entry<String, Object> entry : logInfo.entrySet()) {
             exportedInfo[i] = entry.getKey();
             exportedInfo[i + 1] = entry.getValue();
             i += 2;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
@@ -63,7 +63,7 @@ public class RangeSetTest extends FDBTestBase {
     private Subspace rsSubspace;
     private RangeSet rs;
 
-    private static final byte[] DEADC0DE = new byte[]{(byte)0xde,(byte)0xad,(byte)0xc0,(byte)0xde};
+    private static final byte[] DEADC0DE = new byte[]{(byte)0xde, (byte)0xad, (byte)0xc0, (byte)0xde};
 
     private List<byte[]> createKeys() {
         List<byte[]> keys = new ArrayList<>();
@@ -140,7 +140,7 @@ public class RangeSetTest extends FDBTestBase {
             tr.set(rsSubspace.pack(new byte[]{(byte)0x10}), new byte[]{(byte)0x66});
             tr.set(rsSubspace.pack(new byte[]{(byte)0x77}), new byte[]{(byte)0x88});
             tr.set(rsSubspace.pack(new byte[]{(byte)0x88}), new byte[]{(byte)0x99});
-            tr.set(rsSubspace.pack(new byte[]{(byte)0x99}), new byte[]{(byte)0x99,(byte)0x00});
+            tr.set(rsSubspace.pack(new byte[]{(byte)0x99}), new byte[]{(byte)0x99, (byte)0x00});
             return null;
         });
 
@@ -181,7 +181,7 @@ public class RangeSetTest extends FDBTestBase {
 
     @Test
     public void containsPastFF2() {
-        assertThrows(IllegalArgumentException.class, () -> rs.contains(db, new byte[]{(byte)0xff,(byte)0x00}).join());
+        assertThrows(IllegalArgumentException.class, () -> rs.contains(db, new byte[]{(byte)0xff, (byte)0x00}).join());
     }
 
     @Test
@@ -194,12 +194,12 @@ public class RangeSetTest extends FDBTestBase {
                 Range.startsWith(new byte[]{0x20}), // Step 3: A third disjoint range between them.
                 new Range(new byte[]{0x05}, new byte[]{0x10, 0x10}), // Step 4: A range overlapping the first range.
                 new Range(new byte[]{0x2f}, new byte[]{0x30, 0x10}), // Step 5: A range overlapping the third range.
-                new Range(new byte[]{0x30,0x10}, new byte[]{0x40}), // Step 6: A range overlapping the third range.
-                new Range(new byte[]{0x05,0x10}, new byte[]{0x12}), // Step 7: A range with just a little at the end.
-                new Range(new byte[]{0x20,0x14}, new byte[]{0x30,0x00}), // Step 8: A range that goes between 0x20 and 0x30 ranges.
+                new Range(new byte[]{0x30, 0x10}, new byte[]{0x40}), // Step 6: A range overlapping the third range.
+                new Range(new byte[]{0x05, 0x10}, new byte[]{0x12}), // Step 7: A range with just a little at the end.
+                new Range(new byte[]{0x20, 0x14}, new byte[]{0x30, 0x00}), // Step 8: A range that goes between 0x20 and 0x30 ranges.
                 new Range(new byte[]{0x03}, new byte[]{0x42}), // Step 9: A range that goes over whole range.
-                new Range(new byte[]{0x10,0x11}, new byte[]{0x41}), // Step 10: A range entirely within the given ranges.
-                new Range(new byte[]{0x50}, new byte[]{0x50,0x00}) // Step 11: A range that contains only 1 key.
+                new Range(new byte[]{0x10, 0x11}, new byte[]{0x41}), // Step 10: A range entirely within the given ranges.
+                new Range(new byte[]{0x50}, new byte[]{0x50, 0x00}) // Step 11: A range that contains only 1 key.
         );
         List<Range> ranges = new ArrayList<>();
         int last = 0;
@@ -294,13 +294,13 @@ public class RangeSetTest extends FDBTestBase {
         // Read during write - the reads in the range should fail.
         r1 = new Range(new byte[]{0x07}, new byte[]{0x08});
         List<byte[]> specificKeys = Arrays.asList(
-                new byte[]{0x06,(byte)0xff},
+                new byte[]{0x06, (byte)0xff},
                 new byte[]{0x07},
-                new byte[]{0x07,0x00},
-                new byte[]{0x07,0x10},
+                new byte[]{0x07, 0x00},
+                new byte[]{0x07, 0x10},
                 new byte[]{0x08},
-                new byte[]{0x08,0x00},
-                new byte[]{0x08,0x10},
+                new byte[]{0x08, 0x00},
+                new byte[]{0x08, 0x10},
                 new byte[]{0x09}
         );
 
@@ -369,9 +369,9 @@ public class RangeSetTest extends FDBTestBase {
         // Now, add some ranges to make the gaps interesting.
         List<Range> toAdd = Arrays.asList(
                 new Range(new byte[]{0x10}, new byte[]{0x20}),
-                new Range(new byte[]{0x20}, new byte[]{0x20,0x00}),
+                new Range(new byte[]{0x20}, new byte[]{0x20, 0x00}),
                 new Range(new byte[]{0x30}, new byte[]{0x40}),
-                new Range(new byte[]{0x40,0x00}, new byte[]{0x50}),
+                new Range(new byte[]{0x40, 0x00}, new byte[]{0x50}),
                 new Range(new byte[]{0x60}, new byte[]{0x6a}),
                 new Range(new byte[]{0x62}, new byte[]{0x70}),
                 new Range(new byte[]{0x71}, new byte[]{0x72}),
@@ -379,8 +379,8 @@ public class RangeSetTest extends FDBTestBase {
         );
         List<Range> expected = Arrays.asList(
                 new Range(new byte[]{0x00}, new byte[]{0x10}),
-                new Range(new byte[]{0x20,0x00}, new byte[]{0x30}),
-                new Range(new byte[]{0x40}, new byte[]{0x40,0x00}),
+                new Range(new byte[]{0x20, 0x00}, new byte[]{0x30}),
+                new Range(new byte[]{0x40}, new byte[]{0x40, 0x00}),
                 new Range(new byte[]{0x50}, new byte[]{0x60}),
                 new Range(new byte[]{0x70}, new byte[]{0x71}),
                 new Range(new byte[]{0x7f}, new byte[]{(byte)0xff})

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
@@ -79,7 +79,7 @@ public class BunchedMapScanTest extends FDBTestBase {
     private static Database db;
     private static Subspace bmSubspace;
     private static List<Subspace> subSubspaces;
-    private static BunchedMap<Tuple,Tuple> map;
+    private static BunchedMap<Tuple, Tuple> map;
     private static List<Tuple> keys;
     private static Tuple value;
 
@@ -138,14 +138,14 @@ public class BunchedMapScanTest extends FDBTestBase {
         });
     }
 
-    private void testScan(int limit, boolean reverse, @Nonnull BiFunction<Transaction,byte[],BunchedMapIterator<Tuple,Tuple>> iteratorFunction) {
+    private void testScan(int limit, boolean reverse, @Nonnull BiFunction<Transaction, byte[], BunchedMapIterator<Tuple, Tuple>> iteratorFunction) {
         try (Transaction tr = db.createTransaction()) {
             byte[] continuation = null;
             List<Tuple> readKeys = new ArrayList<>();
             Tuple lastKey = null;
             do {
                 int returned = 0;
-                BunchedMapIterator<Tuple,Tuple> bunchedMapIterator = iteratorFunction.apply(tr, continuation);
+                BunchedMapIterator<Tuple, Tuple> bunchedMapIterator = iteratorFunction.apply(tr, continuation);
                 while (bunchedMapIterator.hasNext()) {
                     Tuple toAdd = bunchedMapIterator.peek().getKey();
                     readKeys.add(toAdd);
@@ -217,7 +217,7 @@ public class BunchedMapScanTest extends FDBTestBase {
         getKeysContinuationRescan(1, reverse); // Limit of 1 to test every key
 
         // Unlimited should return null continuation.
-        BunchedMapIterator<Tuple,Tuple> iterator = map.scan(tr, bmSubspace, null, ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
+        BunchedMapIterator<Tuple, Tuple> iterator = map.scan(tr, bmSubspace, null, ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
         List<Tuple> readKeys = AsyncUtil.collectRemaining(AsyncUtil.mapIterator(iterator, Map.Entry::getKey)).get();
         if (reverse) {
             readKeys = Lists.reverse(readKeys);
@@ -262,7 +262,7 @@ public class BunchedMapScanTest extends FDBTestBase {
         try (Transaction tr1 = db.createTransaction(); Transaction tr2 = db.createTransaction()) {
             CompletableFuture.allOf(tr1.getReadVersion(), tr2.getReadVersion()).get();
 
-            BunchedMapIterator<Tuple,Tuple> iterator = map.scan(tr1, bmSubspace);
+            BunchedMapIterator<Tuple, Tuple> iterator = map.scan(tr1, bmSubspace);
             int count = MoreAsyncUtil.reduce(iterator, 0, (oldCount, item) -> oldCount + 1).get();
             assertEquals(keys.size(), count);
             tr1.addWriteConflictKey(Tuple.from(count).pack());
@@ -283,7 +283,7 @@ public class BunchedMapScanTest extends FDBTestBase {
         try (Transaction tr1 = db.createTransaction(); Transaction tr2 = db.createTransaction()) {
             CompletableFuture.allOf(tr1.getReadVersion(), tr2.getReadVersion()).get();
 
-            BunchedMapIterator<Tuple,Tuple> iterator = map.scan(tr1, bmSubspace);
+            BunchedMapIterator<Tuple, Tuple> iterator = map.scan(tr1, bmSubspace);
 
         }
     }
@@ -295,7 +295,7 @@ public class BunchedMapScanTest extends FDBTestBase {
             do {
                 List<Tuple> mostRecentReadKeys = new ArrayList<>();
                 int returned = 0;
-                BunchedMapIterator<Tuple,Tuple> bunchedMapIterator = map.scan(tr, subSubspaces.get(1), continuation, limit, reverse);
+                BunchedMapIterator<Tuple, Tuple> bunchedMapIterator = map.scan(tr, subSubspaces.get(1), continuation, limit, reverse);
                 while (bunchedMapIterator.hasNext()) {
                     Tuple toAdd = bunchedMapIterator.peek().getKey();
                     assertEquals(toAdd, bunchedMapIterator.next().getKey());
@@ -343,16 +343,16 @@ public class BunchedMapScanTest extends FDBTestBase {
     }
 
     private void testScanMulti(int limit, boolean reverse, List<List<Tuple>> keyLists,
-                               @Nonnull BiFunction<Transaction,byte[],BunchedMapMultiIterator<Tuple,Tuple,Long>> iteratorFunction) {
+                               @Nonnull BiFunction<Transaction, byte[], BunchedMapMultiIterator<Tuple, Tuple, Long>> iteratorFunction) {
         try (Transaction tr = db.createTransaction()) {
             byte[] continuation = null;
-            List<BunchedMapScanEntry<Tuple,Tuple,Long>> entryList = new ArrayList<>();
-            BunchedMapScanEntry<Tuple,Tuple,Long> lastEntry = null;
+            List<BunchedMapScanEntry<Tuple, Tuple, Long>> entryList = new ArrayList<>();
+            BunchedMapScanEntry<Tuple, Tuple, Long> lastEntry = null;
             do {
-                BunchedMapMultiIterator<Tuple,Tuple,Long> iterator = iteratorFunction.apply(tr, continuation);
+                BunchedMapMultiIterator<Tuple, Tuple, Long> iterator = iteratorFunction.apply(tr, continuation);
                 int returned = 0;
                 while (iterator.hasNext()) {
-                    BunchedMapScanEntry<Tuple,Tuple,Long> toAdd = iterator.peek();
+                    BunchedMapScanEntry<Tuple, Tuple, Long> toAdd = iterator.peek();
                     assertEquals(toAdd, iterator.next());
                     if (lastEntry != null) {
                         if (toAdd.getSubspaceTag().equals(lastEntry.getSubspaceTag())) {
@@ -378,7 +378,7 @@ public class BunchedMapScanTest extends FDBTestBase {
             Long tag = null;
             int pos = 0;
             int totalRead = 0;
-            for (BunchedMapScanEntry<Tuple,Tuple,Long> entry : entryList) {
+            for (BunchedMapScanEntry<Tuple, Tuple, Long> entry : entryList) {
                 if (tag == null || !tag.equals(entry.getSubspaceTag())) {
                     if (tag != null) {
                         assertEquals(tag + 1, entry.getSubspaceTag().longValue());
@@ -549,11 +549,11 @@ public class BunchedMapScanTest extends FDBTestBase {
     }
 
     @Test
-    public void scanMultiReversed() throws InterruptedException,ExecutionException {
+    public void scanMultiReversed() throws InterruptedException, ExecutionException {
         scanMultiTest(true);
     }
 
-    private void scanMultiTest(boolean reversed) throws InterruptedException,ExecutionException {
+    private void scanMultiTest(boolean reversed) throws InterruptedException, ExecutionException {
         clearAndPopulateMulti();
         final List<Integer> limits = Arrays.asList(ReadTransaction.ROW_LIMIT_UNLIMITED, 100, 50, 10, 7, 1);
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
@@ -84,7 +84,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag(Tags.RequiresFDB)
 public class BunchedMapTest extends FDBTestBase {
     private static final BunchedTupleSerializer serializer = BunchedTupleSerializer.instance();
-    private static final BunchedMap<Tuple,Tuple> map;
+    private static final BunchedMap<Tuple, Tuple> map;
     private static Subspace bmSubspace;
     private static Database db;
 
@@ -182,7 +182,7 @@ public class BunchedMapTest extends FDBTestBase {
                 List<KeyValue> rangeKVs = tr.getRange(bmSubspace.range()).asList().join();
                 assertEquals(1, rangeKVs.size());
                 assertArrayEquals(bmSubspace.pack(minSoFar), rangeKVs.get(0).getKey());
-                List<Map.Entry<Tuple,Tuple>> entryList = testTuples.subList(0, i + 1).stream()
+                List<Map.Entry<Tuple, Tuple>> entryList = testTuples.subList(0, i + 1).stream()
                         .sorted()
                         .map(t -> new AbstractMap.SimpleImmutableEntry<>(t, value))
                         .collect(Collectors.toList());
@@ -262,7 +262,7 @@ public class BunchedMapTest extends FDBTestBase {
                     .map(KeyValue::getKey)
                     .map(bmSubspace::unpack)
                     .collect(Collectors.toList());
-            List<Map.Entry<Tuple,Tuple>> entryList = rangeKVs.stream()
+            List<Map.Entry<Tuple, Tuple>> entryList = rangeKVs.stream()
                     .flatMap(kv -> serializer.deserializeEntries(bmSubspace.unpack(kv.getKey()), kv.getValue()).stream())
                     .collect(Collectors.toList());
             System.out.println(entryList);
@@ -271,7 +271,7 @@ public class BunchedMapTest extends FDBTestBase {
         }
     }
 
-    private void runWithTwoTrs(@Nonnull BiConsumer<? super Transaction,? super Transaction> operation,
+    private void runWithTwoTrs(@Nonnull BiConsumer<? super Transaction, ? super Transaction> operation,
                                boolean legal,
                                @Nonnull List<Tuple> boundaryKeys) throws ExecutionException, InterruptedException {
         final String id = "two-trs-" + UUID.randomUUID().toString();
@@ -502,7 +502,7 @@ public class BunchedMapTest extends FDBTestBase {
         }, false, Arrays.asList(Tuple.from(97L), Tuple.from(104L), Tuple.from(110L)));
 
         try (Transaction tr = db.createTransaction()) {
-            List<Map.Entry<Tuple,Tuple>> entryList = AsyncUtil.collectRemaining(map.scan(tr, bmSubspace)).get();
+            List<Map.Entry<Tuple, Tuple>> entryList = AsyncUtil.collectRemaining(map.scan(tr, bmSubspace)).get();
             System.out.println(entryList);
         }
     }
@@ -525,7 +525,7 @@ public class BunchedMapTest extends FDBTestBase {
 
         final List<CompletableFuture<Void>> workers = Stream.generate(() -> {
             int bunchSize = r.nextInt(15) + 1;
-            BunchedMap<Tuple,Tuple> workerMap = new BunchedMap<>(serializer, Comparator.naturalOrder(), bunchSize);
+            BunchedMap<Tuple, Tuple> workerMap = new BunchedMap<>(serializer, Comparator.naturalOrder(), bunchSize);
             AtomicInteger trCount = new AtomicInteger(0);
             return AsyncUtil.whileTrue(() -> {
                 final Transaction tr = db.createTransaction();
@@ -618,7 +618,7 @@ public class BunchedMapTest extends FDBTestBase {
                     Subspace mapLogSubspace = logSubspace.subspace(Tuple.from(mapIndex.get()));
                     CompletableFuture<List<Tuple>> logFuture = AsyncUtil.mapIterable(tr.getRange(mapLogSubspace.range()), kv -> Tuple.fromBytes(kv.getValue())).asList();
                     // Verify integrity and then grab all of the keys and values.
-                    CompletableFuture<List<Map.Entry<Tuple,Tuple>>> contentFuture = AsyncUtil.collectRemaining(map.scan(tr, mapSubspace));
+                    CompletableFuture<List<Map.Entry<Tuple, Tuple>>> contentFuture = AsyncUtil.collectRemaining(map.scan(tr, mapSubspace));
                     CompletableFuture<Void> integrityFuture = map.verifyIntegrity(tr, mapSubspace);
                     return integrityFuture.thenCompose(vignore -> contentFuture.thenCombine(logFuture, (mapContents, logEntries) -> {
                         Map<Tuple, Tuple> mapCopy = new TreeMap<>();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedTupleSerializerTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedTupleSerializerTest.java
@@ -124,10 +124,10 @@ public class BunchedTupleSerializerTest {
 
     @Test
     public void serializeEntries() {
-        List<Map.Entry<Tuple,Tuple>> entries = TEST_TUPLES.stream()
+        List<Map.Entry<Tuple, Tuple>> entries = TEST_TUPLES.stream()
                 .map(t -> new AbstractMap.SimpleImmutableEntry<>(t, t))
                 .collect(Collectors.toList());
-        List<Map.Entry<Tuple,Tuple>> deserializedEntries = serializer.deserializeEntries(TEST_TUPLES.get(0), serializer.serializeEntries(entries));
+        List<Map.Entry<Tuple, Tuple>> deserializedEntries = serializer.deserializeEntries(TEST_TUPLES.get(0), serializer.serializeEntries(entries));
         assertEquals(entries, deserializedEntries);
     }
 
@@ -138,11 +138,11 @@ public class BunchedTupleSerializerTest {
 
     @Test
     public void serializeAndAppend() {
-        List<Map.Entry<Tuple,Tuple>> entries = new ArrayList<>(TEST_TUPLES.size());
+        List<Map.Entry<Tuple, Tuple>> entries = new ArrayList<>(TEST_TUPLES.size());
         entries.add(new AbstractMap.SimpleImmutableEntry<>(TEST_TUPLES.get(0), TEST_TUPLES.get(1)));
         byte[] data = serializer.serializeEntries(entries);
         for (int i = 1; i < TEST_TUPLES.size(); i++) {
-            Map.Entry<Tuple,Tuple> entry = new AbstractMap.SimpleEntry<>(TEST_TUPLES.get(i), TEST_TUPLES.get((i + 1) % TEST_TUPLES.size()));
+            Map.Entry<Tuple, Tuple> entry = new AbstractMap.SimpleEntry<>(TEST_TUPLES.get(i), TEST_TUPLES.get((i + 1) % TEST_TUPLES.size()));
             entries.add(entry);
             byte[] nextData = ByteArrayUtil.join(data, serializer.serializeEntry(entry));
             assertArrayEquals(serializer.serializeEntries(entries), nextData);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/LoggableExceptionTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/LoggableExceptionTest.java
@@ -40,7 +40,7 @@ public class LoggableExceptionTest {
     @Test
     public void emptyLogInfo() {
         LoggableException e = new LoggableException("this has no k/v pairs");
-        Map<String,Object> logInfo = e.getLogInfo();
+        Map<String, Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(Collections.emptyMap(), logInfo);
         Object[] logInfoArray = e.exportLogInfo();
@@ -52,7 +52,7 @@ public class LoggableExceptionTest {
     public void oneLogInfo() {
         LoggableException e = new LoggableException("this has one k/v pair")
                 .addLogInfo("key", "value");
-        Map<String,Object> logInfo = e.getLogInfo();
+        Map<String, Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(Collections.singletonMap("key", "value"), logInfo);
         Object[] logInfoArray = e.exportLogInfo();
@@ -62,12 +62,12 @@ public class LoggableExceptionTest {
 
     @Test
     public void multipleLogInfo() {
-        Map<String,Object> expectedLogInfo = new HashMap<>();
+        Map<String, Object> expectedLogInfo = new HashMap<>();
         expectedLogInfo.put("k0", "v0");
         expectedLogInfo.put("k1", "v1");
         expectedLogInfo.put("k2", "v2");
         LoggableException e = new LoggableException("this has multiple k/v pairs", "k0", "v0", "k1", "v1", "k2", "v2");
-        Map<String,Object> logInfo = e.getLogInfo();
+        Map<String, Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(expectedLogInfo, logInfo);
         Object[] logInfoArray = e.exportLogInfo();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Index.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Index.java
@@ -159,7 +159,7 @@ public class Index {
         this.lastModifiedVersion = orig.lastModifiedVersion;
     }
 
-    @SuppressWarnings({"deprecation","squid:CallToDeprecatedMethod"}) // Old (deprecated) index type needs grouping compatibility
+    @SuppressWarnings({"deprecation", "squid:CallToDeprecatedMethod"}) // Old (deprecated) index type needs grouping compatibility
     @SpotBugsSuppressWarnings("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
     public Index(@Nonnull RecordMetaDataProto.Index proto) throws KeyExpression.DeserializationException {
         name = proto.getName();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MappedPool.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/MappedPool.java
@@ -48,17 +48,17 @@ public class MappedPool<K, V, E extends Exception> {
     protected static final int DEFAULT_MAX_ENTRIES = 64;
     protected final Cache<K, Queue<V>> pool;
     protected Callable<Queue<V>> loader;
-    private final MappedPoolProvider<K,V,E> mappedPoolProvider;
+    private final MappedPoolProvider<K, V, E> mappedPoolProvider;
 
-    public MappedPool(MappedPoolProvider<K,V,E> mappedPoolProvider) {
+    public MappedPool(MappedPoolProvider<K, V, E> mappedPoolProvider) {
         this(mappedPoolProvider, DEFAULT_POOL_SIZE);
     }
 
-    public MappedPool(MappedPoolProvider<K,V,E> mappedPoolProvider, int poolSize) {
+    public MappedPool(MappedPoolProvider<K, V, E> mappedPoolProvider, int poolSize) {
         this(mappedPoolProvider, poolSize, DEFAULT_MAX_ENTRIES);
     }
 
-    public MappedPool(MappedPoolProvider<K,V,E> mappedPoolProvider, int defaultPoolSize, int maxEntries) {
+    public MappedPool(MappedPoolProvider<K, V, E> mappedPoolProvider, int defaultPoolSize, int maxEntries) {
         this.pool = CacheBuilder.newBuilder().maximumSize(maxEntries).build();
         this.loader = () -> new ArrayBlockingQueue<>(defaultPoolSize);
         this.mappedPoolProvider = mappedPoolProvider;
@@ -110,7 +110,7 @@ public class MappedPool<K, V, E extends Exception> {
      * @param <V> value type to be pooled
      * @param <E> exception that can be throw, must extend Exception
      */
-    public interface MappedPoolProvider<K,V,E extends Exception> {
+    public interface MappedPoolProvider<K, V, E extends Exception> {
         V get(K key) throws E;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreTimer.java
@@ -266,7 +266,7 @@ public class StoreTimer {
          * @throws RecordCoreArgumentException if the validation assumptions are violated
          */
         @SuppressWarnings("unchecked")
-        default <T extends Event> T[] validate(@Nonnull T...events) {
+        default <T extends Event> T[] validate(@Nonnull T... events) {
             return validate((a, b) -> { return; }, events);
         }
 
@@ -282,7 +282,7 @@ public class StoreTimer {
          * @throws RecordCoreArgumentException if the validation assumptions are violated
          */
         @SuppressWarnings("unchecked")
-        default <T extends Event> T[] validate(@Nonnull BiConsumer<T, T> extraCheck, @Nonnull T...events) {
+        default <T extends Event> T[] validate(@Nonnull BiConsumer<T, T> extraCheck, @Nonnull T... events) {
             if (events.length == 0) {
                 throw new RecordCoreArgumentException("At least one event must be supplied to aggregate");
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/EventKeeperTranslator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/EventKeeperTranslator.java
@@ -44,15 +44,15 @@ class EventKeeperTranslator implements EventKeeper {
     // is preloaded with the old names.
     static {
         eventKeeperMap.put(EventKeeper.Events.JNI_CALL,
-                new Count("JNI_CALLS","jni calls", false));
+                new Count("JNI_CALLS", "jni calls", false));
         eventKeeperMap.put(EventKeeper.Events.RANGE_QUERY_FETCHES,
-                new Count("RANGE_FETCHES","range fetches", false));
+                new Count("RANGE_FETCHES", "range fetches", false));
         eventKeeperMap.put(EventKeeper.Events.RANGE_QUERY_RECORDS_FETCHED,
-                new Count("RANGE_KEYVALUES_FETCHED","range key-values ", false));
+                new Count("RANGE_KEYVALUES_FETCHED", "range key-values ", false));
         eventKeeperMap.put(EventKeeper.Events.RANGE_QUERY_CHUNK_FAILED,
-                new Count("CHUNK_READ_FAILURES","read fails", false));
+                new Count("CHUNK_READ_FAILURES", "read fails", false));
         eventKeeperMap.put(EventKeeper.Events.RANGE_QUERY_FETCH_TIME_NANOS,
-                new Event("FETCHES","fetches"));
+                new Event("FETCHES", "fetches"));
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -3833,7 +3833,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @return a future that completes to the record count for the version checker
      */
     @Nonnull
-    @SuppressWarnings({"PMD.EmptyCatchBlock","PMD.CloseResource"})
+    @SuppressWarnings({"PMD.EmptyCatchBlock", "PMD.CloseResource"})
     protected CompletableFuture<Long> getRecordCountForRebuildIndexes(boolean newStore, boolean rebuildRecordCounts,
                                                                       @Nonnull Map<Index, List<RecordType>> indexes,
                                                                       @Nullable RecordType singleRecordTypeWithPrefixKey) {
@@ -4355,7 +4355,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     @Nonnull
-    private RecordCoreException recordCoreException(@Nonnull String msg, Object...keysAndValues) {
+    private RecordCoreException recordCoreException(@Nonnull String msg, Object... keysAndValues) {
         RecordCoreException err = new RecordCoreException(msg, keysAndValues);
         err.addLogInfo(subspaceProvider.logKey().toString(), subspaceProvider.toString(context));
         return err;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1105,7 +1105,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                                                                         @Nonnull final IndexOrphanBehavior orphanBehavior,
                                                                         @Nonnull final ExecuteState executeState) {
         final Tuple primaryKey = entry.getPrimaryKey();
-        return loadRecordInternal(primaryKey, executeState,false).thenApply(rec -> {
+        return loadRecordInternal(primaryKey, executeState, false).thenApply(rec -> {
             if (rec == null) {
                 switch (orphanBehavior) {
                     case SKIP:

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -653,15 +653,15 @@ public class FDBStoreTimer extends StoreTimer {
         /** Total number of mutation operations. */
         MUTATIONS("mutations", false),
         /** JNI Calls.*/
-        JNI_CALLS("jni calls",false),
+        JNI_CALLS("jni calls", false),
         /**Bytes read.*/
-        BYTES_FETCHED("bytes fetched",false),
+        BYTES_FETCHED("bytes fetched", false),
         /** Number of network fetches performed.*/
-        RANGE_FETCHES("range fetches",false),
+        RANGE_FETCHES("range fetches", false),
         /** Number of Key-values fetched during a range scan.*/
-        RANGE_KEYVALUES_FETCHED("range key-values ",false ),
+        RANGE_KEYVALUES_FETCHED("range key-values ", false),
         /** Number of chunk reads that failed.*/
-        CHUNK_READ_FAILURES("read fails",false ),
+        CHUNK_READ_FAILURES("read fails", false),
         /** Count of commits that failed for any reason. */
         COMMITS_FAILED("commits failed", false),
         /** Count failed due to conflict. */
@@ -734,11 +734,11 @@ public class FDBStoreTimer extends StoreTimer {
         @Nonnull
         private final Set<Count> events;
 
-        CountAggregates(@Nonnull String title, @Nonnull Count...events) {
+        CountAggregates(@Nonnull String title, @Nonnull Count... events) {
             this(title, null, events);
         }
 
-        CountAggregates(@Nonnull String title, @Nullable String logKey, @Nonnull Count...events) {
+        CountAggregates(@Nonnull String title, @Nullable String logKey, @Nonnull Count... events) {
             this.title = title;
             this.logKey = (logKey != null) ? logKey : Aggregate.super.logKey();
             this.events = ImmutableSet.copyOf(validate((first, other) -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/MergeCursor.java
@@ -111,7 +111,7 @@ public abstract class MergeCursor<T, U, S extends MergeCursorState<T>> implement
     // The caller always ignores the result anyway and just uses this as a signal, so it's not
     // a big loss.
     @Nonnull
-    @SuppressWarnings({"squid:S1452","PMD.CloseResource"})
+    @SuppressWarnings({"squid:S1452", "PMD.CloseResource"})
     protected static <T, S extends MergeCursorState<T>> CompletableFuture<?> whenAny(@Nonnull List<S> cursorStates) {
         List<S> nonDoneCursors = new ArrayList<>(cursorStates.size());
         for (S cursorState : cursorStates) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutation.java
@@ -62,7 +62,7 @@ public interface AtomicMutation {
      * @see com.apple.foundationdb.record.RecordCursor#reduce
      */
     @Nonnull
-    BiFunction<Tuple,Tuple,Tuple> getAggregator();
+    BiFunction<Tuple, Tuple, Tuple> getAggregator();
 
     /**
      * Get the initial value for aggregating multiple index entries.
@@ -242,7 +242,7 @@ public interface AtomicMutation {
 
         @Override
         @Nonnull
-        public BiFunction<Tuple,Tuple,Tuple> getAggregator() {
+        public BiFunction<Tuple, Tuple, Tuple> getAggregator() {
             switch (this) {
                 case COUNT:
                 case COUNT_UPDATES:

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
@@ -77,7 +77,7 @@ public class AtomicMutationIndexMaintainer extends StandardIndexMaintainer {
         return index.getBooleanOption(IndexOptions.CLEAR_WHEN_ZERO, false);
     }
 
-    @SuppressWarnings({"deprecation","squid:CallToDeprecatedMethod"})
+    @SuppressWarnings({"deprecation", "squid:CallToDeprecatedMethod"})
     protected static AtomicMutation getAtomicMutation(@Nonnull Index index) {
         if (IndexTypes.COUNT.equals(index.getType())) {
             return getClearWhenZero(index) ? AtomicMutation.Standard.COUNT_CLEAR_WHEN_ZERO : AtomicMutation.Standard.COUNT;
@@ -214,7 +214,7 @@ public class AtomicMutationIndexMaintainer extends StandardIndexMaintainer {
         }
         final RecordCursor<IndexEntry> cursor = scan(IndexScanType.BY_GROUP, range,
                 null, new ScanProperties(ExecuteProperties.newBuilder().setIsolationLevel(isolationveLevel).build()));
-        final BiFunction<Tuple,Tuple,Tuple> aggregator = mutation.getAggregator();
+        final BiFunction<Tuple, Tuple, Tuple> aggregator = mutation.getAggregator();
         return cursor.reduce(mutation.getIdentity(), (accum, kv) -> aggregator.apply(accum, kv.getValue()));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -59,7 +59,7 @@ import java.util.List;
 @AutoService(IndexMaintainerFactory.class)
 @API(API.Status.MAINTAINED)
 public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFactory {
-    @SuppressWarnings({"deprecation","squid:CallToDeprecatedMethod"}) // Support the deprecated names for compatibility.
+    @SuppressWarnings({"deprecation", "squid:CallToDeprecatedMethod"}) // Support the deprecated names for compatibility.
     static final String[] TYPES = {
             IndexTypes.COUNT, IndexTypes.COUNT_UPDATES, IndexTypes.COUNT_NOT_NULL, IndexTypes.SUM,
             IndexTypes.MIN_EVER_TUPLE, IndexTypes.MAX_EVER_TUPLE,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -116,7 +116,7 @@ public abstract class LocatableResolver {
     @Nonnull
     private <T> CompletableFuture<T> runAsync(@Nullable FDBStoreTimer timer,
                                               @Nonnull Function<FDBRecordContext, CompletableFuture<T>> retriable,
-                                              Object...additionalLogMessageKeyValues) {
+                                              Object... additionalLogMessageKeyValues) {
         return database.runAsync(timer, null, context ->
                         // Explicitly get a read version for instrumentation purposes
                         context.getReadVersionAsync().thenCompose(ignore -> retriable.apply(context)),
@@ -127,7 +127,7 @@ public abstract class LocatableResolver {
     @SuppressWarnings({"PMD.CloseResource", "PMD.UseTryWithResources"})
     private <T> CompletableFuture<T> runAsyncBorrowingReadVersion(@Nonnull FDBRecordContext parentContext,
                                                                   @Nonnull Function<FDBRecordContext, CompletableFuture<T>> retriable,
-                                                                  Object...additionalLogMessageKeyValues) {
+                                                                  Object... additionalLogMessageKeyValues) {
         final FDBDatabaseRunner runner = parentContext.newRunner();
         boolean started = false;
         try {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -525,15 +525,15 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
     }
 
     @Nonnull
-    public <M extends Message> CompletableFuture<Pair<Long,Tuple>> timeWindowRankAndEntry(@Nonnull EvaluationContext context,
-                                                                                          @Nonnull TimeWindowForFunction timeWindow,
-                                                                                          @Nonnull FDBRecord<M> record) {
+    public <M extends Message> CompletableFuture<Pair<Long, Tuple>> timeWindowRankAndEntry(@Nonnull EvaluationContext context,
+                                                                                           @Nonnull TimeWindowForFunction timeWindow,
+                                                                                           @Nonnull FDBRecord<M> record) {
         return timeWindowRankAndEntry(record, timeWindow.getLeaderboardType(context), timeWindow.getLeaderboardTimestamp(context));
     }
 
     @Nonnull
-    public <M extends Message> CompletableFuture<Pair<Long,Tuple>> timeWindowRankAndEntry(@Nonnull FDBRecord<M> record,
-                                                                                          int type, long timestamp) {
+    public <M extends Message> CompletableFuture<Pair<Long, Tuple>> timeWindowRankAndEntry(@Nonnull FDBRecord<M> record,
+                                                                                           int type, long timestamp) {
         final List<IndexEntry> indexEntries = evaluateIndex(record);
 
         final CompletableFuture<TimeWindowLeaderboard> leaderboardFuture = oldestLeaderboardMatching(type, timestamp);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -1323,7 +1323,7 @@ public class Comparisons {
         @Nullable
         private final Descriptors.FieldDescriptor.JavaType javaType;
 
-        @SuppressWarnings({"rawtypes","unchecked"})
+        @SuppressWarnings({"rawtypes", "unchecked"})
         public ListComparison(@Nonnull Type type, @Nonnull List comparand) {
             this.type = type;
             switch (this.type) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
@@ -279,7 +279,7 @@ public class TypeRepository {
     private TypeRepository(@Nonnull final FileDescriptorSet fileDescSet,
                            @Nonnull final Map<Type, String> typeToNameMap) throws DescriptorValidationException {
         this.fileDescSet = fileDescSet;
-        Map<String,FileDescriptor> fileDescMap = init(fileDescSet);
+        Map<String, FileDescriptor> fileDescMap = init(fileDescSet);
 
         Set<String> msgDupes = new HashSet<>();
         Set<String> enumDupes = new HashSet<>();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
@@ -130,12 +130,12 @@ public class TestHelpers {
 
     }
 
-    public static void assertThrows(Class<? extends Exception> expectedType, Callable<?> callable, Object ...keyValues) throws Exception {
+    public static void assertThrows(Class<? extends Exception> expectedType, Callable<?> callable, Object ... keyValues) throws Exception {
         assertThrows("", expectedType, callable, keyValues);
     }
 
     public static void assertThrows(String message, Class<? extends Exception> expectedType, Callable<?> callable,
-                                    Object ...keyValues) throws Exception {
+                                    Object ... keyValues) throws Exception {
         if (keyValues.length > 0) {
             if (!LoggableException.class.isAssignableFrom(expectedType)) {
                 fail("Log value checks can only be provided with a LoggableException");

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -304,7 +304,7 @@ public class KeyExpressionTest {
 
     @Test
     void testSubstrFunctionStaticFanout() {
-        final KeyExpression expression = function("substr", concat(field("repeat_me", FanType.FanOut),value(0), value(3)));
+        final KeyExpression expression = function("substr", concat(field("repeat_me", FanType.FanOut), value(0), value(3)));
         expression.validate(TestScalarFieldAccess.getDescriptor());
         List<Key.Evaluated> results = evaluate(expression, plantsBoxesAndBowls);
         assertEquals(2, results.size(), "Wrong number of results");

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
@@ -93,7 +93,7 @@ public class TransformedRecordSerializerTest {
         storeTimer.reset();
     }
 
-    private void logMetrics(@Nonnull String staticMessage, @Nullable Object...keysAndValues) {
+    private void logMetrics(@Nonnull String staticMessage, @Nullable Object... keysAndValues) {
         KeyValueLogMessage message = KeyValueLogMessage.build(staticMessage, keysAndValues);
         message.addKeysAndValues(storeTimer.getKeysAndValues());
         LOGGER.info(message.toString());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -329,7 +329,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         LONG,
         COMPATIBLE;
 
-        @SuppressWarnings({"deprecation","squid:CallToDeprecatedMethod"})
+        @SuppressWarnings({"deprecation", "squid:CallToDeprecatedMethod"})
         public String min() {
             switch (this) {
                 case TUPLE:
@@ -343,7 +343,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             }
         }
 
-        @SuppressWarnings({"deprecation","squid:CallToDeprecatedMethod"})
+        @SuppressWarnings({"deprecation", "squid:CallToDeprecatedMethod"})
         public String max() {
             switch (this) {
                 case TUPLE:

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -649,7 +649,7 @@ public class FDBReverseDirectoryCacheTest extends FDBTestBase {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private static Pair<String,Long>[] zipKeysAndValues(List<String> keys, List<Long> values) {
+    private static Pair<String, Long>[] zipKeysAndValues(List<String> keys, List<Long> values) {
         final Iterator<Long> valuesIter = values.iterator();
         return keys.stream()
                 .map( key -> new ImmutablePair<>(key, valuesIter.next()) )

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -337,8 +337,8 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
         executeQuery(query, planString, expected, FDBQueriedRecord::getRecord);
     }
 
-    <K,V extends Message> Map<K,List<Message>> group(@Nonnull List<V> values, @Nonnull Function<V, K> keyFunction) {
-        Map<K,List<Message>> map = new HashMap<>();
+    <K, V extends Message> Map<K, List<Message>> group(@Nonnull List<V> values, @Nonnull Function<V, K> keyFunction) {
+        Map<K, List<Message>> map = new HashMap<>();
         for (V value : values) {
             K key = keyFunction.apply(value);
             if (map.containsKey(key)) {
@@ -354,7 +354,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
 
     @Nonnull
     List<TestRecords1Proto.MySimpleRecord> updated(@Nonnull List<TestRecords1Proto.MySimpleRecord> origRecords, @Nonnull List<TestRecords1Proto.MySimpleRecord> addedRecords) {
-        Map<Long,TestRecords1Proto.MySimpleRecord> lastRecordWithKey = new HashMap<>();
+        Map<Long, TestRecords1Proto.MySimpleRecord> lastRecordWithKey = new HashMap<>();
         for (TestRecords1Proto.MySimpleRecord record : origRecords) {
             if (record.hasRecNo()) {
                 lastRecordWithKey.put(record.getRecNo(), record);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
@@ -153,7 +153,7 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
         }
 
         long curr = 0;
-        Map<Integer,Long> ranks = new HashMap<>();
+        Map<Integer, Long> ranks = new HashMap<>();
         if (hasNull) {
             curr += 1;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
@@ -58,7 +58,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     private void valueRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
                               int agents, boolean overlap, boolean splitLongRecords) {
         Index index = new Index("newIndex", field("num_value_2"));
-        Function<FDBQueriedRecord<Message>,Integer> projection = rec -> {
+        Function<FDBQueriedRecord<Message>, Integer> projection = rec -> {
             TestRecords1Proto.MySimpleRecord simple = TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(rec.getRecord()).build();
             if (simple.hasNumValue2()) {
                 return simple.getNumValue2();
@@ -79,7 +79,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
                 })
                 .collect(Collectors.toList());
 
-        Function<TestRecords1Proto.MySimpleRecord,Integer> indexValue = msg -> msg.hasNumValue2() ? msg.getNumValue2() : null;
+        Function<TestRecords1Proto.MySimpleRecord, Integer> indexValue = msg -> msg.hasNumValue2() ? msg.getNumValue2() : null;
         Map<Integer, List<Message>> valueMap = group(records, indexValue);
 
         Runnable beforeBuild = () -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
@@ -93,7 +93,7 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
                 })
                 .collect(Collectors.toList());
 
-        Function<TestRecords1Proto.MySimpleRecord,Integer> indexValue = msg -> msg.hasNumValue2() ? msg.getNumValue2() : null;
+        Function<TestRecords1Proto.MySimpleRecord, Integer> indexValue = msg -> msg.hasNumValue2() ? msg.getNumValue2() : null;
         Map<Integer, List<Message>> valueMap = group(records, indexValue);
         Map<Long, FDBRecordVersion> versionMap = new HashMap<>(records.size() + (recordsWhileBuilding == null ? 0 : recordsWhileBuilding.size()));
         AtomicReference<FDBRecordVersion> greatestVersion = new AtomicReference<>(null);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ProbableIntersectionCursorTest.java
@@ -250,7 +250,7 @@ public class ProbableIntersectionCursorTest {
         }
     }
 
-    private void verifyResults(@Nonnull RecordCursor<Integer> cursor, @Nonnull RecordCursor.NoNextReason expectedReason, int...expectedResults) {
+    private void verifyResults(@Nonnull RecordCursor<Integer> cursor, @Nonnull RecordCursor.NoNextReason expectedReason, int... expectedResults) {
         for (int expectedResult : expectedResults) {
             RecordCursorResult<Integer> result = cursor.getNext();
             assertThat(result.hasNext(), is(true));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexTest.java
@@ -650,14 +650,14 @@ class RankIndexTest extends FDBRecordStoreQueryTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            try (RecordCursorIterator<? extends Pair<Message,Long>> cursor =
+            try (RecordCursorIterator<? extends Pair<Message, Long>> cursor =
                          recordStore.executeQuery(plan)
                                  .mapPipelined(record -> ranker.eval(recordStore, EvaluationContext.EMPTY, record.getStoredRecord())
                                          .thenApply(rank -> new ImmutablePair<>(record.getRecord(), rank)), recordStore.getPipelineSize(PipelineOperation.RECORD_FUNCTION))
                                  .asIterator()) {
                 long rank = 0;
                 while (cursor.hasNext()) {
-                    Pair<Message,Long> recWithRank = cursor.next();
+                    Pair<Message, Long> recWithRank = cursor.next();
                     TestRecordsRankProto.BasicRankedRecord.Builder myrec = TestRecordsRankProto.BasicRankedRecord.newBuilder();
                     myrec.mergeFrom(recWithRank.getLeft());
                     assertEquals((Long)rank++, recWithRank.getRight());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/FDBComparatorPlanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/FDBComparatorPlanTest.java
@@ -263,7 +263,7 @@ public abstract class FDBComparatorPlanTest extends FDBRecordStoreQueryTestBase 
 
         // Iteration 2, start with previous continuation, reach end (before limit)
         byte[] continuation = result.getContinuation().toBytes();
-        assertSamePlansWithContinuation(planUnderTest, continuation, 0, 200,16, 1, 66, false, RecordCursor.NoNextReason.SOURCE_EXHAUSTED);
+        assertSamePlansWithContinuation(planUnderTest, continuation, 0, 200, 16, 1, 66, false, RecordCursor.NoNextReason.SOURCE_EXHAUSTED);
     }
 
     @DualPlannerTest

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -163,19 +163,19 @@ public class LuceneEvents {
      */
     public enum Counts implements StoreTimer.Count {
         /** Number of times the getIncrement() function is called in the FDBDirectory. */
-        LUCENE_GET_INCREMENT_CALLS("lucene increments",false),
+        LUCENE_GET_INCREMENT_CALLS("lucene increments", false),
         /** Number of writeFileReference calls in the FDBDirectory.*/
-        LUCENE_WRITE_FILE_REFERENCE_CALL("lucene write file references",false),
+        LUCENE_WRITE_FILE_REFERENCE_CALL("lucene write file references", false),
         /** Total number of bytes that were attempted to be written (not necessarily committed) for file references in the FDBDirectory. */
         LUCENE_WRITE_FILE_REFERENCE_SIZE("lucene write file reference size", true),
         /** Count of writeData calls in FDBDirectory. */
         LUCENE_WRITE_CALL("lucene index writes", false),
         /** Total number of bytes that were attempted to be written (not necessarily committed) to the FDBDirectory.*/
-        LUCENE_WRITE_SIZE("lucene index size",true),
+        LUCENE_WRITE_SIZE("lucene index size", true),
         /** The number of block reads that occur against the FDBDirectory.*/
         LUCENE_BLOCK_READS("lucene block reads", false),
         /** Time to write a file references in Lucene's FDBDirectory.*/
-        LUCENE_WRITE_FILE_REFERENCE("lucene write file reference" ,false),
+        LUCENE_WRITE_FILE_REFERENCE("lucene write file reference" , false),
         /** Matched documents returned from lucene index reader scans. **/
         LUCENE_SCAN_MATCHED_DOCUMENTS("lucene scan matched documents", false),
         /** Matched auto complete suggestions returned from lucene auto complete suggestion lookup. **/

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
@@ -122,8 +122,8 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
                     .build();
             final RecordQueryPlan plan = planner.plan(rq);
             Set<String> appliedIndexNames = plan.getUsedIndexes();
-            Assertions.assertEquals(1,appliedIndexNames.size(),"index selection is incorrect");
-            Assertions.assertTrue(appliedIndexNames.contains(text2Index.getName()),"Did not select the correct index");
+            Assertions.assertEquals(1, appliedIndexNames.size(), "index selection is incorrect");
+            Assertions.assertTrue(appliedIndexNames.contains(text2Index.getName()), "Did not select the correct index");
         }
     }
 
@@ -144,8 +144,8 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
                     .build();
             final RecordQueryPlan plan = planner.plan(rq);
             Set<String> appliedIndexNames = plan.getUsedIndexes();
-            Assertions.assertEquals(1,appliedIndexNames.size(),"index selection is incorrect");
-            Assertions.assertTrue(appliedIndexNames.contains(nestedDualIndex2.getName()),"Did not select the correct index");
+            Assertions.assertEquals(1, appliedIndexNames.size(), "index selection is incorrect");
+            Assertions.assertTrue(appliedIndexNames.contains(nestedDualIndex2.getName()), "Did not select the correct index");
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -68,7 +68,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     public void testGetIncrement() {
         assertEquals(1, directory.getIncrement());
         assertEquals(2, directory.getIncrement());
-        assertCorrectMetricCount(LuceneEvents.Counts.LUCENE_GET_INCREMENT_CALLS,2);
+        assertCorrectMetricCount(LuceneEvents.Counts.LUCENE_GET_INCREMENT_CALLS, 2);
         directory.getContext().commit();
 
         try (FDBRecordContext context = fdb.openContext()) {
@@ -219,7 +219,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     public void testRename() {
         assertThrows(RecordCoreArgumentException.class, () -> directory.rename("NoExist", "newName"));
 
-        assertCorrectMetricCount(LuceneEvents.Waits.WAIT_LUCENE_RENAME,1);
+        assertCorrectMetricCount(LuceneEvents.Waits.WAIT_LUCENE_RENAME, 1);
     }
 
 

--- a/gradle/codequality/checkstyle.xml
+++ b/gradle/codequality/checkstyle.xml
@@ -77,6 +77,9 @@
             <property name="option" value="alone"/>
             <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
         </module>
+        <module name="WhitespaceAfter">
+            <property name="tokens" value="COMMA, SEMI, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, LITERAL_RETURN, LITERAL_CATCH, DO_WHILE, ELLIPSIS, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LAMBDA"/>
+        </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>
             <property name="allowEmptyMethods" value="true"/>


### PR DESCRIPTION
Differs from default by allowing `TYPECAST`, on which there seems to be genuine divergence in the team. I am certainly willing to put that back and also fix everything to require the space, if we think consistency is more important.

Most of the edits involve generic type parameters, for which there isn't any easy way to allow it. So it seems simplest to just add the spaces.