### PR TITLE
introduce `ResolvedAccessor`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -355,7 +355,7 @@ public class AggregateIndexMatchCandidate implements MatchCandidate {
                                          @Nonnull AvailableFields.FieldData fieldData) {
         // TODO field names are for debugging purposes only, we should probably use field ordinals here instead.
         final var simplifiedFieldValue = (FieldValue)fieldValue.simplify(AliasMap.emptyMap(), ImmutableSet.of());
-        for (final var maybeFieldName : simplifiedFieldValue.getFieldPrefix().getFieldNamesMaybe()) {
+        for (final var maybeFieldName : simplifiedFieldValue.getFieldPrefix().getOptionalFieldNames()) {
             Verify.verify(maybeFieldName.isPresent());
             builder = builder.getFieldBuilder(maybeFieldName.get());
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
@@ -333,7 +333,7 @@ public class ValueIndexScanMatchCandidate implements ScanWithFetchMatchCandidate
                                             @Nonnull FieldValue fieldValue,
                                             @Nonnull AvailableFields.FieldData fieldData) {
         // TODO field names are for debugging purposes only, we should probably use field ordinals here instead.
-        for (final var maybeFieldName : fieldValue.getFieldPrefix().getFieldNamesMaybe()) {
+        for (final var maybeFieldName : fieldValue.getFieldPrefix().getOptionalFieldNames()) {
             if (maybeFieldName.isEmpty()) {
                 return false;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
@@ -457,7 +457,7 @@ public class WindowedIndexScanMatchCandidate implements ScanWithFetchMatchCandid
                                             @Nonnull FieldValue fieldValue,
                                             @Nonnull AvailableFields.FieldData fieldData) {
         // TODO field names are for debugging purposes only, we should probably use field ordinals here instead.
-        for (final var maybeFieldName : fieldValue.getFieldPrefix().getFieldNamesMaybe()) {
+        for (final var maybeFieldName : fieldValue.getFieldPrefix().getOptionalFieldNames()) {
             if (maybeFieldName.isEmpty()) {
                 return false;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ValueMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ValueMatchers.java
@@ -97,7 +97,7 @@ public class ValueMatchers {
                         downstreamValue);
         final TypedMatcherWithExtractAndDownstream<FieldValue> downstreamFieldPathOrdinalsMatcher =
                 typedWithDownstream(FieldValue.class,
-                        Extractor.of(f -> f.getFieldPathOrdinals().asList(), name -> "fieldPathOrdinals(" + name + ")"),
+                        Extractor.of(f -> f.getFieldOrdinals().asList(), name -> "fieldPathOrdinals(" + name + ")"),
                         downstreamFieldPathOrdinals);
         final TypedMatcherWithExtractAndDownstream<FieldValue> downstreamFieldPathTypesMatcher =
                 typedWithDownstream(FieldValue.class,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/TransformValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/TransformValue.java
@@ -317,7 +317,7 @@ public class TransformValue implements Value {
             }
 
             final var prefixLength = prefix.size();
-            final var currentField = FieldPath.flat(fieldPath.getFieldNamesMaybe().get(prefixLength), fieldPath.getFieldTypes().get(prefixLength), fieldPath.getFieldOrdinals().get(prefixLength));
+            final var currentField = FieldPath.ofSingle(fieldPath.getFieldAccessors().get(prefixLength));
             final var nestedPrefix = prefix.withSuffix(currentField);
 
             final var currentTrie = computeTrieForFieldPaths(nestedPrefix, transformMap, orderedFieldPathIterator);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/Values.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/Values.java
@@ -93,8 +93,8 @@ public class Values {
 
         for (int i = 0; i < fields.size(); i++) {
             final var field = fields.get(i);
-            final int finalI1 = i;
-            primitiveAccessorsForType(field.getFieldType(), () -> FieldValue.ofFieldsAndFuseIfPossible(baseValueSupplier.get(), FieldValue.FieldPath.flat(field.getFieldNameOptional(), field.getFieldType(), finalI1)), constantAliases).stream()
+            final var singleStepPath = FieldValue.FieldPath.ofSingle(FieldValue.ResolvedAccessor.of(field.getFieldNameOptional().orElse(null), i, field.getFieldType()));
+            primitiveAccessorsForType(field.getFieldType(), () -> FieldValue.ofFieldsAndFuseIfPossible(baseValueSupplier.get(), singleStepPath), constantAliases).stream()
                     .map(orderingValue -> orderingValue.simplify(DefaultValueSimplificationRuleSet.ofSimplificationRules(), AliasMap.emptyMap(), constantAliases))
                     .forEach(orderingValuesBuilder::add);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/CompensateRecordConstructorRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/CompensateRecordConstructorRule.java
@@ -77,7 +77,7 @@ public class CompensateRecordConstructorRule extends ValueComputationRule<Iterab
                 final var argumentValueCompensation = childValueEntry.getValue();
                 final var field = column.getField();
                 mergedMatchedValuesMap.putIfAbsent(argumentValue,
-                        new FieldValueCompensation(FieldValue.FieldPath.flat(field.getFieldNameOptional(), field.getFieldType(), i), argumentValueCompensation));
+                        new FieldValueCompensation(FieldValue.FieldPath.ofSingle(field.getFieldNameOptional().orElse(null), field.getFieldType(), i), argumentValueCompensation));
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/ComposeFieldValueOverRecordConstructorRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/ComposeFieldValueOverRecordConstructorRule.java
@@ -85,7 +85,7 @@ public class ComposeFieldValueOverRecordConstructorRule extends ValueSimplificat
             // just return the child
             call.yield(column.getValue());
         } else {
-            call.yield(FieldValue.ofFields(column.getValue(), root.getFieldPath().skip(1)));
+            call.yield(FieldValue.ofFields(column.getValue(), root.getFieldPath().subList(1)));
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/OrderingTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/OrderingTest.java
@@ -43,9 +43,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class OrderingTest {
     @Test
     void testOrdering() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
 
         final var requestedOrdering = new RequestedOrdering(ImmutableList.of(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT);
 
@@ -64,9 +65,10 @@ class OrderingTest {
 
     @Test
     void testOrdering2() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
 
         final var requestedOrdering = new RequestedOrdering(ImmutableList.of(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT);
 
@@ -86,9 +88,10 @@ class OrderingTest {
 
     @Test
     void testMergeKeys() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
 
         final var leftPartialOrder =
                 PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
@@ -108,9 +111,10 @@ class OrderingTest {
 
     @Test
     void testMergeKeys2() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
 
         final var leftPartialOrder =
                 PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
@@ -129,9 +133,10 @@ class OrderingTest {
 
     @Test
     void testMergeKeys3() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
 
         final var leftPartialOrder =
                 PartiallyOrderedSet.of(ImmutableSet.of(a, b, c),
@@ -148,11 +153,12 @@ class OrderingTest {
 
     @Test
     void testMergePartialOrdersNAry() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
-        final var d = of(field("d"));
-        final var e = of(field("e"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
+        final var d = of(field(rcv, "d"));
+        final var e = of(field(rcv, "e"));
 
         final var one =
                 PartiallyOrderedSet.of(ImmutableSet.of(a, b, c, d),
@@ -180,11 +186,12 @@ class OrderingTest {
 
     @Test
     void testCommonOrdering() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
-        final var d = of(field("d"));
-        final var e = of(field("e"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
+        final var d = of(field(rcv, "d"));
+        final var e = of(field(rcv, "e"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(d.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),
@@ -223,10 +230,11 @@ class OrderingTest {
 
     @Test
     void testCommonOrdering2() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
-        final var x = of(field("x"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
+        final var x = of(field(rcv, "x"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(c.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),
@@ -254,10 +262,11 @@ class OrderingTest {
 
     @Test
     void testCommonOrdering3() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
-        final var x = of(field("x"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
+        final var x = of(field(rcv, "x"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(c.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),
@@ -285,10 +294,11 @@ class OrderingTest {
 
     @Test
     void testCommonOrdering4() {
-        final var a = of(field("a"));
-        final var b = of(field("b"));
-        final var c = of(field("c"));
-        final var x = of(field("x"));
+        final var rcv = rcv();
+        final var a = of(field(rcv, "a"));
+        final var b = of(field(rcv, "b"));
+        final var c = of(field(rcv, "c"));
+        final var x = of(field(rcv, "x"));
 
         final var one = new Ordering(
                 ImmutableSetMultimap.of(c.getValue(), new Comparisons.NullComparison(Comparisons.Type.IS_NULL)),
@@ -311,11 +321,26 @@ class OrderingTest {
     }
 
     @Nonnull
-    private static Value field(@Nonnull final String fieldName) {
+    private static Value field(@Nonnull final RecordConstructorValue rcv, @Nonnull final String fieldName) {
+        return FieldValue.ofFieldName(rcv, fieldName);
+    }
+
+    @Nonnull
+    private static RecordConstructorValue rcv() {
         final ImmutableList<Column<? extends Value>> columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of(fieldName)),
-                                LiteralValue.ofScalar("fieldValue")));
-        return FieldValue.ofFieldName(RecordConstructorValue.ofColumns(columns), fieldName);
+                        Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("a")),
+                                LiteralValue.ofScalar("fieldValueA")),
+                        Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("b")),
+                                LiteralValue.ofScalar("fieldValueB")),
+                        Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("c")),
+                                LiteralValue.ofScalar("fieldValueC")),
+                        Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("d")),
+                                LiteralValue.ofScalar("fieldValueD")),
+                        Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("e")),
+                                LiteralValue.ofScalar("fieldValueE")),
+                        Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("x")),
+                                LiteralValue.ofScalar("fieldValueX")));
+        return RecordConstructorValue.ofColumns(columns);
     }
 }


### PR DESCRIPTION
- got rid of parallel arrays in `FieldPath` in favor of `ResolvedAccessor`