### PR TITLE
Gradle 7 problems with IntelliJ compilation of client.

### DIFF
--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -25,7 +25,7 @@ dependencies {
     api "org.foundationdb:fdb-java:${fdbVersion}"
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-    implementation "com.squareup:javapoet:${javaPoetVersion}"
+    api "com.squareup:javapoet:${javaPoetVersion}"
     compileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
     compileOnly "com.google.auto.service:auto-service:${autoServiceVersion}"
     annotationProcessor "com.google.auto.service:auto-service:${autoServiceVersion}"

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationProcessor.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationProcessor.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.annotation;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableSet;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -122,9 +121,7 @@ public class GenerateVisitorAnnotationProcessor extends AbstractProcessor {
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return ImmutableSet.<String>builder()
-                .add(GenerateVisitor.class.getCanonicalName())
-                .build();
+        return Set.of(GenerateVisitor.class.getCanonicalName());
     }
 
     @Override


### PR DESCRIPTION
Release 3.2.278 was fine for dependent systems compiled with Gradle.
But adding a `@AutoService(javax.annotation.processing.Processor.class)` means all of its runtime implementation also needs to be `api` so that
IntelliJ IDEA can call some of it (to determine that it isn't something it cares about, presumably).