### PR TITLE
Resolves #1827: Lower log severity for remote fetch when index type is unsupported

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Lower the severity of error when logging incompatible index for remote fetch [(Issue #1828)](https://github.com/FoundationDB/fdb-record-layer/issues/1828)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -281,6 +281,6 @@ public abstract class IndexMaintainer {
                                                              @Nonnull final ScanProperties scanProperties,
                                                              @Nonnull final KeyExpression commonPrimaryKey) {
         // Not implemented by default - needs to be overridden by individual maintainers
-        throw new RecordCoreException("scanRemoteFetch operation is not supported by this index maintainer for Index " + state.index.getName());
+        throw new UnsupportedRemoteFetchIndexException("scanRemoteFetch operation is not supported by this index maintainer for Index " + state.index.getName());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedRemoteFetchIndexException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedRemoteFetchIndexException.java
@@ -1,0 +1,46 @@
+/*
+ * UnsupportedFormatVersionException.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Exception thrown when remote fetch is attempted on an index that does not support remote fetch.
+ */
+@SuppressWarnings({"serial", "java:S110"})
+@API(API.Status.EXPERIMENTAL)
+public class UnsupportedRemoteFetchIndexException extends RecordCoreException {
+    public UnsupportedRemoteFetchIndexException(@Nonnull String msg, @Nullable Object ... keyValues) {
+        super(msg, keyValues);
+    }
+
+    public UnsupportedRemoteFetchIndexException(Throwable cause) {
+        super(cause);
+    }
+
+    public UnsupportedRemoteFetchIndexException(@Nonnull String msg, @Nullable Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedRemoteFetchIndexException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedRemoteFetchIndexException.java
@@ -28,6 +28,10 @@ import javax.annotation.Nullable;
 
 /**
  * Exception thrown when remote fetch is attempted on an index that does not support remote fetch.
+ * This exception is to be thrown when an index maintainer that does not support remote fetch is asked to scan an index
+ * using {@link IndexMaintainer#scanRemoteFetch}
+ * <p>Note that this exception is caught and handled by {@link FDBRecordStore} and {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan}
+ * and so should be thrown by any index maintainer (even outside this project) for proper handing of the error case.</p>
  */
 @SuppressWarnings({"serial", "java:S110"})
 @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -53,6 +53,7 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexScanBounds;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanComparisons;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanRange;
+import com.apple.foundationdb.record.provider.foundationdb.UnsupportedRemoteFetchIndexException;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
@@ -217,6 +218,14 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren, Reco
                     return new FallbackCursor<>(
                             executeUsingRemoteFetch(store, context, continuation, executeProperties),
                             lastSuccessfulResult -> fallBackContinueFrom(store, context, continuation, executeProperties, lastSuccessfulResult));
+                } catch (UnsupportedRemoteFetchIndexException ex) {
+                    // In this case (e.g. the index maintainer does not support remote fetch), log as info
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info(KeyValueLogMessage.of("Remote fetch unsupported, continuing with Index scan",
+                                LogMessageKeys.MESSAGE, ex.getMessage(),
+                                LogMessageKeys.INDEX_NAME, indexName));
+                    }
+                    return RecordQueryPlanWithIndex.super.executePlan(store, context, continuation, executeProperties);
                 } catch (Exception ex) {
                     if (LOGGER.isWarnEnabled()) {
                         LOGGER.warn(KeyValueLogMessage.of("Remote Fetch execution failed, falling back to Index scan",

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
@@ -416,7 +416,7 @@ class RemoteFetchIndexScanTest extends RemoteFetchTestBase {
     }
 
     /**
-     * This test uses an index type that does not support remote fetch (BITMAP)
+     * This test uses an index type that does not support remote fetch (BITMAP).
      */
     @ParameterizedTest(name = "testScanUnsupportedIndex(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
     @EnumSource()


### PR DESCRIPTION
When the index type is not supported for remote fetch (e.g. RANK, BITMAP, TEXT), the log message should not be WARN so as not to pollute the logs - this is a case where future development will increasingly support more index types and is not considered an error. 
In the case of `REMOTE_FETCH_WITH_FALLBACK`, the fallback mechanism would perform the scan using the legacy scan and fetch. 
In the case of `USE_REMOTE_FETCH`, the exception thrown (`UnsupportedRemoteFetchIndexException`) should indicate that this is a "not yet implemented" issue.
