### PR TITLE
Add a new kind of FDBDirectory that uses a separate FDBRecordContext …

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -46,8 +46,16 @@ public class LuceneEvents {
         LUCENE_LIST_ALL("lucene list all"),
         /** Time to load the file cache for Lucene's FDBDirectory. */
         LUCENE_LOAD_FILE_CACHE("lucene load file cache"),
+        /** Number of increment new file counter. */
+        LUCENE_GET_INCREMENT("lucene file counter increment"),
         /** Number of file length calls in the FDBDirectory. */
         LUCENE_GET_FILE_LENGTH("lucene get file length"),
+        /** Number of writeFileReference calls in the FDBDirectory.*/
+        LUCENE_WRITE_FILE_REFERENCE("lucene write file references"),
+        /** Number of deleteFile calls in the FDBDirectory.*/
+        LUCENE_DELETE_FILE("lucene delete file"),
+        /** Number of rename calls in the FDBDirectory.*/
+        LUCENE_RENAME("lucene rename"),
         /** Number of documents returned from a single Lucene Index Scan. */
         LUCENE_INDEX_SCAN("lucene search returned documents"),
         /** Number of suggestions returned from a single Lucene Auto Complete Scan. */
@@ -118,12 +126,6 @@ public class LuceneEvents {
      * Wait events.
      */
     public enum Waits implements StoreTimer.Wait {
-        /** Wait to delete a file from Lucene's FDBDirectory.*/
-        WAIT_LUCENE_DELETE_FILE("lucene delete file"),
-        /** Wait to get the length of the a file in Lucene's FDBDirectory.*/
-        WAIT_LUCENE_FILE_LENGTH("lucene file length"),
-        /** Wait to rename a file in Lucene's FDBDirectory.*/
-        WAIT_LUCENE_RENAME("lucene rename"),
         /** Wait to get a new file counter increment. */
         WAIT_LUCENE_GET_INCREMENT("lucene file counter increment"),
         /** Wait to read a file reference. */
@@ -162,10 +164,6 @@ public class LuceneEvents {
      * Count events.
      */
     public enum Counts implements StoreTimer.Count {
-        /** Number of times the getIncrement() function is called in the FDBDirectory. */
-        LUCENE_GET_INCREMENT_CALLS("lucene increments", false),
-        /** Number of writeFileReference calls in the FDBDirectory.*/
-        LUCENE_WRITE_FILE_REFERENCE_CALL("lucene write file references", false),
         /** Total number of bytes that were attempted to be written (not necessarily committed) for file references in the FDBDirectory. */
         LUCENE_WRITE_FILE_REFERENCE_SIZE("lucene write file reference size", true),
         /** Count of writeData calls in FDBDirectory. */
@@ -174,8 +172,6 @@ public class LuceneEvents {
         LUCENE_WRITE_SIZE("lucene index size", true),
         /** The number of block reads that occur against the FDBDirectory.*/
         LUCENE_BLOCK_READS("lucene block reads", false),
-        /** Time to write a file references in Lucene's FDBDirectory.*/
-        LUCENE_WRITE_FILE_REFERENCE("lucene write file reference" , false),
         /** Matched documents returned from lucene index reader scans. **/
         LUCENE_SCAN_MATCHED_DOCUMENTS("lucene scan matched documents", false),
         /** Matched auto complete suggestions returned from lucene auto complete suggestion lookup. **/

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -62,6 +62,8 @@ public class LuceneEvents {
         LUCENE_AUTO_COMPLETE_SUGGESTIONS_SCAN("lucene search returned auto complete suggestions"),
         /** Number of documents returned from a single Lucene spellcheck scan. */
         LUCENE_SPELLCHECK_SCAN("lucene search returned spellcheck suggestions"),
+        /** Time optimizing segments manually. */
+        LUCENE_INDEX_FORCE_MERGE("lucene index force merge"),
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexForceMerge.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexForceMerge.java
@@ -1,0 +1,63 @@
+/*
+ * LuceneIndexForceMerge.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperation;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Optimize Lucene index by merging segments.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LuceneIndexForceMerge extends IndexOperation {
+    @Nonnull
+    private final Tuple groupingKey;
+    private final int maxNumSegments;
+    private final long commitAfterBytesLimit;
+    private final long commitAfterMillisLimit;
+
+    public LuceneIndexForceMerge(@Nonnull Tuple groupingKey, int maxNumSegments, final long commitAfterBytesLimit, final long commitAfterMillisLimit) {
+        this.groupingKey = groupingKey;
+        this.maxNumSegments = maxNumSegments;
+        this.commitAfterBytesLimit = commitAfterBytesLimit;
+        this.commitAfterMillisLimit = commitAfterMillisLimit;
+    }
+
+    @Nonnull
+    public Tuple getGroupingKey() {
+        return groupingKey;
+    }
+
+    public int getMaxNumSegments() {
+        return maxNumSegments;
+    }
+
+    public long getCommitAfterBytesLimit() {
+        return commitAfterBytesLimit;
+    }
+
+    public long getCommitAfterMillisLimit() {
+        return commitAfterMillisLimit;
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexForceMergeResult.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexForceMergeResult.java
@@ -1,0 +1,58 @@
+/*
+ * LuceneIndexForceMergeResult.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperationResult;
+
+/**
+ * Result of {@link LuceneIndexForceMerge}.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LuceneIndexForceMergeResult extends IndexOperationResult {
+    private final int numberOfFilesBefore;
+    private final long totalSizeBefore;
+    private final int numberOfFilesAfter;
+    private final long totalSizeAfter;
+
+    public LuceneIndexForceMergeResult(int numberOfFilesBefore, long totalSizeBefore, int numberOfFilesAfter, long totalSizeAfter) {
+        this.numberOfFilesBefore = numberOfFilesBefore;
+        this.totalSizeBefore = totalSizeBefore;
+        this.numberOfFilesAfter = numberOfFilesAfter;
+        this.totalSizeAfter = totalSizeAfter;
+    }
+
+    public int getNumberOfFilesBefore() {
+        return numberOfFilesBefore;
+    }
+
+    public long getTotalSizeBefore() {
+        return totalSizeBefore;
+    }
+
+    public int getNumberOfFilesAfter() {
+        return numberOfFilesAfter;
+    }
+
+    public long getTotalSizeAfter() {
+        return totalSizeAfter;
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -131,7 +131,7 @@ public class FDBDirectory extends Directory {
      */
     private final AtomicReference<Map<String, FDBLuceneFileReference>> fileReferenceCache;
 
-    private final AtomicLong fileSequenceCounter;
+    protected final AtomicLong fileSequenceCounter;
     private final Cache<Pair<Long, Integer>, CompletableFuture<byte[]>> blockCache;
 
     private final boolean compressionEnabled;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -163,4 +163,9 @@ public class FDBDirectoryManager implements AutoCloseable {
                 LogMessageKeys.INDEX_NAME, state.index.getName(),
                 LogMessageKeys.INDEX_SUBSPACE, state.indexSubspace);
     }
+
+    @Nonnull
+    public FDBDirectoryWithSeparateContext getDirectoryWithSeparateContext(@Nullable Tuple groupingKey) {
+        return new FDBDirectoryWithSeparateContext(state.indexSubspace.subspace(groupingKey), state.context);
+    }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWithSeparateContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWithSeparateContext.java
@@ -1,0 +1,189 @@
+/*
+ * FDBDirectoryWithSeparateContext.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.lucene.LuceneAnalyzerWrapper;
+import com.apple.foundationdb.record.lucene.LuceneLoggerInfoStream;
+import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
+import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCodec;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
+import com.apple.foundationdb.subspace.Subspace;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.TieredMergePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Deque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * An variant of {@link FDBDirectory} that has its own transactionality and can therefore operate on larger datasets for longer.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class FDBDirectoryWithSeparateContext extends FDBDirectory implements AutoCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDBDirectoryWithSeparateContext.class);
+
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+
+    private final Deque<CompletableFuture<?>> pendingReads = new ConcurrentLinkedDeque<>();
+
+    private long commitAfterBytesLimit;
+    private long commitAfterMillisLimit;
+    private long contextStartMillis;
+    private int pendingBytesCount;
+
+    @Nullable
+    IndexWriter indexWriter;
+
+    public FDBDirectoryWithSeparateContext(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context) {
+        super(subspace, openLikeContext(context));
+        contextStartMillis = System.currentTimeMillis();
+    }
+
+    public void setCommitAfterLimits(long commitAfterBytesLimit, long commitAfterMillisLimit) {
+        this.commitAfterBytesLimit = commitAfterBytesLimit;
+        this.commitAfterMillisLimit = commitAfterMillisLimit;
+    }
+
+    @Override
+    public void close() {
+        if (indexWriter != null) {
+            try {
+                indexWriter.close();
+            } catch (IOException ex) {
+                throw new RecordCoreException("error closing writer", ex);
+            }
+        }
+        if (context != null) {
+            context.commit();
+        }
+        super.close();
+    }
+
+    @Override
+    protected <T> CompletableFuture<T> readTransaction(Function<ReadTransaction, CompletableFuture<T>> reader) {
+        Lock lock = readWriteLock.readLock();
+        lock.lock();
+        try {
+            CompletableFuture<T> result = super.readTransaction(reader);
+            pendingReads.removeIf(CompletableFuture::isDone);
+            if (!result.isDone()) {
+                pendingReads.addLast(result);
+            }
+            return result;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    protected void writeTransaction(Consumer<Transaction> writer) {
+        Lock lock = readWriteLock.writeLock();
+        lock.lock();
+        try {
+            super.writeTransaction(writer);
+            if ((commitAfterBytesLimit > 0 && pendingBytesCount > commitAfterBytesLimit) ||
+                    (commitAfterMillisLimit > 0 && System.currentTimeMillis() - contextStartMillis > commitAfterMillisLimit)) {
+                syncTransaction();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    protected void countWriteBytes(long count) {
+        pendingBytesCount += count;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    protected void syncTransaction() {
+        Lock lock = readWriteLock.writeLock();
+        lock.lock();
+        try {
+            super.syncTransaction();
+            while (!pendingReads.isEmpty()) {
+                CompletableFuture<?> future = pendingReads.removeFirst();
+                if (!future.isDone()) {
+                    try {
+                        future.get();
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                    } catch (ExecutionException ex) {
+                        // Swallow exception
+                    }
+                }
+            }
+            context.commit();
+            openNewContext();
+            contextStartMillis = System.currentTimeMillis();
+            pendingBytesCount = 0;
+            fileSequenceCounter.set(-1);    // Fetch again in new transaction.
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Nonnull
+    @SuppressWarnings("PMD.CloseResource")
+    public IndexWriter getIndexWriter(@Nonnull RecordLayerPropertyStorage propertyStorage, @Nonnull LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
+        if (indexWriter == null) {
+            TieredMergePolicy tieredMergePolicy = new TieredMergePolicy()
+                    .setMaxMergedSegmentMB(Math.max(0.0, propertyStorage.getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_MAX_SIZE)));
+            tieredMergePolicy.setNoCFSRatio(1.00);
+            IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzerWrapper.getAnalyzer())
+                    .setUseCompoundFile(true)
+                    .setMergePolicy(tieredMergePolicy)
+                    .setMergeScheduler(new ConcurrentMergeScheduler())
+                    .setCodec(new LuceneOptimizedCodec())
+                    .setInfoStream(new LuceneLoggerInfoStream(LOGGER));
+            indexWriter = new IndexWriter(this, indexWriterConfig);
+        }
+        return indexWriter;
+    }
+
+    protected void openNewContext() {
+        context = openLikeContext(context);
+    }
+
+    @Nonnull
+    private static FDBRecordContext openLikeContext(@Nonnull FDBRecordContext context) {
+        return context.getDatabase().openContext(context.getConfig());
+    }
+}


### PR DESCRIPTION
… and is allowed to commit it along the way.

Because of the way merging happens in multiple threads, it is possible for there to be outstanding reads at the same time as a periodic commit or requested fsync. These all need to be completed before closing the transaction so that they don't fail. A read-write lock prevents more being started before this is all done.

Use this to implement force merge as an index operation.