### PR TITLE
implement simple RecordTypeValue.toString

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordTypeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordTypeValue.java
@@ -117,6 +117,11 @@ public class RecordTypeValue implements QuantifiedValue {
     @Nonnull
     @Override
     public String explain(@Nonnull final Formatter formatter) {
+        return toString();
+    }
+
+    @Override
+    public String toString() {
         return "recordType(" + alias + ")";
     }
 }


### PR DESCRIPTION
... so it doesn't clutter pictorial plan representation.