### PR TITLE
Resolves #1902: Update Artifactory Plugin Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
     id 'com.google.protobuf' version '0.8.19'
     id 'com.github.ben-manes.versions' version '0.38.0'
     id 'com.github.spotbugs' version '4.6.1'
-    id 'com.jfrog.artifactory' version '4.21.0'
+    id 'com.jfrog.artifactory' version '4.29.2'
     id 'de.undercouch.download' version '4.1.1'
     id 'org.sonarqube' version '3.3'
 }


### PR DESCRIPTION
This updates the artifactory plugin version to the latest. This should resolve issues with the `build-info` dependency, which previously depended on a version that has since been taken down from maven.

This resolves #1902.