### PR TITLE
Resolve #1865

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -38,7 +38,7 @@ This release also updates downstream dependency versions. Most notably, the prot
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Add a method to construct a single record from a raw indexed record [(Issue #1865)](https://github.com/FoundationDB/fdb-record-layer/issues/1865)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1175,6 +1175,18 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                                                            @Nonnull IndexOrphanBehavior orphanBehavior);
 
     /**
+     * Build an IndexedRecord from parts returned by the index maintainer's {@link IndexMaintainer#scanRemoteFetch} call.
+     * This method would reconstruct a record from the parts returned by the index scan call, such that the record can
+     * be used separately from the cursor that constructs all records for the index. This can be useful in case there are
+     * some validations that need to be done during the iteration of the cursor without waiting for all records to be serialized.
+     * @param indexedRawRecord the raw records (the set of key-value pairs returned from scanRemoteFetch)
+     * @return a future containing (when completed) the reconstructed record
+     */
+    @Nonnull
+    @API(API.Status.EXPERIMENTAL)
+    CompletableFuture<FDBIndexedRecord<M>> buildSingleRecord(@Nonnull FDBIndexedRawRecord indexedRawRecord);
+
+    /**
      * Given a cursor that iterates over entries in an index, attempts to fetch the associated records for those entries.
      *
      * @param indexCursor a cursor iterating over entries in the index

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -181,6 +181,12 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
         return untypedStore.scanIndexRemoteFetchInternal(index, scanBounds, commonPrimaryKeyLength, continuation, typedSerializer, scanProperties, orphanBehavior);
     }
 
+    @Override
+    @Nonnull
+    public CompletableFuture<FDBIndexedRecord<M>> buildSingleRecord(@Nonnull FDBIndexedRawRecord indexedRawRecord) {
+        return untypedStore.buildSingleRecordInternal(indexedRawRecord, typedSerializer, null);
+    }
+
     @Nonnull
     @Override
     public RecordCursor<RecordIndexUniquenessViolation> scanUniquenessViolations(@Nonnull Index index, @Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {


### PR DESCRIPTION
Refactor the remote fetch indexEntriesToIndexRecords method to use an internal method, and expose a new buildSingleRecord method externally.
The new method, `buildSingleRecord(@Nonnull FDBIndexedRawRecord indexedRawRecord)`, can now be used externally, for example when one needs to get a record from a remote fetch MappedRange structure (as opposed to the previous method that only returned a cursor).