### PR TITLE
Resolve #1845: Remove premature test for illegal PK length for remote fetch

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** incorrect assertion of PK length fails remote fetch with fallback [(Issue #1845)](https://github.com/FoundationDB/fdb-record-layer/issues/1845)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1071,11 +1071,6 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                                                                @Nullable byte[] continuation,
                                                                @Nonnull IndexOrphanBehavior orphanBehavior,
                                                                @Nonnull ScanProperties scanProperties) {
-        // Note that even though it is legal to have 0-len PK, we actually require >0 for remote fetch
-        if ((fetchMethod != IndexFetchMethod.SCAN_AND_FETCH) && (commonPrimaryKeyLength <= 0)) {
-            throw new RecordCoreArgumentException("scanIndexRecords with remote fetch requires a positive commonPrimaryKeyLength",
-                    LogMessageKeys.INDEX_NAME, index.getName());
-        }
         if (!(scanBounds instanceof IndexScanRange)) {
             throw new RecordCoreArgumentException("scanIndexRecords can only be used with IndexScanRange bounds");
         }


### PR DESCRIPTION
In the case of remote fetch with fallback, the check for illegal PK length should fail the remote fetch operation but not the entire operation, so that the scan-and-fetch would still be applicable.
Fixed the tests that were incorrect, as they were incorrectly adapted from the PK expression logic.