### PR TITLE
Add Matchers for SyntheticRecordPlanner outputs.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/JoinedRecordPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/JoinedRecordPlan.java
@@ -278,6 +278,21 @@ class JoinedRecordPlan implements SyntheticRecordFromStoredRecordPlan  {
         return FDBSyntheticRecord.of(joinedRecordType, records);
     }
 
+    @Nonnull
+    public JoinedRecordType getJoinedRecordType() {
+        return joinedRecordType;
+    }
+
+    @Nonnull
+    public List<JoinedType> getJoinedTypes() {
+        return joinedTypes;
+    }
+
+    @Nonnull
+    public List<RecordQueryPlan> getQueries() {
+        return queries;
+    }
+
     @Override
     public String toString() {
         StringBuilder str = new StringBuilder();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordByTypePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordByTypePlan.java
@@ -57,6 +57,11 @@ class SyntheticRecordByTypePlan implements SyntheticRecordFromStoredRecordPlan  
         }
     }
 
+    @Nonnull
+    public Map<String, SyntheticRecordFromStoredRecordPlan> getSubPlans() {
+        return subPlans;
+    }
+
     @Override
     @Nonnull
     public Set<String> getStoredRecordTypes() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordConcatPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordConcatPlan.java
@@ -67,6 +67,15 @@ class SyntheticRecordConcatPlan implements SyntheticRecordFromStoredRecordPlan  
         }
     }
 
+    @Nonnull
+    public List<SyntheticRecordFromStoredRecordPlan> getSubPlans() {
+        return subPlans;
+    }
+
+    public boolean isNeedDistinct() {
+        return needDistinct;
+    }
+
     @Override
     @Nonnull
     public Set<String> getStoredRecordTypes() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticPlanMatchers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticPlanMatchers.java
@@ -1,0 +1,204 @@
+/*
+ * SyntheticPlanMatchers.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.synthetic;
+
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Matchers for {@link SyntheticRecordPlanner} outputs,
+ * such as {@link SyntheticRecordPlan} and {@link SyntheticRecordFromStoredRecordPlan}.
+ */
+public class SyntheticPlanMatchers {
+    public static Matcher<SyntheticRecordPlan> syntheticRecordScan(@Nonnull Matcher<RecordQueryPlan> seedMatcher,
+                                                                   @Nonnull Matcher<SyntheticRecordFromStoredRecordPlan> fromSeedMatcher) {
+        return new SyntheticRecordScanPlanMatcher(seedMatcher, fromSeedMatcher);
+    }
+
+    public static Matcher<SyntheticRecordFromStoredRecordPlan> joinedRecord(@Nonnull List<Matcher<RecordQueryPlan>> planMatchers) {
+        return new JoinedRecordPlanMatcher(planMatchers);
+    }
+
+    public static Matcher<SyntheticRecordFromStoredRecordPlan> syntheticRecordConcat(@Nonnull List<Matcher<SyntheticRecordFromStoredRecordPlan>> planMatchers) {
+        return new SyntheticRecordConcatPlanMatcher(planMatchers);
+    }
+
+    public static Matcher<SyntheticRecordFromStoredRecordPlan> syntheticRecordByType(@Nonnull Map<String, Matcher<SyntheticRecordFromStoredRecordPlan>> subMatchers) {
+        return new SyntheticRecordByTypePlanMatcher(subMatchers);
+    }
+
+    /**
+     * Match {@link SyntheticRecordScanPlan} as {@link SyntheticRecordPlan}.
+     */
+    public static class SyntheticRecordScanPlanMatcher extends TypeSafeMatcher<SyntheticRecordPlan> {
+        @Nonnull
+        private final Matcher<RecordQueryPlan> seedMatcher;
+        @Nonnull
+        private final Matcher<SyntheticRecordFromStoredRecordPlan> fromSeedMatcher;
+
+        public SyntheticRecordScanPlanMatcher(@Nonnull Matcher<RecordQueryPlan> seedMatcher,
+                                              @Nonnull Matcher<SyntheticRecordFromStoredRecordPlan> fromSeedMatcher) {
+            this.seedMatcher = seedMatcher;
+            this.fromSeedMatcher = fromSeedMatcher;
+        }
+
+        @Override
+        public boolean matchesSafely(@Nonnull SyntheticRecordPlan plan) {
+            if (!(plan instanceof SyntheticRecordScanPlan)) {
+                return false;
+            }
+            SyntheticRecordScanPlan syntheticRecordScanPlan = (SyntheticRecordScanPlan)plan;
+            return seedMatcher.matches(syntheticRecordScanPlan.getSeedPlan()) &&
+                   fromSeedMatcher.matches(syntheticRecordScanPlan.getFromSeedPlan());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("seed=(");
+            seedMatcher.describeTo(description);
+            description.appendText(",then=(");
+            fromSeedMatcher.describeTo(description);
+            description.appendText(")");
+        }
+    }
+
+    /**
+     * Match {@link JoinedRecordPlan} as {@link SyntheticRecordFromStoredRecordPlan}.
+     */
+    public static class JoinedRecordPlanMatcher extends TypeSafeMatcher<SyntheticRecordFromStoredRecordPlan> {
+        @Nonnull
+        private final List<Matcher<RecordQueryPlan>> planMatchers;
+
+        public JoinedRecordPlanMatcher(@Nonnull List<Matcher<RecordQueryPlan>> planMatchers) {
+            this.planMatchers = planMatchers;
+        }
+
+        @Override
+        public boolean matchesSafely(@Nonnull SyntheticRecordFromStoredRecordPlan plan) {
+            if (!(plan instanceof JoinedRecordPlan)) {
+                return false;
+            }
+            JoinedRecordPlan joinedPlan = (JoinedRecordPlan)plan;
+            List<RecordQueryPlan> queries = joinedPlan.getQueries();
+            if (queries.size() != planMatchers.size()) {
+                return false;
+            }
+            for (int i = 0; i < queries.size(); i++) {
+                if (!planMatchers.get(i).matches(queries.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendList("plans=(", ", ", ")", planMatchers);
+        }
+    }
+
+    /**
+     * Match {@link SyntheticRecordConcatPlan} as {@link SyntheticRecordFromStoredRecordPlan}.
+     */
+    public static class SyntheticRecordConcatPlanMatcher extends TypeSafeMatcher<SyntheticRecordFromStoredRecordPlan> {
+        @Nonnull
+        private final List<Matcher<SyntheticRecordFromStoredRecordPlan>> planMatchers;
+
+        public SyntheticRecordConcatPlanMatcher(@Nonnull List<Matcher<SyntheticRecordFromStoredRecordPlan>> planMatchers) {
+            this.planMatchers = planMatchers;
+        }
+
+        @Override
+        public boolean matchesSafely(@Nonnull SyntheticRecordFromStoredRecordPlan plan) {
+            if (!(plan instanceof SyntheticRecordConcatPlan)) {
+                return false;
+            }
+            SyntheticRecordConcatPlan concatPlan = (SyntheticRecordConcatPlan)plan;
+            List<SyntheticRecordFromStoredRecordPlan> subPlans = concatPlan.getSubPlans();
+            if (subPlans.size() != planMatchers.size()) {
+                return false;
+            }
+            for (int i = 0; i < subPlans.size(); i++) {
+                if (!planMatchers.get(i).matches(subPlans.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendList("plans=(", ", ", ")", planMatchers);
+        }
+    }
+
+    /**
+     * Match {@link SyntheticRecordByTypePlan} as {@link SyntheticRecordFromStoredRecordPlan}.
+     */
+    public static class SyntheticRecordByTypePlanMatcher extends TypeSafeMatcher<SyntheticRecordFromStoredRecordPlan> {
+        @Nonnull
+        private final Map<String, Matcher<SyntheticRecordFromStoredRecordPlan>> subMatchers;
+
+        public SyntheticRecordByTypePlanMatcher(@Nonnull Map<String, Matcher<SyntheticRecordFromStoredRecordPlan>> subMatchers) {
+            this.subMatchers = subMatchers;
+        }
+
+        @Override
+        public boolean matchesSafely(@Nonnull SyntheticRecordFromStoredRecordPlan plan) {
+            if (!(plan instanceof SyntheticRecordByTypePlan)) {
+                return false;
+            }
+            SyntheticRecordByTypePlan byTypePlan = (SyntheticRecordByTypePlan)plan;
+            Map<String, SyntheticRecordFromStoredRecordPlan> subPlans = byTypePlan.getSubPlans();
+            if (!subPlans.keySet().equals(subMatchers.keySet())) {
+                return false;
+            }
+            for (Map.Entry<String, SyntheticRecordFromStoredRecordPlan> entry : subPlans.entrySet()) {
+                if (!subMatchers.get(entry.getKey()).matches(entry.getValue())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("plans=(");
+            boolean first = true;
+            for (Map.Entry<String, Matcher<SyntheticRecordFromStoredRecordPlan>> entry : subMatchers.entrySet()) {
+                if (first) {
+                    first = false;
+                } else {
+                    description.appendText(", ");
+                }
+                description.appendText(entry.getKey());
+                description.appendText("=");
+                entry.getValue().describeTo(description);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This comment https://github.com/FoundationDB/fdb-record-layer/pull/1873#discussion_r997918275 suggested that matching on the generated plans would be beneficial. This adds that for all the direct calls to the planner in the test class.

The matchers only go against the generated queries inside the synthetic plan objects. It would be straightforward to extend them to match on other pieces of state, if any are deemed important enough. I felt that while they are, of course, necessary for execution, they weren't. But this wasn't strongly felt.