### PR TITLE
name changes

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosure.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/TransitiveClosure.java
@@ -56,23 +56,23 @@ public class TransitiveClosure {
      * @return the transitive closure
      */
     public static <T> ImmutableSetMultimap<T, T> transitiveClosure(@Nonnull Set<T> set, @Nonnull final SetMultimap<T, T> dependsOnMap) {
-        return transitiveClosure(PartialOrder.of(set, dependsOnMap));
+        return transitiveClosure(PartiallyOrderedSet.of(set, dependsOnMap));
     }
 
 
     /**
      * Compute the transitive closure of the depends-on map that is passed in.
-     * @param partialOrder partial order to compute the transitive closure for
+     * @param partiallyOrderedSet partial order to compute the transitive closure for
      * @param <T> type
      * @return the transitive closure of the partial order handed in
      */
-    public static <T> ImmutableSetMultimap<T, T> transitiveClosure(@Nonnull PartialOrder<T> partialOrder) {
-        final var set = partialOrder.getSet();
-        final var dependsOnMap = partialOrder.getDependencyMap();
+    public static <T> ImmutableSetMultimap<T, T> transitiveClosure(@Nonnull PartiallyOrderedSet<T> partiallyOrderedSet) {
+        final var set = partiallyOrderedSet.getSet();
+        final var dependsOnMap = partiallyOrderedSet.getDependencyMap();
         final ImmutableSetMultimap<T, T> usedByMap = dependsOnMap.inverse();
         final Map<T, Integer> inDegreeMap = computeInDegreeMap(set, usedByMap);
-        final Set<T> processed = Sets.newHashSetWithExpectedSize(partialOrder.size());
-        final Deque<T> deque = new ArrayDeque<>(partialOrder.size());
+        final Set<T> processed = Sets.newHashSetWithExpectedSize(partiallyOrderedSet.size());
+        final Deque<T> deque = new ArrayDeque<>(partiallyOrderedSet.size());
         for (final T current : set) {
             if (inDegreeMap.get(current) == 0) {
                 deque.add(current);
@@ -103,7 +103,7 @@ public class TransitiveClosure {
             }
         }
 
-        Preconditions.checkArgument(processed.size() == partialOrder.size(), "circular dependency");
+        Preconditions.checkArgument(processed.size() == partiallyOrderedSet.size(), "circular dependency");
 
         return ImmutableSetMultimap.copyOf(resultMap);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -157,7 +157,7 @@ public interface MatchCandidate {
     }
 
     /**
-     * Compute a list of {@link BoundKeyPart}s which forms a bridge to relate {@link KeyExpression}s and
+     * Compute a list of {@link MatchedOrderingPart}s which forms a bridge to relate {@link KeyExpression}s and
      * {@link QueryPredicate}s.
      * @param matchInfo a pre-existing match info structure
      * @param sortParameterIds the query should be ordered by
@@ -166,9 +166,9 @@ public interface MatchCandidate {
      *         between query and match candidate
      */
     @Nonnull
-    List<BoundKeyPart> computeBoundKeyParts(@Nonnull MatchInfo matchInfo,
-                                            @Nonnull List<CorrelationIdentifier> sortParameterIds,
-                                            boolean isReverse);
+    List<MatchedOrderingPart> computeMatchedOrderingParts(@Nonnull MatchInfo matchInfo,
+                                                          @Nonnull List<CorrelationIdentifier> sortParameterIds,
+                                                          boolean isReverse);
 
     @Nonnull
     Ordering computeOrderingFromScanComparisons(@Nonnull ScanComparisons scanComparisons,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchedOrderingPart.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchedOrderingPart.java
@@ -1,5 +1,5 @@
 /*
- * BoundKeyPart.java
+ * MatchedOrderingPart.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -29,11 +29,11 @@ import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
- * A key expression that can be bound by a comparison during graph matching.
+ * An {@link OrderingPart} that is bound by a comparison during graph matching.
  */
-public class BoundKeyPart {
+public class MatchedOrderingPart {
     @Nonnull
-    private final KeyPart keyPart;
+    private final OrderingPart orderingPart;
 
     @Nonnull
     private final ComparisonRange.Type comparisonRangeType;
@@ -47,30 +47,30 @@ public class BoundKeyPart {
      * @param comparisonRangeType type of comparison
      * @param queryPredicate reference to {@link QueryPredicate} on query side
      */
-    private BoundKeyPart(@Nonnull final Value orderByValue,
-                         @Nonnull final ComparisonRange.Type comparisonRangeType,
-                         @Nullable final QueryPredicate queryPredicate,
-                         final boolean isReverse) {
+    private MatchedOrderingPart(@Nonnull final Value orderByValue,
+                                @Nonnull final ComparisonRange.Type comparisonRangeType,
+                                @Nullable final QueryPredicate queryPredicate,
+                                final boolean isReverse) {
         Preconditions.checkArgument((queryPredicate == null && comparisonRangeType == ComparisonRange.Type.EMPTY) ||
                                     (queryPredicate != null && comparisonRangeType != ComparisonRange.Type.EMPTY));
 
-        this.keyPart = KeyPart.of(orderByValue, isReverse);
+        this.orderingPart = OrderingPart.of(orderByValue, isReverse);
         this.comparisonRangeType = comparisonRangeType;
         this.queryPredicate = queryPredicate;
     }
 
     @Nonnull
-    public KeyPart getKeyPart() {
-        return keyPart;
+    public OrderingPart getOrderingPart() {
+        return orderingPart;
     }
 
     @Nonnull
     public Value getValue() {
-        return keyPart.getValue();
+        return orderingPart.getValue();
     }
 
     public boolean isReverse() {
-        return keyPart.isReverse();
+        return orderingPart.isReverse();
     }
 
     @Nullable
@@ -88,24 +88,24 @@ public class BoundKeyPart {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof BoundKeyPart)) {
+        if (!(o instanceof MatchedOrderingPart)) {
             return false;
         }
-        final BoundKeyPart that = (BoundKeyPart)o;
-        return getKeyPart().equals(that.getKeyPart()) &&
+        final MatchedOrderingPart that = (MatchedOrderingPart)o;
+        return getOrderingPart().equals(that.getOrderingPart()) &&
                Objects.equals(getQueryPredicate(), that.getQueryPredicate());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getKeyPart().hashCode(), getQueryPredicate());
+        return Objects.hash(getOrderingPart().hashCode(), getQueryPredicate());
     }
 
     @Nonnull
-    public static BoundKeyPart of(@Nonnull final Value orderByValue,
-                                  @Nonnull final ComparisonRange.Type comparisonRangeType,
-                                  @Nullable final QueryPredicate queryPredicate,
-                                  final boolean isReverse) {
-        return new BoundKeyPart(orderByValue, comparisonRangeType, queryPredicate, isReverse);
+    public static MatchedOrderingPart of(@Nonnull final Value orderByValue,
+                                         @Nonnull final ComparisonRange.Type comparisonRangeType,
+                                         @Nullable final QueryPredicate queryPredicate,
+                                         final boolean isReverse) {
+        return new MatchedOrderingPart(orderByValue, comparisonRangeType, queryPredicate, isReverse);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/OrderingPart.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/OrderingPart.java
@@ -1,5 +1,5 @@
 /*
- * BoundKeyPart.java
+ * OrderingPart.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 /**
  * A value that is used to express ordered-ness.
  */
-public class KeyPart {
+public class OrderingPart {
     @Nonnull
     private final Value value;
 
@@ -42,7 +42,7 @@ public class KeyPart {
 
     private final Supplier<Integer> hashCodeSupplier;
 
-    protected KeyPart(@Nonnull final Value value, final boolean isReverse) {
+    protected OrderingPart(@Nonnull final Value value, final boolean isReverse) {
         this.value = checkValue(value);
         this.isReverse = isReverse;
         this.hashCodeSupplier = Suppliers.memoize(this::computeHashCode);
@@ -62,10 +62,10 @@ public class KeyPart {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof KeyPart)) {
+        if (!(o instanceof OrderingPart)) {
             return false;
         }
-        final var keyPart = (KeyPart)o;
+        final var keyPart = (OrderingPart)o;
         return getValue().equals(keyPart.getValue()) &&
                isReverse() == keyPart.isReverse();
     }
@@ -85,19 +85,19 @@ public class KeyPart {
     }
 
     @Nonnull
-    public static List<KeyPart> prefix(@Nonnull final List<? extends KeyPart> keyParts, final int endExclusive) {
+    public static List<OrderingPart> prefix(@Nonnull final List<? extends OrderingPart> keyParts, final int endExclusive) {
         return ImmutableList.copyOf(keyParts.subList(0, endExclusive));
     }
 
     @Nonnull
-    public static KeyPart of(@Nonnull final Value orderByValue) {
-        return KeyPart.of(orderByValue, false);
+    public static OrderingPart of(@Nonnull final Value orderByValue) {
+        return OrderingPart.of(orderByValue, false);
     }
 
     @Nonnull
-    public static KeyPart of(@Nonnull final Value orderByValue,
-                             final boolean isReverse) {
-        return new KeyPart(orderByValue, isReverse);
+    public static OrderingPart of(@Nonnull final Value orderByValue,
+                                  final boolean isReverse) {
+        return new OrderingPart(orderByValue, isReverse);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
@@ -24,7 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.Column;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
-import com.apple.foundationdb.record.query.plan.cascades.KeyPart;
+import com.apple.foundationdb.record.query.plan.cascades.OrderingPart;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.RequestedOrdering;
 import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
@@ -285,7 +285,7 @@ public class GroupByExpression implements RelationalExpressionWithChildren, Inte
         Verify.verify(groupingValueType instanceof Type.Record);
 
         return new RequestedOrdering(
-                ImmutableList.of(KeyPart.of(groupingValue)),
+                ImmutableList.of(OrderingPart.of(groupingValue)),
                 RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/MatchableSortExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/MatchableSortExpression.java
@@ -23,7 +23,7 @@ package com.apple.foundationdb.record.query.plan.cascades.expressions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.BoundKeyPart;
+import com.apple.foundationdb.record.query.plan.cascades.MatchedOrderingPart;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
@@ -217,8 +217,8 @@ public class MatchableSortExpression implements RelationalExpressionWithChildren
     }
 
     /**
-     * This synthesizes a list of {@link BoundKeyPart}s from the current partial match and the ordering information
-     * contained in this expression. It delegates to {@link MatchCandidate#computeBoundKeyParts} to do this work as
+     * This synthesizes a list of {@link MatchedOrderingPart}s from the current partial match and the ordering information
+     * contained in this expression. It delegates to {@link MatchCandidate#computeMatchedOrderingParts} to do this work as
      * while there is a lot of commonality across different index kinds, special indexes may need to define and declare
      * their order in a specific unique way.
      * @param partialMatch the pre-existing partial match on {@code (expression, this)} that the caller wants to adjust.
@@ -226,9 +226,9 @@ public class MatchableSortExpression implements RelationalExpressionWithChildren
      *         between query and match candidate
      */
     @Nonnull
-    private List<BoundKeyPart> forPartialMatch(@Nonnull PartialMatch partialMatch) {
+    private List<MatchedOrderingPart> forPartialMatch(@Nonnull PartialMatch partialMatch) {
         final var matchCandidate = partialMatch.getMatchCandidate();
-        return matchCandidate.computeBoundKeyParts(partialMatch.getMatchInfo(), getSortParameterIds(), isReverse());
+        return matchCandidate.computeMatchedOrderingParts(partialMatch.getMatchInfo(), getSortParameterIds(), isReverse());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
@@ -26,7 +26,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.combinatorics.EnumeratingIterable;
-import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
+import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
 import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
@@ -245,13 +245,13 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     }
 
     /**
-     * Method to compute the correlation order as a {@link com.apple.foundationdb.record.query.combinatorics.PartialOrder}.
+     * Method to compute the correlation order as a {@link PartiallyOrderedSet}.
      * @return a partial order representing the transitive closure of all dependencies between quantifiers in this
      *         expression.
      */
     @Nonnull
-    default PartialOrder<CorrelationIdentifier> getCorrelationOrder() {
-        return PartialOrder.empty();
+    default PartiallyOrderedSet<CorrelationIdentifier> getCorrelationOrder() {
+        return PartiallyOrderedSet.empty();
     }
 
     boolean equalsWithoutChildren(@Nonnull RelationalExpression other,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpressionWithChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpressionWithChildren.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.expressions;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
+import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
@@ -86,16 +86,16 @@ public interface RelationalExpressionWithChildren extends RelationalExpression {
 
     @Nonnull
     @Override
-    default PartialOrder<CorrelationIdentifier> getCorrelationOrder() {
+    default PartiallyOrderedSet<CorrelationIdentifier> getCorrelationOrder() {
         if (canCorrelate()) {
             final var aliasToQuantifierMap = Quantifiers.aliasToQuantifierMap(getQuantifiers());
-            return PartialOrder.of(
+            return PartiallyOrderedSet.of(
                     getQuantifiers().stream()
                             .map(Quantifier::getAlias)
                             .collect(ImmutableSet.toImmutableSet()),
                     alias -> Objects.requireNonNull(aliasToQuantifierMap.get(alias)).getCorrelatedTo());
         } else {
-            return PartialOrder.empty();
+            return PartiallyOrderedSet.empty();
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/SelectExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/SelectExpression.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.expressions;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.combinatorics.CrossProduct;
-import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
+import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.apple.foundationdb.record.query.plan.cascades.Compensation;
@@ -92,7 +92,7 @@ public class SelectExpression implements RelationalExpressionWithChildren.Childr
     @Nonnull
     private final Supplier<Map<CorrelationIdentifier, ? extends Quantifier>> aliasToQuantifierMapSupplier;
     @Nonnull
-    private final Supplier<PartialOrder<CorrelationIdentifier>> correlationOrderSupplier;
+    private final Supplier<PartiallyOrderedSet<CorrelationIdentifier>> correlationOrderSupplier;
 
     public SelectExpression(@Nonnull Value resultValue,
                             @Nonnull List<? extends Quantifier> children,
@@ -209,12 +209,12 @@ public class SelectExpression implements RelationalExpressionWithChildren.Childr
 
     @Nonnull
     @Override
-    public PartialOrder<CorrelationIdentifier> getCorrelationOrder() {
+    public PartiallyOrderedSet<CorrelationIdentifier> getCorrelationOrder() {
         return correlationOrderSupplier.get();
     }
 
     @Nonnull
-    private PartialOrder<CorrelationIdentifier> computeCorrelationOrder() {
+    private PartiallyOrderedSet<CorrelationIdentifier> computeCorrelationOrder() {
         return RelationalExpressionWithChildren.ChildrenAsSet.super.getCorrelationOrder();
     }
     

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
@@ -26,7 +26,7 @@ import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
-import com.apple.foundationdb.record.query.plan.cascades.KeyPart;
+import com.apple.foundationdb.record.query.plan.cascades.OrderingPart;
 import com.apple.foundationdb.record.query.plan.cascades.Ordering;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -229,15 +229,15 @@ public class ImplementDistinctUnionRule extends CascadesRule<LogicalDistinctExpr
         }
     }
 
-    private boolean isPrimaryKeyCompatibleWithOrdering(@Nonnull final List<Value> primaryKeyParts,
+    private boolean isPrimaryKeyCompatibleWithOrdering(@Nonnull final List<Value> primaryKeyValues,
                                                        @Nonnull final Ordering ordering) {
-        final var orderingKeys =
+        final var orderingValues =
                 ordering.getOrderingSet().getSet()
                         .stream()
-                        .map(KeyPart::getValue)
+                        .map(OrderingPart::getValue)
                         .collect(ImmutableSet.toImmutableSet());
-        for (final var primaryKeyPart : primaryKeyParts) {
-            if (!orderingKeys.contains(primaryKeyPart)) {
+        for (final var primaryKeyValue : primaryKeyValues) {
+            if (!orderingValues.contains(primaryKeyValue)) {
                 return false;
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
@@ -164,8 +164,8 @@ public class ImplementInUnionRule extends CascadesRule<SelectExpression> {
 
         for (final var planPartition : planPartitions) {
             final var providedOrdering = planPartition.getAttributeValue(OrderingProperty.ORDERING);
-            final var filteredEqualityBoundKeyMap =
-                    Multimaps.filterEntries(providedOrdering.getEqualityBoundKeyMap(),
+            final var filteredEqualityBoundValueMap =
+                    Multimaps.filterEntries(providedOrdering.getEqualityBoundValueMap(),
                             expressionComparisonEntry -> {
                                 final var comparison = expressionComparisonEntry.getValue();
                                 if (comparison.getType() != Comparisons.Type.EQUALS || !(comparison instanceof Comparisons.ParameterComparison)) {
@@ -176,11 +176,11 @@ public class ImplementInUnionRule extends CascadesRule<SelectExpression> {
                                        !explodeAliases.containsAll(parameterComparison.getCorrelatedTo());
                             });
             final var inUnionOrdering =
-                    Ordering.ofUnnormalized(filteredEqualityBoundKeyMap, providedOrdering.getOrderingSet(), providedOrdering.isDistinct());
+                    Ordering.ofUnnormalized(filteredEqualityBoundValueMap, providedOrdering.getOrderingSet(), providedOrdering.isDistinct());
 
             for (final var requestedOrdering : requestedOrderings) {
                 final var equalityBoundValuesBuilder = ImmutableSet.<Value>builder();
-                for (final var expressionComparisonEntry : providedOrdering.getEqualityBoundKeyMap().entries()) {
+                for (final var expressionComparisonEntry : providedOrdering.getEqualityBoundValueMap().entries()) {
                     final var comparison = expressionComparisonEntry.getValue();
                     if (comparison.getType() == Comparisons.Type.EQUALS && comparison instanceof Comparisons.ParameterComparison) {
                         final var parameterComparison = (Comparisons.ParameterComparison)comparison;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSortRule.java
@@ -25,7 +25,7 @@ import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
-import com.apple.foundationdb.record.query.plan.cascades.KeyPart;
+import com.apple.foundationdb.record.query.plan.cascades.OrderingPart;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.RequestedOrdering;
@@ -74,9 +74,9 @@ public class PushRequestedOrderingThroughSortRule extends CascadesRule<LogicalSo
         } else {
             final AliasMap translationMap = AliasMap.of(innerQuantifier.getAlias(), Quantifier.CURRENT);
 
-            final ImmutableList.Builder<KeyPart> keyPartBuilder = ImmutableList.builder();
+            final ImmutableList.Builder<OrderingPart> keyPartBuilder = ImmutableList.builder();
             for (final var sortValue : sortValues) {
-                keyPartBuilder.add(KeyPart.of(sortValue.rebase(translationMap), logicalSortExpression.isReverse()));
+                keyPartBuilder.add(OrderingPart.of(sortValue.rebase(translationMap), logicalSortExpression.isReverse()));
             }
 
             final var orderings =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
@@ -91,7 +91,7 @@ public class RemoveSortRule extends CascadesRule<LogicalSortExpression> {
         final var sortValuesSet = ImmutableSet.copyOf(sortValues);
 
         final var ordering = innerPlanPartition.getAttributeValue(ORDERING);
-        final Set<Value> equalityBoundKeys = ordering.getEqualityBoundKeys();
+        final Set<Value> equalityBoundKeys = ordering.getEqualityBoundValues();
         int equalityBoundUnsorted = equalityBoundKeys.size();
 
         for (final var sortValue : sortValues) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SplitSelectExtractIndependentQuantifiersRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SplitSelectExtractIndependentQuantifiersRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
+import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -114,7 +114,7 @@ public class SplitSelectExtractIndependentQuantifiersRule extends CascadesRule<S
                         .map(Quantifier::getAlias)
                         .collect(ImmutableSet.toImmutableSet());
 
-        final var aliasesPartialOrderBuilder = PartialOrder.<CorrelationIdentifier>builder();
+        final var aliasesPartialOrderBuilder = PartiallyOrderedSet.<CorrelationIdentifier>builder();
 
         for (final var quantifier: selectExpression.getQuantifiers()) {
             final var alias = quantifier.getAlias();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractValueRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractValueRuleSet.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.values.simplification;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
-import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
+import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
 import com.apple.foundationdb.record.query.combinatorics.TopologicalSort;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
@@ -80,7 +80,7 @@ public class AbstractValueRuleSet<R, C extends AbstractValueRuleCall<R, C>> {
                             if (applicableRules.isEmpty()) {
                                 return ImmutableList.of();
                             }
-                            return TopologicalSort.anyTopologicalOrderPermutation(PartialOrder.of(applicableRules, dependsOn)).orElseThrow(() -> new RecordCoreException("circular dependency among simplification rules"));
+                            return TopologicalSort.anyTopologicalOrderPermutation(PartiallyOrderedSet.of(applicableRules, dependsOn)).orElseThrow(() -> new RecordCoreException("circular dependency among simplification rules"));
                         }
                     });
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/combinatorics/PartiallyOrderedSetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/combinatorics/PartiallyOrderedSetTest.java
@@ -1,5 +1,5 @@
 /*
- * PartialOrderTest.java
+ * PartiallyOrderedSetTest.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -32,9 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for {@link PartialOrder}.
+ * Tests for {@link PartiallyOrderedSet}.
  */
-class PartialOrderTest {
+class PartiallyOrderedSetTest {
     @Test
     void testEligibleSetsImpossibleDependencies() {
         final CorrelationIdentifier a = CorrelationIdentifier.of("a");
@@ -45,7 +45,7 @@ class PartialOrderTest {
                 ImmutableMap.of(b, ImmutableSet.of(a), c, ImmutableSet.of(b), a, ImmutableSet.of(c));
 
         final var partialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         id -> dependencies.getOrDefault(id, ImmutableSet.of()));
 
         var eligibleSet = partialOrder.eligibleSet();
@@ -62,7 +62,7 @@ class PartialOrderTest {
                 ImmutableMap.of(b, ImmutableSet.of(a), c, ImmutableSet.of(b));
 
         final var partialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         id -> dependencies.getOrDefault(id, ImmutableSet.of()));
 
         var eligibleSet = partialOrder.eligibleSet();
@@ -84,7 +84,7 @@ class PartialOrderTest {
         final Map<CorrelationIdentifier, Set<CorrelationIdentifier>> dependencies = ImmutableMap.of();
 
         final var partialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         id -> dependencies.getOrDefault(id, ImmutableSet.of()));
 
         var eligibleSet = partialOrder.eligibleSet();
@@ -103,7 +103,7 @@ class PartialOrderTest {
                 ImmutableMap.of(c, ImmutableSet.of(a));
 
         final var partialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         id -> dependencies.getOrDefault(id, ImmutableSet.of()));
 
         var eligibleSet = partialOrder.eligibleSet();
@@ -125,7 +125,7 @@ class PartialOrderTest {
                 ImmutableMap.of(b, ImmutableSet.of(a), c, ImmutableSet.of(a), d, ImmutableSet.of(b, c));
 
         final var partialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c, d),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c, d),
                         id -> dependencies.getOrDefault(id, ImmutableSet.of()));
 
         var eligibleSet = partialOrder.eligibleSet();
@@ -141,7 +141,7 @@ class PartialOrderTest {
     @Test
     void testEligibleSetsEmpty() {
         final var partialOrder =
-                PartialOrder.of(ImmutableSet.of(),
+                PartiallyOrderedSet.of(ImmutableSet.of(),
                         id -> ImmutableSet.of());
 
         var eligibleSet = partialOrder.eligibleSet();
@@ -153,7 +153,7 @@ class PartialOrderTest {
         final CorrelationIdentifier a = CorrelationIdentifier.of("a");
 
         final var partialOrder =
-                PartialOrder.of(ImmutableSet.of(a),
+                PartiallyOrderedSet.of(ImmutableSet.of(a),
                         id -> ImmutableSet.of());
         var eligibleSet = partialOrder.eligibleSet();
         assertEquals(ImmutableSet.of(a), eligibleSet.eligibleElements());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/OrderingTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/OrderingTest.java
@@ -20,7 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
-import com.apple.foundationdb.record.query.combinatorics.PartialOrder;
+import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
@@ -36,15 +36,16 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nonnull;
 import java.util.Optional;
 
+import static com.apple.foundationdb.record.query.plan.cascades.OrderingPart.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class OrderingTest {
     @Test
     void testOrdering() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
 
         final var requestedOrdering = new RequestedOrdering(ImmutableList.of(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT);
 
@@ -63,9 +64,9 @@ class OrderingTest {
 
     @Test
     void testOrdering2() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
 
         final var requestedOrdering = new RequestedOrdering(ImmutableList.of(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT);
 
@@ -85,105 +86,105 @@ class OrderingTest {
 
     @Test
     void testMergeKeys() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
 
         final var leftPartialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         ImmutableSetMultimap.of(b, a));
 
         final var rightPartialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         ImmutableSetMultimap.of(c, a));
 
         final var mergedPartialOrder = Ordering.mergePartialOrderOfOrderings(leftPartialOrder, rightPartialOrder);
 
         assertEquals(
                 // note there is no b -> c here
-                PartialOrder.of(ImmutableSet.of(a, b, c), ImmutableSetMultimap.of(b, a, c, a)),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c), ImmutableSetMultimap.of(b, a, c, a)),
                 mergedPartialOrder);
     }
 
     @Test
     void testMergeKeys2() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
 
         final var leftPartialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         ImmutableSetMultimap.of(c, b, b, a));
 
         final var rightPartialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         ImmutableSetMultimap.of(c, b, b, a));
 
         final var mergedPartialOrder = Ordering.mergePartialOrderOfOrderings(leftPartialOrder, rightPartialOrder);
 
         assertEquals(
-                PartialOrder.of(ImmutableSet.of(a, b, c), ImmutableSetMultimap.of(b, a, c, b)),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c), ImmutableSetMultimap.of(b, a, c, b)),
                 mergedPartialOrder);
     }
 
     @Test
     void testMergeKeys3() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
 
         final var leftPartialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         ImmutableSetMultimap.of(c, b, b, a));
 
         final var rightPartialOrder =
-                PartialOrder.of(ImmutableSet.of(a, b, c),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
                         ImmutableSetMultimap.of(a, b, b, c));
 
         final var mergedPartialOrder = Ordering.mergePartialOrderOfOrderings(leftPartialOrder, rightPartialOrder);
 
-        assertEquals(PartialOrder.empty(), mergedPartialOrder);
+        assertEquals(PartiallyOrderedSet.empty(), mergedPartialOrder);
     }
 
     @Test
     void testMergePartialOrdersNAry() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
-        final var d = KeyPart.of(field("d"));
-        final var e = KeyPart.of(field("e"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
+        final var d = of(field("d"));
+        final var e = of(field("e"));
 
         final var one =
-                PartialOrder.of(ImmutableSet.of(a, b, c, d),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c, d),
                         ImmutableSetMultimap.of(c, b, b, a));
 
         final var two =
-                PartialOrder.of(ImmutableSet.of(a, b, c, d),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c, d),
                         ImmutableSetMultimap.of(c, b, b, a));
 
         final var three =
-                PartialOrder.of(ImmutableSet.of(a, b, c, d),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c, d),
                         ImmutableSetMultimap.of(c, a, b, a));
 
         final var four =
-                PartialOrder.of(ImmutableSet.of(a, b, c, d, e),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c, d, e),
                         ImmutableSetMultimap.of(c, a, b, a));
 
 
         final var mergedPartialOrder = Ordering.mergePartialOrderOfOrderings(ImmutableList.of(one, two, three, four));
 
         assertEquals(
-                PartialOrder.of(ImmutableSet.of(a, b, c, d), ImmutableSetMultimap.of(b, a, c, b)),
+                PartiallyOrderedSet.of(ImmutableSet.of(a, b, c, d), ImmutableSetMultimap.of(b, a, c, b)),
                 mergedPartialOrder);
     }
 
     @Test
     void testCommonOrdering() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
-        final var d = KeyPart.of(field("d"));
-        final var e = KeyPart.of(field("e"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
+        final var d = of(field("d"));
+        final var e = of(field("e"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(d.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),
@@ -222,10 +223,10 @@ class OrderingTest {
 
     @Test
     void testCommonOrdering2() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
-        final var x = KeyPart.of(field("x"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
+        final var x = of(field("x"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(c.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),
@@ -253,10 +254,10 @@ class OrderingTest {
 
     @Test
     void testCommonOrdering3() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
-        final var x = KeyPart.of(field("x"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
+        final var x = of(field("x"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(c.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),
@@ -284,10 +285,10 @@ class OrderingTest {
 
     @Test
     void testCommonOrdering4() {
-        final var a = KeyPart.of(field("a"));
-        final var b = KeyPart.of(field("b"));
-        final var c = KeyPart.of(field("c"));
-        final var x = KeyPart.of(field("x"));
+        final var a = of(field("a"));
+        final var b = of(field("b"));
+        final var c = of(field("c"));
+        final var x = of(field("x"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(c.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),


### PR DESCRIPTION
- `PartialOrder` -> `PartiallyOrderedSet` -- This is more in line with how this should be named judging from wikipedia and other online sources. There is a class (in spi) of that name though.
- `KeyPart` -> `OrderingPart` -- originally part KeyExpression. The new naming is more indicative of its use. As this is moving from a `KeyExpression` to a Value and whether sorting is ascending or descending, I think we can name this `OrderingPart`.
- `BoundKeyPart` -> `MatchedOrderingPart` -- this is only used for matching purposes
- removal of a lot of `...Key...` from local variable names and parameter names