### PR TITLE
Refine Lucene sorting keys

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
@@ -85,7 +85,7 @@ public class IndexKeyValueToPartialRecord {
      * Which side of the {@link IndexEntry} to take a field from.
      */
     public enum TupleSource {
-        KEY, VALUE
+        KEY, VALUE, OTHER
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanWithStoredFields.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanWithStoredFields.java
@@ -50,6 +50,8 @@ public interface PlanWithStoredFields {
      *
      * @param keyFields all of the fields of the index definition (root key expression), normalized and in order
      * @param nonStoredFields the fields that <em>are not</em> stored, that is, available in the index entry, even though they are part of the index definition
+     * @param otherFields fields that come from the index entry in a special way
      */
-    void getStoredFields(@Nonnull List<KeyExpression> keyFields, @Nonnull List<KeyExpression> nonStoredFields);
+    void getStoredFields(@Nonnull List<KeyExpression> keyFields, @Nonnull List<KeyExpression> nonStoredFields,
+                         @Nonnull List<KeyExpression> otherFields);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
@@ -46,7 +46,9 @@ public class LuceneFunctionKeyExpressionFactory implements FunctionKeyExpression
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_FULL_TEXT_FIELD_INDEX_OPTIONS, LuceneFunctionKeyExpression.LuceneFieldConfig::new),
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_FULL_TEXT_FIELD_WITH_TERM_VECTORS, LuceneFunctionKeyExpression.LuceneFieldConfig::new),
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_FULL_TEXT_FIELD_WITH_TERM_VECTOR_POSITIONS, LuceneFunctionKeyExpression.LuceneFieldConfig::new),
-                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_AUTO_COMPLETE_FIELD_INDEX_OPTIONS, LuceneFunctionKeyExpression.LuceneFieldConfig::new)
+                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_AUTO_COMPLETE_FIELD_INDEX_OPTIONS, LuceneFunctionKeyExpression.LuceneFieldConfig::new),
+                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_SORT_BY_RELEVANCE, LuceneFunctionKeyExpression.LuceneSortBy::new),
+                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_SORT_BY_DOCUMENT_NUMBER, LuceneFunctionKeyExpression.LuceneSortBy::new)
         );
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
@@ -35,6 +35,8 @@ public class LuceneFunctionNames {
     public static final String LUCENE_FULL_TEXT_FIELD_WITH_TERM_VECTORS = "lucene_full_text_field_with_term_vectors";
     public static final String LUCENE_FULL_TEXT_FIELD_WITH_TERM_VECTOR_POSITIONS = "lucene_full_text_field_with_term_vector_positions";
     public static final String LUCENE_AUTO_COMPLETE_FIELD_INDEX_OPTIONS = "lucene_auto_complete_field_index_options";
+    public static final String LUCENE_SORT_BY_RELEVANCE = "lucene_sort_by_relevance";
+    public static final String LUCENE_SORT_BY_DOCUMENT_NUMBER = "lucene_sort_by_document_number";
 
     private LuceneFunctionNames() {
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
@@ -155,7 +155,8 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
 
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public void getStoredFields(@Nonnull List<KeyExpression> keyFields, @Nonnull List<KeyExpression> nonStoredFields) {
+    public void getStoredFields(@Nonnull List<KeyExpression> keyFields, @Nonnull List<KeyExpression> nonStoredFields,
+                                @Nonnull List<KeyExpression> otherFields) {
         int i = 0;
         while (i < nonStoredFields.size()) {
             KeyExpression field = nonStoredFields.get(i);
@@ -181,6 +182,14 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
                 nonStoredFields.remove(i);
             } else {
                 i++;
+            }
+        }
+        if (planOrderingKey != null) {
+            // These are available by extending the IndexEntry.
+            for (KeyExpression orderingKey : planOrderingKey.getKeys()) {
+                if (orderingKey instanceof LuceneFunctionKeyExpression.LuceneSortBy) {
+                    otherFields.add(orderingKey);
+                }
             }
         }
     }


### PR DESCRIPTION
Add function key expressions to represent the two built-in sort orders for Lucene searches.
Plumb these through the IndexEntry cursor so that they are available for merging.
For now, do not claim these as part of an intersection / union candidate, as whether they are the same from one search to another is complicated.