### PR TITLE
Resolves #1758: Add index scan plan with additional reads to load the RYW cache

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** A new index scan plan variant has been added that make better use of existing caches in repeated executions of the same query [(Issue #1758)](https://github.com/FoundationDB/fdb-record-layer/issues/1758)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -526,6 +526,8 @@ public class FDBStoreTimer extends StoreTimer {
         PLAN_AGGREGATE("number of streaming aggregate plans", false),
         /** The number of query plans that include an index. */
         PLAN_INDEX("number of index plans", false),
+        /** The number of query plans that include an index scan which overscans to load additional data into a client-side cache. */
+        PLAN_OVERSCAN_INDEX("number of overscan index plans", false),
         /** The number of query plans that include an {@code IN} with parameters. */
         PLAN_IN_PARAMETER("number of in plans with parameters", false),
         /** The number of query plans that include a {@code IN} type of Union. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
@@ -59,6 +59,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnK
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnValuePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryLoadByKeysPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryMapPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryOverscanIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
@@ -117,6 +118,12 @@ public class CardinalitiesProperty implements ExpressionProperty<CardinalitiesPr
         return  new Cardinalities(
                 Cardinality.ofCardinality(valuesSize).times(childCardinalities.getMinCardinality()),
                 Cardinality.ofCardinality(valuesSize).times(childCardinalities.getMaxCardinality()));
+    }
+
+    @Nonnull
+    @Override
+    public Cardinalities visitRecordQueryOverscanIndexPlan(@Nonnull final RecordQueryOverscanIndexPlan element) {
+        return visit(element.getIndexPlan());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
@@ -44,6 +44,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnK
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnValuePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryLoadByKeysPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryMapPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryOverscanIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanVisitor;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
@@ -105,6 +106,12 @@ public class DistinctRecordsProperty implements PlanProperty<Boolean> {
         @Override
         public Boolean visitInValuesJoinPlan(@Nonnull final RecordQueryInValuesJoinPlan inValuesJoinPlan) {
             return visitInJoinPlan(inValuesJoinPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitOverscanIndexPlan(@Nonnull final RecordQueryOverscanIndexPlan element) {
+            return visit(element.getIndexPlan());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
@@ -53,6 +53,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnK
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnValuePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryLoadByKeysPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryMapPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryOverscanIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanVisitor;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
@@ -168,6 +169,12 @@ public class OrderingProperty implements PlanProperty<Ordering> {
         @Override
         public Ordering visitInValuesJoinPlan(@Nonnull final RecordQueryInValuesJoinPlan inValuesJoinPlan) {
             return visitInJoinPlan(inValuesJoinPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Ordering visitOverscanIndexPlan(@Nonnull final RecordQueryOverscanIndexPlan element) {
+            return visit(element.getIndexPlan());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
@@ -43,6 +43,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnK
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnValuePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryLoadByKeysPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryMapPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryOverscanIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanVisitor;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
@@ -106,6 +107,12 @@ public class StoredRecordProperty implements PlanProperty<Boolean> {
         @Override
         public Boolean visitInValuesJoinPlan(@Nonnull final RecordQueryInValuesJoinPlan inValuesJoinPlan) {
             return visitInJoinPlan(inValuesJoinPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitOverscanIndexPlan(@Nonnull final RecordQueryOverscanIndexPlan element) {
+            return visit(element.getIndexPlan());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryComparatorPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryComparatorPlan.java
@@ -176,6 +176,14 @@ public class RecordQueryComparatorPlan extends RecordQueryChooserPlanBase {
         return comparisonKey;
     }
 
+    public int getReferencePlanIndex() {
+        return referencePlanIndex;
+    }
+
+    public boolean isAbortOnComparisonFailure() {
+        return abortOnComparisonFailure;
+    }
+
     @Nonnull
     @Override
     public String toString() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -110,6 +110,10 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
         return indexPlan;
     }
 
+    RecordQueryCoveringIndexPlan withIndexPlan(@Nonnull RecordQueryPlanWithIndex newIndexPlan) {
+        return new RecordQueryCoveringIndexPlan(newIndexPlan, recordTypeName, availableFields, toRecord);
+    }
+
     @Nonnull
     public String getIndexName() {
         return indexPlan.getIndexName();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryOverscanIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryOverscanIndexPlan.java
@@ -1,0 +1,398 @@
+/*
+ * RecordQueryOverscanIndexPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.CursorStreamingMode;
+import com.apple.foundationdb.record.EndpointType;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorEndContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanBounds;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanRange;
+import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
+import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
+import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
+import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Variant of {@link RecordQueryIndexPlan} that scans a larger range internally. Semantically, this
+ * returns the same results as a {@link RecordQueryIndexPlan} over the same range. However, internally,
+ * it will scan additional data for the purposes of loading that data into an in-memory cache that
+ * lives within the FDB client.
+ *
+ * <p>
+ * This is most useful in the following situation: a query with parameters is planned once, and then
+ * executed multiple times in the same transaction with different parameter values. In this case, the
+ * first time the plan is executed, this plan will incur additional I/O in order to place entries in
+ * the cache, but subsequent executions of the plan may be able to be served from this cache, saving
+ * time overall.
+ * </p>
+ *
+ * <p>
+ * This plan's continuations are also designed to be equivalent to a {@link RecordQueryIndexPlan} over the
+ * same scan range, so a query plan with a {@link RecordQueryIndexPlan} can be executed, and then the
+ * continuation from that plan can be given to an identical plan that substitutes the index scan
+ * with this plan (or vice versa).
+ * </p>
+ */
+@API(API.Status.INTERNAL)
+public class RecordQueryOverscanIndexPlan implements RecordQueryPlanWithIndex, RecordQueryPlanWithNoChildren {
+    private final RecordQueryIndexPlan originalIndexPlan;
+
+    @API(API.Status.INTERNAL)
+    public RecordQueryOverscanIndexPlan(RecordQueryIndexPlan originalIndexPlan) {
+        this.originalIndexPlan = originalIndexPlan;
+    }
+
+    @Nonnull
+    @Override
+    public <M extends Message> RecordCursor<IndexEntry> executeEntries(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                       @Nonnull final EvaluationContext context,
+                                                                       @Nullable final byte[] continuation,
+                                                                       @Nonnull final ExecuteProperties executeProperties) {
+        // This plan can only be applied to BY_VALUE index scans
+        if (!IndexScanType.BY_VALUE.equals(originalIndexPlan.getScanType())) {
+            return originalIndexPlan.executeEntries(store, context, continuation, executeProperties);
+        }
+
+        // Evaluate the scan bounds. Again, this optimization can only be done if we have a scan range
+        Index index = store.getRecordMetaData().getIndex(getIndexName());
+        IndexScanBounds scanBounds = originalIndexPlan.getScanParameters().bind(store, index, context);
+        if (!(scanBounds instanceof IndexScanRange)) {
+            return originalIndexPlan.executeEntries(store, context, continuation, executeProperties);
+        }
+
+        // Try to widen the scan range to include everything up
+        IndexScanRange indexScanRange = (IndexScanRange) scanBounds;
+        TupleRange tupleScanRange = indexScanRange.getScanRange();
+        TupleRange widenedScanRange = widenRange(tupleScanRange);
+        if (widenedScanRange == null) {
+            // Unable to widen the range. Fall back to the original execution.
+            return originalIndexPlan.executeEntries(store, context, continuation, executeProperties);
+        }
+
+        final byte[] prefixBytes = getRangePrefixBytes(tupleScanRange);
+        final IndexScanContinuationConvertor continuationConvertor = new IndexScanContinuationConvertor(prefixBytes);
+
+        // Scan a wider range, and then halt when either this scans outside the given range
+        final IndexScanRange newScanRange = new IndexScanRange(IndexScanType.BY_VALUE, widenedScanRange);
+        final Range originalKeyRange = tupleScanRange.toRange();
+        // Make sure to use ITERATOR mode so that the results are paginated (by the FDB Java bindings). This
+        // streaming mode limits the amount of data we might read beyond that which is returned to one page
+        // from the database
+        final ExecuteProperties newExecuteProperties = executeProperties
+                .setDefaultCursorStreamingMode(CursorStreamingMode.ITERATOR);
+        final ScanProperties scanProperties = newExecuteProperties.asScanProperties(isReverse());
+        return store.scanIndex(index, newScanRange, continuationConvertor.unwrapContinuation(continuation), scanProperties).mapResult(result -> {
+            if (!result.hasNext()) {
+                RecordCursorContinuation wrappedContinuation = continuationConvertor.wrapContinuation(result.getContinuation());
+                return result.withContinuation(wrappedContinuation);
+            }
+            // Check if the result is in the range the user actually cares about. If so, return it. Otherwise,
+            // terminate the scan.
+            IndexEntry entry = result.get();
+            byte[] keyBytes = entry.getKey().pack();
+            if ((isReverse() && ByteArrayUtil.compareUnsigned(originalKeyRange.begin, keyBytes) <= 0)
+                    || (!isReverse() && ByteArrayUtil.compareUnsigned(originalKeyRange.end, keyBytes) > 0)) {
+                RecordCursorContinuation wrappedContinuation = continuationConvertor.wrapContinuation(result.getContinuation());
+                return result.withContinuation(wrappedContinuation);
+            } else {
+                return RecordCursorResult.exhausted();
+            }
+        });
+    }
+
+    /**
+     * Continuation convertor to transform the continuations from the physical (wider) scan and the logical (narrower)
+     * scan.
+     */
+    private static class IndexScanContinuationConvertor implements RecordCursor.ContinuationConvertor {
+        @Nonnull
+        private final byte[] prefixBytes;
+
+        public IndexScanContinuationConvertor(@Nonnull byte[] prefixBytes) {
+            this.prefixBytes = prefixBytes;
+        }
+
+        @Nullable
+        @Override
+        public byte[] unwrapContinuation(@Nullable final byte[] continuation) {
+            if (continuation == null) {
+                return null;
+            }
+            // Add the prefix back to the inner continuation
+            return ByteArrayUtil.join(prefixBytes, continuation);
+        }
+
+        @Override
+        public RecordCursorContinuation wrapContinuation(@Nonnull final RecordCursorContinuation continuation) {
+            if (continuation.isEnd()) {
+                return continuation;
+            }
+            final byte[] continuationBytes = continuation.toBytes();
+            if (continuationBytes != null && ByteArrayUtil.startsWith(continuationBytes, prefixBytes)) {
+                // Strip away the prefix. Note that ByteStrings re-use the underlying ByteArray, so this can
+                // save a copy.
+                return new PrefixRemovingContinuation(continuation, prefixBytes.length);
+            } else {
+                // This key does not begin with the prefix. Return an END continuation to indicate that the
+                // scan is over.
+                return RecordCursorEndContinuation.END;
+            }
+        }
+
+        private static class PrefixRemovingContinuation implements RecordCursorContinuation {
+            private final RecordCursorContinuation baseContinuation;
+            private final int prefixLength;
+
+            @SuppressWarnings("squid:S3077") // array immutable once initialized, so AtomicByteArray not necessary
+            @Nullable
+            private volatile byte[] bytes;
+
+            private PrefixRemovingContinuation(RecordCursorContinuation baseContinuation, int prefixLength) {
+                this.baseContinuation = baseContinuation;
+                this.prefixLength = prefixLength;
+            }
+
+            @Nullable
+            @Override
+            public byte[] toBytes() {
+                if (bytes == null) {
+                    synchronized (this) {
+                        if (bytes == null) {
+                            byte[] baseContinuationBytes = baseContinuation.toBytes();
+                            if (baseContinuationBytes == null) {
+                                return null;
+                            }
+                            this.bytes = Arrays.copyOfRange(baseContinuationBytes, prefixLength, baseContinuationBytes.length);
+                        }
+                    }
+                }
+                return bytes;
+            }
+
+            @Nonnull
+            @Override
+            public ByteString toByteString() {
+                return baseContinuation.toByteString().substring(prefixLength);
+            }
+
+            @Override
+            public boolean isEnd() {
+                return false;
+            }
+        }
+    }
+
+    @Nullable
+    private TupleRange widenRange(@Nonnull TupleRange originalRange) {
+        if (originalRange.getLowEndpoint() == EndpointType.PREFIX_STRING || originalRange.getHighEndpoint() == EndpointType.PREFIX_STRING) {
+            return null;
+        }
+
+        // Widen the range so that the we can from the original location to the end of the index. Note that we will
+        // stop executing the scan once we stop getting results within the original range, so even though we're requesting
+        // a fairly large range, the actual extra work done shouldn't be this bad.
+        if (isReverse()) {
+            return new TupleRange(null, originalRange.getHigh(), EndpointType.TREE_START, originalRange.getHighEndpoint());
+        } else {
+            return new TupleRange(originalRange.getLow(), null, originalRange.getLowEndpoint(), EndpointType.TREE_END);
+        }
+    }
+
+    private static byte[] getRangePrefixBytes(TupleRange tupleRange) {
+        byte[] lowBytes = tupleRange.getLow() == null ? null : tupleRange.getLow().pack();
+        byte[] highBytes = tupleRange.getHigh() == null ? null : tupleRange.getHigh().pack();
+        if (lowBytes == null || highBytes == null) {
+            return new byte[0];
+        }
+        int i = 0;
+        while (i < lowBytes.length && i < highBytes.length && lowBytes[i] == highBytes[i]) {
+            i++;
+        }
+        return Arrays.copyOfRange(lowBytes, 0, i);
+    }
+
+    @Nonnull
+    public RecordQueryIndexPlan getIndexPlan() {
+        return originalIndexPlan;
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        // This returns the original plan plan's plan hash because the two plans should be semantically
+        // identical and continuations should be compatible, so swapping out one plan for the other should
+        // always be okay.
+        return originalIndexPlan.planHash(hashKind);
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return originalIndexPlan.getCorrelatedTo();
+    }
+
+    @Nonnull
+    @Override
+    public Value getResultValue() {
+        return originalIndexPlan.getResultValue();
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Quantifier> getQuantifiers() {
+        return originalIndexPlan.getQuantifiers();
+    }
+
+    @Override
+    public boolean equalsWithoutChildren(@Nonnull final RelationalExpression other, @Nonnull final AliasMap equivalences) {
+        return originalIndexPlan.equalsWithoutChildren(other, equivalences);
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(final Object o) {
+        return structuralEquals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return structuralHashCode();
+    }
+
+    @Override
+    public int hashCodeWithoutChildren() {
+        return originalIndexPlan.hashCodeWithoutChildren();
+    }
+
+    @Override
+    public boolean isReverse() {
+        return originalIndexPlan.isReverse();
+    }
+
+    @Override
+    public boolean hasRecordScan() {
+        return originalIndexPlan.hasRecordScan();
+    }
+
+    @Override
+    public boolean hasFullRecordScan() {
+        return originalIndexPlan.hasFullRecordScan();
+    }
+
+    @Override
+    public boolean hasIndexScan(@Nonnull final String indexName) {
+        return originalIndexPlan.hasIndexScan(indexName);
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getUsedIndexes() {
+        return originalIndexPlan.getUsedIndexes();
+    }
+
+    @Override
+    public boolean hasLoadBykeys() {
+        return originalIndexPlan.hasLoadBykeys();
+    }
+
+    @Override
+    public String toString() {
+        return "Overscan(" + originalIndexPlan + ")";
+    }
+
+    @Override
+    public void logPlanStructure(final StoreTimer timer) {
+        timer.increment(FDBStoreTimer.Counts.PLAN_OVERSCAN_INDEX);
+    }
+
+    @Override
+    public int getComplexity() {
+        return originalIndexPlan.getComplexity() + 1;
+    }
+
+    @Nonnull
+    @Override
+    public AvailableFields getAvailableFields() {
+        return originalIndexPlan.getAvailableFields();
+    }
+
+    @Nonnull
+    @Override
+    public String getIndexName() {
+        return originalIndexPlan.getIndexName();
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanType getScanType() {
+        return originalIndexPlan.getScanType();
+    }
+
+    @Nonnull
+    @Override
+    public Optional<? extends MatchCandidate> getMatchCandidateOptional() {
+        return originalIndexPlan.getMatchCandidateOptional();
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithIndex translateCorrelations(@Nonnull final TranslationMap translationMap, @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
+        return originalIndexPlan.translateCorrelations(translationMap, translatedQuantifiers);
+    }
+
+    @Nonnull
+    @Override
+    public PlannerGraph createIndexPlannerGraph(@Nonnull final RecordQueryPlan identity, @Nonnull final NodeInfo nodeInfo, @Nonnull final List<String> additionalDetails, @Nonnull final Map<String, Attribute> additionalAttributeMap) {
+        return originalIndexPlan.createIndexPlannerGraph(identity, nodeInfo, additionalDetails, additionalAttributeMap);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySelectorPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySelectorPlan.java
@@ -150,6 +150,11 @@ public class RecordQuerySelectorPlan extends RecordQueryChooserPlanBase {
         return new SelectorPlanCursor(selectedPlanIndex, innerCursor, store.getTimer());
     }
 
+    @Nonnull
+    public PlanSelector getPlanSelector() {
+        return planSelector;
+    }
+
     @Override
     public int planHash(@Nonnull final PlanHashKind hashKind) {
         return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, getChildren(), isReverse(), planSelector);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/OverscanIndexMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/OverscanIndexMatcher.java
@@ -1,0 +1,54 @@
+/*
+ * OverscanIndexMatcher.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.match;
+
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryOverscanIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Plan matcher for the {@link RecordQueryOverscanIndexPlan}. Allows for test assertions to be made
+ * both that a plan is of the correct type and that the underlying index plan furthermore
+ * matches expectations.
+ */
+public class OverscanIndexMatcher extends TypeSafeMatcher<RecordQueryPlan> {
+    private final Matcher<? super RecordQueryIndexPlan> indexPlanMatcher;
+
+    public OverscanIndexMatcher(Matcher<? super RecordQueryIndexPlan> indexPlanMatcher) {
+        this.indexPlanMatcher = indexPlanMatcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(final RecordQueryPlan item) {
+        return item instanceof RecordQueryOverscanIndexPlan
+               && indexPlanMatcher.matches(((RecordQueryOverscanIndexPlan)item).getIndexPlan());
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("Overscan(");
+        description.appendDescriptionOf(indexPlanMatcher);
+        description.appendText(")");
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/PlanMatchers.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithComparisons;
@@ -34,7 +35,6 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortKey;
-import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import org.hamcrest.Matcher;
 
 import javax.annotation.Nonnull;
@@ -63,6 +63,14 @@ public class PlanMatchers {
 
     public static Matcher<RecordQueryPlan> indexScan(@Nonnull final String indexName) {
         return indexScan(indexName(indexName));
+    }
+
+    public static Matcher<RecordQueryPlan> overscanIndexScan(@Nonnull Matcher<? super RecordQueryIndexPlan> planMatcher) {
+        return new OverscanIndexMatcher(planMatcher);
+    }
+
+    public static Matcher<RecordQueryPlan> overscanIndexScan(@Nonnull final String indexName) {
+        return overscanIndexScan(indexName(indexName));
     }
 
     public static Matcher<RecordQueryPlan> textIndexScan(@Nonnull Matcher<? super RecordQueryTextIndexPlan> planMatcher) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryOverscanIndexPlanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryOverscanIndexPlanTest.java
@@ -1,0 +1,501 @@
+/*
+ * RecordQueryOverscanIndexPlanTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.record.CursorStreamingMode;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.ExecuteState;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorStartContinuation;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.query.FDBRecordStoreQueryTestBase;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
+import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
+import com.apple.test.BooleanSource;
+import com.apple.test.Tags;
+import com.google.protobuf.Message;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.coveringIndexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTupleString;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.overscanIndexScan;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests of {@link RecordQueryOverscanIndexPlan}. This plan should have identical semantics to the
+ * {@link RecordQueryIndexPlan}, but it may scan additional ranges to load a cache. The primary thing
+ * that these tests are designed to verify is that the behavior of an index scan is the same if one
+ * is wrapped with an overscan index plan, including that continuations are compatible.
+ */
+@Tag(Tags.RequiresFDB)
+class RecordQueryOverscanIndexPlanTest extends FDBRecordStoreQueryTestBase {
+    private static final ConvertToRecordQueryOverscanIndexPlanVisitor CONVERTOR = new ConvertToRecordQueryOverscanIndexPlanVisitor();
+
+    @ParameterizedTest(name = "basicScanTest[reverse={0}]")
+    @BooleanSource
+    void basicScanTest(boolean reverse) throws Exception {
+        setupSimpleRecordStore(NO_HOOK, (i, builder) ->
+                builder.setRecNo(i).setStrValueIndexed((char)('a' + (i % 26)) + "_suffix"));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.and(Query.field("str_value_indexed").greaterThan("bar"), Query.field("str_value_indexed").lessThan("foo")))
+                    .setSort(Key.Expressions.field("str_value_indexed"), reverse)
+                    .build();
+            final Matcher<RecordQueryIndexPlan> indexPlanMatcher = allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(hasTupleString("([bar],[foo])")));
+            RecordQueryPlan indexPlan = recordStore.planQuery(query);
+            assertThat(indexPlan, indexScan(indexPlanMatcher));
+            RecordQueryPlan overscanIndexPlan = convertToOverscan(indexPlan);
+            assertThat(overscanIndexPlan, overscanIndexScan(indexPlanMatcher));
+
+            timer.reset();
+            assertTrue(assertSameResults(recordStore, indexPlan, overscanIndexPlan, EvaluationContext.EMPTY, ExecuteProperties.SERIAL_EXECUTE, null).isEnd());
+            // There should be 32 load records, because these values of str_value_indexed should be read:
+            //    c_suffix, d_suffix, e_suffix, f_suffix
+            // There are 100 records, so that corresponds to records: 3, 4, 5, 6, 29, 30, 31, 32, 55, 56, 57, 58, 81, 82, 83 and 84
+            // Those 16 records are read twice, once by each plan
+            assertEquals(32, timer.getCount(FDBStoreTimer.Events.LOAD_RECORD));
+
+            commit(context);
+        }
+    }
+
+    @ParameterizedTest(name = "coveringIndexScanTest[reverse={0}]")
+    @BooleanSource
+    void coveringIndexScanTest(boolean reverse) throws Exception {
+        setupSimpleRecordStore(NO_HOOK, (i, builder) ->
+                builder.setRecNo(i).setStrValueIndexed(i % 2 == 0 ? "foo" : "bar"));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setRequiredResults(List.of(Key.Expressions.field("str_value_indexed"), Key.Expressions.field("rec_no")))
+                    .setFilter(Query.field("str_value_indexed").equalsValue("foo"))
+                    .setSort(Key.Expressions.field("str_value_indexed"), reverse)
+                    .build();
+            final Matcher<RecordQueryIndexPlan> indexPlanMatcher = allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(hasTupleString("[[foo],[foo]]")));
+            RecordQueryPlan indexPlan = recordStore.planQuery(query);
+            assertThat(indexPlan, coveringIndexScan(indexScan(indexPlanMatcher)));
+            RecordQueryPlan overscanIndexPlan = convertToOverscan(indexPlan);
+            assertThat(overscanIndexPlan, coveringIndexScan(overscanIndexScan(indexPlanMatcher)));
+
+            timer.reset();
+            assertTrue(assertSameResults(recordStore, indexPlan, overscanIndexPlan, EvaluationContext.EMPTY, ExecuteProperties.SERIAL_EXECUTE, null).isEnd());
+            assertEquals(0, timer.getCount(FDBStoreTimer.Events.LOAD_RECORD), "covering plans should load 0 records");
+
+            commit(context);
+        }
+    }
+
+    /**
+     * This simulates a case that might actually benefit from using the overscan plan to load more data into the
+     * cache. In this case, there is an index on {@code (str_value_indexed, num_value_3_indexed)}, and this wants to
+     * load the record(s) for a bunch of different values of {@code num_value_3_indexed} for a given value of
+     * {@code str_value_indexed}, some of which will have an associated record and some of which won't. When using
+     * the overscan plan, some empty ranges will be put into the cache, so if a request comes in for an  adjacent
+     * value, the index can be looked up in the cache.
+     *
+     * @param reverse whether to execute individual scans in reverse
+     * @throws Exception rethrown from store set up and opening
+     */
+    @ParameterizedTest(name = "evaluateMultipleParameters[reverse={0}]")
+    @BooleanSource
+    void evaluateMultipleParameters(boolean reverse) throws Exception {
+        final Index compoundIndex = new Index("compoundIndex", Key.Expressions.concat(Key.Expressions.field("str_value_indexed"), Key.Expressions.field("num_value_3_indexed")));
+        RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", compoundIndex);
+        setupSimpleRecordStore(hook, (i, builder) ->
+                builder.setRecNo(i + 100L).setNumValue3Indexed(i).setStrValueIndexed(i % 2 == 0 ? "even" : "odd"));
+
+        Random r = new Random();
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.and(Query.field("str_value_indexed").equalsValue("even"), Query.field("num_value_3_indexed").equalsParameter("val")))
+                    .setSort(compoundIndex.getRootExpression(), reverse)
+                    .build();
+            final Matcher<RecordQueryIndexPlan> indexPlanMatcher = allOf(indexName(compoundIndex.getName()), bounds(hasTupleString("[EQUALS even, EQUALS $val]")));
+            RecordQueryPlan indexPlan = recordStore.planQuery(query);
+            assertThat(indexPlan, indexScan(indexPlanMatcher));
+            RecordQueryPlan overscanPlan = convertToOverscan(indexPlan);
+            assertThat(overscanPlan, overscanIndexScan(indexPlanMatcher));
+
+            for (int i = 0; i < 50; i++) {
+                EvaluationContext evaluationContext = EvaluationContext.EMPTY.withBinding("val", r.nextInt(100));
+                assertSameResults(recordStore, indexPlan, overscanPlan, evaluationContext, ExecuteProperties.SERIAL_EXECUTE, null);
+            }
+
+            commit(context);
+        }
+    }
+
+    @SuppressWarnings("unused") // used as parameter source for parameterized test
+    static Stream<Arguments> withLimits() {
+        List<Integer> limits = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+        return Stream.of(false, true).flatMap(reverse ->
+                limits.stream().map(limit ->
+                        Arguments.of(reverse, limit)));
+    }
+
+    @ParameterizedTest(name = "withLimits[reverse={0}, limit={1}]")
+    @MethodSource
+    void withLimits(boolean reverse, int limit) throws Exception {
+        final Index compoundIndex = new Index("compoundIndex",
+                Key.Expressions.concat(Key.Expressions.field("num_value_2"),
+                        Key.Expressions.field("str_value_indexed"),
+                Key.Expressions.field("num_value_unique")));
+        RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", compoundIndex);
+        setupSimpleRecordStore(hook, (i, builder) ->
+                builder.setRecNo(i).setNumValue2(i % 7).setStrValueIndexed(i % 3 == 0 ? "threven" : "throdd").setNumValueUnique(i));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.and(Query.field("num_value_2").equalsParameter("num_val"), Query.field("str_value_indexed").equalsParameter("str_val")))
+                    .setSort(compoundIndex.getRootExpression(), reverse)
+                    .setRequiredResults(List.of(Key.Expressions.field("num_value_unique")))
+                    .build();
+            final Matcher<RecordQueryIndexPlan> indexPlanMatcher = allOf(indexName(compoundIndex.getName()), bounds(hasTupleString("[EQUALS $num_val, EQUALS $str_val]")));
+            RecordQueryPlan indexPlan = recordStore.planQuery(query);
+            assertThat(indexPlan, coveringIndexScan(indexScan(indexPlanMatcher)));
+            RecordQueryPlan overscanIndexPlan = convertToOverscan(indexPlan);
+            assertThat(overscanIndexPlan, coveringIndexScan(overscanIndexScan(indexPlanMatcher)));
+
+            ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                    .setDefaultCursorStreamingMode(CursorStreamingMode.WANT_ALL)
+                    .setReturnedRowLimit(limit)
+                    .build();
+            EvaluationContext evaluationContext = EvaluationContext.EMPTY
+                    .withBinding("str_val", "threven")
+                    .withBinding("num_val", 2);
+
+            RecordCursorContinuation continuation = RecordCursorStartContinuation.START;
+            do {
+                continuation = assertSameResults(recordStore, indexPlan, overscanIndexPlan, evaluationContext, executeProperties, continuation.toBytes());
+            } while (!continuation.isEnd());
+
+            commit(context);
+        }
+    }
+
+    // Validates that the index plan and the overscan index plan return identical results, including continuations
+    private static RecordCursorContinuation assertSameResults(@Nonnull FDBRecordStore recordStore,
+                                                              @Nonnull RecordQueryPlan indexPlan,
+                                                              @Nonnull RecordQueryPlan overscanIndexPlan,
+                                                              @Nonnull EvaluationContext evaluationContext,
+                                                              @Nonnull ExecuteProperties executeProperties,
+                                                              @Nullable byte[] continuation) {
+        // Ensure the scan properties for each have their own execute state
+        ExecuteProperties indexExecuteProperties = executeProperties.setState(new ExecuteState());
+        ExecuteProperties overscanExecuteProperties = executeProperties.setState(new ExecuteState());
+        try (RecordCursor<FDBQueriedRecord<Message>> indexCursor = indexPlan.execute(recordStore, evaluationContext, continuation, indexExecuteProperties);
+                RecordCursor<FDBQueriedRecord<Message>> overscanCursor = overscanIndexPlan.execute(recordStore, evaluationContext, continuation, overscanExecuteProperties)) {
+            RecordCursorResult<FDBQueriedRecord<Message>> indexResult;
+            RecordCursorResult<FDBQueriedRecord<Message>> overscanResult;
+            do {
+                indexResult = indexCursor.getNext();
+                overscanResult = overscanCursor.getNext();
+                assertEquals(indexResult.getContinuation().toByteString(), overscanResult.getContinuation().toByteString(), "Continuation byte strings should match");
+                assertArrayEquals(indexResult.getContinuation().toBytes(), overscanResult.getContinuation().toBytes(), "Continuation byte arrays should match");
+
+                assertEquals(indexResult.hasNext(), overscanResult.hasNext(), "Overscan cursor should have next if index result has next");
+                if (indexResult.hasNext()) {
+                    assertEquals(indexResult.get().getRecord(), overscanResult.get().getRecord(), "Result returned via overscan cursor should match regular cursor");
+                } else {
+                    assertEquals(indexResult.getNoNextReason(), overscanResult.getNoNextReason(), "Overscan cursor should have same no next reason as index result");
+                }
+            } while (indexResult.hasNext());
+
+            return indexResult.getContinuation();
+        }
+    }
+
+    private static RecordQueryPlan convertToOverscan(RecordQueryPlan plan) {
+        RecordQueryPlan overscanPlan = CONVERTOR.visit(plan);
+        assertEquals(plan.planHash(), overscanPlan.planHash(), () -> String.format("Plan %s should have identical plan hash after being converted to overscan index plan %s", plan, overscanPlan));
+        return overscanPlan;
+    }
+
+    /**
+     * Record query plan visitor to convert the instances of a query plan that use the overscan index plan. We
+     * may want to replace this with a call to the planner once the planner can do that, but for now, this allows
+     * us to rewrite an existing plan (perhaps one produced by a planner) and add the new plan for testing purposes.
+     */
+    private static class ConvertToRecordQueryOverscanIndexPlanVisitor implements RecordQueryPlanVisitor<RecordQueryPlan> {
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitPredicatesFilterPlan(@Nonnull final RecordQueryPredicatesFilterPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitLoadByKeysPlan(@Nonnull final RecordQueryLoadByKeysPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitInValuesJoinPlan(@Nonnull final RecordQueryInValuesJoinPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitOverscanIndexPlan(@Nonnull final RecordQueryOverscanIndexPlan element) {
+            return element;
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitCoveringIndexPlan(@Nonnull final RecordQueryCoveringIndexPlan element) {
+            RecordQueryPlanWithIndex indexPlan = element.getIndexPlan();
+            RecordQueryPlan newIndexPlan = visit(indexPlan);
+            if (newIndexPlan instanceof RecordQueryPlanWithIndex) {
+                return element.withIndexPlan((RecordQueryPlanWithIndex) newIndexPlan);
+            } else {
+                return element;
+            }
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitMapPlan(@Nonnull final RecordQueryMapPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitComparatorPlan(@Nonnull final RecordQueryComparatorPlan element) {
+            List<RecordQueryPlan> newChildren = element.getChildStream()
+                    .map(this::visit)
+                    .collect(Collectors.toList());
+            return RecordQueryComparatorPlan.from(newChildren, element.getComparisonKey(), element.getReferencePlanIndex(), element.isAbortOnComparisonFailure());
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitUnorderedDistinctPlan(@Nonnull final RecordQueryUnorderedDistinctPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitIntersectionOnKeyExpressionPlan(@Nonnull final RecordQueryIntersectionOnKeyExpressionPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitSelectorPlan(@Nonnull final RecordQuerySelectorPlan element) {
+            List<RecordQueryPlan> newChildren = element.getChildStream()
+                    .map(this::visit)
+                    .collect(Collectors.toList());
+            return RecordQuerySelectorPlan.from(newChildren, element.getPlanSelector());
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitExplodePlan(@Nonnull final RecordQueryExplodePlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitIntersectionOnValuePlan(@Nonnull final RecordQueryIntersectionOnValuePlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitScoreForRankPlan(@Nonnull final RecordQueryScoreForRankPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryOverscanIndexPlan visitIndexPlan(@Nonnull final RecordQueryIndexPlan element) {
+            // HERE: Convert the index plan to an overscan index plan.
+            return new RecordQueryOverscanIndexPlan(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitFirstOrDefaultPlan(@Nonnull final RecordQueryFirstOrDefaultPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitUnionOnKeyExpressionPlan(@Nonnull final RecordQueryUnionOnKeyExpressionPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitFilterPlan(@Nonnull final RecordQueryFilterPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitUnorderedPrimaryKeyDistinctPlan(@Nonnull final RecordQueryUnorderedPrimaryKeyDistinctPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitTextIndexPlan(@Nonnull final RecordQueryTextIndexPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitFetchFromPartialRecordPlan(@Nonnull final RecordQueryFetchFromPartialRecordPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitTypeFilterPlan(@Nonnull final RecordQueryTypeFilterPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitInUnionOnKeyExpressionPlan(@Nonnull final RecordQueryInUnionOnKeyExpressionPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitInParameterJoinPlan(@Nonnull final RecordQueryInParameterJoinPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitFlatMapPlan(@Nonnull final RecordQueryFlatMapPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitStreamingAggregationPlan(@Nonnull final RecordQueryStreamingAggregationPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitUnionOnValuePlan(@Nonnull final RecordQueryUnionOnValuePlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitUnorderedUnionPlan(@Nonnull final RecordQueryUnorderedUnionPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitScanPlan(@Nonnull final RecordQueryScanPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitInUnionOnValuePlan(@Nonnull final RecordQueryInUnionOnValuePlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitComposedBitmapIndexQueryPlan(@Nonnull final ComposedBitmapIndexQueryPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitSortPlan(@Nonnull final RecordQuerySortPlan element) {
+            return visitDefault(element);
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryPlan visitDefault(@Nonnull final RecordQueryPlan element) {
+            if (element instanceof RecordQueryPlanWithChild) {
+                return visitPlanWithChild((RecordQueryPlanWithChild) element);
+            } else if (element instanceof RecordQuerySetPlan) {
+                return visitSetPlan((RecordQuerySetPlan) element);
+            }
+            return element;
+        }
+
+        private RecordQueryPlanWithChild visitPlanWithChild(@Nonnull RecordQueryPlanWithChild planWithChild) {
+            return planWithChild.withChild(visit(planWithChild.getChild()));
+        }
+
+        private RecordQuerySetPlan visitSetPlan(@Nonnull RecordQuerySetPlan setPlan) {
+            List<ExpressionRef<RecordQueryPlan>> newChildrenRef = setPlan.getChildren()
+                    .stream()
+                    .map(this::visit)
+                    .map(GroupExpressionRef::of)
+                    .collect(Collectors.toList());
+            return setPlan.withChildrenReferences(newChildrenRef);
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `RecordQueryPlan` that has the same semantics (in terms of results returned, including continuations) as a `RecordQueryIndexPlan`, but that scans additional ranges for the purposes
of loading the FDB C client's read-your-writes cache. If the query is executed multiple times in the same transaction with different bound parameters, then loading this cache might result in performance
wins because query executions (after the first) can use the cache to avoid having to make additional requests to the database. At the same time, because FDB paginates range scans, the amount of additional
work that each scan has to do to load the cache should be bounded as well (to approximately one page of results per scan).

This resolves #1758.