### PR TITLE
Resolve #1432: Merge online indexer sub modules - "by records" and 'm…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -41,7 +41,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Merge online indexer sub modules - "by records" and 'multi target by records" [(Issue #1432)](https://github.com/FoundationDB/fdb-record-layer/issues/1432)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/TupleRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/TupleRange.java
@@ -214,6 +214,18 @@ public class TupleRange {
     }
 
     /**
+     * Create a <code>TupleRange</code> over all keys between the given {@link Tuple}s, including both endpoints.
+     * @param low the inclusive start of the range
+     * @param high the inclusive end of the range
+     * @return a <code>TupleRange</code> between <code>start</code> and <code>end</code>, inclusive
+     */
+    public static TupleRange betweenInclusive(@Nullable Tuple low, @Nullable Tuple high) {
+        EndpointType lowEndpoint = (low == null) ? EndpointType.TREE_START : EndpointType.RANGE_INCLUSIVE;
+        EndpointType highEndpoint = (high == null) ? EndpointType.TREE_END : EndpointType.RANGE_INCLUSIVE;
+        return new TupleRange(low, high, lowEndpoint, highEndpoint);
+    }
+
+    /**
      * Create a <code>TupleRange</code> over all keys prefixed by some {@link String}. This
      * is a shortcut for creating a <code>TupleRange</code> where both the low- and high-endpoints
      * are <code>Tuple</code>s containing a single <code>String</code> where both the low

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -823,6 +823,12 @@ public abstract class IndexingBase {
                 getRunner().getExecutor());
     }
 
+    protected static boolean allRangesExhausted(Tuple cont, Tuple end) {
+        // if cont isn't null, it means that the cursor was not exhausted
+        // if end isn't null, it means that the range is a segment (i.e. closed or half-open interval) - the rangeSet may contain more unbuilt ranges
+        return end == null && cont == null;
+    }
+
     // rebuildIndexAsync - builds the whole index inline (without committing)
     @Nonnull
     public CompletableFuture<Void> rebuildIndexAsync(@Nonnull FDBRecordStore store) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
@@ -48,7 +48,6 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -192,7 +191,7 @@ public class IndexingByIndex extends IndexingBase {
                                           lastResult.get().get().getIndexEntry().getKey() :
                                           rangeEnd)
                     .thenCompose(cont -> rangeSet.insertRange(store.ensureContextActive(), packOrNull(rangeStart), packOrNull(cont), true)
-                                .thenApply(ignore -> !Objects.equals(cont, rangeEnd)));
+                                .thenApply(ignore -> !allRangesExhausted(cont, rangeEnd)));
 
         });
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -151,12 +151,12 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
 
         return maybePresetRangeFuture.thenCompose(ignore ->
                 iterateAllRanges(additionalLogMessageKeyValues,
-                        (store, recordsScanned) -> buildRangeOnly(store, rangeStart, rangeEnd , recordsScanned),
+                        (store, recordsScanned) -> buildRangeOnly(store, recordsScanned),
                 subspaceProvider, subspace));
     }
 
     @Nonnull
-    private CompletableFuture<Boolean> buildRangeOnly(@Nonnull FDBRecordStore store, byte[] startBytes, byte[] endBytes, @Nonnull AtomicLong recordsScanned) {
+    private CompletableFuture<Boolean> buildRangeOnly(@Nonnull FDBRecordStore store, @Nonnull AtomicLong recordsScanned) {
         // return false when done
         /* Multi target consistency:
          * 1. Identify missing ranges from only the first index
@@ -165,7 +165,7 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
          */
         validateSameMetadataOrThrow(store);
         RangeSet rangeSet = new RangeSet(store.indexRangeSubspace(common.getPrimaryIndex()));
-        AsyncIterator<Range> ranges = rangeSet.missingRanges(store.ensureContextActive(), startBytes, endBytes).iterator();
+        AsyncIterator<Range> ranges = rangeSet.missingRanges(store.ensureContextActive()).iterator();
         final List<Index> targetIndexes = common.getTargetIndexes();
         final List<RangeSet> targetRangeSets = targetIndexes.stream().map(targetIndex -> new RangeSet(store.indexRangeSubspace(targetIndex))).collect(Collectors.toList());
         final boolean isIdempotent = areTheyAllIdempotent(store, targetIndexes);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -54,7 +54,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -194,7 +193,7 @@ public class IndexingScrubDangling extends IndexingBase {
                                         return false;
                                     }
                                 }
-                                return !Objects.equals(cont, rangeEnd);
+                                return !allRangesExhausted(cont, rangeEnd);
                             }));
         });
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -190,7 +190,7 @@ public class IndexingScrubMissing extends IndexingBase {
                                         return false;
                                     }
                                 }
-                                return !Objects.equals(cont, rangeEnd);
+                                return !allRangesExhausted(cont, rangeEnd);
                             }));
         });
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -2596,6 +2596,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         runLocalityTest(() -> testBoundaryPrimaryKeysImpl());
     }
 
+    @SuppressWarnings("deprecation")
     public void testBoundaryPrimaryKeysImpl() {
         final FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setLocalityProvider(MockedLocalityUtil.instance());
@@ -2674,6 +2675,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         runLocalityTest(() -> testNoBoundaryPrimaryKeysImpl());
     }
 
+    @SuppressWarnings("deprecation")
     public void testNoBoundaryPrimaryKeysImpl() {
         final FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
         factory.setLocalityProvider(MockedLocalityUtil.instance());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -75,6 +75,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
         this.safeBuild = safeBuild;
     }
 
+    @SuppressWarnings("deprecation")
     void singleRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
                                  int agents, boolean overlap, boolean splitLongRecords,
                                  @Nonnull Index index, @Nonnull Runnable beforeBuild, @Nonnull Runnable afterBuild, @Nonnull Runnable afterReadable) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerConflictsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerConflictsTest.java
@@ -197,6 +197,7 @@ public class OnlineIndexerConflictsTest extends OnlineIndexerTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testAddRecordOutsideRangeWhileIndexedIdempotent() {
 
         List<TestRecords1Proto.MySimpleRecord> records =

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -94,8 +94,7 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
             assertThrows(RecordCoreException.class, indexBuilder::buildIndex);
             // The index should be partially built
         }
-        final int expected = policy == null ? count + 1 : count; // by-records performs an extra range while building endpoints
-        assertEquals(expected , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
+        assertEquals(count, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
@@ -807,7 +807,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             context.commit();
         }
 
-        // build target index from source index
+        // build target index from source index (note - may fall back to by-records)
         try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
                 .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()


### PR DESCRIPTION
…ulti target by records"
At this step, we still keep the old `IndexingByRecords` module - used for implementing `buildRange`, `splitIndexBuildRange`, `buildUnbuiltRange`,`buildEndpoints`. Maybe it'll be possible to delete it after implementing parallel indexing in the new modules. 