### PR TITLE
Add tests for the behavior of the Lucene planner when faced with various combinations …

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -637,6 +637,13 @@ public class RecordQueryPlanner implements QueryPlanner {
                 if (p != null) {
                     p = computeIndexFilters(planContext, p);
                 }
+                if (p != null && p.getNumNonSargables() > 0) {
+                    PlanOrderingKey planOrderingKey = PlanOrderingKey.forPlan(metaData, p.plan, planContext.commonPrimaryKey);
+                    if (planOrderingKey != null && sort != null) {
+                        p.planOrderingKey = planOrderingKey;
+                        intersectionCandidates.add(p);
+                    }
+                }
                 return p;
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -64,6 +64,7 @@ public class RecordQueryPlannerConfiguration {
      * {@link com.apple.foundationdb.record.IndexScanType#BY_VALUE_OVER_SCAN} is preferred to use.
      */
     private final Set<String> valueIndexesOverScanNeeded;
+    private final boolean planOtherAttemptWholeFilter;
 
     private RecordQueryPlannerConfiguration(@Nonnull QueryPlanner.IndexScanPreference indexScanPreference,
                                             boolean attemptFailedInJoinAsOr,
@@ -79,7 +80,8 @@ public class RecordQueryPlannerConfiguration {
                                             @Nullable RecordQueryPlannerSortConfiguration sortConfiguration,
                                             @Nonnull final Set<Class<? extends PlannerRule<?>>> disabledTransformationRules,
                                             @Nonnull final IndexFetchMethod indexFetchMethod,
-                                            @Nonnull final Set<String> valueIndexesOverScanNeeded) {
+                                            @Nonnull final Set<String> valueIndexesOverScanNeeded,
+                                            boolean planOtherAttemptWholeFilter) {
         this.indexScanPreference = indexScanPreference;
         this.attemptFailedInJoinAsOr = attemptFailedInJoinAsOr;
         this.attemptFailedInJoinAsUnionMaxSize = attemptFailedInJoinAsUnionMaxSize;
@@ -95,6 +97,7 @@ public class RecordQueryPlannerConfiguration {
         this.disabledTransformationRules = ImmutableSet.copyOf(disabledTransformationRules);
         this.indexFetchMethod = indexFetchMethod;
         this.valueIndexesOverScanNeeded = valueIndexesOverScanNeeded;
+        this.planOtherAttemptWholeFilter = planOtherAttemptWholeFilter;
     }
 
     /**
@@ -247,6 +250,10 @@ public class RecordQueryPlannerConfiguration {
         return valueIndexesOverScanNeeded.contains(indexName);
     }
 
+    public boolean shouldPlanOtherAttemptWholeFilter() {
+        return planOtherAttemptWholeFilter;
+    }
+
     @Nonnull
     public Builder asBuilder() {
         return new Builder(this);
@@ -282,6 +289,7 @@ public class RecordQueryPlannerConfiguration {
 
         @Nonnull
         private Set<String> valueIndexesOverScanNeeded = Sets.newHashSet();
+        private boolean planOtherAttemptWholeFilter;
 
         public Builder(@Nonnull RecordQueryPlannerConfiguration configuration) {
             this.indexScanPreference = configuration.indexScanPreference;
@@ -465,6 +473,17 @@ public class RecordQueryPlannerConfiguration {
             return this;
         }
 
+        /**
+         * Set whether the planner attempts to plan a complex filter using non-VALUE indexes before splitting it up.
+         * @param planOtherAttemptWholeFilter whether to attempt planning the whole filter
+         * @return this builder
+         */
+        @API(API.Status.EXPERIMENTAL)
+        public Builder setPlanOtherAttemptWholeFilter(final boolean planOtherAttemptWholeFilter) {
+            this.planOtherAttemptWholeFilter = planOtherAttemptWholeFilter;
+            return this;
+        }
+
         public RecordQueryPlannerConfiguration build() {
             return new RecordQueryPlannerConfiguration(indexScanPreference,
                     attemptFailedInJoinAsOr,
@@ -480,7 +499,8 @@ public class RecordQueryPlannerConfiguration {
                     sortConfiguration,
                     disabledTransformationRules,
                     indexFetchMethod,
-                    valueIndexesOverScanNeeded);
+                    valueIndexesOverScanNeeded,
+                    planOtherAttemptWholeFilter);
         }
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
@@ -1,0 +1,306 @@
+/*
+ * LucenePlannerTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.TestRecordsTextProto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.PlannableIndexTypes;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.test.Tags;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.query;
+import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.scanParams;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
+import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.COMPLEX_DOC;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.filter;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTupleString;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScanType;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.intersection;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.primaryKeyDistinct;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.scan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.typeFilter;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.union;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.unorderedUnion;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasToString;
+
+/**
+ * Tests for {@link LucenePlanner}.
+ */
+@Tag(Tags.RequiresFDB)
+public class LucenePlannerTest extends FDBRecordStoreTestBase {
+
+    private static final FunctionKeyExpression docIdSortKey = function(LuceneFunctionNames.LUCENE_SORTED, field("doc_id"));
+    private static final FunctionKeyExpression text1Key = function(LuceneFunctionNames.LUCENE_TEXT, field("text"));
+    private static final FunctionKeyExpression text2Key = function(LuceneFunctionNames.LUCENE_TEXT, field("text2"));
+
+    private static final Index COMPLEX_TEXT1_INDEX = new Index("Complex$text1",
+            text1Key.groupBy(field("group")),
+            LuceneIndexTypes.LUCENE);
+
+    private static final Index COMPLEX_TEXT2_INDEX = new Index("Complex$text2",
+            text2Key.groupBy(field("group")),
+            LuceneIndexTypes.LUCENE);
+
+    private static final Index COMPLEX_BOTH_INDEX = new Index("Complex$both",
+            concat(text1Key, text2Key).groupBy(field("group")),
+            LuceneIndexTypes.LUCENE);
+
+    private static final Index COMPLEX_TEXT1_SORTED_INDEX = new Index("Complex$text1",
+            concat(docIdSortKey, text1Key).groupBy(field("group")),
+            LuceneIndexTypes.LUCENE);
+
+    private static final Index COMPLEX_TEXT2_SORTED_INDEX = new Index("Complex$text2",
+            concat(docIdSortKey, text2Key).groupBy(field("group")),
+            LuceneIndexTypes.LUCENE);
+
+    private static final Index COMPLEX_BOTH_SORTED_INDEX = new Index("Complex$both",
+            concat(docIdSortKey, text1Key, text2Key).groupBy(field("group")),
+            LuceneIndexTypes.LUCENE);
+
+    private static final RecordMetaDataHook separateHook = metaDataBuilder -> {
+        metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_TEXT1_INDEX);
+        metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_TEXT2_INDEX);
+    };
+
+    private static final RecordMetaDataHook combinedHook = metaDataBuilder -> {
+        metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_BOTH_INDEX);
+    };
+
+    private static final RecordMetaDataHook separateSortedHook = metaDataBuilder -> {
+        metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_TEXT1_SORTED_INDEX);
+        metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_TEXT2_SORTED_INDEX);
+    };
+
+    private static final RecordMetaDataHook combinedSortedHook = metaDataBuilder -> {
+        metaDataBuilder.addIndex(COMPLEX_DOC, COMPLEX_BOTH_SORTED_INDEX);
+    };
+
+    private static final LuceneQueryComponent luceneSyntaxAnd =
+            new LuceneQueryComponent("text:\"first\" AND text2:\"second\"", List.of("text", "text2"));
+
+    private static final LuceneQueryComponent luceneText1 =
+            new LuceneQueryComponent("text:\"first\"", List.of("text"));
+
+    private static final LuceneQueryComponent luceneText2 =
+            new LuceneQueryComponent("text2:\"second\"", List.of("text2"));
+
+    private static final RecordQuery luceneSyntaxAndQuery = RecordQuery.newBuilder()
+            .setRecordType(COMPLEX_DOC)
+            .setFilter(Query.and(
+                    Query.field("group").equalsParameter("group_value"),
+                    luceneSyntaxAnd
+            ))
+            .build();
+
+    private static final RecordQuery andLuceneQuery = RecordQuery.newBuilder()
+            .setRecordType(COMPLEX_DOC)
+            .setFilter(Query.and(
+                    Query.field("group").equalsParameter("group_value"),
+                    luceneText1,
+                    luceneText2
+            ))
+            .build();
+
+    private static final RecordQuery andLuceneQueryOrdered = RecordQuery.newBuilder()
+            .setRecordType(COMPLEX_DOC)
+            .setFilter(Query.and(
+                    Query.field("group").equalsParameter("group_value"),
+                    luceneText1,
+                    luceneText2
+            ))
+            .setSort(field("doc_id"))
+            .build();
+
+    private static final RecordQuery orLuceneQuery = RecordQuery.newBuilder()
+            .setRecordType(COMPLEX_DOC)
+            .setFilter(Query.and(
+                    Query.field("group").equalsParameter("group_value"),
+                    Query.or(luceneText1, luceneText2)
+                    ))
+            .build();
+
+    private static final RecordQuery orLuceneQueryOrdered = RecordQuery.newBuilder()
+            .setRecordType(COMPLEX_DOC)
+            .setFilter(Query.and(
+                    Query.field("group").equalsParameter("group_value"),
+                    Query.or(luceneText1, luceneText2)
+                    ))
+            .setSort(field("doc_id"))
+            .build();
+
+    protected void openRecordStore(FDBRecordContext context, FDBRecordStoreTestBase.RecordMetaDataHook hook) {
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
+        metaDataBuilder.getRecordType(TextIndexTestUtils.COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
+        hook.apply(metaDataBuilder);
+        recordStore = getStoreBuilder(context, metaDataBuilder.getRecordMetaData())
+                .setSerializer(TextIndexTestUtils.COMPRESSING_SERIALIZER)
+                .createOrOpen();
+        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), PlannableIndexTypes.DEFAULT, recordStore.getTimer());
+    }
+
+    @Test
+    void testLuceneSyntaxAndCombined() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, combinedHook);
+            RecordQueryPlan plan = planner.plan(luceneSyntaxAndQuery);
+            Matcher<RecordQueryPlan> matcher = indexScan(allOf(
+                    indexName(COMPLEX_BOTH_INDEX.getName()),
+                    indexScanType(LuceneScanTypes.BY_LUCENE),
+                    scanParams(query(hasToString("text:\"first\" AND text2:\"second\"")))));
+            assertThat(plan, matcher);
+        }
+    }
+
+    @Test
+    void testLuceneSyntaxAndSeparate() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, separateHook);
+            RecordQueryPlan plan = planner.plan(luceneSyntaxAndQuery);
+            // This residual filter doesn't actually work, but there isn't an index.
+            Matcher<RecordQueryPlan> matcher = filter(luceneSyntaxAnd, typeFilter(contains(COMPLEX_DOC), scan(bounds(hasTupleString("[EQUALS $group_value]")))));
+            assertThat(plan, matcher);
+        }
+    }
+
+    @Test
+    void testAndCombined() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, combinedHook);
+            RecordQueryPlan plan = planner.plan(andLuceneQuery);
+            Matcher<RecordQueryPlan> matcher = indexScan(allOf(
+                    indexName(COMPLEX_BOTH_INDEX.getName()),
+                    indexScanType(LuceneScanTypes.BY_LUCENE),
+                    scanParams(query(hasToString("text:\"first\" AND text2:\"second\"")))));
+            assertThat(plan, matcher);
+        }
+    }
+
+    @Test
+    void testAndSeparate() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, separateHook);
+            RecordQueryPlan plan = planner.plan(andLuceneQuery);
+            // Again, this does not actually run.
+            Matcher<RecordQueryPlan> matcher = filter(luceneText2,
+                    indexScan(allOf(
+                            indexName(COMPLEX_TEXT1_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text:\"first\""))))));
+            assertThat(plan, matcher);
+        }
+    }
+
+    @Test
+    void testAndSeparateOrdered() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, separateSortedHook);
+            RecordQueryPlan plan = planner.plan(andLuceneQueryOrdered);
+            Matcher<RecordQueryPlan> matcher = intersection(
+                    indexScan(allOf(
+                            indexName(COMPLEX_TEXT1_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text:\"first\""))))),
+                    indexScan(allOf(
+                            indexName(COMPLEX_TEXT2_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text2:\"second\""))))));
+            assertThat(plan, matcher);
+        }
+    }
+
+    @Test
+    void testOrCombined() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, combinedHook);
+            RecordQueryPlan plan = planner.plan(orLuceneQuery);
+            // TODO: Better would be to combine in Lucene term queries, since it's the same index.
+            Matcher<RecordQueryPlan> matcher = primaryKeyDistinct(unorderedUnion(
+                    indexScan(allOf(
+                            indexName(COMPLEX_BOTH_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text:\"first\""))))),
+                    indexScan(allOf(
+                            indexName(COMPLEX_BOTH_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text2:\"second\"")))))));
+            assertThat(plan, matcher);
+        }
+    }
+
+    @Test
+    void testOrSeparate() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, separateHook);
+            RecordQueryPlan plan = planner.plan(orLuceneQuery);
+            Matcher<RecordQueryPlan> matcher = primaryKeyDistinct(unorderedUnion(
+                    indexScan(allOf(
+                            indexName(COMPLEX_TEXT1_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text:\"first\""))))),
+                    indexScan(allOf(
+                            indexName(COMPLEX_TEXT2_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text2:\"second\"")))))));
+            assertThat(plan, matcher);
+        }
+    }
+
+    @Test
+    void testOrSeparateOrdered() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, separateSortedHook);
+            RecordQueryPlan plan = planner.plan(orLuceneQueryOrdered);
+            Matcher<RecordQueryPlan> matcher = union(
+                    indexScan(allOf(
+                            indexName(COMPLEX_TEXT1_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text:\"first\""))))),
+                    indexScan(allOf(
+                            indexName(COMPLEX_TEXT2_INDEX.getName()),
+                            indexScanType(LuceneScanTypes.BY_LUCENE),
+                            scanParams(query(hasToString("text2:\"second\""))))));
+            assertThat(plan, matcher);
+        }
+    }
+
+}


### PR DESCRIPTION
… of `AND` and `OR` queries and separate / combined Lucene indexes for the clauses' fields.

Enhance `planOther` so that intersection of compatibly (meaning, explicitly) ordered scans is attempted.

Add a planner configuration setting (default off) that gives the Lucene planner a chance at the whole filter before normalization, `OR`, and `IN` handling. With this on, `AND` and `OR` are handled symmetrically: using a combined Lucene boolean query when a single index is available with both requested fields.

Note that no changes are made to the Lucene planner itself, just when and how it is invoked.