### PR TITLE
Fix broke "Getting Started": add note on protobuf versions, use the `basic` gradle type, update dependencies, and mix in some missing info

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -71,7 +71,7 @@ for a listing of published versions).
 ### ProtoBuf Configuration
 
 Our sample project will use [Protocol Buffers](https://developers.google.com/protocol-buffers/) (protobuf)
-to define our record meta-data. First, since we are using Gradle, let's apply the
+to define our record meta-data. First, since we are using Gradle, let's include the
 [protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin),
 which will allow us to add protobuf compilation as a step in our build process.
 Add this to the top of your `build.gradle`, ahead of the above `repositories` and
@@ -83,7 +83,7 @@ plugins {
     id 'com.google.protobuf' version "0.8.19"
 }
 ```
-Gradle complains the java plugin must be appled before the protobuf plugin will run so also
+Gradle complains the `java` plugin must be included for the protobuf plugin to run so also
 include `id'java'`.
 
 Additionally, add the following:
@@ -136,33 +136,35 @@ for our application that will keep track of customer orders for flowers. Add the
 as the file `record_layer_demo.proto` in the `src/main/proto` directory:
 
 ```protobuf
-syntax = "proto3";
+// While we pull in the proto3 org.foundationdb:fdb-record-layer-core-pb3 dependency
+// above, we write record-layer protos files using `proto2` syntax.
+syntax = "proto2";
 
 option java_outer_classname = "RecordLayerDemoProto";
 
 import "record_metadata_options.proto";
 
 message Order {
-    int64 order_id = 1;
-    Flower flower = 2;
-    int32 price = 3;
+    optional int64 order_id = 1;
+    optional Flower flower = 2;
+    optional int32 price = 3;
 }
 
 message Flower {
-    string type = 1;
-    Color color = 2;
+    optional string type = 1;
+    optional Color color = 2;
 }
 
 enum Color {
-    RED = 0;
-    BLUE = 1;
-    YELLOW = 2;
-    PINK = 3;
+    RED = 1;
+    BLUE = 2;
+    YELLOW = 3;
+    PINK = 4;
 }
 
 message UnionDescriptor {
     option (com.apple.foundationdb.record.record).usage = UNION;
-    Order _Order = 1;
+    optional Order _Order = 1;
 }
 ```
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -244,7 +244,7 @@ The primary and secondary index definitions take a `Key.Expression` as an argume
 complex index definitions (e.g., compound primary keys or fan-out indexes on repeated fields).
 For more advanced examples, see the [Record Layer Overview](Overview.md).
 
-Now we have finished with configuraiton, build the `RecordMetaData`:
+Now we have finished with configuration, build the `RecordMetaData`:
 
 ```java
 RecordMetaData recordMetaData = metaDataBuilder.build();


### PR DESCRIPTION
This "Getting Started" page didn't work for me and confused. Here are some cleanups:
* Acknowledge we use protobuf3 but syntax is proto2.
 * Gradle `--type java-application` creates an 'app' subdir now with its own build.gradle -- so two build.gradles -- which complicates the example (example won't work if you edit the wrong build.properties). Lets do 'basic' to keep things simple.
 * Add answers for the questions gradle `init` asks.
 * plugins need to be added at the top of the build.gradle -- the example implies the clause can go anywhere -- and our protobuf plugin won't run if no mention of the java plugin.
 * Example code was missing the line where we build the RecordMetaData.