### PR TITLE
Resolves #1430: Support non-idempotent target indexes while indexing by index

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Non-idempotent target indexes can now be built from an existing index [(Issue #1430)](https://github.com/FoundationDB/fdb-record-layer/issues/1430)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Support planning aggregate indexes in Cascades. [(Issue #1885)](https://github.com/FoundationDB/fdb-record-layer/issues/1885)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -3492,9 +3492,17 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return IndexBuildState.loadIndexBuildStateAsync(this, index);
     }
 
+    /**
+     * Load the indexing type stamp for an index. This stamp contains information about the kind of
+     * index build being used to construct a new index. This method is {@link API.Status#INTERNAL}.
+     *
+     * @param index the index being built
+     * @return the indexing type stamp for the index's current build
+     * @see #saveIndexingTypeStamp(Index, IndexBuildProto.IndexBuildIndexingStamp)
+     */
     @API(API.Status.INTERNAL)
     @Nonnull
-    public CompletableFuture<IndexBuildProto.IndexBuildIndexingStamp> loadIndexBuildStampAsync(Index index) {
+    public CompletableFuture<IndexBuildProto.IndexBuildIndexingStamp> loadIndexingTypeStampAsync(Index index) {
         byte[] stampKey = IndexingBase.indexBuildTypeSubspace(this, index).pack();
         return ensureContextActive().get(stampKey).thenApply(serializedStamp -> {
             if (serializedStamp == null) {
@@ -3512,8 +3520,17 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         });
     }
 
+    /**
+     * Update the indexing type stamp for the given index. This is used by the {@link OnlineIndexer}
+     * to document what kind of indexing procedure is being used to build the given index. This method
+     * is {@link API.Status#INTERNAL}.
+     *
+     * @param index the index being built
+     * @param stamp the new value of the index's indexing type stamp
+     * @see #loadIndexingTypeStampAsync(Index)
+     */
     @API(API.Status.INTERNAL)
-    public void saveIndexBuildStamp(Index index, IndexBuildProto.IndexBuildIndexingStamp stamp) {
+    public void saveIndexingTypeStamp(Index index, IndexBuildProto.IndexBuildIndexingStamp stamp) {
         byte[] stampKey = IndexingBase.indexBuildTypeSubspace(this, index).pack();
         ensureContextActive().set(stampKey, stamp.toByteArray());
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -190,11 +190,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     public static final int CACHEABLE_STATE_FORMAT_VERSION = 7;
     // 8 - add custom fields to store header
     public static final int HEADER_USER_FIELDS_FORMAT_VERSION = 8;
-
+    // 9 - add READABLE_UNIQUE_PENDING index state
     public static final int READABLE_UNIQUE_PENDING_FORMAT_VERSION = 9;
+    // 10 - check index build type during update
+    public static final int CHECK_INDEX_BUILD_TYPE_DURING_UPDATE_FORMAT_VERSION = 10;
 
     // The current code can read and write up to the format version below
-    public static final int MAX_SUPPORTED_FORMAT_VERSION = READABLE_UNIQUE_PENDING_FORMAT_VERSION;
+    public static final int MAX_SUPPORTED_FORMAT_VERSION = CHECK_INDEX_BUILD_TYPE_DURING_UPDATE_FORMAT_VERSION;
 
     // By default, record stores attempt to upgrade to this version
     // NOTE: Updating this can break certain users during upgrades.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -121,6 +121,10 @@ public abstract class IndexMaintainer {
     public abstract <M extends Message> CompletableFuture<Void> update(@Nullable FDBIndexableRecord<M> oldRecord,
                                                                        @Nullable FDBIndexableRecord<M> newRecord);
 
+    @Nonnull
+    public abstract <M extends Message> CompletableFuture<Void> updateWhileWriteOnly(@Nullable FDBIndexableRecord<M> oldRecord,
+                                                                                     @Nullable FDBIndexableRecord<M> newRecord);
+
 
     /**
      * Scans through the list of uniqueness violations within the database.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -115,12 +115,26 @@ public abstract class IndexMaintainer {
      * @param oldRecord the previous stored record or <code>null</code> if a new record is being created
      * @param newRecord the new record or <code>null</code> if an old record is being deleted
      * @param <M> type of message
-     * @return a future that is complete when the record update is done
+     * @return a future that is complete when the index update is done
      */
     @Nonnull
     public abstract <M extends Message> CompletableFuture<Void> update(@Nullable FDBIndexableRecord<M> oldRecord,
                                                                        @Nullable FDBIndexableRecord<M> newRecord);
 
+    /**
+     * Update the associated index for a changed record while the index is in
+     * {@link com.apple.foundationdb.record.IndexState#WRITE_ONLY} mode. For most indexes, this should do the
+     * same thing that a normal update does, but if the index is not {@linkplain #isIdempotent() idempotent},
+     * then during an index build, it may need to perform additional checks to make sure each record is only
+     * added to the index once. In particular, it can check the {@link com.apple.foundationdb.async.RangeSet}
+     * associated with the index build to check to see if the record has already been indexed, and then decide
+     * to update (or not update) the index as appropriate.
+     *
+     * @param oldRecord the previous stored record or <code>null</code> if a new record is being created
+     * @param newRecord the new record or <code>null</code> if an old record is being deleted
+     * @param <M> type of message
+     * @return a future that is complete when the index update is done
+     */
     @Nonnull
     public abstract <M extends Message> CompletableFuture<Void> updateWhileWriteOnly(@Nullable FDBIndexableRecord<M> oldRecord,
                                                                                      @Nullable FDBIndexableRecord<M> newRecord);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -2174,7 +2174,9 @@ public class OnlineIndexer implements AutoCloseable {
              * the index build will not be executed using the given source index unless the store's
              * format version is at least {@link FDBRecordStore#CHECK_INDEX_BUILD_TYPE_DURING_UPDATE_FORMAT_VERSION},
              * as concurrent updates to the index during such a build on older format versions can
-             * result in corrupting the index.
+             * result in corrupting the index. On older format versions, the indexer will throw an
+             * exception and the build may fall back to building the index by a records scan depending
+             * on the value given to {@link #setForbidRecordScan(boolean)}.
              *
              * @param sourceIndex an existing, readable, index.
              * @return this builder

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -2168,8 +2168,13 @@ public class OnlineIndexer implements AutoCloseable {
 
             /**
              * Use this source index to scan records for indexing.
-             * Some sanity checks will be performed, but it is the caller's responsibility to verify that this source-index
-             * covers <em>all</em> the relevant records for the target-index.
+             * Some sanity checks will be performed, but it is the caller's responsibility to verify that this
+             * source-index covers <em>all</em> the relevant records for the target-index. Also, note that
+             * if the {@linkplain OnlineIndexer.Builder#setIndex(Index) target index} is not idempotent,
+             * the index build will not be executed using the given source index unless the store's
+             * format version is at least {@link FDBRecordStore#CHECK_INDEX_BUILD_TYPE_DURING_UPDATE_FORMAT_VERSION},
+             * as concurrent updates to the index during such a build on older format versions can
+             * result in corrupting the index.
              *
              * @param sourceIndex an existing, readable, index.
              * @return this builder

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainer.java
@@ -75,6 +75,12 @@ public class NoOpIndexMaintainer extends IndexMaintainer {
 
     @Nonnull
     @Override
+    public <M extends Message> CompletableFuture<Void> updateWhileWriteOnly(@Nullable final FDBIndexableRecord<M> oldRecord, @Nullable final FDBIndexableRecord<M> newRecord) {
+        return AsyncUtil.DONE;
+    }
+
+    @Nonnull
+    @Override
     public RecordCursor<IndexEntry> scanUniquenessViolations(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
         return RecordCursor.empty();
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -2127,7 +2127,14 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             context.commit();
         }
         // Build the index to make it actually usable.
-        try (OnlineIndexer onlineIndexBuilder = OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(recordMetaData).setIndex(index.getName()).setSubspace(recordStore.getSubspace()).build()) {
+        try (OnlineIndexer onlineIndexBuilder = OnlineIndexer.newBuilder()
+                .setDatabase(fdb)
+                .setMetaData(recordMetaData)
+                .setIndex(index.getName())
+                .setSubspace(recordStore.getSubspace())
+                .setIndexMaintenanceFilter(recordStore.getIndexMaintenanceFilter())
+                .setFormatVersion(recordStore.getFormatVersion())
+                .build()) {
             onlineIndexBuilder.buildIndex();
         }
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -66,8 +66,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
     }
 
     private void buildIndex(Index srcIndex) {
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(srcIndex).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(srcIndex)
                 .build()) {
             indexer.buildIndex(true);
         }
@@ -96,8 +96,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
         openSimpleMetaData(hook);
         buildIndex(tgtIndex);
 
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setLogWarningsLimit(Integer.MAX_VALUE)
                         .setAllowRepair(false)
@@ -130,8 +130,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // verify the missing entries are found and fixed
         timer.reset();
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .build())
                 .setTimer(timer)
@@ -145,8 +145,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // now verify it's fixed
         timer.reset();
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .build())
                 .setTimer(timer)
@@ -174,8 +174,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
         openSimpleMetaData(hook);
         buildIndex(tgtIndex);
 
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setLogWarningsLimit(Integer.MAX_VALUE)
                         .build())
@@ -207,8 +207,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // verify the missing entries are found (report only, no repair)
         timer.reset();
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setLogWarningsLimit(Integer.MAX_VALUE)
                         .setAllowRepair(false))
@@ -223,8 +223,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // verify the missing entries are found and fixed
         timer.reset();
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setLogWarningsLimit(Integer.MAX_VALUE)
                         .build())
@@ -241,8 +241,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // now verify it's fixed
         timer.reset();
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setLogWarningsLimit(Integer.MAX_VALUE)
                         .build())
@@ -275,8 +275,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
         buildIndex(tgtIndex);
 
         // Scrub both dangling & missing. Scan counts in this test should be doubles.
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 // user default ScrubbingPolicy
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setAllowRepair(false)
@@ -298,8 +298,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // Scrub dangling with a quota
         timer.reset();
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setEntriesScanLimit(1))
                 .setTimer(timer)
@@ -315,8 +315,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // Scrub both with a quota
         timer.reset();
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setEntriesScanLimit(chunkSize * 3))
                 .setTimer(timer)
@@ -349,8 +349,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
         // refuse to scrub a non-readable index
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
-            try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+            try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                    .setIndex(tgtIndex)
                     .build()) {
                 recordStore.markIndexWriteOnly(tgtIndex).join();
                 context.commit();
@@ -365,8 +365,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         openSimpleMetaData(hook2);
         buildIndex(nonValueIndex);
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(nonValueIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(nonValueIndex)
                 .build()) {
             assertThrows(IndexingBase.ValidationException.class, indexScrubber::scrubDanglingIndexEntries);
             assertThrows(IndexingBase.ValidationException.class, indexScrubber::scrubMissingIndexEntries);
@@ -387,8 +387,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
         openSimpleMetaData(hook);
         buildIndex(tgtIndex);
 
-        try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder()
+                .setIndex(tgtIndex)
                 .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
                         .setLogWarningsLimit(Integer.MAX_VALUE)
                         .ignoreIndexTypeCheck() // required to allow non-value index scrubbing

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildGroupedCountIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildGroupedCountIndexTest.java
@@ -1,0 +1,504 @@
+/*
+ * OnlineIndexerBuildGroupedCountIndexTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.common.collect.Maps;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.empty;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for building a grouped count index.
+ */
+public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
+    private static final KeyExpression PRIMARY_KEY = concatenateFields("num_value_2", "rec_no");
+
+    private static final Index COUNT_BY_NUM_VALUE_2 = new Index("countByNumValue2",
+            empty().groupBy(field("num_value_2")),
+            IndexTypes.COUNT,
+            Map.of(IndexOptions.CLEAR_WHEN_ZERO, "true"));
+
+    private static final Index NUM_VALUE_2_INDEX = new Index("MySimpleRecord$num_value_2", field("num_value_2"));
+    private static final Index STR_VALUE_INDEX = new Index("MySimpleRecord$str_value_index", concatenateFields("num_value_2", "str_value_indexed"));
+
+    private static Stream<String> sourceIndexNames() {
+        return Stream.of(null, "MySimpleRecord$primary_key", NUM_VALUE_2_INDEX.getName(), STR_VALUE_INDEX.getName());
+    }
+
+    static Stream<Arguments> sourceIndexes() {
+        return sourceIndexNames()
+                .map(Arguments::of);
+    }
+
+    private static String randomString(@Nonnull Random r) {
+        char[] chars = new char[r.nextInt(15) + 1];
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = (char)('a' + r.nextInt(26));
+        }
+        return new String(chars);
+    }
+
+    private static TestRecords1Proto.MySimpleRecord randomSimpleRecord(@Nonnull Random r) {
+        return TestRecords1Proto.MySimpleRecord.newBuilder()
+                .setRecNo(r.nextLong())
+                .setNumValue2(r.nextInt(10))
+                .setStrValueIndexed(randomString(r))
+                .setNumValue3Indexed(r.nextInt(20))
+                .build();
+    }
+
+    private static TestRecords1Proto.MyOtherRecord randomOtherRecord(@Nonnull Random r) {
+        return TestRecords1Proto.MyOtherRecord.newBuilder()
+                .setRecNo(r.nextLong())
+                .setNumValue2(r.nextInt(10))
+                .build();
+    }
+
+    @FunctionalInterface
+    private interface RecordsUpdater {
+        Collection<TestRecords1Proto.MySimpleRecord> update(Collection<TestRecords1Proto.MySimpleRecord> recordsBefore,
+                                                            Collection<TestRecords1Proto.MyOtherRecord> otherRecordsBefore);
+    }
+
+    private static final RecordsUpdater NO_UPDATES = (recordsBefore, otherRecordsBefore) -> recordsBefore;
+
+    private static FDBRecordStoreTestBase.RecordMetaDataHook baseGroupedHook() {
+        return metaDataBuilder -> {
+            for (String recordTypeName : List.of("MySimpleRecord", "MyOtherRecord")) {
+                RecordTypeBuilder recordTypeBuilder = metaDataBuilder.getRecordType(recordTypeName);
+                recordTypeBuilder.setPrimaryKey(PRIMARY_KEY);
+                for (Index index : new ArrayList<>(recordTypeBuilder.getIndexes())) {
+                    metaDataBuilder.removeIndex(index.getName());
+                }
+                for (Index index : new ArrayList<>(recordTypeBuilder.getMultiTypeIndexes())) {
+                    metaDataBuilder.removeIndex(index.getName());
+                }
+                metaDataBuilder.addIndex(recordTypeBuilder, new Index(recordTypeName + "$primary_key", PRIMARY_KEY));
+            }
+
+            metaDataBuilder.addIndex("MySimpleRecord", NUM_VALUE_2_INDEX);
+            metaDataBuilder.addIndex("MySimpleRecord", STR_VALUE_INDEX);
+        };
+    }
+
+    private static FDBRecordStoreTestBase.RecordMetaDataHook withCountIndexHook() {
+        FDBRecordStoreTestBase.RecordMetaDataHook base = baseGroupedHook();
+        return metaDataBuilder -> {
+            base.apply(metaDataBuilder);
+            metaDataBuilder.addIndex("MySimpleRecord", COUNT_BY_NUM_VALUE_2);
+        };
+    }
+
+    private Map<Integer, Long> countByGroup() {
+        try (FDBRecordContext context = openContext()) {
+            Map<Integer, Long> values = new HashMap<>();
+            recordStore.scanIndex(COUNT_BY_NUM_VALUE_2, IndexScanType.BY_GROUP, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)
+                    .forEach(indexEntry -> {
+                        int numValue2 = (int)indexEntry.getKey().getLong(indexEntry.getKey().size() - 1);
+                        long count = indexEntry.getValue().getLong(0);
+                        values.put(numValue2, count);
+                    }).join();
+            context.commit();
+            return values;
+        }
+    }
+
+    private static <M extends Message> Map<Tuple, M> byPrimaryKey(@Nonnull Collection<M> records) {
+        Map<Tuple, M> recordMap = Maps.newHashMapWithExpectedSize(records.size());
+        records.forEach(rec -> recordMap.put(PRIMARY_KEY.evaluateMessageSingleton(null, rec).toTuple(), rec));
+        return recordMap;
+    }
+
+    private static Map<Integer, Long> expectedCountByGroup(@Nonnull Collection<TestRecords1Proto.MySimpleRecord> records) {
+        Map<Integer, Long> values = new HashMap<>();
+        records.forEach(rec -> values.compute(rec.getNumValue2(), (numValue2, count) -> count == null ? 1L : (count + 1L)));
+        return values;
+    }
+
+    private void validateCountByGroup(@Nonnull Collection<TestRecords1Proto.MySimpleRecord> records) {
+        Map<Integer, Long> expected = expectedCountByGroup(records);
+        Map<Integer, Long> scanned = countByGroup();
+        assertEquals(expected, scanned);
+    }
+
+    private void rebuildGroupedCount(@Nonnull Collection<TestRecords1Proto.MySimpleRecord> recordsBefore,
+                                     @Nullable Collection<TestRecords1Proto.MyOtherRecord> otherRecordsBefore,
+                                     @Nullable String sourceIndex,
+                                     @Nonnull RecordsUpdater updater) {
+        openSimpleMetaData(baseGroupedHook());
+        try (FDBRecordContext context = openContext()) {
+            recordsBefore.forEach(recordStore::saveRecord);
+            if (otherRecordsBefore != null) {
+                otherRecordsBefore.forEach(recordStore::saveRecord);
+            }
+            context.commit();
+        }
+
+        openSimpleMetaData(withCountIndexHook());
+        OnlineIndexer.IndexingPolicy.Builder policyBuilder = OnlineIndexer.IndexingPolicy.newBuilder()
+                .setForbidRecordScan(sourceIndex != null)
+                .setIfDisabled(OnlineIndexer.IndexingPolicy.DesiredAction.REBUILD)
+                .setIfWriteOnly(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR)
+                .setIfReadable(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR);
+        if (sourceIndex != null) {
+            policyBuilder.setSourceIndex(sourceIndex);
+        }
+
+        Collection<TestRecords1Proto.MySimpleRecord> recordsAfter;
+
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(COUNT_BY_NUM_VALUE_2)
+                .setIndexingPolicy(policyBuilder.build())
+                .setLimit(10)
+                .setMaxRetries(Integer.MAX_VALUE)
+                .setRecordsPerSecond(OnlineIndexer.DEFAULT_RECORDS_PER_SECOND * 100)
+                .build()) {
+            CompletableFuture<?> buildFuture = indexer.buildIndexAsync(true);
+            recordsAfter = updater.update(recordsBefore, otherRecordsBefore);
+            buildFuture.join();
+        }
+
+        validateCountByGroup(recordsAfter);
+    }
+
+    private void rebuildGroupedCount(@Nonnull Collection<TestRecords1Proto.MySimpleRecord> recordsBefore,
+                                     @Nullable Collection<TestRecords1Proto.MyOtherRecord> otherRecordsBefore,
+                                     @Nullable String sourceIndex) {
+        rebuildGroupedCount(recordsBefore, otherRecordsBefore, sourceIndex, NO_UPDATES);
+    }
+
+    @ParameterizedTest(name = "buildOneHundredGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildOneHundredGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(100)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, null, sourceIndex);
+    }
+
+    @ParameterizedTest(name = "buildOneHundredWithOthersGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildOneHundredWithOthersGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(100)
+                .collect(Collectors.toList());
+        List<TestRecords1Proto.MyOtherRecord> otherRecords = Stream.generate(() -> randomOtherRecord(r))
+                .limit(50)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, otherRecords, sourceIndex);
+    }
+
+    @ParameterizedTest(name = "buildWhileInsertingGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildWhileInsertingGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(200)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, null, sourceIndex, (recordsBefore, ignore) -> {
+            List<TestRecords1Proto.MySimpleRecord> recordsAfter = new ArrayList<>(recordsBefore);
+            for (int i = 0; i < 5; i++) {
+                List<TestRecords1Proto.MySimpleRecord> newRecords = Stream.generate(() -> randomSimpleRecord(r))
+                        .limit(10)
+                        .collect(Collectors.toList());
+                fdb.run(context -> {
+                    FDBRecordStore innerStore = recordStore.asBuilder()
+                            .setContext(context)
+                            .setMetaDataProvider(metaData)
+                            .open();
+                    newRecords.forEach(innerStore::saveRecord);
+                    return null;
+                });
+                recordsAfter.addAll(newRecords);
+            }
+            return recordsAfter;
+        });
+    }
+
+    @ParameterizedTest(name = "buildWhileUpdatingGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildWhileUpdatingGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(200)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, null, sourceIndex, (recordsBefore, ignore) -> {
+            for (int i = 0; i < 5; i++) {
+                List<TestRecords1Proto.MySimpleRecord> updatedRecords = records.stream()
+                        .filter(rec -> r.nextDouble() < 0.05)
+                        .map(rec -> rec.toBuilder().setStrValueIndexed(randomString(r)).build())
+                        .collect(Collectors.toList());
+                fdb.run(context -> {
+                    FDBRecordStore innerStore = recordStore.asBuilder()
+                            .setContext(context)
+                            .setMetaDataProvider(metaData)
+                            .open();
+                    updatedRecords.forEach(innerStore::saveRecord);
+                    return null;
+                });
+            }
+            return recordsBefore;
+        });
+    }
+
+    @ParameterizedTest(name = "buildWhileDeletingGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildWhileDeletingGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(200)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, null, sourceIndex, (recordsBefore, ignore) -> {
+            Map<Tuple, TestRecords1Proto.MySimpleRecord> recordMap = byPrimaryKey(recordsBefore);
+            for (int i = 0; i < 5; i++) {
+                List<Tuple> toDelete = recordMap.keySet().stream()
+                        .filter(key -> r.nextDouble() < 0.05)
+                        .collect(Collectors.toList());
+                fdb.run(context -> {
+                    FDBRecordStore innerStore = recordStore.asBuilder()
+                            .setContext(context)
+                            .setMetaDataProvider(metaData)
+                            .open();
+                    toDelete.forEach(innerStore::deleteRecord);
+                    return null;
+                });
+                toDelete.forEach(recordMap::remove);
+            }
+            return recordMap.values();
+        });
+    }
+
+    @ParameterizedTest(name = "buildWhileDeletingGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildWhileConvertingTypeGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(200)
+                .collect(Collectors.toList());
+        List<TestRecords1Proto.MyOtherRecord> otherRecords = Stream.generate(() -> randomOtherRecord(r))
+                .limit(100)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, otherRecords, sourceIndex, (recordsBefore, otherRecordsBefore) -> {
+            Map<Tuple, TestRecords1Proto.MySimpleRecord> recordMap = byPrimaryKey(recordsBefore);
+            Map<Tuple, TestRecords1Proto.MyOtherRecord> otherRecordMap = byPrimaryKey(otherRecordsBefore);
+            for (int i = 0; i < 5; i++) {
+                // Convert some simple records to other records, and some other records to simple records.
+                // In each of these cases, the primary key is kept the same
+                Map<Tuple, TestRecords1Proto.MyOtherRecord> toOther = recordMap.entrySet().stream()
+                        .filter(key -> r.nextDouble() < 0.03)
+                        .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                            TestRecords1Proto.MySimpleRecord simple = entry.getValue();
+                            return TestRecords1Proto.MyOtherRecord.newBuilder()
+                                    .setRecNo(simple.getRecNo())
+                                    .setNumValue2(simple.getNumValue2())
+                                    .setNumValue3Indexed(simple.getNumValue3Indexed())
+                                    .build();
+                        }));
+                Map<Tuple, TestRecords1Proto.MySimpleRecord> toSimple = otherRecordMap.entrySet().stream()
+                        .filter(key -> r.nextDouble() < 0.03)
+                        .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                            TestRecords1Proto.MyOtherRecord other = entry.getValue();
+                            return TestRecords1Proto.MySimpleRecord.newBuilder()
+                                    .setRecNo(other.getRecNo())
+                                    .setNumValue2(other.getNumValue2())
+                                    .setNumValue3Indexed(other.getNumValue3Indexed())
+                                    .setStrValueIndexed(randomString(r))
+                                    .build();
+                        }));
+                fdb.run(context -> {
+                    FDBRecordStore innerStore = recordStore.asBuilder()
+                            .setContext(context)
+                            .setMetaDataProvider(metaData)
+                            .open();
+                    toSimple.values().forEach(innerStore::saveRecord);
+                    toOther.values().forEach(innerStore::saveRecord);
+                    return null;
+                });
+
+                toSimple.forEach((key, simple) -> {
+                    recordMap.put(key, simple);
+                    otherRecordMap.remove(key);
+                });
+                toOther.forEach((key, other) -> {
+                    otherRecordMap.put(key, other);
+                    recordMap.remove(key);
+                });
+            }
+            return recordMap.values();
+        });
+    }
+
+    @ParameterizedTest(name = "buildWhileDeletingGroupsGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildWhileDeletingGroupsGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(200)
+                .collect(Collectors.toList());
+        List<TestRecords1Proto.MyOtherRecord> otherRecords = Stream.generate(() -> randomOtherRecord(r))
+                .limit(100)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, otherRecords, sourceIndex, (recordsBefore, otherRecordsBefore) -> {
+            List<TestRecords1Proto.MySimpleRecord> newRecords = new ArrayList<>(recordsBefore);
+            for (int i = 0; i < 3; i++) {
+                int numValue2 = r.nextInt(10);
+                fdb.run(cx -> {
+                    FDBRecordStore innerStore = recordStore.asBuilder()
+                            .setContext(cx)
+                            .setMetaDataProvider(metaData)
+                            .open();
+                    innerStore.deleteRecordsWhere(Query.field("num_value_2").equalsValue(numValue2));
+                    return null;
+                });
+                newRecords.removeIf(mySimpleRecord -> mySimpleRecord.getNumValue2() == numValue2);
+            }
+            return newRecords;
+        });
+    }
+
+    @ParameterizedTest(name = "buildWhileRandomlyMutatingGroupedCount[sourceIndex={0}]")
+    @MethodSource("sourceIndexes")
+    @Tag(Tags.Slow)
+    void buildWhileRandomlyMutatingGroupedCount(String sourceIndex) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
+                .limit(400)
+                .collect(Collectors.toList());
+        List<TestRecords1Proto.MyOtherRecord> otherRecords = Stream.generate(() -> randomOtherRecord(r))
+                .limit(200)
+                .collect(Collectors.toList());
+        rebuildGroupedCount(records, otherRecords, sourceIndex, (recordsBefore, otherRecordsBefore) -> {
+            Map<Tuple, TestRecords1Proto.MySimpleRecord> simpleMap = byPrimaryKey(recordsBefore);
+            Map<Tuple, TestRecords1Proto.MyOtherRecord> otherMap = byPrimaryKey(otherRecordsBefore);
+            for (int i = 0; i < 10; i++) {
+                fdb.run(cx -> {
+                    FDBRecordStore innerStore = recordStore.asBuilder()
+                            .setContext(cx)
+                            .setMetaDataProvider(metaData)
+                            .open();
+
+                    double choice = r.nextDouble();
+                    if (choice < 0.3) {
+                        // Insert
+                        List<TestRecords1Proto.MySimpleRecord> newSimple = Stream.generate(() -> randomSimpleRecord(r))
+                                .limit(5)
+                                .collect(Collectors.toList());
+                        List<TestRecords1Proto.MyOtherRecord> newOthers = Stream.generate(() -> randomOtherRecord(r))
+                                .limit(5)
+                                .collect(Collectors.toList());
+                        newSimple.forEach(innerStore::saveRecord);
+                        newOthers.forEach(innerStore::saveRecord);
+                        cx.addAfterCommit(() -> {
+                            simpleMap.putAll(byPrimaryKey(newSimple));
+                            otherMap.putAll(byPrimaryKey(newOthers));
+                        });
+                    } else if (choice < 0.6) {
+                        // Delete
+                        List<Tuple> simpleDeletes = simpleMap.keySet().stream()
+                                .filter(key -> r.nextDouble() < 0.02)
+                                .collect(Collectors.toList());
+                        List<Tuple> otherDeletes = otherMap.keySet().stream()
+                                .filter(key -> r.nextDouble() < 0.02)
+                                .collect(Collectors.toList());
+                        simpleDeletes.forEach(innerStore::deleteRecord);
+                        otherDeletes.forEach(innerStore::deleteRecord);
+                        cx.addAfterCommit(() -> {
+                            simpleDeletes.forEach(simpleMap::remove);
+                            otherDeletes.forEach(otherMap::remove);
+                        });
+                    } else if (choice < 0.9) {
+                        // Update
+                        List<TestRecords1Proto.MySimpleRecord> simpleUpdates = simpleMap.values().stream()
+                                .filter(rec -> r.nextDouble() < 0.05)
+                                .map(rec -> rec.toBuilder().setStrValueIndexed(randomString(r)).build())
+                                .collect(Collectors.toList());
+                        List<TestRecords1Proto.MyOtherRecord> otherUpdates = otherMap.values().stream()
+                                .filter(rec -> r.nextDouble() < 0.05)
+                                .map(rec -> rec.toBuilder().setNumValue3Indexed(r.nextInt(20)).build())
+                                .collect(Collectors.toList());
+                        simpleUpdates.forEach(innerStore::saveRecord);
+                        otherUpdates.forEach(innerStore::saveRecord);
+                        cx.addAfterCommit(() -> {
+                            simpleMap.putAll(byPrimaryKey(simpleUpdates));
+                            otherMap.putAll(byPrimaryKey(otherUpdates));
+                        });
+                    } else {
+                        // Delete records where
+                        int numValue2 = r.nextInt(10);
+                        innerStore.deleteRecordsWhere(Query.field("num_value_2").equalsValue(numValue2));
+                        cx.addAfterCommit(() -> {
+                            List<Tuple> simpleDeletes = simpleMap.keySet().stream()
+                                    .filter(key -> key.getLong(0) == numValue2)
+                                    .collect(Collectors.toList());
+                            List<Tuple> otherDeletes = otherMap.keySet().stream()
+                                    .filter(key -> key.getLong(0) == numValue2)
+                                    .collect(Collectors.toList());
+                            simpleDeletes.forEach(simpleMap::remove);
+                            otherDeletes.forEach(otherMap::remove);
+                        });
+                    }
+                    return null;
+                });
+            }
+            return simpleMap.values();
+        });
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -308,11 +308,15 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                 }
             }
 
+            // With a non-null source index, updated records aren't necessarily scanned. In particular, if a record is
+            // deleted from a range that has not been built and placed into a range that has already been built, the
+            // record might not be scanned
+            int updateRecordMargin = (sourceIndex == null || recordsWhileBuilding == null) ? 0 : recordsWhileBuilding.size();
             int deletedRecordCount = deleteWhileBuilding == null ? 0 : deleteWhileBuilding.size();
             if (sourceIndex == null || getIndexMaintenanceFilter().equals(IndexMaintenanceFilter.NORMAL)) {
                 assertThat(indexBuilder.getTotalRecordsScanned(),
                         allOf(
-                                greaterThanOrEqualTo((long)(records.size() - deletedRecordCount)),
+                                greaterThanOrEqualTo((long)(records.size() - deletedRecordCount - updateRecordMargin)),
                                 lessThanOrEqualTo((long)records.size() + additionalScans)
                         ));
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -53,6 +53,10 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -312,13 +316,14 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                 }
             }
 
-            /*
-            assertThat(indexBuilder.getTotalRecordsScanned(),
-                    allOf(
-                            greaterThanOrEqualTo((long)records.size()),
-                            lessThanOrEqualTo((long)records.size() + additionalScans)
-                    ));
-             */
+            int deletedRecordCount = deleteWhileBuilding == null ? 0 : deleteWhileBuilding.size();
+            if (sourceIndex == null || getIndexMaintenanceFilter().equals(IndexMaintenanceFilter.NORMAL)) {
+                assertThat(indexBuilder.getTotalRecordsScanned(),
+                        allOf(
+                                greaterThanOrEqualTo((long)(records.size() - deletedRecordCount)),
+                                lessThanOrEqualTo((long)records.size() + additionalScans)
+                        ));
+            }
         }
         KeyValueLogMessage msg = KeyValueLogMessage.build("building index - completed", TestLogMessageKeys.INDEX, index);
         msg.addKeysAndValues(timer.getKeysAndValues());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -123,12 +123,8 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
         if (sourceIndex != null) {
             LOGGER.info(KeyValueLogMessage.of("building source index",
                     LogMessageKeys.INDEX_NAME, sourceIndex.getName()));
-            try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
+            try (OnlineIndexer indexer = newIndexerBuilder()
                     .setIndex(sourceIndex)
-                    .setMetaData(metaData)
-                    .setDatabase(fdb)
-                    .setSubspace(subspace)
-                    .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
                     .build()) {
                 indexer.buildIndex(true);
             }
@@ -161,12 +157,8 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                 LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.pack()),
                 LogMessageKeys.LIMIT, 20,
                 TestLogMessageKeys.RECORDS_PER_SECOND, OnlineIndexer.DEFAULT_RECORDS_PER_SECOND * 100));
-        final OnlineIndexer.Builder builder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb)
-                .setMetaData(metaData)
+        final OnlineIndexer.Builder builder = newIndexerBuilder()
                 .setIndex(index)
-                .setSubspace(subspace)
-                .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
                 .setConfigLoader(old -> {
                     OnlineIndexer.Config.Builder conf = OnlineIndexer.Config.newBuilder()
                             .setMaxLimit(20)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -124,6 +124,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                     .setMetaData(metaData)
                     .setDatabase(fdb)
                     .setSubspace(subspace)
+                    .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
                     .build()) {
                 indexer.buildIndex(true);
             }
@@ -161,6 +162,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                 .setMetaData(metaData)
                 .setIndex(index)
                 .setSubspace(subspace)
+                .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
                 .setConfigLoader(old -> {
                     OnlineIndexer.Config.Builder conf = OnlineIndexer.Config.newBuilder()
                             .setMaxLimit(20)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
@@ -190,7 +190,7 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
             }
         };
 
-        singleRebuild(records, recordsWhileBuilding, agents, overlap, false, index, beforeBuild, afterBuild, afterReadable);
+        singleRebuild(records, recordsWhileBuilding, agents, overlap, false, index, null, beforeBuild, afterBuild, afterReadable);
     }
 
     private void rankRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
@@ -190,7 +190,7 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
             }
         };
 
-        singleRebuild(records, recordsWhileBuilding, agents, overlap, false, index, null, beforeBuild, afterBuild, afterReadable);
+        singleRebuild(records, recordsWhileBuilding, null, agents, overlap, false, index, null, beforeBuild, afterBuild, afterReadable);
     }
 
     private void rankRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
@@ -31,6 +31,8 @@ import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.query.FDBRestrictedIndexQueryTest;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
+import com.google.protobuf.Descriptors;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,17 +41,20 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test building sum indexes.
@@ -57,6 +62,35 @@ import static org.junit.jupiter.api.Assertions.fail;
 public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildIndexTest {
     private static final Index REC_NO_INDEX = new Index("simple$rec_no", "rec_no");
     private static final Index NUM_VALUE_2_INDEX = new Index("simple$num_value_2", "num_value_2");
+
+    private static final Function<List<TestRecords1Proto.MySimpleRecord>, Long> ALL_RECORDS_SUM = records ->
+            records.stream()
+                    .mapToLong(TestRecords1Proto.MySimpleRecord::getNumValue2)
+                    .sum();
+    private static final Function<List<TestRecords1Proto.MySimpleRecord>, Long> ODD_NUM_VALUE_3_RECORDS_SUM = records ->
+            records.stream()
+                    .filter(rec -> rec.getNumValue3Indexed() % 2 != 0)
+                    .mapToLong(TestRecords1Proto.MySimpleRecord::getNumValue2)
+                    .sum();
+
+    private static IndexMaintenanceFilter filterOddsForIndexes(@Nonnull Collection<String> indexNames) {
+        return (index, record) -> {
+            if (!indexNames.contains(index.getName())) {
+                return IndexMaintenanceFilter.IndexValues.ALL;
+            }
+            if (!record.getDescriptorForType().equals(TestRecords1Proto.MySimpleRecord.getDescriptor())) {
+                return IndexMaintenanceFilter.IndexValues.ALL;
+            }
+            Descriptors.FieldDescriptor numValue3Field = TestRecords1Proto.MySimpleRecord.getDescriptor()
+                    .findFieldByNumber(TestRecords1Proto.MySimpleRecord.NUM_VALUE_3_INDEXED_FIELD_NUMBER);
+            Object numValue3 = record.getField(numValue3Field);
+            if (numValue3 == null || ((Number)numValue3).longValue() % 2 != 0) {
+                return IndexMaintenanceFilter.IndexValues.ALL;
+            } else {
+                return IndexMaintenanceFilter.IndexValues.NONE;
+            }
+        };
+    }
 
     private OnlineIndexerBuildSumIndexTest(boolean safeBuild) {
         super(safeBuild);
@@ -66,9 +100,12 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     private void sumRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records,
                             @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
                             @Nullable List<Long> deletedIds,
+                            @Nullable IndexMaintenanceFilter filter,
+                            @Nonnull Function<List<TestRecords1Proto.MySimpleRecord>, Long> sumFunction,
                             @Nullable Index sourceIndex,
                             int agents,
                             boolean overlap) {
+        setIndexMaintenanceFilter(filter);
         Index index = new Index("newSumIndex", field("num_value_2").ungrouped(), IndexTypes.SUM);
         IndexAggregateFunction aggregateFunction = new IndexAggregateFunction(FunctionNames.SUM, index.getRootExpression(), index.getName());
 
@@ -87,8 +124,6 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
                                 recordStore.evaluateAggregateFunction(Collections.singletonList("MySimpleRecord"),
                                         aggregateFunction, TupleRange.ALL, IsolationLevel.SNAPSHOT),
                         "newSumIndex.sum(Field { 'num_value_2' None} group 1)");
-            } catch (Exception e) {
-                fail();
             }
         };
 
@@ -110,7 +145,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         } else {
             deletePrimaryKeys = null;
         }
-        long expected = updatedRecords.stream().mapToLong(TestRecords1Proto.MySimpleRecord::getNumValue2).sum();
+        long expected = sumFunction.apply(updatedRecords);
 
         Runnable afterReadable = () -> {
             try (FDBRecordContext context = openContext()) {
@@ -120,6 +155,16 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         };
 
         singleRebuild(records, recordsWhileBuilding, deletePrimaryKeys, agents, overlap, false, index, sourceIndex, beforeBuild, afterBuild, afterReadable);
+    }
+
+    @SuppressWarnings("try")
+    private void sumRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records,
+                            @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
+                            @Nullable List<Long> deletedIds,
+                            @Nullable Index sourceIndex,
+                            int agents,
+                            boolean overlap) {
+        sumRebuild(records, recordsWhileBuilding, deletedIds, null, ALL_RECORDS_SUM, sourceIndex, agents, overlap);
     }
 
     private void sumRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records,
@@ -136,9 +181,30 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, null);
     }
 
+    private void sumRebuildFiltered(@Nonnull List<TestRecords1Proto.MySimpleRecord> records,
+                                    @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
+                                    @Nullable List<Long> deletedIds,
+                                    @Nullable Index sourceIndex,
+                                    boolean filterSource) {
+        Set<String> filteredIndexes = new HashSet<>();
+        filteredIndexes.add("newSumIndex");
+        if (filterSource) {
+            Assumptions.assumeTrue(sourceIndex != null);
+            filteredIndexes.add(sourceIndex.getName());
+        }
+        IndexMaintenanceFilter filter = filterOddsForIndexes(filteredIndexes);
+        sumRebuild(records, recordsWhileBuilding, deletedIds, filter, ODD_NUM_VALUE_3_RECORDS_SUM, sourceIndex, 1, false);
+    }
+
     static Stream<Arguments> sourceIndexes() {
         return Stream.of(null, REC_NO_INDEX, NUM_VALUE_2_INDEX)
                 .map(Arguments::of);
+    }
+
+    static Stream<Arguments> sourceIndexesAndFiltered() {
+        return Stream.of(null, REC_NO_INDEX, NUM_VALUE_2_INDEX)
+                .flatMap(sourceIndex -> Stream.of(false, true)
+                        .map(filtered -> Arguments.of(sourceIndex, filtered)));
     }
 
     @Test
@@ -161,7 +227,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void oneHundredElementsSum(@Nullable Index sourceIndex) {
         Random r = new Random(0x5ca1ab1e);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setNumValue2(r.nextInt(10))
+                        .build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         sumRebuild(records, null, sourceIndex);
     }
@@ -171,7 +240,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void oneHundredElementsParallelSum() {
         Random r = new Random(0x5ca1ab1e);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong() / 2)
+                        .setNumValue2(r.nextInt(10))
+                        .build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         sumRebuild(records, null, null, null, 5, false);
     }
@@ -181,7 +253,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void oneHundredElementsParallelOverlapSum() {
         Random r = new Random(0xf005ba11);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong() / 2)
+                        .setNumValue2(r.nextInt(10))
+                        .build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         sumRebuild(records, null, null, null, 5, true);
     }
@@ -192,7 +267,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void addWhileBuildingSum(Index sourceIndex) {
         Random r = new Random(0xdeadc0de);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setNumValue2(r.nextInt(10))
+                        .build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
@@ -205,7 +283,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void addWhileBuildingParallelSum() {
         Random r = new Random(0xdeadc0de);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong() / 2)
+                        .setNumValue2(r.nextInt(10))
+                        .build()
         ).limit(200).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
@@ -219,7 +300,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void somePreloadedSum(Index sourceIndex) {
         Random r = new Random(0x5ca1ab1e);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setNumValue2(r.nextInt(10))
+                        .build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         openSimpleMetaData(metaDataBuilder -> {
             if (sourceIndex != null) {
@@ -246,7 +330,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void addSequentialWhileBuildingSum(Index sourceIndex) {
         Random r = new Random(0xba5eba11);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(val)
+                        .setNumValue2(r.nextInt(20))
+                        .build()
         ).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextInt(100)).setNumValue2(r.nextInt(20) + 20).build()
@@ -259,7 +346,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void addSequentialWhileBuildingParallelSum() {
         Random r = new Random(0xba5eba11);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj( val ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(val)
+                        .setNumValue2(r.nextInt(20))
+                        .build()
         ).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextInt(100)).setNumValue2(r.nextInt(20) + 20).build()
@@ -273,7 +363,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void updateRecordsWhileBuildingSum(@Nullable Index sourceIndex) {
         Random r = new Random();
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(20)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setNumValue2(r.nextInt(20))
+                        .build()
         ).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = records.stream()
                 .filter(rec -> r.nextBoolean())
@@ -288,7 +381,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void deleteRecordsWhileBuildingSum(@Nullable Index sourceIndex) {
         Random r = new Random();
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(50)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setNumValue2(r.nextInt(50))
+                        .build()
         ).collect(Collectors.toList());
         List<Long> toDelete = records.stream()
                 .filter(rec -> r.nextBoolean())
@@ -303,7 +399,10 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     public void updateAndDeleteRecordsWhileBuildingSum(@Nullable Index sourceIndex) {
         Random r = new Random();
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
-                TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(50)).build()
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setNumValue2(r.nextInt(50))
+                        .build()
         ).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = records.stream()
                 .filter(rec -> r.nextBoolean())
@@ -316,6 +415,43 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, toDelete, sourceIndex, 1, false);
     }
 
+    @ParameterizedTest(name = "oneHundredFilteredSum[sourceIndex={0}, filterSource={1}]")
+    @MethodSource("sourceIndexesAndFiltered")
+    @Tag(Tags.Slow)
+    public void oneHundredFilteredSum(@Nullable Index sourceIndex, boolean filterSource) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(val)
+                        .setNumValue2(r.nextInt(20))
+                        .setNumValue3Indexed(r.nextInt(2))
+                        .build()
+        ).collect(Collectors.toList());
+        sumRebuildFiltered(records, null, null, sourceIndex, filterSource);
+    }
+
+    @ParameterizedTest(name = "updateWhileBuildingFilteredSum[sourceIndex={0}, filterSource={1}]")
+    @MethodSource("sourceIndexesAndFiltered")
+    @Tag(Tags.Slow)
+    public void updateWhileBuildingFilteredSum(@Nullable Index sourceIndex, boolean filterSource) {
+        Random r = new Random();
+        List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 500).mapToObj(val ->
+                TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(r.nextLong())
+                        .setNumValue2(r.nextInt(50) - 25)
+                        .setNumValue3Indexed(r.nextInt(2))
+                        .build()
+        ).collect(Collectors.toList());
+        List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = records.stream()
+                .filter(rec -> r.nextBoolean())
+                .map(rec -> rec.toBuilder().setNumValue2(r.nextInt(50) - 25).setNumValue3Indexed(r.nextInt(2)).build())
+                .collect(Collectors.toList());
+        List<Long> deleteWhileBuilding = records.stream()
+                .filter(rec -> r.nextDouble() < 0.1)
+                .map(TestRecords1Proto.MySimpleRecord::getRecNo)
+                .collect(Collectors.toList());
+        sumRebuildFiltered(records, recordsWhileBuilding, deleteWhileBuilding, sourceIndex, filterSource);
+    }
 
     /**
      * Build indexes with the unchecked index build interfaces.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
@@ -146,7 +146,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
             }
         };
 
-        singleRebuild(records, recordsWhileBuilding, agents, overlap, splitLongRecords, index, null, beforeBuild, afterBuild, afterReadable);
+        singleRebuild(records, recordsWhileBuilding, null, agents, overlap, splitLongRecords, index, null, beforeBuild, afterBuild, afterReadable);
     }
 
     private void valueRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
@@ -146,7 +146,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
             }
         };
 
-        singleRebuild(records, recordsWhileBuilding, agents, overlap, splitLongRecords, index, beforeBuild, afterBuild, afterReadable);
+        singleRebuild(records, recordsWhileBuilding, agents, overlap, splitLongRecords, index, null, beforeBuild, afterBuild, afterReadable);
     }
 
     private void valueRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
@@ -206,7 +206,7 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
             }
         };
 
-        singleRebuild(records, recordsWhileBuilding, agents, overlap, false, index, null, beforeBuild, afterBuild, afterReadable);
+        singleRebuild(records, recordsWhileBuilding, null, agents, overlap, false, index, null, beforeBuild, afterBuild, afterReadable);
     }
 
     private void versionRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
@@ -206,7 +206,7 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
             }
         };
 
-        singleRebuild(records, recordsWhileBuilding, agents, overlap, false, index, beforeBuild, afterBuild, afterReadable);
+        singleRebuild(records, recordsWhileBuilding, agents, overlap, false, index, null, beforeBuild, afterBuild, afterReadable);
     }
 
     private void versionRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -224,10 +224,10 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 .setTimer(timer)
                 .build()) {
 
-            assertThrows(IndexingByIndex.ValidationException.class, indexBuilder::buildIndex);
+            indexBuilder.buildIndex(true);
         }
-        assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
-        assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+        assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -47,12 +47,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
     private void populateData(final long numRecords) {
-        List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, numRecords).mapToObj(val ->
+        populateData(numRecords, 0);
+    }
+
+    private void populateData(final long numRecords, final long numOtherRecords) {
+        List<TestRecords1Proto.MySimpleRecord> simpleRecords = LongStream.range(0, numRecords).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).build()
+        ).collect(Collectors.toList());
+        List<TestRecords1Proto.MyOtherRecord> otherRecords = LongStream.range(0, numOtherRecords).mapToObj(val ->
+                TestRecords1Proto.MyOtherRecord.newBuilder().setRecNo(numRecords + val).setNumValue2((int) val).build()
         ).collect(Collectors.toList());
 
         try (FDBRecordContext context = openContext())  {
-            records.forEach(recordStore::saveRecord);
+            simpleRecords.forEach(recordStore::saveRecord);
+            otherRecords.forEach(recordStore::saveRecord);
             context.commit();
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -73,8 +73,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
     }
 
     private void buildSrcIndex(Index srcIndex) {
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(srcIndex).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .addTargetIndex(srcIndex)
                 .build()) {
             indexer.buildIndex(true);
         }
@@ -86,8 +86,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
     private void buildIndexAndCrashHalfway(Index tgtIndex, int chunkSize, int count, FDBStoreTimer timer, @Nullable OnlineIndexer.IndexingPolicy policy) {
         final AtomicLong counter = new AtomicLong(0);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(policy)
                 .setLimit(chunkSize)
                 .setTimer(timer)
@@ -122,8 +122,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         buildSrcIndex(srcIndex);
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -156,8 +156,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         buildSrcIndex(srcIndex);
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -191,8 +191,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         buildSrcIndex(srcIndex);
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .build())
@@ -223,8 +223,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         buildSrcIndex(srcIndex);
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -257,8 +257,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).addTargetIndex(srcIndex).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                    .addTargetIndex(srcIndex)
                     .build()) {
                 // change srcIndex back to writeOnly
                 recordStore.markIndexWriteOnly(srcIndex).join();
@@ -269,8 +269,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -302,8 +302,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         buildSrcIndex(srcIndex);
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -344,8 +344,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 .build());
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -389,8 +389,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                         .build());
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setIfDisabled(OnlineIndexer.IndexingPolicy.DesiredAction.CONTINUE)
                         .setIfWriteOnly(OnlineIndexer.IndexingPolicy.DesiredAction.CONTINUE)
@@ -406,8 +406,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -450,8 +450,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                         .build());
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setIfReadable(OnlineIndexer.IndexingPolicy.DesiredAction.CONTINUE)
                         .setIfWriteOnly(OnlineIndexer.IndexingPolicy.DesiredAction.CONTINUE)
@@ -466,8 +466,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setTimer(timer)
                 .build()) {
 
@@ -502,8 +502,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         buildIndexAndCrashHalfway(tgtIndex, chunkSize, 2, timer, null);
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -518,8 +518,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setTimer(timer)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
@@ -558,8 +558,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         buildIndexAndCrashHalfway(tgtIndex, chunkSize, 2, timer, null);
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -576,12 +576,12 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setTimer(timer)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
-                        .forbidRecordScan()
+                       .forbidRecordScan()
                         .build())
                 .build()) {
 
@@ -617,8 +617,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         openSimpleMetaData(hook);
         timer.reset();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -657,8 +657,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         openSimpleMetaData(hook);
         timer.reset();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -678,8 +678,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // now check FORCE_BUILD
         openSimpleMetaData(hook);
         timer.reset();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -700,8 +700,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // now check BUILD_IF_DISABLED when WRITE_ONLY (from previous test)
         openSimpleMetaData(hook);
         timer.reset();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setIfWriteOnly(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR)
                         .setIfReadable(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR))
@@ -722,8 +722,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(srcIndex).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .addTargetIndex(srcIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setIfWriteOnly(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR)
                         .setIfReadable(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR))
@@ -764,8 +764,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // update src index last modified version (and its subspace key)
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).addTargetIndex(srcIndex).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                    .addTargetIndex(srcIndex)
                     .build()) {
                 recordStore.markIndexWriteOnly(srcIndex).join();
                 srcIndex.setLastModifiedVersion(srcIndex.getLastModifiedVersion() + 1);
@@ -777,8 +777,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         // try index continuation, expect failure
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -793,8 +793,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // try index continuation, but allow rebuild
         openSimpleMetaData(hook);
         timer.reset();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index")
                         .forbidRecordScan()
@@ -849,8 +849,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         // try index continuation with src_index2, expect failure
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index2")
                         .forbidRecordScan()
@@ -865,8 +865,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         // try indexing with src_index2, but allow continuation of previous method (src_index)
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index2")
                         .build()) // continue previous if policy changed
@@ -920,8 +920,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // make 'prev' source unreadable
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).addTargetIndex(srcIndex).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                    .addTargetIndex(srcIndex)
                     .build()) {
                 // change src_index back to writeOnly
                 recordStore.markIndexWriteOnly(srcIndex).join();
@@ -934,8 +934,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // try indexing with src_index2. Since src_index isn't usable, it should rebuild
         openSimpleMetaData(hook);
         timer.reset();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex("src_index2")
                         .build()) // rebuild after failing to continue prev
@@ -968,8 +968,8 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                    .addTargetIndex(tgtIndex)
                     .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                             .setSourceIndex("src_index")
                             .forbidRecordScan()

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -91,7 +91,6 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
     private void buildIndexAndCrashHalfway(int chunkSize, int count, FDBStoreTimer timer, @Nullable OnlineIndexer.Builder builder) {
         final AtomicLong counter = new AtomicLong(0);
         try (OnlineIndexer indexBuilder = builder
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setLimit(chunkSize)
                 .setTimer(timer)
                 .setConfigLoader(old -> {
@@ -148,8 +147,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
         openSimpleMetaData(hook);
         disableAll(indexes);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .build()) {
@@ -173,8 +171,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         // Test building non-idempotent + force
         timer.reset();
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
@@ -199,8 +196,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         // Now use an arbitrary primary index
         timer.reset();
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
@@ -245,8 +241,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
         openSimpleMetaData(hook);
         disableAll(indexes);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .setLimit(chunkSize)
@@ -281,14 +276,13 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         disableAll(indexes);
 
         // built one index
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(indexes.get(1)).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(indexes.get(1))
                 .build()) {
             indexer.buildIndex(false);
         }
 
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .build()) {
@@ -303,8 +297,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         // Now finish with REBUILD
         timer.reset();
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
@@ -340,17 +333,16 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         disableAll(indexes);
 
         // 1. partly build multi
-        buildIndexAndCrashHalfway(chunkSize, 2, timer, OnlineIndexer.newBuilder()
+        buildIndexAndCrashHalfway(chunkSize, 2, timer, newIndexerBuilder()
                 .setTargetIndexes(indexes));
 
         // 2. let one index continue ahead
         timer.reset();
-        buildIndexAndCrashHalfway(chunkSize, 2, timer, OnlineIndexer.newBuilder()
+        buildIndexAndCrashHalfway(chunkSize, 2, timer, newIndexerBuilder()
                 .setIndex(indexes.get(2)));
 
         // 3. assert mismatch type stamp
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .setLimit(chunkSize)
@@ -386,15 +378,14 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         disableAll(indexes);
 
         // 1. partly build multi
-        buildIndexAndCrashHalfway(chunkSize, 2, timer, OnlineIndexer.newBuilder()
+        buildIndexAndCrashHalfway(chunkSize, 2, timer, newIndexerBuilder()
                 .setTargetIndexes(indexes));
 
         // 2. Change indexes set
         indexes.remove(2);
 
         // 3. assert mismatch type stamp
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .setLimit(chunkSize)
@@ -430,12 +421,11 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         disableAll(indexes);
 
         // 1. partly build multi
-        buildIndexAndCrashHalfway(chunkSize, 5, timer, OnlineIndexer.newBuilder()
+        buildIndexAndCrashHalfway(chunkSize, 5, timer, newIndexerBuilder()
                 .setTargetIndexes(indexes));
 
         // 2. continue and done
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .setLimit(chunkSize)
@@ -481,13 +471,12 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         disableAll(indexes);
 
         // 1. partly build multi
-        buildIndexAndCrashHalfway(chunkSize, 3, timer, OnlineIndexer.newBuilder()
+        buildIndexAndCrashHalfway(chunkSize, 3, timer, newIndexerBuilder()
                 .setTargetIndexes(indexes));
 
         // 2. continue each index to done
         for (Index index: indexes) {
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
                     .setIndex(index)
                     .setLimit(chunkSize)
                     .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
@@ -533,12 +522,11 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         disableAll(indexes);
 
         // 1. partly build multi
-        buildIndexAndCrashHalfway(chunkSize, 3, timer, OnlineIndexer.newBuilder()
+        buildIndexAndCrashHalfway(chunkSize, 3, timer, newIndexerBuilder()
                 .setTargetIndexes(indexes));
 
         // 2. Finish building "num_value_3_indexed", to be used as a source index
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setIndex(indexes.get(0))
                 .setLimit(chunkSize)
                 .build()) {
@@ -550,8 +538,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         }
 
         // 3. Build "num_value_2" by index, forbid fallback to by-record
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setIndex(indexes.get(1))
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex(indexes.get(0).getName())
@@ -564,8 +551,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         }
 
         // 4. Build "num_value_2" by index, allow fallback to by-record
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setIndex(indexes.get(1))
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex(indexes.get(0).getName())
@@ -600,8 +586,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
                     .setTargetIndexes(indexes)
                     .setTimer(timer)
                     .build()) {
@@ -645,8 +630,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
             metaDataBuilder.addIndex("MyOtherRecord", indexOtherB);
         };
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .addTargetIndex(indexMyA)
                 .addTargetIndex(indexOtherA)
                 .addTargetIndex(indexMyB)
@@ -682,8 +666,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         final AtomicLong counter = new AtomicLong(0);
         final String testThrowMsg = "Intentionally crash during test";
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setLimit(chunkSize)
                 .setTimer(timer)
                 .setIndex(indexes.get(0))
@@ -703,8 +686,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         // Here: the index should be partially built by the single target module
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .build()) {
@@ -735,8 +717,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         }
 
         for (long i = 0; (i + 1) * 10 < numRecords; i ++) {
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
                     .setTimer(timer)
                     .setIndex(indexes.get(0))
                     .build()) {
@@ -750,8 +731,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         // Here: the index has multiple built chunks
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)
                 .build()) {
@@ -784,8 +764,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         long startSingle = System.currentTimeMillis();
         for (Index index : indexes) {
             openSimpleMetaData(hook);
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
                     .setTimer(singleTimer)
                     .setIndex(index)
                     .build()) {
@@ -798,8 +777,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         long startMulti =  System.currentTimeMillis();
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(multiTimer)
                 .build()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -113,8 +113,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             recordStore.markIndexWriteOnly(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             final RangeSet rangeSet = new RangeSet(recordStore.indexRangeSubspace(index));
 
@@ -238,8 +238,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         };
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             try (FDBRecordContext context = openContext()) {
                 recordStore.markIndexWriteOnly(index).join();
@@ -332,8 +332,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             recordStore.markIndexWriteOnly(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             indexBuilder.buildRange(null, null).join();
             assertEquals(Tuple.from(20100L), getAggregate.get());
@@ -359,8 +359,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         try (FDBRecordContext context = openContext()) {
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             indexBuilder.buildIndex();
         }
@@ -373,8 +373,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
     @Test
     public void run() {
         Index index = runAsyncSetup();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setLimit(100).setMaxRetries(3).setRecordsPerSecond(10000)
                 .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
                 .setMaxAttempts(2)
@@ -459,8 +459,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
     @Test
     public void lessenLimits() {
         Index index = runAsyncSetup();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setLimit(100).setMaxRetries(30).setRecordsPerSecond(10000)
                 .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
                 .setMaxAttempts(3)
@@ -501,8 +501,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             queue.add(Pair.of(42, null));
         }
         reincreaseLimit(queue, index ->
-                OnlineIndexer.newBuilder()
-                        .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                newIndexerBuilder()
+                        .setIndex(index)
                         .setLimit(100).setMaxRetries(queue.size() + 3).setRecordsPerSecond(10000)
                         .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
                         .setMaxAttempts(3)
@@ -557,8 +557,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         queue.add(Pair.of(42, null));
 
         reincreaseLimit(queue, index ->
-                OnlineIndexer.newBuilder()
-                        .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+                newIndexerBuilder()
+                        .setIndex(index)
                         .setLimit(100).setMaxRetries(queue.size() + 3).setRecordsPerSecond(10000)
                         .setIncreaseLimitAfter(10)
                         .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
@@ -615,8 +615,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         Index index = runAsyncSetup();
 
 
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setMdcContext(ImmutableMap.of("mdcKey", "my cool mdc value"))
                 .setMaxAttempts(3)
                 .setConfigLoader(old ->
@@ -662,8 +662,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             Index index = runAsyncSetup();
 
             FDBDatabase.WeakReadSemantics weakReadSemantics = new FDBDatabase.WeakReadSemantics(0L, Long.MAX_VALUE, true);
-            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                    .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+            try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                    .setIndex(index)
                     .setWeakReadSemantics(weakReadSemantics)
                     .build()) {
                 long readVersion = runAndHandleLessenWorkCodes(indexBuilder, recordStore -> {
@@ -686,16 +686,16 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
     @Test
     public void runWithPriorities() throws InterruptedException, ExecutionException {
         Index index = runAsyncSetup();
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             runAndHandleLessenWorkCodes(indexBuilder, recordStore -> {
                 assertEquals(FDBTransactionPriority.BATCH, recordStore.getContext().getPriority());
                 return AsyncUtil.DONE;
             }).get();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setPriority(FDBTransactionPriority.DEFAULT)
                 .build()) {
             runAndHandleLessenWorkCodes(indexBuilder, recordStore -> {
@@ -726,34 +726,34 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         // Absent index
         RecordCoreException e = assertThrows(MetaDataException.class, () -> {
             Index absentIndex = new Index("absent", field("num_value_2"));
-            OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(absentIndex).setSubspace(subspace).build();
+            newIndexerBuilder().setIndex(absentIndex).build();
         });
         assertEquals("Index absent not contained within specified metadata", e.getMessage());
         // Limit
         e = assertThrows(RecordCoreException.class, () ->
-                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setLimit(-1).build()
+                newIndexerBuilder().setIndex(indexPrime).setLimit(-1).build()
         );
         assertEquals("Non-positive value -1 given for record limit", e.getMessage());
         e = assertThrows(RecordCoreException.class, () ->
-                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setLimit(0).build()
+                newIndexerBuilder().setIndex(indexPrime).setLimit(0).build()
         );
         assertEquals("Non-positive value 0 given for record limit", e.getMessage());
         // Retries
         e = assertThrows(RecordCoreException.class, () ->
-                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setMaxRetries(-1).build()
+                newIndexerBuilder().setIndex(indexPrime).setMaxRetries(-1).build()
         );
         assertEquals("Non-positive value -1 given for maximum retries", e.getMessage());
         e = assertThrows(RecordCoreException.class, () ->
-                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setMaxRetries(0).build()
+                newIndexerBuilder().setIndex(indexPrime).setMaxRetries(0).build()
         );
         assertEquals("Non-positive value 0 given for maximum retries", e.getMessage());
         // Records per second
         e = assertThrows(RecordCoreException.class, () ->
-                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setRecordsPerSecond(-1).build()
+                newIndexerBuilder().setIndex(indexPrime).setRecordsPerSecond(-1).build()
         );
         assertEquals("Non-positive value -1 given for records per second value", e.getMessage());
         e = assertThrows(RecordCoreException.class, () ->
-                OnlineIndexer.newBuilder().setDatabase(fdb).setMetaData(metaData).setIndex(indexPrime).setSubspace(subspace).setRecordsPerSecond(0).build()
+                newIndexerBuilder().setIndex(indexPrime).setRecordsPerSecond(0).build()
         );
         assertEquals("Non-positive value 0 given for records per second value", e.getMessage());
         // WeakReadSemantics before runner
@@ -787,8 +787,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
 
         final FDBStoreTimer timer = new FDBStoreTimer();
         final CompletableFuture<Void> future;
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setLimit(1).setMaxRetries(Integer.MAX_VALUE).setRecordsPerSecond(Integer.MAX_VALUE)
                 .setTimer(timer)
                 .build()) {
@@ -823,8 +823,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             context.commit();
         }
 
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             // No need to build range because there is no record.
             indexer.asyncToSync(FDBStoreTimer.Waits.WAIT_ONLINE_BUILD_INDEX, indexer.buildEndpoints());
@@ -857,8 +857,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
 
         final FDBStoreTimer timer = new FDBStoreTimer();
         final CompletableFuture<Void> future;
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setConfigLoader(old ->
                         old.toBuilder()
                                 .setMaxLimit(old.getMaxLimit() - 1)
@@ -969,8 +969,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         }
 
         timer.reset();
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
                 .setTimer(timer)
                 .setIndex(index)
                 .setLimit(100000)
@@ -1000,8 +999,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             indexer.buildIndex(true);
         }
@@ -1033,8 +1032,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         Index index = new Index("newIndex", field("num_value_2").ungrouped(), IndexTypes.SUM);
         FDBRecordStoreTestBase.RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(index)
                 .setTimeLimitMilliseconds(1)
                 .setLimit(20)
                 .setConfigLoader(old -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -54,6 +55,7 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
     FDBRecordStore recordStore;
     FDBDatabase fdb;
     Subspace subspace;
+    private IndexMaintenanceFilter indexMaintenanceFilter;
 
     private static long oldMaxDelayMillis;
     private static long oldInitialDelayMillis;
@@ -74,6 +76,19 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
         FDBDatabaseFactory.instance().setMaxDelayMillis(oldMaxDelayMillis);
         FDBDatabaseFactory.instance().setInitialDelayMillis(oldInitialDelayMillis);
         FDBDatabaseFactory.instance().setMaxAttempts(oldMaxAttempts);
+    }
+
+    public void setIndexMaintenanceFilter(@Nullable IndexMaintenanceFilter indexMaintenanceFilter) {
+        this.indexMaintenanceFilter = indexMaintenanceFilter;
+    }
+
+    @Nonnull
+    public IndexMaintenanceFilter getIndexMaintenanceFilter() {
+        if (indexMaintenanceFilter == null) {
+            return IndexMaintenanceFilter.NORMAL;
+        } else {
+            return indexMaintenanceFilter;
+        }
     }
 
     @BeforeEach
@@ -126,7 +141,8 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
                 .setMetaDataProvider(metaData)
                 .setContext(context)
                 .setFormatVersion(FDBRecordStore.READABLE_UNIQUE_PENDING_FORMAT_VERSION)
-                .setSubspace(subspace);
+                .setSubspace(subspace)
+                .setIndexMaintenanceFilter(getIndexMaintenanceFilter());
         if (checked) {
             recordStore = builder.createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
         } else {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -56,6 +56,7 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
     FDBDatabase fdb;
     Subspace subspace;
     private IndexMaintenanceFilter indexMaintenanceFilter;
+    int formatVersion = FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION;
 
     private static long oldMaxDelayMillis;
     private static long oldInitialDelayMillis;
@@ -141,7 +142,7 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
                 .setMetaData(metaData)
                 .setSubspace(subspace)
                 .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
-                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION);
+                .setFormatVersion(formatVersion);
     }
 
     OnlineIndexScrubber.Builder newScrubberBuilder() {
@@ -150,7 +151,7 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
                 .setMetaData(metaData)
                 .setSubspace(subspace)
                 .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
-                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION);
+                .setFormatVersion(formatVersion);
     }
 
     FDBRecordContext openContext(boolean checked) {
@@ -158,7 +159,7 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
         FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
                 .setMetaDataProvider(metaData)
                 .setContext(context)
-                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION)
+                .setFormatVersion(formatVersion)
                 .setSubspace(subspace)
                 .setIndexMaintenanceFilter(getIndexMaintenanceFilter());
         if (checked) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -135,12 +135,30 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
         openMetaData(TestRecords1Proto.getDescriptor(), hook);
     }
 
+    OnlineIndexer.Builder newIndexerBuilder() {
+        return OnlineIndexer.newBuilder()
+                .setDatabase(fdb)
+                .setMetaData(metaData)
+                .setSubspace(subspace)
+                .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
+                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION);
+    }
+
+    OnlineIndexScrubber.Builder newScrubberBuilder() {
+        return OnlineIndexScrubber.newBuilder()
+                .setDatabase(fdb)
+                .setMetaData(metaData)
+                .setSubspace(subspace)
+                .setIndexMaintenanceFilter(getIndexMaintenanceFilter())
+                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION);
+    }
+
     FDBRecordContext openContext(boolean checked) {
         FDBRecordContext context = fdb.openContext();
         FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
                 .setMetaDataProvider(metaData)
                 .setContext(context)
-                .setFormatVersion(FDBRecordStore.READABLE_UNIQUE_PENDING_FORMAT_VERSION)
+                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION)
                 .setSubspace(subspace)
                 .setIndexMaintenanceFilter(getIndexMaintenanceFilter());
         if (checked) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
@@ -81,8 +81,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             recordStore.markIndexWriteOnly(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             buildIndexAssertThrowUniquenessViolation(indexBuilder);
 
@@ -123,8 +123,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             }
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             buildIndexAssertThrowUniquenessViolation(indexBuilder);
         }
@@ -149,8 +149,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             }
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             indexBuilder.buildUnbuiltRange(Key.Evaluated.scalar(0L), Key.Evaluated.scalar(5L)).join();
             try (FDBRecordContext context = openContext()) {
@@ -182,8 +182,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             recordStore.markIndexWriteOnly(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             indexBuilder.buildIndex();
         }
@@ -214,8 +214,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             recordStore.markIndexWriteOnly(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             indexBuilder.buildUnbuiltRange(Key.Evaluated.scalar(0L), Key.Evaluated.scalar(5L)).join();
             try (FDBRecordContext context = openContext()) {
@@ -249,8 +249,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             recordStore.markIndexWriteOnly(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             try (FDBRecordContext context = openContext()) {
                 context.getReadVersion();
@@ -316,8 +316,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             recordStore.markIndexWriteOnly(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .build()) {
             buildIndexAssertThrowUniquenessViolation(indexBuilder);
         }
@@ -366,8 +366,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             context.commit();
         }
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState())
                 .build()) {
@@ -402,8 +402,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         }
 
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState())
                 .build()) {
@@ -465,8 +465,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         // Force a RecordCoreException failure
         final String throwMsg = "Intentionally crash during test";
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setLimit(1)
                 .setConfigLoader(old -> {
@@ -481,8 +480,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
 
         // build normally
         disableAll(indexes);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState(allowUniquePending))
@@ -542,8 +540,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             context.commit();
         }
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .setIndex(index)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState())
                 .build()) {
@@ -573,8 +571,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         }
         openSimpleMetaData(hook);
         disableAll(indexes);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState(true))
@@ -650,8 +647,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         }
         openSimpleMetaData(hook);
         disableAll(indexes);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState(true))
@@ -701,8 +697,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         }
 
         // mark readable via build index's short circuit
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState(true))
@@ -742,8 +737,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
 
         // partly build the index
         final AtomicLong counter = new AtomicLong(0);
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setLimit(1)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
@@ -792,8 +786,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         openSimpleMetaData(hook);
         disableAll(indexes);
         // build source index
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setIndex(srcIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .allowUniquePendingState())
@@ -808,8 +801,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         }
 
         // build target index from source index (note - may fall back to by-records)
-        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).addTargetIndex(tgtIndex).setSubspace(subspace)
+        try (OnlineIndexer indexBuilder = newIndexerBuilder()
+                .addTargetIndex(tgtIndex)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setSourceIndex(srcIndex.getName())
                         .build())

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TerribleIndexMaintainer.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/TerribleIndexMaintainer.java
@@ -96,6 +96,12 @@ public class TerribleIndexMaintainer extends IndexMaintainer {
 
     @Nonnull
     @Override
+    public <M extends Message> CompletableFuture<Void> updateWhileWriteOnly(@Nullable final FDBIndexableRecord<M> oldRecord, @Nullable final FDBIndexableRecord<M> newRecord) {
+        return AsyncUtil.DONE;
+    }
+
+    @Nonnull
+    @Override
     public RecordCursor<IndexEntry> scanUniquenessViolations(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
         throw new UnsupportedOperationException("Terrible index cannot scan uniqueness violations");
     }


### PR DESCRIPTION
This adds support for building a non-idempotent target index when indexing from a different source index. This works in a manner that is analogous to the way that this operation works for non-idempotent indexes built by a record scan, except that as the range set contains ranges of index entries from the source index, the maintainer needs to be updated to: (1) check the indexing type stamp and (2) modify the range set check to use the index key instead of the primary key. Then there are some updates to the indexers to adjust logic that assumed the target index type would always be idempotent.

I played around with the tests added in this PR, and I've validated that if I inject a few bugs into the code (like checking the wrong value in the range set) that they fail, so I'm fairly confident in their ability to cover the interesting scenarios. The exception there would be `deleteRecordsWhere`, which is not currently validated in any of the indexing tests, though which I believe to be correctly handled.

This resolves #1430.