### PR TITLE
Resolves #1862: Lucene search with highlighting the terms

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Lucene search with highlighting the terms [(Issue #1862)](https://github.com/FoundationDB/fdb-record-layer/issues/1862)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexEntry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexEntry.java
@@ -24,10 +24,8 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin;
-import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
-import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -228,17 +226,6 @@ public class IndexEntry {
             System.arraycopy(nullStandins, startIdx, subKey.nullStandins, 0, endIdx - startIdx);
         }
         return subKey;
-    }
-
-    /**
-     * Rewrite the fetched stored record if needed. The default behavior is to keep the original fetched record.
-     * @param record the fetched record to rewrite
-     * @param <M> type used to represent stored records
-     * @return the rewritten record
-     */
-    @Nonnull
-    public <M extends Message> FDBStoredRecord<M> rewriteStoredRecord(@Nonnull FDBStoredRecord<M> record) {
-        return record;
     }
 
     private void checkIfNullTypeAvailable() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexEntry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexEntry.java
@@ -24,8 +24,10 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.Key.Evaluated.NullStandin;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
+import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -226,6 +228,17 @@ public class IndexEntry {
             System.arraycopy(nullStandins, startIdx, subKey.nullStandins, 0, endIdx - startIdx);
         }
         return subKey;
+    }
+
+    /**
+     * Rewrite the fetched stored record if needed. The default behavior is to keep the original fetched record.
+     * @param record the fetched record to rewrite
+     * @param <M> type used to represent stored records
+     * @return the rewritten record
+     */
+    @Nonnull
+    public <M extends Message> FDBStoredRecord<M> rewriteStoredRecord(@Nonnull FDBStoredRecord<M> record) {
+        return record;
     }
 
     private void checkIfNullTypeAvailable() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1311,7 +1311,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                         throw new RecordCoreException("Unexpected index orphan behavior: " + orphanBehavior);
                 }
             }
-            return new FDBIndexedRecord<>(entry, entry.rewriteStoredRecord(rec));
+            return new FDBIndexedRecord<>(entry, rec);
         });
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1311,7 +1311,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                         throw new RecordCoreException("Unexpected index orphan behavior: " + orphanBehavior);
                 }
             }
-            return new FDBIndexedRecord<>(entry, rec);
+            return new FDBIndexedRecord<>(entry, entry.rewriteStoredRecord(rec));
         });
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
@@ -151,22 +151,11 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     }
 
     /**
-     * Get a builder with the parameters of a given {@link FDBStoredRecord}.
-     * @param record given record
-     * @param <M> type used to represent stored records
-     * @return a new builder
+     * Get a builder with the parameters of this stored record.
+     * @return a builder
      */
-    @Nonnull
-    public static <M extends Message> FDBStoredRecordBuilder<M> newBuilder(@Nonnull FDBStoredRecord<M> record) {
-        return new FDBStoredRecordBuilder<>(record.getRecord())
-                .setPrimaryKey(record.getPrimaryKey())
-                .setRecordType(record.getRecordType())
-                .setKeyCount(record.getKeyCount())
-                .setKeySize(record.getKeySize())
-                .setValueSize(record.getValueSize())
-                .setSplit(record.isSplit())
-                .setVersion(record.getVersion())
-                .setVersionedInline(record.isVersionedInline());
+    public FDBStoredRecordBuilder<M> asBuilder() {
+        return new FDBStoredRecordBuilder<>(this);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecord.java
@@ -151,6 +151,25 @@ public class FDBStoredRecord<M extends Message> implements FDBIndexableRecord<M>
     }
 
     /**
+     * Get a builder with the parameters of a given {@link FDBStoredRecord}.
+     * @param record given record
+     * @param <M> type used to represent stored records
+     * @return a new builder
+     */
+    @Nonnull
+    public static <M extends Message> FDBStoredRecordBuilder<M> newBuilder(@Nonnull FDBStoredRecord<M> record) {
+        return new FDBStoredRecordBuilder<>(record.getRecord())
+                .setPrimaryKey(record.getPrimaryKey())
+                .setRecordType(record.getRecordType())
+                .setKeyCount(record.getKeyCount())
+                .setKeySize(record.getKeySize())
+                .setValueSize(record.getValueSize())
+                .setSplit(record.isSplit())
+                .setVersion(record.getVersion())
+                .setVersionedInline(record.isVersionedInline());
+    }
+
+    /**
      * Copy this record with a different version.
      * @param recordVersion new version
      * @return a new stored record with the given version

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoredRecordBuilder.java
@@ -59,6 +59,18 @@ public class FDBStoredRecordBuilder<M extends Message> implements FDBRecord<M>, 
         this.protoRecord = protoRecord;
     }
 
+    public FDBStoredRecordBuilder(@Nonnull FDBStoredRecord<M> record) {
+        this.protoRecord = record.getRecord();
+        this.primaryKey = record.getPrimaryKey();
+        this.recordType = record.getRecordType();
+        this.keyCount = record.getKeyCount();
+        this.keySize = record.getKeySize();
+        this.valueSize = record.getValueSize();
+        this.split = record.isSplit();
+        this.recordVersion = record.getVersion();
+        this.versionedInline = record.isVersionedInline();
+    }
+
     @Override
     @Nonnull
     public Tuple getPrimaryKey() {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
@@ -38,9 +38,12 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Helper class for converting {@link FDBRecord}s to Lucene documents.
@@ -129,6 +132,42 @@ public class LuceneDocumentFromRecord {
         final DocumentFieldList<FDBRecordSource<M>> fields = new DocumentFieldList<>();
         LuceneIndexExpressions.getFields(expression, new FDBRecordSource<>(rec, message), fields, fieldNamePrefix);
         return fields.getFields();
+    }
+
+    // Modify the Lucene fields of a record message with highlighting the terms from the given termMap
+    @Nonnull
+    public static <M extends Message> void highlightTermsInMessage(@Nonnull KeyExpression expression, @Nonnull Message.Builder builder, @Nonnull Map<String, Set<String>> termMap,
+                                                                   @Nonnull LuceneAnalyzerCombinationProvider analyzerSelector,
+                                                                   @Nonnull LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters) {
+        LuceneIndexKeyValueToPartialRecordUtils.RecordRebuildSource<M> recordRebuildSource = new LuceneIndexKeyValueToPartialRecordUtils.RecordRebuildSource<>(null, builder.getDescriptorForType(), builder, builder.build());
+
+        LuceneIndexExpressions.getFields(expression, recordRebuildSource,
+                (source, fieldName, value, type, stored, sorted, overriddenKeyRanges, groupingKeyIndex, keyIndex, fieldConfigsIgnored) -> {
+                    Set<String> terms = new HashSet<>();
+                    terms.addAll(termMap.getOrDefault(fieldName, Collections.emptySet()));
+                    terms.addAll(termMap.getOrDefault("", Collections.emptySet()));
+                    if (terms.isEmpty()) {
+                        return;
+                    }
+                    for (Map.Entry<Descriptors.FieldDescriptor, Object> entry : source.message.getAllFields().entrySet()) {
+                        Object entryValue = entry.getValue();
+                        if (entryValue instanceof String && entryValue.equals(value)
+                                && terms.stream().filter(t -> ((String) entryValue).toLowerCase(Locale.ROOT).contains(t.toLowerCase(Locale.ROOT))).findAny().isPresent()) {
+                            String highlightedText = LuceneAutoCompleteResultCursor.searchAllMaybeHighlight(fieldName, analyzerSelector.provideIndexAnalyzer((String) entryValue).getAnalyzer(), (String) entryValue, termMap.get(fieldName), null, false, luceneQueryHighlightParameters);
+                            source.buildMessage(highlightedText, entry.getKey(), null, null, true, 0);
+                        } else if (entryValue instanceof List) {
+                            int index = 0;
+                            for (Object entryValueElement : ((List) entryValue)) {
+                                if (entryValueElement instanceof String && entryValueElement.equals(value)
+                                        && terms.stream().filter(t -> ((String) entryValueElement).toLowerCase(Locale.ROOT).contains(t.toLowerCase(Locale.ROOT))).findAny().isPresent()) {
+                                    String highlightedText = LuceneAutoCompleteResultCursor.searchAllMaybeHighlight(fieldName, analyzerSelector.provideIndexAnalyzer((String) entryValueElement).getAnalyzer(), (String) entryValueElement, termMap.get(fieldName), null, false, luceneQueryHighlightParameters);
+                                    source.buildMessage(highlightedText, entry.getKey(), null, null, true, index);
+                                }
+                                index++;
+                            }
+                        }
+                    }
+                }, null);
     }
 
     protected static class FDBRecordSource<M extends Message> implements LuceneIndexExpressions.RecordSource<FDBRecordSource<M>> {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -186,6 +186,8 @@ public class LuceneEvents {
         LUCENE_SHARED_CACHE_HITS("lucene shared cache hits", false),
         /** Block to read came not in shared cache. **/
         LUCENE_SHARED_CACHE_MISSES("lucene shared cache misses", false),
+        /** Plan contains highlight operator. **/
+        PLAN_HIGHLIGHT_TERMS("lucene highlight plans", false),
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
@@ -48,7 +48,8 @@ public class LuceneFunctionKeyExpressionFactory implements FunctionKeyExpression
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_FULL_TEXT_FIELD_WITH_TERM_VECTOR_POSITIONS, LuceneFunctionKeyExpression.LuceneFieldConfig::new),
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_AUTO_COMPLETE_FIELD_INDEX_OPTIONS, LuceneFunctionKeyExpression.LuceneFieldConfig::new),
                 new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_SORT_BY_RELEVANCE, LuceneFunctionKeyExpression.LuceneSortBy::new),
-                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_SORT_BY_DOCUMENT_NUMBER, LuceneFunctionKeyExpression.LuceneSortBy::new)
+                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_SORT_BY_DOCUMENT_NUMBER, LuceneFunctionKeyExpression.LuceneSortBy::new),
+                new FunctionKeyExpression.BiFunctionBuilder(LuceneFunctionNames.LUCENE_HIGHLIGHT_TAG, LuceneFunctionKeyExpression.LuceneFieldConfig::new)
         );
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
@@ -38,6 +38,8 @@ public class LuceneFunctionNames {
     public static final String LUCENE_SORT_BY_RELEVANCE = "lucene_sort_by_relevance";
     public static final String LUCENE_SORT_BY_DOCUMENT_NUMBER = "lucene_sort_by_document_number";
 
+    public static final String LUCENE_HIGHLIGHT_TAG = "lucene_highlight_tag";
+
     private LuceneFunctionNames() {
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneHighlightTermsPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneHighlightTermsPlan.java
@@ -1,0 +1,213 @@
+/*
+ * LuceneHighlightTermsPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBIndexedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
+import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
+import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithChild;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Lucene query plan for highlighting terms in record fields.
+ */
+public class LuceneHighlightTermsPlan implements RecordQueryPlanWithChild {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Lucene-Highlight-Terms-Plan");
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(LuceneHighlightTermsPlan.class);
+
+    @Nonnull
+    private final Quantifier.Physical inner;
+
+    public LuceneHighlightTermsPlan(@Nonnull RecordQueryPlan inner) {
+        this(Quantifier.physical(GroupExpressionRef.of(inner)));
+    }
+
+    public LuceneHighlightTermsPlan(@Nonnull Quantifier.Physical inner) {
+        this.inner = inner;
+    }
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("PMD.CloseResource")
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
+        final RecordCursor<QueryResult> results = getInnerPlan().executePlan(store, context, continuation, executeProperties);
+
+        return results .map(result -> QueryResult.fromQueriedRecord(highlightTermsInRecord(result.getQueriedRecord())));
+    }
+
+    @Nullable
+    @SuppressWarnings("unchecked")
+    private <M extends Message> FDBQueriedRecord<M> highlightTermsInRecord(@Nullable FDBQueriedRecord<M> queriedRecord) {
+        if (queriedRecord == null) {
+            return queriedRecord;
+        }
+        IndexEntry indexEntry = queriedRecord.getIndexEntry();
+        if (!(indexEntry instanceof LuceneRecordCursor.ScoreDocIndexEntry)) {
+            return queriedRecord;
+        }
+        LuceneRecordCursor.ScoreDocIndexEntry docIndexEntry = (LuceneRecordCursor.ScoreDocIndexEntry)indexEntry;
+        if (!docIndexEntry.getLuceneQueryHighlightParameters().isHighlight()) {
+            return queriedRecord;
+        }
+        M message = queriedRecord.getRecord();
+        M.Builder builder = message.toBuilder();
+        LuceneDocumentFromRecord.highlightTermsInMessage(docIndexEntry.getIndexKey(), builder,
+                docIndexEntry.getTermMap(), docIndexEntry.getAnalyzerSelector(), docIndexEntry.getLuceneQueryHighlightParameters());
+        FDBStoredRecord<M> storedRecord = queriedRecord.getStoredRecord().asBuilder().setRecord((M) builder.build()).build();
+        return FDBQueriedRecord.indexed(new FDBIndexedRecord<>(indexEntry, storedRecord));
+    }
+
+    @Override
+    public boolean isReverse() {
+        return getInnerPlan().isReverse();
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(this.inner);
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return "Highlight(" + getInnerPlan() + ")";
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    public LuceneHighlightTermsPlan translateCorrelations(@Nonnull final TranslationMap translationMap,
+                                                           @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
+        return new LuceneHighlightTermsPlan(
+                Iterables.getOnlyElement(translatedQuantifiers).narrow(Quantifier.Physical.class));
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public boolean equalsWithoutChildren(@Nonnull final RelationalExpression other, @Nonnull final AliasMap equivalences) {
+        if (this == other) {
+            return true;
+        }
+        return getClass() == other.getClass();
+    }
+
+    @Override
+    public int hashCodeWithoutChildren() {
+        return 0;
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final RecordQueryPlan child) {
+        return new LuceneHighlightTermsPlan(child);
+    }
+
+    @Nonnull
+    @Override
+    public Value getResultValue() {
+        return getInnerPlan().getResultValue();
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(final Object other) {
+        return structuralEquals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return structuralHashCode();
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        return PlanHashable.objectsPlanHash(hashKind, BASE_HASH, getInnerPlan());
+    }
+
+    @Nonnull
+    public RecordQueryPlan getInnerPlan() {
+        return inner.getRangesOverPlan();
+    }
+
+    @Override
+    @Nonnull
+    public RecordQueryPlan getChild() {
+        return getInnerPlan();
+    }
+
+    @Override
+    public void logPlanStructure(StoreTimer timer) {
+        timer.increment(LuceneEvents.Counts.PLAN_HIGHLIGHT_TERMS);
+        getInnerPlan().logPlanStructure(timer);
+    }
+
+    @Override
+    public int getComplexity() {
+        return 1 + getInnerPlan().getComplexity();
+    }
+
+    @Nonnull
+    @Override
+    public PlannerGraph rewritePlannerGraph(@Nonnull List<? extends PlannerGraph> childGraphs) {
+        return PlannerGraph.fromNodeAndChildGraphs(
+                new PlannerGraph.OperatorNodeWithInfo(this, NodeInfo.TYPE_FILTER_OPERATOR, List.of("Highlight")),
+                childGraphs);
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -133,7 +133,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
             return new LuceneRecordCursor(executor, state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_EXECUTOR_SERVICE),
                     state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_CURSOR_PAGE_SIZE),
                     scanProperties, state, scanQuery.getQuery(), scanQuery.getSort(), continuation,
-                    scanQuery.getGroupKey(), scanQuery.getStoredFields(), scanQuery.getStoredFieldTypes());
+                    scanQuery.getGroupKey(), scanQuery.getLuceneQueryHighlightParameters(),
+                    scanQuery.getStoredFields(), scanQuery.getStoredFieldTypes(), indexAnalyzerSelector);
         }
 
         if (scanType.equals(LuceneScanTypes.BY_LUCENE_AUTO_COMPLETE)) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryComponent.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryComponent.java
@@ -54,6 +54,7 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
      */
     public enum Type {
         QUERY,
+        QUERY_HIGHLIGHT,
         AUTO_COMPLETE_HIGHLIGHT,
         AUTO_COMPLETE,
         SPELL_CHECK,
@@ -67,6 +68,9 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
 
     @Nonnull
     private final List<String> fields;
+
+    @Nonnull
+    private LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters;
 
     //MultiFieldSearch determines whether MultiFieldQueryParser or QueryParserBase is used.
     // QueryParserBase expects the query to contain the fields to be run against and takes a default field
@@ -86,11 +90,17 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
     }
 
     public LuceneQueryComponent(Type type, String query, boolean queryIsParameter, List<String> fields, boolean multiFieldSearch) {
+        this(type, query, queryIsParameter, fields, multiFieldSearch, new LuceneScanQueryParameters.LuceneQueryHighlightParameters(false));
+    }
+
+    public LuceneQueryComponent(Type type, String query, boolean queryIsParameter, List<String> fields, boolean multiFieldSearch,
+                                @Nonnull LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters) {
         this.type = type;
         this.query = query;
         this.queryIsParameter = queryIsParameter;
         this.fields = fields;
         this.multiFieldSearch = multiFieldSearch;
+        this.luceneQueryHighlightParameters = luceneQueryHighlightParameters;
     }
 
     @Nonnull
@@ -134,6 +144,11 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
 
     public boolean isMultiFieldSearch() {
         return multiFieldSearch;
+    }
+
+    @Nonnull
+    public LuceneScanQueryParameters.LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
+        return luceneQueryHighlightParameters;
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
@@ -44,14 +44,19 @@ public class LuceneScanQuery extends LuceneScanBounds {
     @Nullable
     private final List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes;
 
+    @Nonnull
+    private final LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters;
+
     public LuceneScanQuery(@Nonnull IndexScanType scanType, @Nonnull Tuple groupKey,
-                           @Nonnull Query query, @Nullable Sort sort,
-                           @Nullable List<String> storedFields, @Nullable List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes) {
+                           @Nonnull Query query, @Nullable Sort sort, @Nullable List<String> storedFields,
+                           @Nullable List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes,
+                           @Nonnull LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters) {
         super(scanType, groupKey);
         this.query = query;
         this.sort = sort;
         this.storedFields = storedFields;
         this.storedFieldTypes = storedFieldTypes;
+        this.luceneQueryHighlightParameters = luceneQueryHighlightParameters;
     }
 
     @Nonnull
@@ -72,6 +77,11 @@ public class LuceneScanQuery extends LuceneScanBounds {
     @Nullable
     public List<LuceneIndexExpressions.DocumentFieldType> getStoredFieldTypes() {
         return storedFieldTypes;
+    }
+
+    @Nonnull
+    public LuceneScanQueryParameters.LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
+        return luceneQueryHighlightParameters;
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -38,8 +38,10 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.text.AllSuffixesTextTokenizer;
 import com.apple.foundationdb.record.provider.common.text.TextSamples;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 import com.apple.foundationdb.record.provider.foundationdb.query.FDBRecordStoreQueryTestBase;
@@ -61,7 +63,11 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
@@ -113,12 +119,23 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Sophisticated queries involving full text predicates.
  */
 @Tag(Tags.RequiresFDB)
 public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
+
+    static class BooleanArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+            return Stream.of(Arguments.of(false, false),
+                    Arguments.of(true, false),
+                    Arguments.of(false, true),
+                    Arguments.of(true, true));
+        }
+    }
 
     private static final List<TestRecordsTextProto.SimpleDocument> DOCUMENTS = TextIndexTestUtils.toSimpleDocuments(Arrays.asList(
             TextSamples.ANGSTROM,
@@ -335,6 +352,39 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
+    @Test
+    void luceneQueryCustomizedHighlighting() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context);
+            final String text = "record record record record record record " +
+                                "layer " +
+                                "record record record record record record record record record record " +
+                                "layer " +
+                                "record record " +
+                                "layer " +
+                                "record record record record record record record record";
+            TestRecordsTextProto.SimpleDocument simpleDocument = TestRecordsTextProto.SimpleDocument.newBuilder().setDocId(0).setGroup(0).setText(text).build();
+            recordStore.saveRecord(simpleDocument);
+
+            final QueryComponent filter = new LuceneQueryComponent(LuceneQueryComponent.Type.QUERY_HIGHLIGHT,
+                    "layer", false, Lists.newArrayList(), true,
+                    new LuceneScanQueryParameters.LuceneQueryHighlightParameters(true, "<a>", "</a>", true, 6));
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType(TextIndexTestUtils.SIMPLE_DOC)
+                    .setFilter(filter)
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+
+            List<FDBQueriedRecord<Message>> queriedRecordList = recordStore.executeQuery(plan).asList().get();
+
+            Set<String> texts = queriedRecordList.stream().map(FDBQueriedRecord::getStoredRecord).map(FDBStoredRecord::getRecord).map(m -> (String) m.getField(m.getDescriptorForType().findFieldByName("text"))).collect(Collectors.toSet());
+            assertEquals(1, texts.size());
+            assertEquals("... record record record <a>layer</a> record record record ... record record record <a>layer</a> record record <a>layer</a> record record record record record record ... ",
+                    texts.iterator().next());
+        }
+    }
+
     @ParameterizedTest(name = "testSynonym[shouldDeferFetch={0}]")
     @BooleanSource
     void testSynonym(boolean shouldDeferFetch) throws Exception {
@@ -392,13 +442,15 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         assertTermIndexedOrNot("rning", false, shouldDeferFetch);
     }
 
-    @ParameterizedTest(name = "simpleLuceneScans[shouldDeferFetch={0}]")
-    @BooleanSource
-    void simpleLuceneScans(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(BooleanArgumentsProvider.class)
+    void simpleLuceneScans(boolean shouldDeferFetch, boolean withHighlight) throws Exception {
         initializeFlat();
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            final QueryComponent filter1 = new LuceneQueryComponent("civil blood makes civil hands unclean", Lists.newArrayList());
+            final QueryComponent filter1 = new LuceneQueryComponent(withHighlight ? LuceneQueryComponent.Type.QUERY_HIGHLIGHT : LuceneQueryComponent.Type.QUERY,
+                    "civil blood makes civil hands unclean", false, Lists.newArrayList(), true,
+                    new LuceneScanQueryParameters.LuceneQueryHighlightParameters(withHighlight, true));
             // Query for full records
             RecordQuery query = RecordQuery.newBuilder()
                     .setRecordType(TextIndexTestUtils.SIMPLE_DOC)
@@ -410,10 +462,12 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
                     scanParams(query(hasToString("MULTI civil blood makes civil hands unclean")))));
             RecordQueryPlan plan = planner.plan(query);
             assertThat(plan, matcher);
-            RecordCursor<FDBQueriedRecord<Message>> fdbQueriedRecordRecordCursor = recordStore.executeQuery(plan);
-            RecordCursor<Tuple> map = fdbQueriedRecordRecordCursor.map(FDBQueriedRecord::getPrimaryKey);
-            List<Long> primaryKeys = map.map(t -> t.getLong(0)).asList().get();
+            List<FDBQueriedRecord<Message>> queriedRecordList = recordStore.executeQuery(plan).asList().get();
+            Set<Long> primaryKeys = queriedRecordList.stream().map(FDBQueriedRecord::getPrimaryKey).map(t -> t.getLong(0)).collect(Collectors.toSet());
             assertEquals(Set.of(2L, 4L), Set.copyOf(primaryKeys));
+
+            Set<String> texts = queriedRecordList.stream().map(FDBQueriedRecord::getStoredRecord).map(FDBStoredRecord::getRecord).map(m -> (String) m.getField(m.getDescriptorForType().findFieldByName("text"))).collect(Collectors.toSet());
+            texts.forEach(t -> assertTrue(t.contains(withHighlight ? "<b>civil</b> <b>blood</b> <b>makes</b> <b>civil</b> <b>hands</b> <b>unclean</b>" : "civil blood makes civil hands unclean")));
         }
     }
 
@@ -546,14 +600,16 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @ParameterizedTest(name = "delayFetchOnOrOfLuceneFiltersGivesUnion[shouldDeferFetch={0}]")
-    @BooleanSource
-    void delayFetchOnOrOfLuceneFiltersGivesUnion(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(BooleanArgumentsProvider.class)
+    void delayFetchOnOrOfLuceneFiltersGivesUnion(boolean shouldDeferFetch, boolean withHighlight) throws Exception {
         initializeFlat();
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            final QueryComponent filter1 = new LuceneQueryComponent("(\"civil blood makes civil hands unclean\")", Lists.newArrayList("text"), true);
-            final QueryComponent filter2 = new LuceneQueryComponent("(\"was king from 966 to 1016\")", Lists.newArrayList());
+            final QueryComponent filter1 = new LuceneQueryComponent(withHighlight ? LuceneQueryComponent.Type.QUERY_HIGHLIGHT : LuceneQueryComponent.Type.QUERY, "(\"civil blood makes civil hands unclean\")", false, Lists.newArrayList("text"), true,
+                    new LuceneScanQueryParameters.LuceneQueryHighlightParameters(withHighlight, true));
+            final QueryComponent filter2 = new LuceneQueryComponent(withHighlight ? LuceneQueryComponent.Type.QUERY_HIGHLIGHT : LuceneQueryComponent.Type.QUERY, "(\"was king from 966 to 1016\")", false, Lists.newArrayList(), true,
+                    new LuceneScanQueryParameters.LuceneQueryHighlightParameters(withHighlight, true));
             // Query for full records
             RecordQuery query = RecordQuery.newBuilder()
                     .setRecordType(TextIndexTestUtils.SIMPLE_DOC)
@@ -578,24 +634,36 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
                                 scanParams(query(hasToString("MULTI (\"was king from 966 to 1016\")")))))))));
             }
             assertThat(plan, matcher);
-            List<Long> primaryKeys = recordStore.executeQuery(plan).map(FDBQueriedRecord::getPrimaryKey).map(t -> t.getLong(0)).asList().get();
-            assertEquals(Set.of(1L, 2L, 4L), Set.copyOf(primaryKeys));
+            List<FDBQueriedRecord<Message>> queriedRecordList = recordStore.executeQuery(plan).asList().get();
+            Set<Long> primaryKeys = queriedRecordList.stream().map(FDBRecord::getPrimaryKey).map(t -> t.getLong(0)).collect(Collectors.toSet());
+            assertEquals(Set.of(1L, 2L, 4L), primaryKeys);
             if (shouldDeferFetch) {
                 assertLoadRecord(5, context);
             } else {
                 assertLoadRecord(6, context);
             }
+
+            Set<String> texts = queriedRecordList.stream().map(FDBQueriedRecord::getStoredRecord).map(FDBStoredRecord::getRecord).map(m -> (String) m.getField(m.getDescriptorForType().findFieldByName("text"))).collect(Collectors.toSet());
+            for (String text : texts) {
+                boolean match1 = text.contains(withHighlight ? "<b>was</b> <b>king</b> <b>from</b> <b>966</b> <b>to</b> <b>1016</b>" : "was king from 966 to 1016");
+                boolean match2 = text.contains(withHighlight ? "<b>civil</b> <b>blood</b> <b>makes</b> <b>civil</b> <b>hands</b> <b>unclean</b>" : "civil blood makes civil hands unclean");
+                assertTrue(match1 || match2);
+            }
         }
     }
 
-    @ParameterizedTest(name = "delayFetchOnAndOfLuceneFilters[shouldDeferFetch={0}]")
-    @BooleanSource
-    void delayFetchOnAndOfLuceneFilters(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(BooleanArgumentsProvider.class)
+    void delayFetchOnAndOfLuceneFilters(boolean shouldDeferFetch, boolean withHighlight) throws Exception {
         initializeFlat();
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
-            final QueryComponent filter1 = new LuceneQueryComponent("\"the continuance\"", Lists.newArrayList());
-            final QueryComponent filter2 = new LuceneQueryComponent("grudge", Lists.newArrayList());
+            final QueryComponent filter1 = new LuceneQueryComponent(withHighlight ? LuceneQueryComponent.Type.QUERY_HIGHLIGHT : LuceneQueryComponent.Type.QUERY,
+                    "\"the continuance\"", false, Lists.newArrayList(), true,
+                    new LuceneScanQueryParameters.LuceneQueryHighlightParameters(withHighlight, true));
+            final QueryComponent filter2 = new LuceneQueryComponent(withHighlight ? LuceneQueryComponent.Type.QUERY_HIGHLIGHT : LuceneQueryComponent.Type.QUERY,
+                    "grudge", false, Lists.newArrayList(), true,
+                    new LuceneScanQueryParameters.LuceneQueryHighlightParameters(withHighlight, true));
             // Query for full records
             RecordQuery query = RecordQuery.newBuilder()
                     .setRecordType(TextIndexTestUtils.SIMPLE_DOC)
@@ -607,12 +675,20 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
                     indexName(SIMPLE_TEXT_SUFFIXES.getName()),
                     scanParams(query(hasToString("MULTI \"the continuance\" AND MULTI grudge")))));
             assertThat(plan, matcher);
-            List<Long> primaryKeys = recordStore.executeQuery(plan).map(FDBQueriedRecord::getPrimaryKey).map(t -> t.getLong(0)).asList().get();
-            assertEquals(Set.of(4L), Set.copyOf(primaryKeys));
+            List<FDBQueriedRecord<Message>> queriedRecordList = recordStore.executeQuery(plan).asList().get();
+            Set<Long> primaryKeys = queriedRecordList.stream().map(FDBQueriedRecord::getPrimaryKey).map(t -> t.getLong(0)).collect(Collectors.toSet());
+            assertEquals(Set.of(4L), primaryKeys);
             if (shouldDeferFetch) {
                 assertLoadRecord(3, context);
             } else {
                 assertLoadRecord(4, context);
+            }
+
+            Set<String> texts = queriedRecordList.stream().map(FDBQueriedRecord::getStoredRecord).map(FDBStoredRecord::getRecord).map(m -> (String) m.getField(m.getDescriptorForType().findFieldByName("text"))).collect(Collectors.toSet());
+            for (String text : texts) {
+                boolean match1 = text.contains(withHighlight ? "<b>the</b> <b>continuance</b>" : "the continuance");
+                boolean match2 = text.contains(withHighlight ? "<b>grudge</b>" : "grudge");
+                assertTrue(match1 || match2);
             }
         }
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteResultCursorTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteResultCursorTest.java
@@ -126,7 +126,8 @@ class LuceneAutoCompleteResultCursorTest {
         assertEquals(expectedPrefixToken, prefixToken);
 
         Set<String> queryTokenSet = new HashSet<>(tokens);
-        @Nullable String match = LuceneAutoCompleteResultCursor.searchAllMaybeHighlight(analyzer, text, queryTokenSet, prefixToken, highlight);
+        @Nullable String match = LuceneAutoCompleteResultCursor.searchAllMaybeHighlight("text", analyzer, text, queryTokenSet, prefixToken, true,
+                new LuceneScanQueryParameters.LuceneQueryHighlightParameters(highlight));
         assertEquals(expectedMatch, match);
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -340,9 +340,15 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
     }
 
     private LuceneScanBounds fullTextSearch(Index index, String search) {
+        return fullTextSearch(index, search, false);
+    }
+
+    private LuceneScanBounds fullTextSearch(Index index, String search, boolean highlight) {
         LuceneScanParameters scan = new LuceneScanQueryParameters(
                 ScanComparisons.EMPTY,
-                new LuceneQueryMultiFieldSearchClause(search, false));
+                new LuceneQueryMultiFieldSearchClause(search, false),
+                null, null, null,
+                new LuceneScanQueryParameters.LuceneQueryHighlightParameters(false));
         return scan.bind(recordStore, index, EvaluationContext.EMPTY);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlanMatchers.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlanMatchers.java
@@ -22,7 +22,9 @@ package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.match.PlanMatcherWithChild;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -45,6 +47,11 @@ public class LucenePlanMatchers {
     public static Matcher<IndexScanParameters> group(@Nonnull Matcher<ScanComparisons> boundsMatcher) {
         return new GroupBoundsMatcher(boundsMatcher);
     }
+
+    public static Matcher<RecordQueryPlan> highlight(@Nonnull Matcher<RecordQueryPlan> childMatcher) {
+        return new HighlightMatcher(childMatcher);
+    }
+
 
     /**
      * Match {@link IndexScanParameters}.
@@ -115,6 +122,27 @@ public class LucenePlanMatchers {
         public void describeTo(Description description) {
             description.appendText("group=(");
             boundsMatcher.describeTo(description);
+            description.appendText(")");
+        }
+    }
+
+    /**
+     * Match {@link LuceneHighlightTermsPlan}.
+     */
+    public static class HighlightMatcher extends PlanMatcherWithChild {
+        public HighlightMatcher(@Nonnull Matcher<RecordQueryPlan> childMatcher) {
+            super(childMatcher);
+        }
+
+        @Override
+        public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
+            return plan instanceof LuceneHighlightTermsPlan && super.matchesSafely(plan);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("Highlight(");
+            super.describeTo(description);
             description.appendText(")");
         }
     }


### PR DESCRIPTION
Follow-up to #1863.

Instead of introducing a new way of intercepting the loading of a record from its index entry, add a new plan operator to do highlighting. This makes changes to `-core` (hopefully) uncontroversial.

Other than that, the changes are intentionally minimal from the earlier PR.

Note that Union plans are different: there is no case of `Union` of `Covering` with deferred `Fetch`. The `Highlight` prevents this. It should be possible to defer the `Highlight` to after the `Fetch` and so allow a union of index entries inside. However, that requires planner support. Moreover, all these plans, including the one in the earlier PR, have a problem when results from two differently shaped searches are combined. The desired outcome is that the record's fields highlight terms from either side. But the `Union` throws one side away on the assumption that they are equivalent when the primary-key matches. Since the highlighting params are currently stored in the index entry, the `Union` would need to produce a merged highlighting params to be carried on with its output's index entry and used by `Highlight`.