### PR TITLE
Make time-window leaderboard rebuild when directory first added …

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `TimeWindowLeaderboardWindowUpdate` `rebuild` = `NEVER` is not honored for new directory [(Issue #1878)](https://github.com/FoundationDB/fdb-record-layer/issues/1878)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -683,7 +683,15 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
 
             if (directory == null) {
                 directory = new TimeWindowLeaderboardDirectory(update.isHighScoreFirst());
-                rebuild = true;
+                if (isRebuildConditional()) {
+                    rebuild = true;
+                }
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info(KeyValueLogMessage.of(rebuild ?
+                                                      "rebuilding leaderboard index for initial directory" :
+                                                      "need to rebuild leaderboard index for initial directory",
+                            LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(state.indexSubspace.pack())));
+                }
             }
         }
 


### PR DESCRIPTION
… conditional in the same way as when existing records overlap a new window.

Specifically, if `rebuild` = `NEVER`, log a message but do not rebuild anyway. Caller will need to take care of it.

Fixes  #1878.