### PR TITLE
Ignore CollectionTerminatedException.

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -196,13 +196,11 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
                             final LeafReaderContext ctx = result.getLeft();
                             if (scorer != null && scorer.getLeft() != null && scorer.getRight() != null) {
                                 try {
-                                    try {
-                                        scorer.getRight().score(scorer.getLeft(), ctx.reader().getLiveDocs());
-                                    } catch (IOException e) {
-                                        throw new WrapperException(e);
-                                    }
+                                    scorer.getRight().score(scorer.getLeft(), ctx.reader().getLiveDocs());
                                 } catch (CollectionTerminatedException cte) {
                                     // no-op just ignore.
+                                } catch (IOException ioe) {
+                                    throw new WrapperException(ioe); // to be cascaded.
                                 }
                             }
                         });

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -169,6 +169,7 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
      * WrapperException used for retrieving an {@link IOException} from an asynchronous execution block.
      */
     private static class WrapperException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
         @Nonnull
         private final IOException ioe;
 


### PR DESCRIPTION
This PR made the LuceneOptimizedIndexSearcher, however it mistakenly allowed `CollectionTerminatedException` to be propagated to the outside.

In the original code, that exception was [properly ignored](https://github.com/FoundationDB/fdb-record-layer/commit/e98cf6aa234563acc7c45e57c3a6f19e22af0a1f#diff-f59fd6db59846daffb972ed37a5e1e7352965c1905e97b1b75c418bef7c61275L112) as suggested in Lucene Docs:

> Note: IndexSearcher swallows this exception and never re-throws it. As a consequence, you should not catch it when calling [IndexSearcher.search(org.apache.lucene.search.Query, int)](https://lucene.apache.org/core/7_4_0/core/org/apache/lucene/search/IndexSearcher.html#search-org.apache.lucene.search.Query-int-) as it is unnecessary and might hide misuse of this exception.

This PR attempts to restore that behaviour, in addition, it cascades `IOException` instead of ignoring it within asynchronous execution blocks.