### PR TITLE
Revert #1888

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -35,6 +35,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Revert** Reverts [PR #1888](https://github.com/FoundationDB/fdb-record-layer/pull/1888) which led to plan instability issues
 
 // end next release
 -->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
@@ -29,14 +29,10 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnKeyExpressionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithChild;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionOnKeyExpressionPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -103,17 +99,8 @@ public class PlanOrderingKey {
         if (primaryKey == null) {
             return null;
         }
-        while (queryPlan instanceof RecordQueryPlanWithChild) {
-            // as long as we can tunnel through single-child plans
-            if (queryPlan instanceof RecordQueryFilterPlan ||
-                    queryPlan instanceof RecordQueryTypeFilterPlan ||
-                    queryPlan instanceof RecordQueryUnorderedDistinctPlan ||
-                    queryPlan instanceof RecordQueryUnorderedPrimaryKeyDistinctPlan) {
-                // if we know the kind of plan does not modify the ordered-ness
-                queryPlan = ((RecordQueryPlanWithChild)queryPlan).getChild();
-            } else {
-                break;
-            }
+        while (queryPlan instanceof RecordQueryFilterPlan) {
+            queryPlan = ((RecordQueryFilterPlan)queryPlan).getInnerPlan();
         }
         if (queryPlan instanceof PlanWithOrderingKey) {
             return ((PlanWithOrderingKey)queryPlan).getPlanOrderingKey();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -79,7 +79,6 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlanOf;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexScanType;
-import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.intersectionOnExpressionPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicates;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicatesFilterPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.queryComponents;
@@ -411,12 +410,8 @@ class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
             // Does not understand duplicate condition, and so plans an extraneous (but harmless, semantically speaking)
             // intersection with the "duplicates" index
             assertMatchesExactly(plan,
-                    intersectionOnExpressionPlan(
-                            unorderedPrimaryKeyDistinctPlan(indexPlanMatcher),
-                            indexPlan()
-                                    .where(indexName("duplicates"))
-                                    .and(scanComparisons(range("[[something, something, 1],[something, something, 1]]")))
-                    ));
+                    filterPlan(unorderedPrimaryKeyDistinctPlan(indexPlanMatcher))
+                            .where(queryComponents(only(equalsObject(Query.field("name").equalsValue("something"))))));
         } else {
             assertMatchesExactly(plan,
                     fetchFromPartialRecordPlan(


### PR DESCRIPTION
This reverts #1888, which could lead to plan instability problems with certain queries that had complex intersections or unions in them. These are, for the most part, preëxisting issues that were being hidden before #1888, though sometimes it would result in errors (not just inefficient plans). We do eventually want something equivalent to #1888, but we'll need to consider how that will happen precisely.