### PR TITLE
Resolve #1792: Skip failing tests in dev

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
@@ -244,7 +244,8 @@ public class VersionIndexTest extends FDBTestBase {
     // Provide a combination of format versions, split and a remote fetch option
     private static Stream<Arguments> formatVersionArgumentsWithRemoteFetch() {
         return formatVersionArguments()
-                .flatMap(arg -> Arrays.stream(IndexFetchMethod.values())
+                // USE_REMOTE_FETCH is skipped for now in order to allow the test to pass when running with fdb < 7.1.10
+                .flatMap(arg -> Stream.of(IndexFetchMethod.SCAN_AND_FETCH, IndexFetchMethod.USE_REMOTE_FETCH_WITH_FALLBACK)
                         .map(indexFetchMethod -> Arguments.of(arg.get()[0], arg.get()[1], indexFetchMethod)));
     }
 
@@ -2335,6 +2336,9 @@ public class VersionIndexTest extends FDBTestBase {
     @ParameterizedTest(name = "testScanVersionIndex [" + ARGUMENTS_PLACEHOLDER + "]")
     @EnumSource(IndexFetchMethod.class)
     void testScanVersionIndex(IndexFetchMethod fetchMethod) throws Exception {
+        // This is skipped for now in order to allow the test to pass when running with fdb < 7.1.10
+        Assumptions.assumeTrue(fetchMethod != IndexFetchMethod.USE_REMOTE_FETCH);
+
         MySimpleRecord record1 = MySimpleRecord.newBuilder().setRecNo(1066L).setNumValue2(42).setNumValue3Indexed(1).build();
         MySimpleRecord record2 = MySimpleRecord.newBuilder().setRecNo(1067L).setNumValue2(42).setNumValue3Indexed(2).build();
         MySimpleRecord record3 = MySimpleRecord.newBuilder().setRecNo(1068L).setNumValue2(43).setNumValue3Indexed(2).build();


### PR DESCRIPTION
Remove USE_REMOTE_FETCH test for version index for now in order to allow tests to pass when using FDB version < 7.1.10
THis should be enabled again once 7.1.10 gets wider adoption.