### PR TITLE
Fixes #1876: AndWithThenPlanner does not handle OneOfThemWithComponent expressions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `RecordQueryPlanner` now chooses more efficient indexes for and-queries with one-of-them predicates on repeated nested fields [(Issue #1876)](https://github.com/FoundationDB/fdb-record-layer/issues/1876)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -79,6 +79,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlanOf;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexScanType;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.intersectionOnExpressionPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicates;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicatesFilterPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.queryComponents;
@@ -407,10 +408,15 @@ class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
         var indexPlanMatcher = indexPlan().where(indexName("complex"))
                 .and(scanComparisons(range("[[something, 1, 10, 20],[something, 1, 10, 20]]")));
         if (planner instanceof RecordQueryPlanner) {
-            // Does not understand duplicate condition
+            // Does not understand duplicate condition, and so plans an extraneous (but harmless, semantically speaking)
+            // intersection with the "duplicates" index
             assertMatchesExactly(plan,
-                    filterPlan(unorderedPrimaryKeyDistinctPlan(indexPlanMatcher))
-                            .where(queryComponents(only(equalsObject(Query.field("name").equalsValue("something"))))));
+                    intersectionOnExpressionPlan(
+                            unorderedPrimaryKeyDistinctPlan(indexPlanMatcher),
+                            indexPlan()
+                                    .where(indexName("duplicates"))
+                                    .and(scanComparisons(range("[[something, something, 1],[something, something, 1]]")))
+                    ));
         } else {
             assertMatchesExactly(plan,
                     fetchFromPartialRecordPlan(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
@@ -1226,13 +1226,10 @@ public class SyntheticRecordPlannerTest {
                                     PlanMatchers.typeFilter(Matchers.contains("CustomerWithHeader"),
                                             PlanMatchers.scan(PlanMatchers.bounds(PlanMatchers.hasTupleString("[EQUALS $_j1, EQUALS $__in_int_rec_id__0]"))))))),
                     "cust",
-                    // This should be able to use the OrderWithHeader$cc index, but for some reason, is favoring a full scan
                     SyntheticPlanMatchers.joinedRecord(List.of(
-                            PlanMatchers.filter(Query.field("cc").oneOfThem().matches(Query.field("string_value").equalsParameter("_j2")),
-                                    PlanMatchers.typeFilter(Matchers.contains("OrderWithHeader"),
-                                            PlanMatchers.scan(PlanMatchers.bounds(PlanMatchers.hasTupleString("[EQUALS $_j1]")))))
-                    ))
-            ));
+                            PlanMatchers.primaryKeyDistinct(
+                                    PlanMatchers.indexScan(Matchers.allOf(PlanMatchers.indexName("OrderWithHeader$cc"), PlanMatchers.bounds(PlanMatchers.hasTupleString("[EQUALS $_j1, EQUALS $_j2]"))))))))
+            );
 
             for (int i = 0; i < customers.size(); i++) {
                 recordStore.saveRecord(customers.get(i));


### PR DESCRIPTION
This adds support to the old planner to address a shortcoming where certain queries were choosing to use less efficient indexes due to a shortcoming with the `AndWithThenPlanner`. Based on the tests in the `NestedFieldQueryTest`, it looks like the new planner was already matching such expressions in this case, and so this shortcoming should only be in the old planner.
    
This fixes #1876.