### PR TITLE
Fix Lucene optimised index searcher

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -26,21 +26,26 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BulkScorer;
-import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.ThreadInterruptedException;
+
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static org.apache.lucene.search.QueryHelper.getQueriesTerms;
 
@@ -63,7 +68,7 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
     /**
      * Lower-level search API.
      *
-     * This is optimized into an attempt to parallelize database access in FDB
+     * This is optimized into an attempt to parallelize database access in FDB, for each collector in {@code collectorManager}.
      *
      * <p>
      * {@link LeafCollector#collect(int)} is called for every document. <br>
@@ -72,47 +77,87 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
      * NOTE: this method executes the searches on all given leaves exclusively.
      * To search across all the searchers leaves use {@link #leafContexts}.
      *
-     * @param leaves
-     *          the searchers leaves to execute the searches on
-     * @param weight
-     *          to match documents
-     * @param collector
-     *          to receive hits
-     * @throws BooleanQuery.TooManyClauses If a query would exceed
-     *         {@link BooleanQuery#getMaxClauseCount()} clauses.
+     * @param query
+     *          the search query
+     * @param collectorManager
+     *          manager of collectors that receive hits
      */
-    @Override
-    @SuppressWarnings("PMD")
-    protected void search(List<LeafReaderContext> leaves, Weight weight, Collector collector)
-            throws IOException {
-        Executor executor = getExecutor();
-        if (executor == null) {
-            super.search(leaves, weight, collector);
+    public <C extends Collector, T> T search(Query query, CollectorManager<C, T> collectorManager) throws IOException {
+        final var leafSlices = getSlices();
+        final var executor = getExecutor();
+        if (executor == null || leafSlices.length <= 1) {
+            final C collector = collectorManager.newCollector();
+            search(query, collector);
+            return collectorManager.reduce(Collections.singletonList(collector));
         } else {
-            // Used to parallelize weight.bulkScorer database access
-            Map<LeafReaderContext, CompletableFuture<Pair<LeafCollector, BulkScorer>>> leafScorers =
-                    new ConcurrentHashMap<>();
-            leaves.forEach(ctx -> leafScorers.put(ctx, CompletableFuture.supplyAsync(() -> {
-                try {
-                    return Pair.of(collector.getLeafCollector(ctx), weight.bulkScorer(ctx));
-                } catch (IOException e) {
-                    return null;
-                }
-            }, getExecutor())));
-
-            // Need to be able to throw IOExceptions out of this stack.
-            // For example, attempting to perform phrase search without pos/freqs throws out of this
-            // piece of code.
-            for (LeafReaderContext ctx : leaves) {
-                try {
-                    Pair<LeafCollector, BulkScorer> scorer = leafScorers.get(ctx).join();
-                    if (scorer != null && scorer.getLeft() != null && scorer.getRight() != null) {
-                        scorer.getRight().score(scorer.getLeft(), ctx.reader().getLiveDocs());
-                    }
-                } catch (CollectionTerminatedException ioe) {
-                    // No Op
+            final List<C> collectors = new ArrayList<>(leafSlices.length);
+            ScoreMode scoreMode = null;
+            for (int i = 0; i < leafSlices.length; ++i) {
+                final C collector = collectorManager.newCollector();
+                collectors.add(collector);
+                if (scoreMode == null) {
+                    scoreMode = collector.scoreMode();
+                } else if (scoreMode != collector.scoreMode()) {
+                    throw new IllegalStateException("CollectorManager does not always produce collectors with the same score mode");
                 }
             }
+            if (scoreMode == null) {
+                // no segments
+                scoreMode = ScoreMode.COMPLETE;
+            }
+            query = rewrite(query);
+            final Weight weight = createWeight(query, scoreMode, 1);
+            final List<Future<C>> topDocsFutures = new ArrayList<>(leafSlices.length);
+
+            for (int i = 0; i < leafSlices.length - 1; ++i) {
+                final LeafReaderContext[] leaves = leafSlices[i].leaves;
+                final C collector = collectors.get(i);
+
+                // 1. spawn a list of parallel tasks that interact with the DB for better throughput.
+                final List<CompletableFuture<Pair<LeafReaderContext, Pair<LeafCollector, BulkScorer>>>> dependencies = Arrays.stream(leaves).map(ctx -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        final var result = Pair.of(collector.getLeafCollector(ctx), weight.bulkScorer(ctx));
+                        return Pair.of(ctx, result);
+                    } catch (IOException e) {
+                        return null;
+                    }
+                }, getExecutor())).collect(Collectors.toList());
+
+                // 2. once we finish processing all of them, we can proceed with the final scoring task.
+                final var future = CompletableFuture.allOf(dependencies.toArray(new CompletableFuture[dependencies.size()])).thenApplyAsync(ignored -> {
+                    dependencies.stream().map(CompletableFuture::join).collect(Collectors.toList())
+                            .forEach((Pair<LeafReaderContext, Pair<LeafCollector, BulkScorer>> result) -> {
+                                final Pair<LeafCollector, BulkScorer> scorer = result.getRight();
+                                final LeafReaderContext ctx = result.getLeft();
+                                if (scorer != null && scorer.getLeft() != null && scorer.getRight() != null) {
+                                    try {
+                                        scorer.getRight().score(scorer.getLeft(), ctx.reader().getLiveDocs());
+                                    } catch (IOException e) {
+                                        // no-op just ignore.
+                                    }
+                                }
+                            });
+                    return collector;
+                }, getExecutor());
+                topDocsFutures.add(future);
+            }
+
+            final LeafReaderContext[] leaves = leafSlices[leafSlices.length - 1].leaves;
+            final C collector = collectors.get(leafSlices.length - 1);
+            // execute the last on the caller thread
+            search(Arrays.asList(leaves), weight, collector);
+            topDocsFutures.add(CompletableFuture.completedFuture(collector));
+            final List<C> collectedCollectors = new ArrayList<>();
+            for (Future<C> future : topDocsFutures) {
+                try {
+                    collectedCollectors.add(future.get());
+                } catch (InterruptedException e) {
+                    throw new ThreadInterruptedException(e);
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return collectorManager.reduce(collectors);
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -696,7 +696,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     private static Stream<Integer> threadCount() {
-        return Stream.of(1, 100);
+        return Stream.of(1, 10);
     }
 
     @ParameterizedTest(name = "threadedLuceneScanDoesntBreakPlannerAndSearch-PoolThreadCount={0}")

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -699,11 +699,11 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         return Stream.of(1, 100);
     }
 
-    @ParameterizedTest(name = "threadedLuceneScanDoesntBreakPlannerAndSearch-ExecutorThreadCount={0}")
+    @ParameterizedTest(name = "threadedLuceneScanDoesntBreakPlannerAndSearch-PoolThreadCount={0}")
     @MethodSource("threadCount")
-    void threadedLuceneScanDoesntBreakPlannerAndSearch(@Nonnull Object value) throws Exception {
+    void threadedLuceneScanDoesntBreakPlannerAndSearch(@Nonnull Integer value) throws Exception {
         CountingThreadFactory threadFactory = new CountingThreadFactory();
-        executorService = Executors.newFixedThreadPool((Integer)value, threadFactory);
+        executorService = Executors.newFixedThreadPool(value, threadFactory);
         initializeFlat();
         for (int i = 0; i < 200; i++) {
             try (FDBRecordContext context = openContext()) {
@@ -738,12 +738,10 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
         @Override
         public Thread newThread(Runnable r) {
-            var t = delegate.newThread(() -> {
+            return delegate.newThread(() -> {
                 threadCounts.merge(Thread.currentThread().getName(), 1, Integer::sum);
                 r.run();
             });
-            t.setName("COUNTING_THREAD_FACTORY_THREAD");
-            return t;
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -60,6 +60,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -76,6 +77,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.TestHelpers.assertLoadRecord;
 import static com.apple.foundationdb.record.lucene.LuceneIndexTest.generateRandomWords;
@@ -693,10 +695,15 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Test
-    void threadedLuceneScanDoesntBreakPlannerAndSearch() throws Exception {
+    private static Stream<Integer> threadCount() {
+        return Stream.of(1, 100);
+    }
+
+    @ParameterizedTest(name = "threadedLuceneScanDoesntBreakPlannerAndSearch-ExecutorThreadCount={0}")
+    @MethodSource("threadCount")
+    void threadedLuceneScanDoesntBreakPlannerAndSearch(@Nonnull Object value) throws Exception {
         CountingThreadFactory threadFactory = new CountingThreadFactory();
-        executorService = Executors.newFixedThreadPool(10, threadFactory);
+        executorService = Executors.newFixedThreadPool((Integer)value, threadFactory);
         initializeFlat();
         for (int i = 0; i < 200; i++) {
             try (FDBRecordContext context = openContext()) {
@@ -731,10 +738,12 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
         @Override
         public Thread newThread(Runnable r) {
-            return delegate.newThread(() -> {
+            var t = delegate.newThread(() -> {
                 threadCounts.merge(Thread.currentThread().getName(), 1, Integer::sum);
                 r.run();
             });
+            t.setName("COUNTING_THREAD_FACTORY_THREAD");
+            return t;
         }
     }
 


### PR DESCRIPTION
In previous implementation there was a potential for a deadlock which could happen as the following:

- Let's assume we have a `FDBRecordContextConfig` configured with an `ExecutorService` using a thread pool containing 2 threads, (`T1`, `T2`) , execution a `LuceneScanIndex` query starts.
- `LuceneRecordCursor` calls `searchForTopDocs`, this method invokes [`IndexSearcher#search`](https://github.com/apache/lucene/blob/2cf12b8cdcc629617b2d58c0a2a6336679ff9249/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java#L651) method which will do, among other things, the following:

```java
for (int i = 0; i < leafSlices.length - 1; ++i) {
    final LeafReaderContext[] leaves = leafSlices[i].leaves;
    final C collector = collectors.get(i);
    FutureTask<C> task = new FutureTask<>(() -> {
        search(Arrays.asList(leaves), weight, collector);
        return collector;
    });
    executor.execute(task); // [*]
    topDocsFutures.add(task);
}
```

at `[*]` it could be that we have some tasks scheduled, let's say 3 tasks (Task1, Task2, Task3) in total. Let's say `T1` now works on `Task1` and `T2` starts working on `Task2`.

Execution service status: `{Task1 (running T1), Task2 (running T2), Task3 (waiting)}`.

The call to `search` on that line will delegate to [`LuceneOptimizedIndexSearcher#search`](https://github.com/FoundationDB/fdb-record-layer/blob/2f0b6e7de2fdabee1579f9969a958e145852c003/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java#L86), which might schedule other tasks on the same executor:

```java
leaves.forEach(ctx -> leafScorers.put(ctx, CompletableFuture.supplyAsync(() -> {
    try {
        return Pair.of(collector.getLeafCollector(ctx), weight.bulkScorer(ctx));
    } catch (IOException e) {
        return null;
    }
}, getExecutor())));
```

Let's stay `Task1` spawns `Task4` and `Task5`, while `Task2` spawns `Task6`.

Execution service status: `{Task1 (running T1), Task2 (running T2), Task3 (wait), Task5 (wait), Task6 (wait), Task7 (wait)}`.

The deadlock happens later on in that method when _all_ worker threads block waiting for the newly spawned sub-tasks to finish:

```java
for (LeafReaderContext ctx : leaves) {
    try {
        Pair<LeafCollector, BulkScorer> scorer = leafScorers.get(ctx).join(); [**]
        if (scorer != null && scorer.getLeft() != null && scorer.getRight() != null) {
            scorer.getRight().score(scorer.getLeft(), ctx.reader().getLiveDocs());
        }
    } catch (CollectionTerminatedException ioe) {
        // No Op
    }
}
```

Execution service status: `{Task1 (blocking T1, wait Task5 and Task6), Task2 (blocking T2, wait Task7), Task3 (waiting), Task5(wait), Task6 (wait), Task7 (wait)}`.

All worker threads are busy waiting for some tasks scheduled to their executor service => deadlock.

To solve this problem, we can model these dependencies via [`CompletableFuture#allOf`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html#allOf-java.util.concurrent.CompletableFuture...-), this would require overriding `search(Query query, CollectorManager<C, T> collectorManager)` instead so we can control how the spawned tasks are modelled and scheduled.

In the new version, the `LuceneOptimizedIndexSearcher` will first run all of the `collector` scoring sub-tasks on parallel using `allOf`, and instead of blocking on them with `join`, it will use `thenApplyAsync` to synchronise the execution.

This way, we avoid the deadlock scenario, as a proof, we repeat the test `threadedLuceneScanDoesntBreakPlannerAndSearch` two times, one using 10 threads (which was sporadically failing before), and another time using 1 thread (which consistently deadlocks), in both cases, the test now passes uses this new approach.