### PR TITLE
improvements for joins

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
@@ -76,7 +76,7 @@ public class RecordMetaData implements RecordMetaDataProvider {
     @Nonnull
     private final Map<String, Index> indexes;
     @Nonnull
-    private Map<String, Index> universalIndexes;
+    private final Map<String, Index> universalIndexes;
     @Nonnull
     private final List<FormerIndex> formerIndexes;
     private final boolean splitLongRecords;
@@ -661,7 +661,7 @@ public class RecordMetaData implements RecordMetaDataProvider {
                                     }
                                     // TODO improve
                                     if (fieldDescriptor.getType().getJavaType() ==
-                                        fieldDescriptor2.getType().getJavaType()) {
+                                            fieldDescriptor2.getType().getJavaType()) {
                                         return fieldDescriptor;
                                     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
@@ -661,7 +661,7 @@ public class RecordMetaData implements RecordMetaDataProvider {
                                     }
                                     // TODO improve
                                     if (fieldDescriptor.getType().getJavaType() ==
-                                            fieldDescriptor2.getType().getJavaType()) {
+                                        fieldDescriptor2.getType().getJavaType()) {
                                         return fieldDescriptor;
                                     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
@@ -162,8 +162,13 @@ public class IndexScanComparisons implements IndexScanParameters {
 
     @Nonnull
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap) {
-        return withScanComparisons(scanComparisons.translateCorrelations(translationMap));
+        final var translatedScanComparisons = scanComparisons.translateCorrelations(translationMap);
+        if (translatedScanComparisons != scanComparisons) {
+            return withScanComparisons(translatedScanComparisons);
+        }
+        return this;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
@@ -26,12 +26,16 @@ import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
 import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * {@link ScanComparisons} for use in an index scan.
@@ -118,6 +122,53 @@ public class IndexScanComparisons implements IndexScanParameters {
         }
     }
 
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return scanComparisons.getCorrelatedTo();
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanParameters rebase(@Nonnull final AliasMap translationMap) {
+        return translateCorrelations(TranslationMap.rebaseWithAliasMap(translationMap));
+    }
+
+    @Override
+    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        final IndexScanComparisons that = (IndexScanComparisons)other;
+
+        if (!scanType.equals(that.scanType)) {
+            return false;
+        }
+        return scanComparisons.semanticEquals(that.scanComparisons, aliasMap);
+    }
+
+    @Override
+    public int semanticHashCode() {
+        int result = scanType.hashCode();
+        result = 31 * result + scanComparisons.semanticHashCode();
+        return result;
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap) {
+        return withScanComparisons(scanComparisons.translateCorrelations(translationMap));
+    }
+
+    @Nonnull
+    protected IndexScanParameters withScanComparisons(@Nonnull final ScanComparisons newScanComparisons) {
+        return new IndexScanComparisons(scanType, newScanComparisons);
+    }
+
     @Override
     public String toString() {
         return scanType + ":" + scanComparisons;
@@ -125,25 +176,11 @@ public class IndexScanComparisons implements IndexScanParameters {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        final IndexScanComparisons that = (IndexScanComparisons)o;
-
-        if (!scanType.equals(that.scanType)) {
-            return false;
-        }
-        return scanComparisons.equals(that.scanComparisons);
+        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
     @Override
     public int hashCode() {
-        int result = scanType.hashCode();
-        result = 31 * result + scanComparisons.hashCode();
-        return result;
+        return semanticHashCode();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.TupleRange;
@@ -135,6 +136,7 @@ public class IndexScanComparisons implements IndexScanParameters {
     }
 
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
         if (this == other) {
             return true;
@@ -175,6 +177,8 @@ public class IndexScanComparisons implements IndexScanParameters {
     }
 
     @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
         return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
@@ -25,6 +25,8 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.query.plan.cascades.Correlated;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
 import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,7 +38,7 @@ import javax.annotation.Nonnull;
  * These parameters are stored in the plan and then bound to the context before passing on to the index maintainer.
  */
 @API(API.Status.UNSTABLE)
-public interface IndexScanParameters extends PlanHashable {
+public interface IndexScanParameters extends PlanHashable, Correlated<IndexScanParameters> {
     /**
      * Get the type of index scan to be performed.
      * @return the scan type
@@ -77,4 +79,7 @@ public interface IndexScanParameters extends PlanHashable {
      * @param attributeMapBuilder builder into which to put attributes
      */
     void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder);
+
+    @Nonnull
+    IndexScanParameters translateCorrelations(@Nonnull TranslationMap translationMap);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowScanComparisons.java
@@ -72,6 +72,12 @@ public class TimeWindowScanComparisons extends IndexScanComparisons {
         attributeMapBuilder.put("timeWindowTimestamp", Attribute.gml(timeWindow.leaderboardTimestampString()));
     }
 
+    @Nonnull
+    @Override
+    protected TimeWindowScanComparisons withScanComparisons(@Nonnull final ScanComparisons newScanComparisons) {
+        return new TimeWindowScanComparisons(timeWindow, newScanComparisons);
+    }
+
     @Override
     public String toString() {
         return super.toString() + "@" + timeWindow;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartialOrder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartialOrder.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.combinatorics;
 
+import com.apple.foundationdb.record.query.plan.cascades.matching.graph.DependencyUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
@@ -262,7 +263,7 @@ public class PartialOrder<T> {
     }
 
     public static <T> PartialOrder<T> of(@Nonnull final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
-        return new PartialOrder<>(set, cleanseDependencyMap(set, dependencyMap));
+        return new PartialOrder<>(set, DependencyUtils.cleanseDependencyMap(set, dependencyMap));
     }
 
     @Nonnull
@@ -278,20 +279,6 @@ public class PartialOrder<T> {
     @Nonnull
     public static <T> PartialOrder<T> ofInverted(@Nonnull final Set<T> set, @Nonnull final Function<T, Set<T>> dependsOnFn) {
         return of(set, invertFromFunctionalDependencies(set, dependsOnFn));
-    }
-
-    @Nonnull
-    private static <T> SetMultimap<T, T> cleanseDependencyMap(@Nonnull  final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
-        final ImmutableSetMultimap.Builder<T, T> cleanDependencyMapBuilder = ImmutableSetMultimap.builder();
-
-        for (final Map.Entry<T, T> entry : dependencyMap.entries()) {
-            final T key = entry.getKey();
-            final T value = entry.getValue();
-            if (set.contains(key) && set.contains(value)) {
-                cleanDependencyMapBuilder.put(key, entry.getValue());
-            }
-        }
-        return cleanDependencyMapBuilder.build();
     }
 
     public static <T> PartialOrder.Builder<T> builder() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartialOrder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartialOrder.java
@@ -68,7 +68,7 @@ public class PartialOrder<T> {
     @Nonnull
     private final Supplier<ImmutableSetMultimap<T, T>> transitiveClosureSupplier;
 
-    public PartialOrder(@Nonnull final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
+    private PartialOrder(@Nonnull final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
         this.set = ImmutableSet.copyOf(set);
         this.dependencyMap = ImmutableSetMultimap.copyOf(dependencyMap);
         this.dualSupplier = Suppliers.memoize(() -> PartialOrder.of(set, this.dependencyMap.inverse()));
@@ -262,7 +262,7 @@ public class PartialOrder<T> {
     }
 
     public static <T> PartialOrder<T> of(@Nonnull final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
-        return new PartialOrder<>(set, dependencyMap);
+        return new PartialOrder<>(set, cleanseDependencyMap(set, dependencyMap));
     }
 
     @Nonnull
@@ -278,6 +278,20 @@ public class PartialOrder<T> {
     @Nonnull
     public static <T> PartialOrder<T> ofInverted(@Nonnull final Set<T> set, @Nonnull final Function<T, Set<T>> dependsOnFn) {
         return of(set, invertFromFunctionalDependencies(set, dependsOnFn));
+    }
+
+    @Nonnull
+    private static <T> SetMultimap<T, T> cleanseDependencyMap(@Nonnull  final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
+        final ImmutableSetMultimap.Builder<T, T> cleanDependencyMapBuilder = ImmutableSetMultimap.builder();
+
+        for (final Map.Entry<T, T> entry : dependencyMap.entries()) {
+            final T key = entry.getKey();
+            final T value = entry.getValue();
+            if (set.contains(key) && set.contains(value)) {
+                cleanDependencyMapBuilder.put(key, entry.getValue());
+            }
+        }
+        return cleanDependencyMapBuilder.build();
     }
 
     public static <T> PartialOrder.Builder<T> builder() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosure.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosure.java
@@ -56,7 +56,7 @@ public class TransitiveClosure {
      * @return the transitive closure
      */
     public static <T> ImmutableSetMultimap<T, T> transitiveClosure(@Nonnull Set<T> set, @Nonnull final ImmutableSetMultimap<T, T> dependsOnMap) {
-        return transitiveClosure(new PartialOrder<>(set, dependsOnMap));
+        return transitiveClosure(PartialOrder.of(set, dependsOnMap));
     }
 
 
@@ -96,7 +96,7 @@ public class TransitiveClosure {
                     deque.add(using);
                     final ImmutableSet<T> dependsOnSet = dependsOnMap.get(using);
                     for (final T dependsOn : dependsOnSet) {
-                        Verify.verify(resultMap.put(using, dependsOn));
+                        resultMap.put(using, dependsOn);
                         resultMap.get(dependsOn).forEach(ancestor -> resultMap.put(using, ancestor));
                     }
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosure.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosure.java
@@ -55,7 +55,7 @@ public class TransitiveClosure {
      * @param <T> type
      * @return the transitive closure
      */
-    public static <T> ImmutableSetMultimap<T, T> transitiveClosure(@Nonnull Set<T> set, @Nonnull final ImmutableSetMultimap<T, T> dependsOnMap) {
+    public static <T> ImmutableSetMultimap<T, T> transitiveClosure(@Nonnull Set<T> set, @Nonnull final SetMultimap<T, T> dependsOnMap) {
         return transitiveClosure(PartialOrder.of(set, dependsOnMap));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
@@ -251,6 +252,7 @@ public class ScanComparisons implements PlanHashable, Correlated<ScanComparisons
         }
 
         @Nonnull
+        @Override
         protected ScanComparisons.Builder withComparisons(@Nonnull List<Comparisons.Comparison> equalityComparisons,
                                                           @Nonnull Set<Comparisons.Comparison> inequalityComparisons) {
             return new Builder().addAll(equalityComparisons, inequalityComparisons);
@@ -344,8 +346,8 @@ public class ScanComparisons implements PlanHashable, Correlated<ScanComparisons
         return translateCorrelations(TranslationMap.rebaseWithAliasMap(translationMap));
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     @Override
+    @SuppressWarnings({"UnstableApiUsage", "PMD.CompareObjectsWithEquals"})
     public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
         if (this == other) {
             return true;
@@ -396,6 +398,8 @@ public class ScanComparisons implements PlanHashable, Correlated<ScanComparisons
     }
 
     @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object o) {
         return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
@@ -30,7 +30,11 @@ import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
+import com.apple.foundationdb.record.query.plan.cascades.Correlated;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.CollectionMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Extractor;
@@ -38,6 +42,9 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Plan
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.PrimitiveMatchers;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.TypedMatcher;
 import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.ProtocolMessageEnum;
@@ -48,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -62,7 +70,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * inequality comparisons to be applied to the next field.
  */
 @API(API.Status.INTERNAL)
-public class ScanComparisons implements PlanHashable {
+public class ScanComparisons implements PlanHashable, Correlated<ScanComparisons> {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Scan-Comparisons");
 
     @Nonnull
@@ -235,6 +243,20 @@ public class ScanComparisons implements PlanHashable {
         }
 
         @Nonnull
+        public Builder addAll(@Nonnull List<Comparisons.Comparison> newEqualityComparisons,
+                              @Nonnull Set<Comparisons.Comparison> newInequalityComparisons) {
+            equalityComparisons.addAll(newEqualityComparisons);
+            inequalityComparisons.addAll(newInequalityComparisons);
+            return this;
+        }
+
+        @Nonnull
+        protected ScanComparisons.Builder withComparisons(@Nonnull List<Comparisons.Comparison> equalityComparisons,
+                                                          @Nonnull Set<Comparisons.Comparison> inequalityComparisons) {
+            return new Builder().addAll(equalityComparisons, inequalityComparisons);
+        }
+
+        @Nonnull
         public ScanComparisons build() {
             return new ScanComparisons(equalityComparisons, inequalityComparisons);
         }
@@ -305,23 +327,82 @@ public class ScanComparisons implements PlanHashable {
         }
     }
 
+    @Nonnull
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        final ImmutableSet.Builder<CorrelationIdentifier> resultBuilder = ImmutableSet.builder();
+
+        equalityComparisons.forEach(comparison -> resultBuilder.addAll(comparison.getCorrelatedTo()));
+        inequalityComparisons.forEach(comparison -> resultBuilder.addAll(comparison.getCorrelatedTo()));
+
+        return resultBuilder.build();
+    }
+
+    @Nonnull
+    @Override
+    public ScanComparisons rebase(@Nonnull final AliasMap translationMap) {
+        return translateCorrelations(TranslationMap.rebaseWithAliasMap(translationMap));
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+        if (this == other) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
 
-        ScanComparisons that = (ScanComparisons)o;
-        return this.equalityComparisons.equals(that.equalityComparisons) &&
-               this.inequalityComparisons.equals(that.inequalityComparisons);
+        ScanComparisons that = (ScanComparisons)other;
+
+        if (this.equalityComparisons.size() != that.equalityComparisons.size()) {
+            return false;
+        }
+
+        if (this.inequalityComparisons.size() != that.inequalityComparisons.size()) {
+            return false;
+        }
+
+        return Streams.zip(this.equalityComparisons.stream(), that.equalityComparisons.stream(), (a, b) -> a.semanticEquals(b, aliasMap)).allMatch(e -> e) &&
+               this.inequalityComparisons.stream()
+                       .allMatch(thisComparison -> that.inequalityComparisons.stream().anyMatch(thatComparison -> thisComparison.semanticEquals(thatComparison, aliasMap)));
+    }
+
+    @Override
+    public int semanticHashCode() {
+        final int equalityComparisonsHash =
+                equalityComparisons.stream().map(Comparisons.Comparison::semanticHashCode).collect(ImmutableList.toImmutableList()).hashCode();
+        final int inequalityComparisonsHash =
+                inequalityComparisons.stream().map(Comparisons.Comparison::semanticHashCode).collect(ImmutableSet.toImmutableSet()).hashCode();
+        return Objects.hash(equalityComparisonsHash, inequalityComparisonsHash);
+    }
+
+    @Nonnull
+    public ScanComparisons translateCorrelations(@Nonnull final TranslationMap translationMap) {
+        final List<Comparisons.Comparison> translatedEqualityComparisons = equalityComparisons.stream()
+                .map(comparison -> comparison.translateCorrelations(translationMap))
+                .collect(ImmutableList.toImmutableList());
+        final Set<Comparisons.Comparison> translatedInequalityComparisons = inequalityComparisons.stream()
+                .map(comparison -> comparison.translateCorrelations(translationMap))
+                .collect(ImmutableSet.toImmutableSet());
+        return withComparisons(translatedEqualityComparisons, translatedInequalityComparisons);
+    }
+
+    @Nonnull
+    protected ScanComparisons withComparisons(@Nonnull List<Comparisons.Comparison> equalityComparisons,
+                                              @Nonnull Set<Comparisons.Comparison> inequalityComparisons) {
+        return new ScanComparisons(equalityComparisons, inequalityComparisons);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
     @Override
     public int hashCode() {
-        return equalityComparisons.hashCode() + inequalityComparisons.hashCode();
+        return semanticHashCode();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AliasMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AliasMap.java
@@ -162,8 +162,10 @@ import java.util.function.Function;
  *
  */
 public class AliasMap {
+    @Nonnull
     private static final AliasMap EMPTY = new AliasMap(ImmutableBiMap.of());
 
+    @Nonnull
     private final ImmutableBiMap<CorrelationIdentifier, CorrelationIdentifier> map;
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -59,6 +59,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -320,10 +321,9 @@ public class CascadesPlanner implements QueryPlanner {
     @Nonnull
     @Override
     public RecordQueryPlan plan(@Nonnull RecordQuery query, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
-        final PlanContext context = new MetaDataPlanContext(configuration, metaData, recordStoreState, query);
         try {
-            planPartial(context,
-                    () -> GroupExpressionRef.of(RelationalExpression.fromRecordQuery(context, metaData, query)));
+            planPartial(() -> GroupExpressionRef.of(RelationalExpression.fromRecordQuery(metaData, query)),
+                    rootReference -> MetaDataPlanContext.forRecordQuery(configuration, metaData, recordStoreState, query));
             return resultOrFail();
         } finally {
             Debugger.withDebugger(Debugger::onDone);
@@ -333,20 +333,20 @@ public class CascadesPlanner implements QueryPlanner {
 
     @Nonnull
     public RecordQueryPlan planGraph(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier,
-                                     @Nonnull final Optional<Collection<String>> recordTypeNamesOptional,
                                      @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
                                      @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
                                      final boolean isSortReverse,
                                      @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
-        final PlanContext context = new MetaDataPlanContext(configuration,
-                metaData,
-                recordStoreState,
-                recordTypeNamesOptional,
-                allowedIndexesOptional,
-                indexQueryabilityFilter,
-                isSortReverse);
         try {
-            planPartial(context, expressionRefSupplier);
+            planPartial(expressionRefSupplier,
+                    rootReference ->
+                            MetaDataPlanContext.forRootReference(configuration,
+                                    metaData,
+                                    recordStoreState,
+                                    rootReference,
+                                    allowedIndexesOptional,
+                                    indexQueryabilityFilter,
+                                    isSortReverse));
             return resultOrFail();
         } finally {
             Debugger.withDebugger(Debugger::onDone);
@@ -369,8 +369,10 @@ public class CascadesPlanner implements QueryPlanner {
         }
     }
 
-    private void planPartial(@Nonnull PlanContext context, @Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier) {
+    private void planPartial(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier, @Nonnull Function<GroupExpressionRef<RelationalExpression>, PlanContext> contextCreatorFunction) {
         currentRoot = expressionRefSupplier.get();
+        final var context = contextCreatorFunction.apply(currentRoot);
+
         final RelationalExpression expression = currentRoot.get();
         Debugger.withDebugger(debugger -> debugger.onQuery(expression.toString(), context));
         aliasResolver = AliasResolver.withRoot(currentRoot);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -514,7 +514,8 @@ public class CascadesPlanner implements QueryPlanner {
                     throw new RecordCoreException("there we no members in a group expression used by the Cascades planner");
                 }
                 group.clear();
-                group.insert(bestMember);
+                // call unchecked as this is the first expression to be inserted
+                group.insertUnchecked(bestMember);
                 group.commitExploration();
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
@@ -110,7 +110,7 @@ public class CascadesRuleCall implements PlannerRuleCall {
     @Override
     public <T> Optional<T> getPlannerConstraint(@Nonnull final PlannerConstraint<T> plannerConstraint) {
         if (rule.getConstraintDependencies().contains(plannerConstraint)) {
-            return root.getRequirementsMap().getConstraintOptional(plannerConstraint);
+            return root.getConstraintsMap().getConstraintOptional(plannerConstraint);
         }
 
         throw new RecordCoreArgumentException("rule is not dependent on requested planner requirement");
@@ -163,7 +163,7 @@ public class CascadesRuleCall implements PlannerRuleCall {
                                    @Nonnull final PlannerConstraint<T> plannerConstraint,
                                    @Nonnull final T requirement) {
         Verify.verify(root != reference);
-        final ConstraintsMap requirementsMap = reference.getRequirementsMap();
+        final ConstraintsMap requirementsMap = reference.getConstraintsMap();
         if (requirementsMap.pushProperty(plannerConstraint, requirement).isPresent()) {
             referencesWithPushedRequirements.add(reference);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
@@ -84,6 +84,12 @@ public class CascadesRuleCall implements PlannerRuleCall {
 
     @Nonnull
     @Override
+    public ExpressionRef<? extends RelationalExpression> getRoot() {
+        return root;
+    }
+
+    @Nonnull
+    @Override
     public AliasResolver getAliasResolver() {
         return aliasResolver;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
@@ -576,6 +576,13 @@ public interface Compensation {
         private final Set<Quantifier> matchedQuantifiers;
         @Nonnull
         private final Set<Quantifier> unmatchedQuantifiers;
+
+        /**
+         * We keep track of compensated aliases which define a kind of responsibility for this compensation,
+         * that is, when the compensation is applied, the caller can be ensured that the match replacement
+         * together with the compensation can replace those quantifiers. Normally the set of compensated aliases
+         * comprises all matched quantifiers and existential non-matched quantifiers.
+         */
         @Nonnull
         private final Set<CorrelationIdentifier> compensatedAliases;
         @Nonnull
@@ -683,6 +690,11 @@ public interface Compensation {
                 relationalExpression = childCompensation.apply(relationalExpression);
             }
 
+            if (predicateCompensationMap.isEmpty()) {
+                // all predicates taken care of and no remaining computation
+                return relationalExpression;
+            }
+
             final var matchedQuantifierMap =
                     Quantifiers.aliasToQuantifierMap(matchedQuantifiers);
 
@@ -697,12 +709,7 @@ public interface Compensation {
 
             Verify.verify(matchedForEachQuantifierAliases.size() <= 1);
             final var matchedForEachQuantifierAlias = Iterables.getOnlyElement(matchedForEachQuantifierAliases);
-
-            if (predicateCompensationMap.isEmpty()) {
-                // all predicates taken care of and no remaining computation
-                return relationalExpression;
-            }
-
+            
             //
             // At this point we definitely need a new SELECT expression.
             //

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
@@ -308,6 +308,7 @@ public interface Compensation {
      *        used for compensation
      * @param matchedQuantifiers a set of quantifiers that are mapped in the original {@link PartialMatch}
      * @param unmatchedQuantifiers a set of quantifiers that are not mapped in the original {@link PartialMatch}
+     * @param compensatedAliases a set of aliases this compensation covers and compensates for
      * @param remainingComputationOptional an optional containing (if not empty) a {@link Value} that needs to be
      *        computed by some means when this compensation is applied
      * @return a new compensation

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionRef.java
@@ -112,7 +112,7 @@ public interface ExpressionRef<T extends RelationalExpression> extends Correlate
     boolean addPartialMatchForCandidate(MatchCandidate candidate, PartialMatch partialMatch);
 
     @Nonnull
-    ConstraintsMap getRequirementsMap();
+    ConstraintsMap getConstraintsMap();
 
     /**
      * An exception thrown when {@link #get()} is called on a reference that does not support it, such as a group reference.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionRefs.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionRefs.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.combinatorics.TopologicalSort;
+import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpressionWithChildren;
 import com.apple.foundationdb.record.query.plan.cascades.properties.ReferencesAndDependenciesProperty;
@@ -94,10 +95,12 @@ public class ExpressionRefs {
                             translatedMember = member;
                         } else {
                             translatedMember = member.translateCorrelations(translationMap, translatedQuantifiers);
+                            Debugger.withDebugger(debugger -> debugger.onEvent(new Debugger.TranslateCorrelationsEvent(translatedMember, Debugger.Location.COUNT)));
                             allMembersSame = false;
                         }
                     } else {
                         translatedMember = member.translateCorrelations(translationMap, translatedQuantifiers);
+                        Debugger.withDebugger(debugger -> debugger.onEvent(new Debugger.TranslateCorrelationsEvent(translatedMember, Debugger.Location.COUNT)));
                         allMembersSame = false;
                     }
                     translatedMembersBuilder.add(translatedMember);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GroupExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GroupExpressionRef.java
@@ -105,7 +105,7 @@ public class GroupExpressionRef<T extends RelationalExpression> implements Expre
 
     @Nonnull
     @Override
-    public ConstraintsMap getRequirementsMap() {
+    public ConstraintsMap getConstraintsMap() {
         return constraintsMap;
     }
 
@@ -230,19 +230,17 @@ public class GroupExpressionRef<T extends RelationalExpression> implements Expre
                             }));
         } else {
             final AliasMap.Builder aliasMapBuilder = combinedEquivalenceMap.derived(quantifiers.size());
-            var nestedEquivalencesMap = AliasMap.emptyMap();
             for (int i = 0; i < quantifiers.size(); i++) {
                 final Quantifier quantifier = Objects.requireNonNull(quantifiers.get(i));
                 final Quantifier otherQuantifier = Objects.requireNonNull(otherQuantifiers.get(i));
-                aliasMapBuilder.put(quantifier.getAlias(), otherQuantifier.getAlias());
-                nestedEquivalencesMap = aliasMapBuilder.build();
                 if (!quantifier.getRangesOver()
-                        .containsAllInMemo(otherQuantifier.getRangesOver(), nestedEquivalencesMap)) {
+                        .containsAllInMemo(otherQuantifier.getRangesOver(), aliasMapBuilder.build())) {
                     return false;
                 }
+                aliasMapBuilder.put(quantifier.getAlias(), otherQuantifier.getAlias());
             }
 
-            aliasMapIterable = ImmutableList.of(nestedEquivalencesMap);
+            aliasMapIterable = ImmutableList.of(aliasMapBuilder.build());
         }
 
         // if there is more than one match we only need one such match that also satisfies the equality condition between

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GroupExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GroupExpressionRef.java
@@ -114,6 +114,13 @@ public class GroupExpressionRef<T extends RelationalExpression> implements Expre
         insertUnchecked(newValue);
     }
 
+    /**
+     * Inserts a new expression into this reference. This method checks for prior memoization of the expression passed
+     * in within the reference. If the expression is already contained in this reference, the reference is not modified.
+     * @param newValue new expression to be inserted
+     * @return {@code true} if and only if the new expression was successfully inserted into this reference, {@code false}
+     *         otherwise.
+     */
     @Override
     public boolean insert(@Nonnull T newValue) {
         Debugger.withDebugger(debugger -> debugger.onEvent(new Debugger.InsertIntoMemoEvent(newValue, Debugger.Location.BEGIN)));
@@ -130,6 +137,13 @@ public class GroupExpressionRef<T extends RelationalExpression> implements Expre
         return false;
     }
 
+    /**
+     * Inserts a new expression into this reference. Unlike {{@link #insert(RelationalExpression)}}, this method does
+     * not check for prior memoization of the expression passed in within the reference. The caller needs to exercise
+     * caution to only call this method on a reference if it is known that the reference cannot possibly already have
+     * the expression memoized.
+     * @param newValue new expression to be inserted (without check)
+     */
     public void insertUnchecked(final @Nonnull T newValue) {
         // Call debugger hook to potentially register this new expression.
         Debugger.registerExpression(newValue);
@@ -185,9 +199,13 @@ public class GroupExpressionRef<T extends RelationalExpression> implements Expre
         return false;
     }
 
-    private static boolean containsInMember(@Nonnull RelationalExpression member,
-                                            @Nonnull RelationalExpression otherMember,
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private static boolean containsInMember(@Nonnull final RelationalExpression member,
+                                            @Nonnull final RelationalExpression otherMember,
                                             @Nonnull final AliasMap equivalenceMap) {
+        if (member == otherMember) {
+            return true;
+        }
         if (member.getClass() != otherMember.getClass()) {
             return false;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentityMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentityMap.java
@@ -30,6 +30,7 @@ import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 /**
@@ -120,6 +121,11 @@ public class LinkedIdentityMap<K, V> extends AbstractMap<K, V> {
     @Override
     public Set<Entry<K, V>> entrySet() {
         return entrySetSupplier.get();
+    }
+
+    @Override
+    public void replaceAll(final BiFunction<? super K, ? super V, ? extends V> function) {
+        map.replaceAll((wrappedK, v) -> function.apply(wrappedK.get(), v));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentitySet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentitySet.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
 import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
@@ -49,6 +50,11 @@ public class LinkedIdentitySet<T> extends AbstractSet<T> {
 
     public LinkedIdentitySet() {
         this.members = Sets.newLinkedHashSet();
+    }
+
+    public LinkedIdentitySet(@Nonnull final Collection<? extends T> collection) {
+        this.members = Sets.newLinkedHashSet();
+        collection.forEach(element -> this.members.add(identity.wrap(element)));
     }
 
     @Override
@@ -118,7 +124,7 @@ public class LinkedIdentitySet<T> extends AbstractSet<T> {
         if (!(o instanceof LinkedIdentitySet)) {
             return false;
         }
-        return members.equals(o);
+        return members.equals(((LinkedIdentitySet<?>)o).members);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
@@ -217,7 +217,6 @@ public class PartialMatch {
     private Set<CorrelationIdentifier> computeCompensatedAliases() {
         final var compensatedAliasesBuilder = ImmutableSet.<CorrelationIdentifier>builder();
 
-        final var queryExpression = getQueryExpression();
         final var matchedAliases =
                 queryExpression.computeMatchedQuantifiers(this)
                         .stream()
@@ -225,9 +224,7 @@ public class PartialMatch {
                         .collect(ImmutableSet.toImmutableSet());
         compensatedAliasesBuilder.addAll(matchedAliases);
 
-        final var matchInfo = getMatchInfo();
         final var predicatesMap = matchInfo.getPredicateMap();
-
         for (final QueryPredicate queryPredicate : predicatesMap.keySet()) {
             final Iterable<? extends QueryPredicate> existsPredicates =
                     queryPredicate.filter(predicate -> predicate instanceof ExistsPredicate);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
@@ -20,11 +20,14 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ExistsPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.ValueComparisonRangePredicate;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
@@ -92,6 +95,9 @@ public class PartialMatch {
     @Nonnull
     private final Supplier<Set<QueryPredicate>> bindingPredicatesSupplier;
 
+    @Nonnull
+    private final Supplier<Set<CorrelationIdentifier>> compensatedAliasesSupplier;
+
     public PartialMatch(@Nonnull final AliasMap boundAliasMap,
                         @Nonnull final MatchCandidate matchCandidate,
                         @Nonnull final ExpressionRef<? extends RelationalExpression> queryRef,
@@ -106,6 +112,7 @@ public class PartialMatch {
         this.matchInfo = matchInfo;
         this.boundParameterPrefixMapSupplier = Suppliers.memoize(this::computeBoundParameterPrefixMap);
         this.bindingPredicatesSupplier = Suppliers.memoize(this::computeBindingQueryPredicates);
+        this.compensatedAliasesSupplier = Suppliers.memoize(this::computeCompensatedAliases);
     }
 
     @Nonnull
@@ -191,8 +198,48 @@ public class PartialMatch {
     }
 
     @Nonnull
-    public final Set<QueryPredicate> getBindingPredidcates() {
+    public final Set<QueryPredicate> getBindingPredicates() {
         return bindingPredicatesSupplier.get();
+    }
+
+
+    /**
+     * Return a set of aliases that this partial match is responsible for covering, that is either the matches
+     * replacement or compensation will take care of the aliases in the returned set.
+     * @return a set of compensated aliases
+     */
+    @Nonnull
+    public final Set<CorrelationIdentifier> getCompensatedAliases() {
+        return compensatedAliasesSupplier.get();
+    }
+
+    @Nonnull
+    private Set<CorrelationIdentifier> computeCompensatedAliases() {
+        final var compensatedAliasesBuilder = ImmutableSet.<CorrelationIdentifier>builder();
+
+        final var queryExpression = getQueryExpression();
+        final var matchedAliases =
+                queryExpression.computeMatchedQuantifiers(this)
+                        .stream()
+                        .map(Quantifier::getAlias)
+                        .collect(ImmutableSet.toImmutableSet());
+        compensatedAliasesBuilder.addAll(matchedAliases);
+
+        final var matchInfo = getMatchInfo();
+        final var predicatesMap = matchInfo.getPredicateMap();
+
+        for (final QueryPredicate queryPredicate : predicatesMap.keySet()) {
+            final Iterable<? extends QueryPredicate> existsPredicates =
+                    queryPredicate.filter(predicate -> predicate instanceof ExistsPredicate);
+
+            for (final var predicate : existsPredicates) {
+                final var existsPredicate =
+                        predicate.narrowMaybe(ExistsPredicate.class).orElseThrow(() -> new RecordCoreException("cast expected to succeed"));
+                compensatedAliasesBuilder.add(existsPredicate.getExistentialAlias());
+            }
+        }
+
+        return compensatedAliasesBuilder.build();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPartition.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPartition.java
@@ -42,7 +42,7 @@ public class PlanPartition {
 
     public PlanPartition(final Map<PlanProperty<?>, ?> attributesMap, final Collection<RecordQueryPlan> plans) {
         this.attributesMap = ImmutableMap.copyOf(attributesMap);
-        this.plans = ImmutableSet.copyOf(plans);
+        this.plans = new LinkedIdentitySet<>(plans);
     }
 
     public Map<PlanProperty<?>, ?> getAttributesMap() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleCall.java
@@ -70,6 +70,9 @@ public interface PlannerRuleCall {
     @Nonnull
     PlanContext getContext();
 
+    @Nonnull
+    ExpressionRef<? extends RelationalExpression> getRoot();
+
     /**
      * Return the bindable that is bound to the given key.
      *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Models the concept of quantification.
@@ -397,12 +398,6 @@ public abstract class Quantifier implements Correlated<Quantifier> {
 
         @Override
         @Nonnull
-        public String toString() {
-            return rangesOver.toString();
-        }
-
-        @Override
-        @Nonnull
         public Physical overNewReference(@Nonnull final ExpressionRef<? extends RelationalExpression> reference) {
             return Quantifier.physicalBuilder()
                     .from(this)
@@ -519,12 +514,18 @@ public abstract class Quantifier implements Correlated<Quantifier> {
     @Override
     @Nonnull
     public String toString() {
-        return getShorthand() + " " + getRangesOver();
+        return getShorthand() + "(" + getAlias() + ") -> {" +
+               getCorrelatedTo().stream().map(CorrelationIdentifier::toString).collect(Collectors.joining(", ")) +
+               "}";
     }
 
     @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedTo() {
+//        final var cachedCorrelatedTo = correlatedToSupplier.get();
+//        final var correlatedTo = getRangesOver().getCorrelatedTo();
+//        Verify.verify(cachedCorrelatedTo.equals(correlatedTo));
+//        return correlatedTo;
         return correlatedToSupplier.get();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
@@ -522,10 +522,6 @@ public abstract class Quantifier implements Correlated<Quantifier> {
     @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedTo() {
-//        final var cachedCorrelatedTo = correlatedToSupplier.get();
-//        final var correlatedTo = getRangesOver().getCorrelatedTo();
-//        Verify.verify(cachedCorrelatedTo.equals(correlatedTo));
-//        return correlatedTo;
         return correlatedToSupplier.get();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScanWithFetchMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScanWithFetchMatchCandidate.java
@@ -36,5 +36,6 @@ public interface ScanWithFetchMatchCandidate extends WithPrimaryKeyMatchCandidat
     
     @Nonnull
     Optional<Value> pushValueThroughFetch(@Nonnull Value value,
+                                          @Nonnull CorrelationIdentifier sourceAlias,
                                           @Nonnull CorrelationIdentifier targetAlias);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/TranslationMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/TranslationMap.java
@@ -35,6 +35,8 @@ import java.util.Optional;
  * Map used to specify translations.
  */
 public class TranslationMap {
+    @Nonnull
+    private static final TranslationMap EMPTY = new TranslationMap(ImmutableMap.of());
 
     @Nonnull
     private final Map<CorrelationIdentifier, TranslationTarget> aliasToTargetMap;
@@ -81,6 +83,11 @@ public class TranslationMap {
     @Nonnull
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Nonnull
+    public static TranslationMap empty() {
+        return EMPTY;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
@@ -361,21 +361,12 @@ public class WindowedIndexScanMatchCandidate implements ScanWithFetchMatchCandid
     @Nonnull
     @Override
     public Optional<Value> pushValueThroughFetch(@Nonnull Value value,
+                                                 @Nonnull CorrelationIdentifier sourceAlias,
                                                  @Nonnull CorrelationIdentifier targetAlias) {
-
-        final Set<Value> quantifiedObjectValues = ImmutableSet.copyOf(value.filter(v -> v instanceof QuantifiedObjectValue));
-
-        // if this is a value that is referring to more than one value from its quantifier or two multiple quantifiers
-        if (quantifiedObjectValues.size() != 1) {
-            return Optional.empty();
-        }
-
-        final QuantifiedObjectValue quantifiedObjectValue = (QuantifiedObjectValue)Iterables.getOnlyElement(quantifiedObjectValues);
-
         // replace the quantified column value inside the given value with the quantified value in the match candidate
         final var baseObjectValue = QuantifiedObjectValue.of(baseAlias);
         final Value translatedValue =
-                value.rebase(AliasMap.of(quantifiedObjectValue.getAlias(), baseAlias));
+                value.rebase(AliasMap.of(sourceAlias, baseAlias));
         final AliasMap equivalenceMap = AliasMap.identitiesFor(ImmutableSet.of(baseAlias));
 
         for (final Value matchResultValue : Iterables.concat(ImmutableList.of(baseObjectValue), indexKeyValues)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalIntersectionExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalIntersectionExpression.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
  * To work, each child cursor must order its children the same way according to the comparison key.
  */
 @API(API.Status.INTERNAL)
-public class LogicalIntersectionExpression implements RelationalExpressionWithChildren, InternalPlannerGraphRewritable {
+public class LogicalIntersectionExpression implements RelationalExpressionWithChildren.ChildrenAsSet, InternalPlannerGraphRewritable {
     public static final Logger LOGGER = LoggerFactory.getLogger(LogicalIntersectionExpression.class);
 
     private static final String INTERSECT = "∩"; // U+2229

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUnionExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUnionExpression.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * @see com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan for the fallback implementation
  */
 @API(API.Status.EXPERIMENTAL)
-public class LogicalUnionExpression implements RelationalExpressionWithChildren {
+public class LogicalUnionExpression implements RelationalExpressionWithChildren.ChildrenAsSet {
     @Nonnull
     private final List<? extends Quantifier> quantifiers;
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.combinatorics.EnumeratingIterable;
+import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
 import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
@@ -237,6 +238,16 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
      */
     default boolean canCorrelate() {
         return false;
+    }
+
+    /**
+     * Method to compute the correlation order as a {@link com.apple.foundationdb.record.query.combinatorics.PartialOrder}.
+     * @return a partial order representing the transitive closure of all dependencies between quantifiers in this
+     *         expression.
+     */
+    @Nonnull
+    default PartialOrder<CorrelationIdentifier> getCorrelationOrder() {
+        return PartialOrder.empty();
     }
 
     boolean equalsWithoutChildren(@Nonnull RelationalExpression other,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
@@ -41,7 +41,6 @@ import com.apple.foundationdb.record.query.plan.cascades.IterableHelpers;
 import com.apple.foundationdb.record.query.plan.cascades.MatchInfo;
 import com.apple.foundationdb.record.query.plan.cascades.Narrowable;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
-import com.apple.foundationdb.record.query.plan.cascades.PlanContext;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;
 import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
@@ -112,8 +111,7 @@ import java.util.stream.StreamSupport;
 @GenerateVisitor
 public interface RelationalExpression extends Correlated<RelationalExpression>, Typed, Narrowable<RelationalExpression> {
     @Nonnull
-    static RelationalExpression fromRecordQuery(@Nonnull PlanContext context,
-                                                @Nonnull RecordMetaData recordMetaData,
+    static RelationalExpression fromRecordQuery(@Nonnull RecordMetaData recordMetaData,
                                                 @Nonnull RecordQuery query) {
         query.validate(recordMetaData);
         final var allRecordTypes = recordMetaData.getRecordTypes().keySet();
@@ -745,6 +743,11 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
 
     @Nonnull
     RelationalExpression translateCorrelations(@Nonnull TranslationMap translationMap, @Nonnull List<? extends Quantifier> translatedQuantifiers);
+
+    @Nonnull
+    default Set<Quantifier> computeMatchedQuantifiers(@Nonnull final PartialMatch partialMatch) {
+        return ImmutableSet.of();
+    }
 
     /**
      * Compute the semantic hash code of this expression. The logic computing the hash code is agnostic to the order

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpressionWithChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpressionWithChildren.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.expressions;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
 import com.apple.foundationdb.record.query.combinatorics.TopologicalSort;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
@@ -97,5 +98,19 @@ public interface RelationalExpressionWithChildren extends RelationalExpression {
             }
         }
         return mappedForEachQuantifiers;
+    }
+
+    @Nonnull
+    default PartialOrder<CorrelationIdentifier> getCorrelationOrder() {
+        if (canCorrelate()) {
+            final var aliasToQuantifierMap = Quantifiers.aliasToQuantifierMap(getQuantifiers());
+            return PartialOrder.of(
+                    getQuantifiers().stream()
+                            .map(Quantifier::getAlias)
+                            .collect(ImmutableSet.toImmutableSet()),
+                    alias -> Objects.requireNonNull(aliasToQuantifierMap.get(alias)).getCorrelatedTo());
+        } else {
+            return PartialOrder.empty();
+        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpressionWithChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpressionWithChildren.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.query.plan.cascades.expressions;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
-import com.apple.foundationdb.record.query.combinatorics.TopologicalSort;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
@@ -34,9 +33,7 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A parent interface for {@link RelationalExpression}s that have relational children (as opposed to non-relation
@@ -53,20 +50,6 @@ public interface RelationalExpressionWithChildren extends RelationalExpression {
         final ImmutableSet.Builder<CorrelationIdentifier> builder = ImmutableSet.builder();
         final List<? extends Quantifier> quantifiers = getQuantifiers();
         final Map<CorrelationIdentifier, ? extends Quantifier> aliasToQuantifierMap = Quantifiers.aliasToQuantifierMap(quantifiers);
-
-        if (false) {
-            // We should check if the graph is sound here, if it is not we should throw an exception. This method
-            // will properly return with an empty. There are other algorithms that may not be as defensive and we
-            // must protect ourselves from illegal graphs (and bugs).
-            final Optional<List<CorrelationIdentifier>> orderedOptional =
-                    TopologicalSort.anyTopologicalOrderPermutation(
-                            quantifiers.stream()
-                                    .map(Quantifier::getAlias)
-                                    .collect(Collectors.toSet()),
-                            alias -> Objects.requireNonNull(aliasToQuantifierMap.get(alias)).getCorrelatedTo());
-
-            orderedOptional.orElseThrow(() -> new IllegalArgumentException("correlations are cyclic"));
-        }
 
         getCorrelatedToWithoutChildren()
                 .stream()
@@ -89,6 +72,7 @@ public interface RelationalExpressionWithChildren extends RelationalExpression {
     Set<CorrelationIdentifier> getCorrelatedToWithoutChildren();
 
     @Nonnull
+    @Override
     default Set<Quantifier> computeMatchedQuantifiers(@Nonnull final PartialMatch partialMatch) {
         final var matchInfo = partialMatch.getMatchInfo();
         final var mappedForEachQuantifiers = new LinkedIdentitySet<Quantifier>();
@@ -101,6 +85,7 @@ public interface RelationalExpressionWithChildren extends RelationalExpression {
     }
 
     @Nonnull
+    @Override
     default PartialOrder<CorrelationIdentifier> getCorrelationOrder() {
         if (canCorrelate()) {
             final var aliasToQuantifierMap = Quantifiers.aliasToQuantifierMap(getQuantifiers());
@@ -112,5 +97,17 @@ public interface RelationalExpressionWithChildren extends RelationalExpression {
         } else {
             return PartialOrder.empty();
         }
+    }
+
+    /**
+     * Tag interface to signal that the children this expression owns, that is the owned {@link Quantifier}s, are
+     * to be treated as an unordered set. This is true for implementors like {@link SelectExpression} or
+     * {@link LogicalUnionExpression}, but not
+     * {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryFlatMapPlan}.
+     * This interface allows the respective classes to announce their behavior which may impact matching performance
+     * drastically.
+     */
+    interface ChildrenAsSet extends RelationalExpressionWithChildren {
+        // nothing
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/BaseMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/BaseMatcher.java
@@ -283,7 +283,6 @@ public class BaseMatcher<T> {
 
                             return IterableHelpers.flatMap(combinationsIterable,
                                     combination -> {
-                                        //System.out.println("this: " + combination + "; other: " + otherPermutation);
                                         final EnumeratingIterable<CorrelationIdentifier> permutationsIterable =
                                                 topologicalOrderPermutations(
                                                         combination,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/BaseMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/BaseMatcher.java
@@ -383,10 +383,10 @@ public class BaseMatcher<T> {
      * @param aliasMap alias map to define the translation
      * @param alias alias on this side
      * @param otherAlias alias on the other side
-     * @return {@code Optional.empty()} if the dependsOn functions for the given aliases sets is are isomorphic under
-     *         translation using {@code aliasMap},
+     * @return {@code Optional.empty()} if the dependsOn functions for the given aliases sets is are not isomorphic
+     *         under translation using {@code aliasMap},
      *         {@code Optional.of(resultMap)} where {@code resultMap} is an {@link AliasMap} only containing mappings
-     *         from the dependsOn set of {@code alias} that are also contained i {@code aliasMap}, otherwise.
+     *         from the dependsOn set of {@code alias} that are also contained in {@code aliasMap}, otherwise.
      */
     @Nonnull
     protected Optional<AliasMap> mapDependenciesToOther(@Nonnull AliasMap aliasMap,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/ComputingMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/ComputingMatcher.java
@@ -235,14 +235,14 @@ public class ComputingMatcher<T, M, R> extends BaseMatcher<T> implements Generic
                                                                               @Nonnull final Function<T, Set<CorrelationIdentifier>> otherDependsOnFn,
                                                                               @Nonnull final MatchFunction<T, M> matchFunction,
                                                                               @Nonnull final Supplier<MatchAccumulator<M, R>> matchAccumulatorSupplier) {
-        ImmutableSet<CorrelationIdentifier> aliases = BaseMatcher.computeAliases(elements, elementToAliasFn);
-        final ImmutableMap<CorrelationIdentifier, T> aliasToElementMap = BaseMatcher.computeAliasToElementMap(elements, elementToAliasFn);
+        ImmutableSet<CorrelationIdentifier> aliases = DependencyUtils.computeAliases(elements, elementToAliasFn);
+        final ImmutableMap<CorrelationIdentifier, T> aliasToElementMap = DependencyUtils.computeAliasToElementMap(elements, elementToAliasFn);
 
-        final ImmutableSet<CorrelationIdentifier> otherAliases = BaseMatcher.computeAliases(otherElements, otherElementToAliasFn);
-        final ImmutableMap<CorrelationIdentifier, T> otherAliasToElementMap = BaseMatcher.computeAliasToElementMap(otherElements, otherElementToAliasFn);
+        final ImmutableSet<CorrelationIdentifier> otherAliases = DependencyUtils.computeAliases(otherElements, otherElementToAliasFn);
+        final ImmutableMap<CorrelationIdentifier, T> otherAliasToElementMap = DependencyUtils.computeAliasToElementMap(otherElements, otherElementToAliasFn);
 
-        ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> dependsOnMap = TransitiveClosure.transitiveClosure(aliases, BaseMatcher.computeDependsOnMapWithAliases(aliases, aliasToElementMap, dependsOnFn));
-        final ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> otherDependsOnMap = TransitiveClosure.transitiveClosure(otherAliases, BaseMatcher.computeDependsOnMapWithAliases(otherAliases, otherAliasToElementMap, otherDependsOnFn));
+        ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> dependsOnMap = TransitiveClosure.transitiveClosure(aliases, DependencyUtils.computeDependsOnMapWithAliases(aliases, aliasToElementMap, dependsOnFn));
+        final ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> otherDependsOnMap = TransitiveClosure.transitiveClosure(otherAliases, DependencyUtils.computeDependsOnMapWithAliases(otherAliases, otherAliasToElementMap, otherDependsOnFn));
 
         return new ComputingMatcher<>(
                 boundAliasesMap,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/ComputingMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/ComputingMatcher.java
@@ -189,7 +189,8 @@ public class ComputingMatcher<T, M, R> extends BaseMatcher<T> implements Generic
 
                     if (i == size) {
                         iterator.skip(i - 1);
-                        return BoundMatch.withAliasMapAndMatchResult(boundAliasesMap.combine(aliasMapBuilder.build()), result);
+                        final var finalAliasMap = aliasMapBuilder.build();
+                        return BoundMatch.withAliasMapAndMatchResult(boundAliasesMap.combine(finalAliasMap), result);
                     } else {
                         iterator.skip(i);
                     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/DependencyUtils.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/DependencyUtils.java
@@ -137,6 +137,7 @@ public class DependencyUtils {
 
     @Nonnull
     public static <T> SetMultimap<T, T> cleanseDependencyMap(@Nonnull final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
+        boolean needsCopy = false;
         final ImmutableSetMultimap.Builder<T, T> cleanDependencyMapBuilder = ImmutableSetMultimap.builder();
 
         for (final Map.Entry<T, T> entry : dependencyMap.entries()) {
@@ -144,8 +145,14 @@ public class DependencyUtils {
             final T value = entry.getValue();
             if (set.contains(key) && set.contains(value)) {
                 cleanDependencyMapBuilder.put(key, entry.getValue());
+            } else {
+                // There is an entry we don't want in the dependency map.
+                needsCopy = true;
             }
         }
-        return cleanDependencyMapBuilder.build();
+        if (needsCopy) {
+            return cleanDependencyMapBuilder.build();
+        }
+        return dependencyMap;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/DependencyUtils.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/DependencyUtils.java
@@ -1,0 +1,147 @@
+/*
+ * DependencyUtils.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.matching.graph;
+
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.SetMultimap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+
+/**
+ * Helper methods useful for managing dependency sets using {@link CorrelationIdentifier}s.
+ */
+public class DependencyUtils {
+
+    /**
+     * Static helper to compute a set of {@link CorrelationIdentifier}s from a collection of elements of type {@code T}
+     * using the given element-to-alias function. Note that we allow a collection of elements to be passed in, we
+     * compute a set of {@link CorrelationIdentifier}s from it (i.e. duplicate aliases are not allowed).
+     * @param elements an iterable of elements of type {@code T}
+     * @param elementToAliasFn element to alias function
+     * @param <T> element type
+     * @return a set of aliases
+     */
+    @Nonnull
+    public static <T> ImmutableSet<CorrelationIdentifier> computeAliases(@Nonnull final Iterable<? extends T> elements,
+                                                                         @Nonnull final Function<T, CorrelationIdentifier> elementToAliasFn) {
+        return StreamSupport.stream(elements.spliterator(), false)
+                .map(elementToAliasFn)
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+    /**
+     * Static helper to compute the alias-to-element map based on a collection of elements and on the element-to-alias function
+     * tht are both passed in.
+     * @param elements an iterable of elements of type {@code T}
+     * @param elementToAliasFn element to alias function
+     * @param <T> element type
+     * @return a map from {@link CorrelationIdentifier} to {@code T} representing the conceptual inverse of the
+     *         element to alias function passed in
+     */
+    @Nonnull
+    public static <T> ImmutableMap<CorrelationIdentifier, T> computeAliasToElementMap(@Nonnull final Iterable<? extends T> elements,
+                                                                                      @Nonnull final Function<T, CorrelationIdentifier> elementToAliasFn) {
+        return StreamSupport.stream(elements.spliterator(), false)
+                .collect(ImmutableMap.toImmutableMap(elementToAliasFn, Function.identity()));
+    }
+
+    /**
+     * Static helper to compute a dependency map from {@link CorrelationIdentifier} to {@link CorrelationIdentifier} based
+     * on a set of aliases and mappings between {@link CorrelationIdentifier} and type {@code T}.
+     * @param aliases a set of aliases
+     * @param elementToAliasFn element to alias function
+     * @param aliasToElementMap a map from {@link CorrelationIdentifier} to {@code T} representing the conceptual inverse of the
+     *        element to alias function passed in
+     * @param dependsOnFn function defining the dependOn relationships between an element and other elements (via aliases)
+     * @param <T> element type
+     * @return a multimap from {@link CorrelationIdentifier} to {@link CorrelationIdentifier} where a contained
+     *         {@code key, values} pair signifies that {@code key} depends on each value in {@code values}
+     */
+    @Nonnull
+    public static <T> ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> computeDependsOnMap(@Nonnull Set<CorrelationIdentifier> aliases,
+                                                                                                             @Nonnull final Function<T, CorrelationIdentifier> elementToAliasFn,
+                                                                                                             @Nonnull final Map<CorrelationIdentifier, T> aliasToElementMap,
+                                                                                                             @Nonnull final Function<T, ? extends Collection<T>> dependsOnFn) {
+        final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder = ImmutableSetMultimap.builder();
+        for (final CorrelationIdentifier alias : aliases) {
+            final Collection<T> dependsOn = dependsOnFn.apply(aliasToElementMap.get(alias));
+            for (final T dependsOnElement : dependsOn) {
+                @Nullable final CorrelationIdentifier dependsOnAlias = elementToAliasFn.apply(dependsOnElement);
+                if (dependsOnAlias != null && aliases.contains(dependsOnAlias)) {
+                    builder.put(alias, dependsOnAlias);
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Static helper to compute a dependency map from {@link CorrelationIdentifier} to {@link CorrelationIdentifier} based
+     * on a set of aliases and mappings between {@link CorrelationIdentifier} and type {@code T}. This method optimizes
+     * for the case that the client uses dependsOn functions that already map to {@link CorrelationIdentifier} as opposed
+     * to type {@code T}. See the matching logic in {@link com.apple.foundationdb.record.query.plan.cascades.Quantifiers}
+     * for examples.
+     * @param aliases a set of aliases
+     * @param aliasToElementMap a map from {@link CorrelationIdentifier} to {@code T}
+     * @param dependsOnFn function defining the dependOn relationships between an element and aliases ({@link CorrelationIdentifier}s)
+     * @param <T> element type
+     * @return a multimap from {@link CorrelationIdentifier} to {@link CorrelationIdentifier} where a contained
+     *         {@code key, values} pair signifies that {@code key} depends on each value in {@code values}
+     */
+    @Nonnull
+    public static <T> ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> computeDependsOnMapWithAliases(@Nonnull Set<CorrelationIdentifier> aliases,
+                                                                                                                        @Nonnull final Map<CorrelationIdentifier, T> aliasToElementMap,
+                                                                                                                        @Nonnull final Function<T, Set<CorrelationIdentifier>> dependsOnFn) {
+        final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder = ImmutableSetMultimap.builder();
+        for (final CorrelationIdentifier alias : aliases) {
+            final Set<CorrelationIdentifier> dependsOn = dependsOnFn.apply(aliasToElementMap.get(alias));
+            for (final CorrelationIdentifier dependsOnAlias : dependsOn) {
+                if (dependsOnAlias != null && aliases.contains(dependsOnAlias)) {
+                    builder.put(alias, dependsOnAlias);
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    @Nonnull
+    public static <T> SetMultimap<T, T> cleanseDependencyMap(@Nonnull final Set<T> set, @Nonnull final SetMultimap<T, T> dependencyMap) {
+        final ImmutableSetMultimap.Builder<T, T> cleanDependencyMapBuilder = ImmutableSetMultimap.builder();
+
+        for (final Map.Entry<T, T> entry : dependencyMap.entries()) {
+            final T key = entry.getKey();
+            final T value = entry.getValue();
+            if (set.contains(key) && set.contains(value)) {
+                cleanDependencyMapBuilder.put(key, entry.getValue());
+            }
+        }
+        return cleanDependencyMapBuilder.build();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/DependencyUtils.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/DependencyUtils.java
@@ -39,6 +39,10 @@ import java.util.stream.StreamSupport;
  */
 public class DependencyUtils {
 
+    private DependencyUtils() {
+        // nothing
+    }
+
     /**
      * Static helper to compute a set of {@link CorrelationIdentifier}s from a collection of elements of type {@code T}
      * using the given element-to-alias function. Note that we allow a collection of elements to be passed in, we

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/FindingMatcher.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/graph/FindingMatcher.java
@@ -212,11 +212,11 @@ public class FindingMatcher<T> extends BaseMatcher<T> implements PredicatedMatch
                 aliases,
                 Function.identity(),
                 identityMappingMap,
-                TransitiveClosure.transitiveClosure(aliases, BaseMatcher.computeDependsOnMap(aliases, Function.identity(), identityMappingMap, dependsOnFn)),
+                TransitiveClosure.transitiveClosure(aliases, DependencyUtils.computeDependsOnMap(aliases, Function.identity(), identityMappingMap, dependsOnFn)),
                 otherAliases,
                 Function.identity(),
                 otherIdentityMappingMap,
-                TransitiveClosure.transitiveClosure(otherAliases, BaseMatcher.computeDependsOnMap(otherAliases, Function.identity(), otherIdentityMappingMap, otherDependsOnFn)),
+                TransitiveClosure.transitiveClosure(otherAliases, DependencyUtils.computeDependsOnMap(otherAliases, Function.identity(), otherIdentityMappingMap, otherDependsOnFn)),
                 matchPredicate);
     }
 
@@ -249,21 +249,21 @@ public class FindingMatcher<T> extends BaseMatcher<T> implements PredicatedMatch
                                                             @Nonnull final Function<T, CorrelationIdentifier> otherElementToAliasFn,
                                                             @Nonnull final Function<T, Set<CorrelationIdentifier>> otherDependsOnFn,
                                                             @Nonnull final MatchPredicate<T> matchPredicate) {
-        final ImmutableSet<CorrelationIdentifier> aliases = BaseMatcher.computeAliases(elements, elementToAliasFn);
-        final ImmutableMap<CorrelationIdentifier, T> aliasToElementMap = BaseMatcher.computeAliasToElementMap(elements, elementToAliasFn);
+        final ImmutableSet<CorrelationIdentifier> aliases = DependencyUtils.computeAliases(elements, elementToAliasFn);
+        final ImmutableMap<CorrelationIdentifier, T> aliasToElementMap = DependencyUtils.computeAliasToElementMap(elements, elementToAliasFn);
 
-        final ImmutableSet<CorrelationIdentifier> otherAliases = BaseMatcher.computeAliases(otherElements, otherElementToAliasFn);
-        final ImmutableMap<CorrelationIdentifier, T> otherAliasToElementMap = BaseMatcher.computeAliasToElementMap(otherElements, otherElementToAliasFn);
+        final ImmutableSet<CorrelationIdentifier> otherAliases = DependencyUtils.computeAliases(otherElements, otherElementToAliasFn);
+        final ImmutableMap<CorrelationIdentifier, T> otherAliasToElementMap = DependencyUtils.computeAliasToElementMap(otherElements, otherElementToAliasFn);
         return new FindingMatcher<>(
                 boundAliasesMap,
                 aliases,
                 elementToAliasFn,
                 aliasToElementMap,
-                TransitiveClosure.transitiveClosure(aliases, BaseMatcher.computeDependsOnMapWithAliases(aliases, aliasToElementMap, dependsOnFn)),
+                TransitiveClosure.transitiveClosure(aliases, DependencyUtils.computeDependsOnMapWithAliases(aliases, aliasToElementMap, dependsOnFn)),
                 otherAliases,
                 otherElementToAliasFn,
                 otherAliasToElementMap,
-                TransitiveClosure.transitiveClosure(otherAliases, BaseMatcher.computeDependsOnMapWithAliases(otherAliases, otherAliasToElementMap, otherDependsOnFn)),
+                TransitiveClosure.transitiveClosure(otherAliases, DependencyUtils.computeDependsOnMapWithAliases(otherAliases, otherAliasToElementMap, otherDependsOnFn)),
                 matchPredicate);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ReferenceMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ReferenceMatchers.java
@@ -105,7 +105,7 @@ public class ReferenceMatchers {
     @SuppressWarnings("unchecked")
     public static BindingMatcher<Collection<PlanPartition>> rollUpTo(@Nonnull final BindingMatcher<? extends Iterable<? extends PlanPartition>> downstream, @Nonnull final Set<PlanProperty<?>> interestingAttributes) {
         return TypedMatcherWithExtractAndDownstream.typedWithDownstream((Class<Collection<PlanPartition>>)(Class<?>)Collection.class,
-                Extractor.of(planPartitions -> PlanPartition.rollUpTo(planPartitions, interestingAttributes), name -> "filtered planPartitions(" + name + ")"),
+                Extractor.of(planPartitions -> PlanPartition.rollUpTo(planPartitions, interestingAttributes), name -> "rolled planPartitions(" + name + ")"),
                 downstream);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ReferenceMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ReferenceMatchers.java
@@ -105,7 +105,7 @@ public class ReferenceMatchers {
     @SuppressWarnings("unchecked")
     public static BindingMatcher<Collection<PlanPartition>> rollUpTo(@Nonnull final BindingMatcher<? extends Iterable<? extends PlanPartition>> downstream, @Nonnull final Set<PlanProperty<?>> interestingAttributes) {
         return TypedMatcherWithExtractAndDownstream.typedWithDownstream((Class<Collection<PlanPartition>>)(Class<?>)Collection.class,
-                Extractor.of(planPartitions -> PlanPartition.rollUpTo(planPartitions, interestingAttributes), name -> "rolled planPartitions(" + name + ")"),
+                Extractor.of(planPartitions -> PlanPartition.rollUpTo(planPartitions, interestingAttributes), name -> "rolled up planPartitions(" + name + ")"),
                 downstream);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RelationalExpressionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RelationalExpressionMatchers.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpressionWithPredicates;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
@@ -85,6 +86,18 @@ public class RelationalExpressionMatchers {
         return typedWithDownstream(bindableClass,
                 Extractor.of(RelationalExpression::getQuantifiers, name -> "quantifiers(" + name + ")"),
                 downstream);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <R extends RelationalExpression, C extends Collection<? extends Quantifier>> BindingMatcher<R> owning(@Nonnull final BindingMatcher<C> downstream) {
+        return ofTypeOwning((Class<R>)(Class<?>)RelationalExpression.class, downstream);
+    }
+
+    public static <R extends RelationalExpression> BindingMatcher<R> canBeImplemented() {
+        return PrimitiveMatchers.satisfies(relationalExpression ->
+                relationalExpression.getQuantifiers()
+                        .stream()
+                        .allMatch(quantifier -> quantifier.getRangesOver().getMembers().stream().anyMatch(innerExpression -> innerExpression instanceof RecordQueryPlan)));
     }
 
     public static <R extends RelationalExpressionWithPredicates, C1 extends Collection<? extends QueryPredicate>, C2 extends Collection<? extends Quantifier>> BindingMatcher<R> ofTypeWithPredicatesAndOwning(@Nonnull final Class<R> bindableClass,
@@ -182,6 +195,11 @@ public class RelationalExpressionMatchers {
     @Nonnull
     public static BindingMatcher<PrimaryScanExpression> primaryScanExpression() {
         return ofTypeOwning(PrimaryScanExpression.class, CollectionMatcher.empty());
+    }
+
+    @Nonnull
+    public static BindingMatcher<SelectExpression> selectExpression() {
+        return ofType(SelectExpression.class);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
@@ -169,9 +169,6 @@ public class ExistsPredicate implements LeafQueryPredicate {
     private GraphExpansion injectCompensation(@Nonnull final PartialMatch partialMatch, @Nonnull final TranslationMap translationMap) {
         Verify.verify(!translationMap.containsSourceAlias(existentialAlias));
 
-        //
-        // Find the quantifier referenced by this exists(), translate the graph underneath and recreate a new exists on top
-        //
         final var containingExpression = partialMatch.getQueryExpression();
         Verify.verify(containingExpression.canCorrelate());
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/QueryPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/QueryPredicate.java
@@ -322,4 +322,17 @@ public interface QueryPredicate extends Correlated<QueryPredicate>, TreeLike<Que
                     .orElse(null);
         });
     }
+
+    @Nonnull
+    static List<QueryPredicate> translatePredicates(@Nonnull final TranslationMap translationMap,
+                                                    @Nonnull final List<QueryPredicate> predicates) {
+        final var resultPredicatesBuilder = ImmutableList.<QueryPredicate>builder();
+        for (final var predicate : predicates) {
+            final var newOuterInnerPredicate =
+                    predicate.replaceLeavesMaybe(leafPredicate -> leafPredicate.translateLeafPredicate(translationMap))
+                            .orElseThrow(() -> new RecordCoreException("unable to translate predicate"));
+            resultPredicatesBuilder.add(newOuterInnerPredicate);
+        }
+        return resultPredicatesBuilder.build();
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
@@ -142,7 +142,7 @@ public class OrderingProperty implements PlanProperty<Ordering> {
                                 }
                                 return Pair.of(keyExpression, valueComparisonPair.getRight());
                             })
-                            .collect(ImmutableSetMultimap.toImmutableSetMultimap(Pair::getLeft, Pair::getRight));
+                            .collect(ImmutableSetMultimap.toImmutableSetMultimap(Pair::getLeft, Pair::getRight));                                        
 
             final var resultOrderingKeyParts =
                     childOrdering.getOrderingKeyParts()

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
@@ -259,7 +259,7 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
                         .filter(partialMatch -> !satisfiedOrderings(partialMatch, interestedOrderings).isEmpty())
                         .map(partialMatch -> new PartialMatchWithCompensation(partialMatch, partialMatch.compensate()))
                         .filter(partialMatchWithCompensation -> !partialMatchWithCompensation.getCompensation().isImpossible())
-                        .sorted(Comparator.comparing((Function<PartialMatchWithCompensation, Integer>)p -> p.getPartialMatch().getBindingPredidcates().size()).reversed())
+                        .sorted(Comparator.comparing((Function<PartialMatchWithCompensation, Integer>)p -> p.getPartialMatch().getBindingPredicates().size()).reversed())
                         .collect(ImmutableList.toImmutableList());
 
         final var maximumCoverageMatchesBuilder = ImmutableList.<PartialMatchWithCompensation>builder();
@@ -267,13 +267,13 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
             final var outerPartialMatchWithCompensation =
                     partialMatchesWithCompensation.get(i);
             final var outerMatch = outerPartialMatchWithCompensation.getPartialMatch();
-            final var outerBindingPredicates = outerMatch.getBindingPredidcates();
+            final var outerBindingPredicates = outerMatch.getBindingPredicates();
 
             var foundContainingInner = false;
             for (var j = 0; j < partialMatchesWithCompensation.size(); j++) {
                 final var innerPartialMatchWithCompensation =
                         partialMatchesWithCompensation.get(j);
-                final var innerBindingPredicates = innerPartialMatchWithCompensation.getPartialMatch().getBindingPredidcates();
+                final var innerBindingPredicates = innerPartialMatchWithCompensation.getPartialMatch().getBindingPredicates();
                 // check if outer is completely contained in inner
                 if (outerBindingPredicates.size() >= innerBindingPredicates.size()) {
                     break;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
@@ -183,6 +183,9 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
      * @param planContext the plan context associated with this planner rule execution
      * @param requestedOrderings a set of requested orderings
      * @param matchPartition a match partition of compatibly-matching {@link PartialMatch}es
+     * @return an expression reference that contains all compensated data access plans for the given match partition.
+     *         Note that the reference can also include index-ANDed plans for match intersections and that other matches
+     *         contained in the match partition passed in may not be planned at all.
      */
     protected ExpressionRef<? extends RelationalExpression> dataAccessForMatchPartition(@Nonnull PlanContext planContext,
                                                                                         @Nonnull Set<RequestedOrdering> requestedOrderings,
@@ -206,7 +209,7 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
         // create single scan accesses
         for (final var bestMatch : bestMaximumCoverageMatches) {
             applyCompensationForSingleDataAccess(bestMatch, bestMatchToExpressionMap.get(bestMatch.getPartialMatch()))
-                    .ifPresent(toBeInjectedReference::insert);
+                    .ifPresent(toBeInjectedReference::insertUnchecked);
         }
 
         final Map<PartialMatch, RelationalExpression> bestMatchToDistinctExpressionMap =
@@ -236,7 +239,7 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
                                     bestMatchToDistinctExpressionMap,
                                     partition,
                                     requestedOrderings).stream())
-                    .forEach(toBeInjectedReference::insert);
+                    .forEach(toBeInjectedReference::insertUnchecked);
         });
         return toBeInjectedReference;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
@@ -179,14 +179,14 @@ public class ImplementDistinctUnionRule extends PlannerRule<LogicalDistinctExpre
                         merge.add(Pair.of(orderings.get(0), orderings.get(0)));
                     } else {
                         //
-                        // TODO We currently are unable to incrementally compute a merged order as the operation is
+                        //TODO We currently are unable to incrementally compute a merged order as the operation is
                         //  not associative in all cases. The reason for that is that orderings are not represented
                         //  as PartialOrder<KeyPart> but as List<KeyPart>. While we do the reasoning for all
                         //  ordering-related logic in PartialOrder space, we transform back to a list which proves
                         //  to be lossy in some cases causing associativity to not hold).
                         //  https://github.com/FoundationDB/fdb-record-layer/issues/1618
                         
-                        // TODO
+                        //TODO
                         //  final var lastMerged = merge.size() - 1;
                         //  final Ordering mergedOrdering =
                         //      OrderingVisitor.deriveForUnionFromOrderings(ImmutableList.of(merge.get(lastMerged).getKey(), orderings.get(merge.size())),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementPhysicalScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementPhysicalScanRule.java
@@ -31,6 +31,8 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 
 import javax.annotation.Nonnull;
 
+import java.util.Optional;
+
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.primaryScanExpression;
 
 /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementPhysicalScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementPhysicalScanRule.java
@@ -31,8 +31,6 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 
 import javax.annotation.Nonnull;
 
-import java.util.Optional;
-
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.primaryScanExpression;
 
 /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushFilterThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushFilterThroughFetchRule.java
@@ -179,7 +179,7 @@ public class PushFilterThroughFetchRule extends PlannerRule<RecordQueryPredicate
 
         for (final QueryPredicate queryPredicate : queryPredicates) {
             final Optional<QueryPredicate> pushedPredicateOptional =
-                    queryPredicate.replaceLeavesMaybe(leafPredicate -> pushLeafPredicate(fetchPlan, newInnerAlias, leafPredicate));
+                    queryPredicate.replaceLeavesMaybe(leafPredicate -> pushLeafPredicate(fetchPlan, quantifierOverFetch.getAlias(), newInnerAlias, leafPredicate));
 
             if (pushedPredicateOptional.isPresent()) {
                 pushedPredicatesBuilder.add(pushedPredicateOptional.get());
@@ -229,6 +229,7 @@ public class PushFilterThroughFetchRule extends PlannerRule<RecordQueryPredicate
 
     @Nullable
     private QueryPredicate pushLeafPredicate(@Nonnull RecordQueryFetchFromPartialRecordPlan fetchPlan,
+                                             @Nonnull CorrelationIdentifier oldInnerAlias,
                                              @Nonnull CorrelationIdentifier newInnerAlias,
                                              @Nonnull final QueryPredicate leafPredicate) {
         if (leafPredicate instanceof QueryComponentPredicate) {
@@ -244,7 +245,7 @@ public class PushFilterThroughFetchRule extends PlannerRule<RecordQueryPredicate
         final PredicateWithValue predicateWithValue = (PredicateWithValue)leafPredicate;
 
         final Value value = predicateWithValue.getValue();
-        final Optional<Value> pushedValueOptional = fetchPlan.pushValue(value, newInnerAlias);
+        final Optional<Value> pushedValueOptional = fetchPlan.pushValue(value, oldInnerAlias, newInnerAlias);
         // Something went wrong when attempting to push this value through the fetch.
         // We must return null to prevent pushing of this conjunct.
         return pushedValueOptional.map(predicateWithValue::withValue).orElse(null);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSelectRule.java
@@ -77,6 +77,7 @@ public class PushRequestedOrderingThroughSelectRule extends PlannerRule<SelectEx
                         .orElse(ImmutableSet.of());
 
         if (isInnerQuantifierOnlyForEach) {
+            // TODO we can only really do this if the SELECT is a SELECT *
             call.pushConstraint(lowerRef,
                     RequestedOrderingConstraint.REQUESTED_ORDERING,
                     requestedOrderings);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushSetOperationThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushSetOperationThroughFetchRule.java
@@ -174,8 +174,9 @@ public class PushSetOperationThroughFetchRule<P extends RecordQuerySetPlan> exte
         Verify.verify(quantifiersOverFetches.size() == fetchPlans.size());
         Verify.verify(fetchPlans.size() == dependentFunctions.size());
 
-        final List<? extends Value> requiredValues = setOperationPlan.getRequiredValues(CorrelationIdentifier.uniqueID(), new Type.Any());
-        final Set<CorrelationIdentifier> pushableAliases = setOperationPlan.tryPushValues(dependentFunctions, quantifiersOverFetches, requiredValues);
+        final CorrelationIdentifier sourceAlias = CorrelationIdentifier.uniqueID();
+        final List<? extends Value> requiredValues = setOperationPlan.getRequiredValues(sourceAlias, new Type.Any());
+        final Set<CorrelationIdentifier> pushableAliases = setOperationPlan.tryPushValues(dependentFunctions, quantifiersOverFetches, requiredValues, sourceAlias);
 
         // if set operation is dynamic all aliases must be pushable
         if (setOperationPlan.isDynamic()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushSetOperationThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushSetOperationThroughFetchRule.java
@@ -21,20 +21,21 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQuerySetPlan;
-import com.apple.foundationdb.record.query.plan.plans.TranslateValueFunction;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
-import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.PlannerBindings;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQuerySetPlan;
+import com.apple.foundationdb.record.query.plan.plans.TranslateValueFunction;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
@@ -164,6 +165,10 @@ public class PushSetOperationThroughFetchRule<P extends RecordQuerySetPlan> exte
                 return;
             }
         }
+        if (setOperationPlan.getRequiredFields().stream().anyMatch(KeyExpression::createsDuplicates)) {
+            // there are nested repeateds in the required fields which we currently cannot handle
+            return;
+        }
 
         final List<? extends RecordQueryFetchFromPartialRecordPlan> fetchPlans = bindings.getAll(fetchPlanMatcher);
         final ImmutableList<TranslateValueFunction> dependentFunctions =
@@ -175,6 +180,7 @@ public class PushSetOperationThroughFetchRule<P extends RecordQuerySetPlan> exte
         Verify.verify(fetchPlans.size() == dependentFunctions.size());
 
         final CorrelationIdentifier sourceAlias = CorrelationIdentifier.uniqueID();
+
         final List<? extends Value> requiredValues = setOperationPlan.getRequiredValues(sourceAlias, new Type.Any());
         final Set<CorrelationIdentifier> pushableAliases = setOperationPlan.tryPushValues(dependentFunctions, quantifiersOverFetches, requiredValues, sourceAlias);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectDataAccessRule.java
@@ -53,7 +53,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 
 /**
  * A rule that utilizes index matching information compiled by {@link CascadesPlanner} to create one or more
- * expressions for data access specifically for a {@link SelectExpression}. A {@link SelectExpression} is behaves
+ * expressions for data access specifically for a {@link SelectExpression}. A {@link SelectExpression} behaves
  * different compared to essentially all other expressions in a way that we can conceptually deconstruct such an expression
  * on the fly and only replace the matched part of the original expression with the scan over the materialized view.
  * That allows us to relax restrictions (.e.g. to match all quantifiers the select expression owns) while matching

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectDataAccessRule.java
@@ -21,12 +21,10 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
-import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentityMap;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.MatchPartition;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
@@ -36,17 +34,16 @@ import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;
 import com.apple.foundationdb.record.query.plan.cascades.RequestedOrderingConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -98,96 +95,93 @@ public class SelectDataAccessRule extends AbstractDataAccessRule<SelectExpressio
         }
 
         final var requestedOrderings = requestedOrderingsOptional.get();
-
-        final Map<Set<CorrelationIdentifier>, ? extends List<? extends PartialMatch>> matchPartitionsByAliasesMap =
-                completeMatches
-                        .stream()
-                        .collect(Collectors.groupingBy(match -> expression.computeMatchedQuantifiers(match).stream()
-                                        .map(Quantifier::getAlias)
-                                        .collect(ImmutableSet.toImmutableSet()),
-                                LinkedHashMap::new,
-                                ImmutableList.toImmutableList()));
-
         final var aliasToQuantifierMap = Quantifiers.aliasToQuantifierMap(expression.getQuantifiers());
 
-        for(final var matchPartitionByAliasesEntry : matchPartitionsByAliasesMap.entrySet()) {
-            final var matchedAliases = matchPartitionByAliasesEntry.getKey();
+        final var matchPartitionsByAliasesMap =
+                completeMatches
+                        .stream()
+                        .map(match -> {
+                            final var matchedAliases =
+                                    expression.computeMatchedQuantifiers(match).stream().map(Quantifier::getAlias).collect(ImmutableSet.toImmutableSet());
+                            final Set<CorrelationIdentifier> matchedForEachAliases =
+                                    matchedAliases.stream()
+                                            .filter(matchedAlias -> Objects.requireNonNull(aliasToQuantifierMap.get(matchedAlias)) instanceof Quantifier.ForEach)
+                                            .collect(ImmutableSet.toImmutableSet());
+                            return Pair.of(match, matchedForEachAliases);
+                        })
+                        .filter(pair -> pair.getRight().size() == 1)
+                        .collect(Collectors.groupingBy(
+                                pair -> Pair.of(pair.getLeft().getCompensatedAliases(), Iterables.getOnlyElement(pair.getRight())),
+                                LinkedHashMap::new,
+                                Collectors.mapping(Pair::getLeft, ImmutableList.toImmutableList())));
+
+
+        for (final var matchPartitionByAliasesEntry : matchPartitionsByAliasesMap.entrySet()) {
+            final var entryKey = matchPartitionByAliasesEntry.getKey();
+            final var compensatedAliases = entryKey.getLeft();
+            final var matchedAlias = entryKey.getRight();
             final var matchPartitionForAliases = matchPartitionByAliasesEntry.getValue();
-            Verify.verify(!matchedAliases.isEmpty());
 
-            final var matchedForEachAliases =
-                    matchedAliases.stream()
-                            .filter(matchedAlias -> Objects.requireNonNull(aliasToQuantifierMap.get(matchedAlias)) instanceof Quantifier.ForEach)
-                            .collect(ImmutableSet.toImmutableSet());
+            final var toBePulledUpQuantifiers =
+                    expression
+                            .getQuantifiers()
+                            .stream()
+                            .filter(quantifier -> !compensatedAliases.contains(quantifier.getAlias()))
+                            .collect(LinkedIdentitySet.toLinkedIdentitySet());
 
-            if (matchedForEachAliases.size() == 1) {
-                final var toBePulledUpQuantifiers =
-                        expression
-                                .getQuantifiers()
+            //
+            // We do know that local predicates (which includes predicates only using the matchedAlias quantifier)
+            // are definitely handled by the logic expressed by the partial matches of the current match partition.
+            // Join predicates are different in a sense that there will be matches that handle those predicates and
+            // there will be matches where these predicates will not be handled. We further need to sub-partition the
+            // current match partition, by the predicates that are being handled by the matches.
+            //
+            final var matchPartitionsForAliasesByPredicates =
+                    matchPartitionForAliases
+                            .stream()
+                            .collect(Collectors.groupingBy(match -> new LinkedIdentitySet<>(match.getMatchInfo().getPredicateMap().keySet()),
+                                    HashMap::new,
+                                    ImmutableList.toImmutableList()));
+
+            //
+            // Note that this works because there is only one for-each and potentially 0 - n existential quantifiers
+            // that are covered by the match partition. Even though that logically forms a join, the existential
+            // quantifiers do not mutate the result of the join, they only cause filtering, that is, the resulting
+            // record is exactly what the for each quantifier produced filtered by the predicates expressed on the
+            // existential quantifiers.
+            //
+            for (final var matchPartitionEntry : matchPartitionsForAliasesByPredicates.entrySet()) {
+                final var matchedPredicates = matchPartitionEntry.getKey();
+                final var matchPartition = matchPartitionEntry.getValue();
+
+                //
+                // The current match partition covers all matches that match the aliases in matchedAliases
+                // as well as all predicates in matchedPredicates. In other words we now have to compensate
+                // for all the remaining quantifiers and all remaining predicates.
+                //
+                final var dataAccessReference =
+                        dataAccessForMatchPartition(call.getContext(),
+                                requestedOrderings,
+                                matchPartition);
+
+                final var dataAccessQuantifier = Quantifier.forEachBuilder()
+                        .withAlias(matchedAlias)
+                        .build(dataAccessReference);
+
+                final var toBePulledUpPredicates =
+                        expression.getPredicates()
                                 .stream()
-                                .filter(quantifier -> !matchedAliases.contains(quantifier.getAlias()))
+                                .filter(predicate -> !matchedPredicates.contains(predicate))
                                 .collect(LinkedIdentitySet.toLinkedIdentitySet());
 
-                //
-                // We do know that local predicates (which includes predicates only using the matchedAlias quantifier)
-                // are definitely handled by the logic expressed by the partial matches of the current match partition.
-                // Join predicates are different in a sense that there will be matches that handle those predicates and
-                // there will be matches where these predicates will not be handled. We further need to sub-partition the
-                // current match partition, by the predicates that are being handled by the matches.
-                //
-                final var matchPartitionsForAliasesByPredicates =
-                        matchPartitionForAliases
-                                .stream()
-                                .collect(Collectors.groupingBy(match -> match.getMatchInfo().getPredicateMap().keySet(),
-                                        LinkedIdentityMap::new,
-                                        ImmutableList.toImmutableList()));
-
-                //
-                // Note that this works because there is only one for-each and potentially 0 - n existential quantifiers
-                // that are covered by the match partition. Even though that logically forms a join, the existential
-                // quantifiers do not mutate the result of the join, they only cause filtering, that is, the resulting
-                // record is exactly what the for each quantifier produced filtered by the predicates expressed on the
-                // existential quantifiers.
-                //
-                final var matchedAlias = Iterables.getOnlyElement(matchedForEachAliases);
-
-                for(final var matchPartitionEntry : matchPartitionsForAliasesByPredicates.entrySet()) {
-                    final var matchedPredicates = matchPartitionEntry.getKey();
-                    final var matchPartition = matchPartitionEntry.getValue();
-
-                    //
-                    // The current match partition covers all matches that match the aliases in matchedAliases
-                    // as well as all predicates in matchedPredicates. In other words we now have to compensate
-                    // for all the remaining quantifiers and all remaining predicates.
-                    //
-                    final var dataAccessReference =
-                            dataAccessForMatchPartition(call.getContext(),
-                                    requestedOrderings,
-                                    matchPartition);
-
-                    final var dataAccessQuantifier = Quantifier.forEachBuilder()
-                            .withAlias(matchedAlias)
-                            .build(dataAccessReference);
-
-                    final var toBePulledUpPredicates =
-                            expression.getPredicates()
-                                    .stream()
-                                    .filter(predicate -> !matchedPredicates.contains(predicate))
-                                    .collect(LinkedIdentitySet.toLinkedIdentitySet());
-
-                    final var compensatedDataAccessExpression =
-                            GraphExpansion.builder()
-                                    .addQuantifier(dataAccessQuantifier)
-                                    .addAllQuantifiers(toBePulledUpQuantifiers)
-                                    .addAllPredicates(toBePulledUpPredicates)
-                                    .build()
-                                    .buildSelectWithResultValue(expression.getResultValue());
-                    call.yield(GroupExpressionRef.of(compensatedDataAccessExpression));
-                }
-            } else {
-                if (logger.isWarnEnabled()) {
-                    logger.warn(KeyValueLogMessage.of("unable to plan join index yet"));
-                }
+                final var compensatedDataAccessExpression =
+                        GraphExpansion.builder()
+                                .addQuantifier(dataAccessQuantifier)
+                                .addAllQuantifiers(toBePulledUpQuantifiers)
+                                .addAllPredicates(toBePulledUpPredicates)
+                                .build()
+                                .buildSelectWithResultValue(expression.getResultValue());
+                call.yield(GroupExpressionRef.of(compensatedDataAccessExpression));
             }
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/Value.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/Value.java
@@ -258,6 +258,10 @@ public interface Value extends Correlated<Value>, TreeLike<Value>, PlanHashable,
             if (value instanceof LeafValue) {
                 final var leafValue = (LeafValue)value;
                 final var correlatedTo = value.getCorrelatedTo();
+                if (correlatedTo.isEmpty()) {
+                    return leafValue;
+                }
+
                 Verify.verify(correlatedTo.size() == 1);
                 final var sourceAlias = Iterables.getOnlyElement(correlatedTo);
                 if (translationMap.containsSourceAlias(sourceAlias)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -39,16 +39,15 @@ import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
-import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.ScanWithFetchMatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
 import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.values.IndexedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -198,7 +197,7 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
     @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedTo() {
-        return ImmutableSet.of();
+        return indexPlan.getCorrelatedTo();
     }
 
     @Nonnull
@@ -214,10 +213,11 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
 
     @Nonnull
     public Optional<Value> pushValueThroughFetch(@Nonnull Value value,
-                                                 @Nonnull CorrelationIdentifier baseAlias) {
+                                                 @Nonnull CorrelationIdentifier sourceAlias,
+                                                 @Nonnull CorrelationIdentifier targetAlias) {
         return indexPlan.getMatchCandidateMaybe()
                 .flatMap(matchCandidate -> matchCandidate instanceof ScanWithFetchMatchCandidate ? Optional.of((ScanWithFetchMatchCandidate)matchCandidate) : Optional.empty())
-                .flatMap(scanWithFetchMatchCandidate -> scanWithFetchMatchCandidate.pushValueThroughFetch(value, baseAlias));
+                .flatMap(scanWithFetchMatchCandidate -> scanWithFetchMatchCandidate.pushValueThroughFetch(value, sourceAlias, targetAlias));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
@@ -154,8 +154,8 @@ public class RecordQueryFetchFromPartialRecordPlan implements RecordQueryPlanWit
     }
 
     @Nonnull
-    public Optional<Value> pushValue(@Nonnull Value value, @Nonnull CorrelationIdentifier targetAlias) {
-        return translateValueFunction.translateValue(value, targetAlias);
+    public Optional<Value> pushValue(@Nonnull Value value, @Nonnull CorrelationIdentifier sourceAlias, @Nonnull CorrelationIdentifier targetAlias) {
+        return translateValueFunction.translateValue(value, sourceAlias, targetAlias);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFlatMapPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFlatMapPlan.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpressionWithChildren;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -50,6 +51,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * A query plan that applies the values it contains over the incoming ones. In a sense, this is similar to the {@code Stream.map()}
@@ -66,6 +68,10 @@ public class RecordQueryFlatMapPlan implements RecordQueryPlanWithChildren, Rela
     @Nonnull
     private final Value resultValue;
     private final boolean inheritOuterRecordProperties;
+    @Nonnull
+    private final Supplier<Integer> hashCodeWithoutChildrenSupplier;
+    @Nonnull
+    private final Supplier<Set<CorrelationIdentifier>> correlatedToWithoutChildrenSupplier;
 
     public RecordQueryFlatMapPlan(@Nonnull final Quantifier.Physical outerQuantifier,
                                   @Nonnull final Quantifier.Physical innerQuantifier,
@@ -75,6 +81,8 @@ public class RecordQueryFlatMapPlan implements RecordQueryPlanWithChildren, Rela
         this.innerQuantifier = innerQuantifier;
         this.resultValue = resultValue;
         this.inheritOuterRecordProperties = inheritOuterRecordProperties;
+        this.hashCodeWithoutChildrenSupplier = Suppliers.memoize(this::computeHashCodeWithoutChildren);
+        this.correlatedToWithoutChildrenSupplier = Suppliers.memoize(this::computeCorrelatedToWithoutChildren);
     }
 
     @Nonnull
@@ -145,6 +153,11 @@ public class RecordQueryFlatMapPlan implements RecordQueryPlanWithChildren, Rela
     @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
+        return correlatedToWithoutChildrenSupplier.get();
+    }
+
+    @Nonnull
+    private Set<CorrelationIdentifier> computeCorrelatedToWithoutChildren() {
         return resultValue.getCorrelatedTo();
     }
 
@@ -212,6 +225,10 @@ public class RecordQueryFlatMapPlan implements RecordQueryPlanWithChildren, Rela
 
     @Override
     public int hashCodeWithoutChildren() {
+        return hashCodeWithoutChildrenSupplier.get();
+    }
+
+    private int computeHashCodeWithoutChildren() {
         return Objects.hash(getResultValue(), inheritOuterRecordProperties);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFlatMapPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFlatMapPlan.java
@@ -106,8 +106,6 @@ public class RecordQueryFlatMapPlan implements RecordQueryPlanWithChildren, Rela
                                                                      @Nonnull final EvaluationContext context,
                                                                      @Nullable final byte[] continuation,
                                                                      @Nonnull final ExecuteProperties executeProperties) {
-        final Value resultValue = getResultValue();
-
         return RecordCursor.flatMapPipelined(
                 outerContinuation ->
                         outerQuantifier.getRangesOverPlan().executePlan(store, context, continuation, executeProperties),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -263,15 +263,20 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedTo() {
-        return ImmutableSet.of();
+        return comparisons.getCorrelatedTo();
     }
 
     @Nonnull
     @Override
     public RecordQueryScanPlan translateCorrelations(@Nonnull final TranslationMap translationMap,
                                                      @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
-        // TODO make return this dependent on whether the index scan is correlated according to the translation map
-        return this;
+        return new RecordQueryScanPlan(recordTypes,
+                flowedType,
+                commonPrimaryKey,
+                comparisons.translateCorrelations(translationMap),
+                reverse,
+                strictlySorted,
+                matchCandidateOptional);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/TranslateValueFunction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/TranslateValueFunction.java
@@ -33,22 +33,24 @@ import java.util.Optional;
  */
 @FunctionalInterface
 public interface TranslateValueFunction {
-    TranslateValueFunction UNABLE_TO_TRANSLATE = (v, i) -> Optional.empty();
+    TranslateValueFunction UNABLE_TO_TRANSLATE = (v, o, n) -> Optional.empty();
 
     /**
      * Translate a value to an equivalent value that can be evaluated prior to the operation that we are trying to push
      * through. That operation normally is a {@link RecordQueryFetchFromPartialRecordPlan} but could potentially be
      * any {@link RelationalExpression}.
-     * @param value a value that is correlated to a quantifier ranging over the current expression or that is
-     *        only externally correlated. External correlations do not matter for translations as they are still
+     * @param value a value that is correlated to a quantifier ranging over the current expression via
+     *        {@code sourceAlias}. External correlations do not matter for translations as they are still
      *        valid after pushing the value though the current operation.
-     * @param baseAlias an alias that the referencing sub-values should be rebased to
+     * @param sourceAlias an alias that the referencing sub-values need to be rebased from
+     * @param targetAlias an alias that the referencing sub-values should be rebased to
      * @return an optional containing the translated value if this method is successful in translating the {@code value}
      *         passed in, {@code Optional.empty()} if the value passed in could not be translated.
      */
     @Nonnull
     Optional<Value> translateValue(@Nonnull Value value,
-                                   @Nonnull CorrelationIdentifier baseAlias);
+                                   @Nonnull CorrelationIdentifier sourceAlias,
+                                   @Nonnull CorrelationIdentifier targetAlias);
 
     /**
      * Shorthand for a function that never translates any value successfully.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -56,6 +56,7 @@ import com.google.protobuf.Message;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -195,8 +196,12 @@ class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     private void addDataForNested() throws Exception {
+        addDataForNested(null);
+    }
+
+    private void addDataForNested(@Nullable final RecordMetaDataHook hook) throws Exception {
         try (FDBRecordContext context = openContext()) {
-            openNestedRecordStore(context);
+            openNestedRecordStore(context, hook);
 
             TestRecords4Proto.RestaurantReviewer.Builder reviewerBuilder = TestRecords4Proto.RestaurantReviewer.newBuilder();
             reviewerBuilder.setId(1);
@@ -385,11 +390,9 @@ class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
             metaData.addIndex("RestaurantRecord", "duplicates", concat(field("name"), field("name")));
         };
 
-        addDataForNested();
+        addDataForNested(hook);
 
         final QueryComponent nestedComponent =
-                //Query.field("reviews").oneOfThem().matches(Query.field("reviewer").equalsValue(10L))
-                //Query.field("reviews").oneOfThem().matches(Query.field("rating").equalsValue(20))
                 Query.field("reviews").oneOfThem().matches(Query.and(Query.field("reviewer").equalsValue(10L), Query.field("rating").equalsValue(20)));
         final RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("RestaurantRecord")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBStreamAggregationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBStreamAggregationTest.java
@@ -55,7 +55,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBStreamAggregationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBStreamAggregationTest.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosureTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosureTest.java
@@ -33,9 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Tests for {@link TransitiveClosure}.
  */
-public class TransitiveClosureTest {
+class TransitiveClosureTest {
     @Test
-    public void testChainedDependencies() {
+    void testChainedDependencies() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
                 ImmutableSetMultimap.builder();
@@ -60,7 +60,7 @@ public class TransitiveClosureTest {
     }
 
     @Test
-    public void testNoDependencies() {
+    void testNoDependencies() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> dependsOnMap = ImmutableSetMultimap.of();
 
@@ -73,7 +73,7 @@ public class TransitiveClosureTest {
     }
 
     @Test
-    public void testSomeDependencies1() {
+    void testSomeDependencies1() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
                 ImmutableSetMultimap.builder();
@@ -98,7 +98,7 @@ public class TransitiveClosureTest {
     }
 
     @Test
-    public void testSomeDependencies2() {
+    void testSomeDependencies2() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
                 ImmutableSetMultimap.builder();
@@ -121,7 +121,7 @@ public class TransitiveClosureTest {
     }
 
     @Test
-    public void testSomeDependencies3() {
+    void testSomeDependencies3() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
                 ImmutableSetMultimap.builder();
@@ -142,7 +142,7 @@ public class TransitiveClosureTest {
     }
 
     @Test
-    public void testSomeDependencies4() {
+    void testSomeDependencies4() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
                 ImmutableSetMultimap.builder();
@@ -168,7 +168,7 @@ public class TransitiveClosureTest {
     }
 
     @Test
-    public void testCircularDependencies1() {
+    void testCircularDependencies1() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
                 ImmutableSetMultimap.builder();
@@ -186,7 +186,7 @@ public class TransitiveClosureTest {
     }
 
     @Test
-    public void testCircularDependencies2() {
+    void testCircularDependencies2() {
         final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("a"), of("b"), of("c"), of("d"), of("e"));
         final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
                 ImmutableSetMultimap.builder();
@@ -200,5 +200,26 @@ public class TransitiveClosureTest {
         final ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> dependsOnMap = builder.build();
 
         assertThrows(IllegalArgumentException.class, () -> TransitiveClosure.transitiveClosure(set, dependsOnMap));
+    }
+
+    @Test
+    void testDoublyUsedDependencies() {
+        final ImmutableSet<CorrelationIdentifier> set = ImmutableSet.of(of("c11"), of("c53"), of("c69"), of("c88"));
+        final ImmutableSetMultimap.Builder<CorrelationIdentifier, CorrelationIdentifier> builder =
+                ImmutableSetMultimap.builder();
+
+        builder.putAll(of("c11"), of("c88"), of("c53"));
+        builder.putAll(of("c88"), of("c69"), of("c53"));
+        final ImmutableSetMultimap<CorrelationIdentifier, CorrelationIdentifier> dependsOnMap = builder.build();
+
+        final SetMultimap<CorrelationIdentifier, CorrelationIdentifier> transitiveClosure =
+                TransitiveClosure.transitiveClosure(set, dependsOnMap);
+
+        assertEquals(
+                ImmutableSetMultimap.<CorrelationIdentifier, CorrelationIdentifier>builder()
+                        .putAll(of("c88"), of("c69"), of("c53"))
+                        .putAll(of("c11"), of("c69"), of("c53"), of("c88"))
+                        .build(),
+                transitiveClosure);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/State.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/State.java
@@ -346,7 +346,9 @@ class State {
         stringBuilder.append("<th scope=\"col\">Location</th>");
         stringBuilder.append("<th scope=\"col\">Count</th>");
         stringBuilder.append("<th scope=\"col\">Total Time (micros)</th>");
-        stringBuilder.append("<th scope=\"col\">Own Time (micros)</th>");
+        stringBuilder.append("<th scope=\"col\">Average Time (micros)</th>");
+        stringBuilder.append("<th scope=\"col\">Total Own Time (micros)</th>");
+        stringBuilder.append("<th scope=\"col\">Average Own Time (micros)</th>");
         stringBuilder.append("</tr>");
         stringBuilder.append("</thead>");
     }
@@ -366,7 +368,9 @@ class State {
                 stringBuilder.append("<td class=\"text-end\">").append(locationEntry.getValue()).append("</td>");
                 if (locationEntry.getKey() == Debugger.Location.BEGIN) {
                     stringBuilder.append("<td class=\"text-end\">").append(formatNsInMicros(stats.getTotalTimeInNs())).append("</td>");
+                    stringBuilder.append("<td class=\"text-end\">").append(formatNsInMicros(stats.getTotalTimeInNs() / stats.getCount(Debugger.Location.BEGIN))).append("</td>");
                     stringBuilder.append("<td class=\"text-end\">").append(formatNsInMicros(stats.getOwnTimeInNs())).append("</td>");
+                    stringBuilder.append("<td class=\"text-end\">").append(formatNsInMicros(stats.getOwnTimeInNs() / stats.getCount(Debugger.Location.BEGIN))).append("</td>");
                 } else {
                     stringBuilder.append("<td></td>");
                     stringBuilder.append("<td></td>");

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/State.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/State.java
@@ -289,8 +289,8 @@ class State {
     private void updateCounts(@Nonnull final Debugger.Event event) {
         final Stats forEventClass = getEventStatsForEventClass(event.getClass());
         forEventClass.increaseCount(event.getLocation(), 1L);
-        if (event instanceof Debugger.TransformRuleCallEvent) {
-            final PlannerRule<?> rule = ((Debugger.TransformRuleCallEvent)event).getRule();
+        if (event instanceof Debugger.EventWithRule) {
+            final PlannerRule<?> rule = ((Debugger.EventWithRule)event).getRule();
             final Class<? extends PlannerRule<?>> ruleClass = (Class<? extends PlannerRule<?>>)rule.getClass();
             final Stats forPlannerRuleClass = getEventStatsForPlannerRuleClass(ruleClass);
             forPlannerRuleClass.increaseCount(event.getLocation(), 1L);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
 import com.apple.foundationdb.record.query.plan.PlanOrderingKey;
@@ -42,6 +43,7 @@ import com.apple.foundationdb.record.query.plan.plans.QueryPlanUtils;
 import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Verify;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -202,5 +204,14 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), planOrderingKey, storedFields);
+    }
+
+    @Nonnull
+    @Override
+    protected RecordQueryIndexPlan withIndexScanParameters(@Nonnull final IndexScanParameters newIndexScanParameters) {
+        Verify.verify(newIndexScanParameters instanceof LuceneScanParameters);
+
+        // TODO this seems to be too simplistic
+        return new LuceneIndexQueryPlan(getIndexName(), (LuceneScanParameters)newIndexScanParameters, reverse, planOrderingKey, storedFields);
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanAutoCompleteParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanAutoCompleteParameters.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
@@ -109,6 +110,7 @@ public class LuceneScanAutoCompleteParameters extends LuceneScanParameters {
     }
 
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
         if (this == other) {
             return true;
@@ -139,6 +141,8 @@ public class LuceneScanAutoCompleteParameters extends LuceneScanParameters {
     }
 
     @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
         return semanticEquals(o, AliasMap.emptyMap());
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanAutoCompleteParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanAutoCompleteParameters.java
@@ -26,12 +26,19 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
 import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * Scan parameters for making a {@link LuceneScanAutoComplete}.
@@ -83,21 +90,34 @@ public class LuceneScanAutoCompleteParameters extends LuceneScanParameters {
         }
     }
 
+    @Nonnull
     @Override
-    public String toString() {
-        return super.toString() + " " + (isParameter ? "$" : "") + key;
+    public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanParameters rebase(@Nonnull final AliasMap translationMap) {
+        return this;
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
+    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+        if (this == other) {
             return true;
         }
-        if (!super.equals(o)) {
+        if (!super.equals(other)) {
             return false;
         }
 
-        final LuceneScanAutoCompleteParameters that = (LuceneScanAutoCompleteParameters)o;
+        final LuceneScanAutoCompleteParameters that = (LuceneScanAutoCompleteParameters)other;
 
         if (isParameter != that.isParameter) {
             return false;
@@ -106,10 +126,25 @@ public class LuceneScanAutoCompleteParameters extends LuceneScanParameters {
     }
 
     @Override
-    public int hashCode() {
+    public int semanticHashCode() {
         int result = super.hashCode();
         result = 31 * result + key.hashCode();
         result = 31 * result + (isParameter ? 1 : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " " + (isParameter ? "$" : "") + key;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return semanticEquals(o, AliasMap.emptyMap());
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
@@ -151,6 +152,7 @@ public class LuceneScanQueryParameters extends LuceneScanParameters {
     }
 
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
         if (this == other) {
             return true;
@@ -180,6 +182,8 @@ public class LuceneScanQueryParameters extends LuceneScanParameters {
     }
 
     @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
         return semanticEquals(o, AliasMap.emptyMap());
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
@@ -26,16 +26,22 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
 import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.search.Sort;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Scan parameters for making a {@link LuceneScanQuery}.
@@ -126,6 +132,48 @@ public class LuceneScanQueryParameters extends LuceneScanParameters {
         }
     }
 
+    @Nonnull
+    @Override
+    public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanParameters rebase(@Nonnull final AliasMap translationMap) {
+        return translateCorrelations(TranslationMap.rebaseWithAliasMap(translationMap));
+    }
+
+    @Override
+    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+        if (this == other) {
+            return true;
+        }
+        if (!super.equals(other)) {
+            return false;
+        }
+
+        final LuceneScanQueryParameters that = (LuceneScanQueryParameters)other;
+
+        return query.equals(that.query) && Objects.equals(sort, that.sort);
+    }
+
+    @Override
+    public int semanticHashCode() {
+        int result = super.hashCode();
+        result = 31 * result + query.hashCode();
+        if (sort != null) {
+            result = 31 * result + sort.hashCode();
+        }
+        return result;
+    }
+
     @Override
     public String toString() {
         return super.toString() + " " + query;
@@ -133,25 +181,11 @@ public class LuceneScanQueryParameters extends LuceneScanParameters {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        final LuceneScanQueryParameters that = (LuceneScanQueryParameters)o;
-
-        return query.equals(that.query) && Objects.equals(sort, that.sort);
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + query.hashCode();
-        if (sort != null) {
-            result = 31 * result + sort.hashCode();
-        }
-        return result;
+        return semanticHashCode();
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
@@ -27,14 +27,21 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
 import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
 import com.apple.foundationdb.util.LogMessageKeys;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Scan parameters for making a {@link LuceneScanSpellCheck}.
@@ -96,21 +103,34 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters {
         }
     }
 
+    @Nonnull
     @Override
-    public String toString() {
-        return super.toString() + " " + (isParameter ? "$" : "") + key;
+    public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanParameters rebase(@Nonnull final AliasMap translationMap) {
+        return this;
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
+    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+        if (this == other) {
             return true;
         }
-        if (!super.equals(o)) {
+        if (!super.equals(other)) {
             return false;
         }
 
-        final LuceneScanSpellCheckParameters that = (LuceneScanSpellCheckParameters)o;
+        final LuceneScanSpellCheckParameters that = (LuceneScanSpellCheckParameters)other;
 
         if (isParameter != that.isParameter) {
             return false;
@@ -119,10 +139,25 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters {
     }
 
     @Override
-    public int hashCode() {
+    public int semanticHashCode() {
         int result = super.hashCode();
         result = 31 * result + key.hashCode();
         result = 31 * result + (isParameter ? 1 : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " " + (isParameter ? "$" : "") + key;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return semanticEquals(o, AliasMap.emptyMap());
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
@@ -122,6 +123,7 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters {
     }
 
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
         if (this == other) {
             return true;
@@ -152,6 +154,8 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters {
     }
 
     @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
         return semanticEquals(o, AliasMap.emptyMap());
     }


### PR DESCRIPTION
- fixes a matching problem in `ComputingMatcher` where a join predicate could not be matched because the match was not considered.
- change the data access rules in a way that joins can be planned utilizing join indexes (once we have them) as well utilize index matches using local and join indexes.
- changes in the matching logic to properly treat join predicates.
- lots of performance-oriented changes which either address over-enumeration or implementation snafus like excessive list-copying, etc.
- I added several comments titled **Comment for reviewer** which are placed at the preamble of a class or if pertaining to a particular piece of logic near the place it's talking about. I tried to only address why the change is necessary, not necessarily how it works as that should go into comments if not already there.