### PR TITLE
Fix pulling up `Value` through `Ordering`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug** Pulling up a Value through Ordering is not entirely correct [(Issue #1905)](https://github.com/FoundationDB/fdb-record-layer/issues/1905)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartiallyOrderedSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartiallyOrderedSet.java
@@ -177,7 +177,10 @@ public class PartiallyOrderedSet<T> {
             } else {
                 if (!elementsToMappedElementsMap.containsKey(value)) {
                     // key depends on value that does not exist -- do not insert the dependency and also remove key
-                    mappedElements.remove(key);
+                    final var mappedKey = elementsToMappedElementsMap.get(key);
+                    if (mappedKey != null) {
+                        mappedElements.remove(mappedKey);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When pulling up a `Value` through `Ordering`, it is possible that we do not clean up dependency lineage (found through the transitive closure) correctly if we don't find a dependency target in the pulled up `Value`.

This causes some plan partitions to misrepresent their order causing Cascades to fail to plan some queries due to not being able to satisfy their ordering requirement because of that.

It fixes #1905.