### PR TITLE
Resolve #1915: add support for additional cursor streaming modes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Support additional streaming modes: LARGE, MEDIUM, SMALL [(Issue ##1915)](https://github.com/FoundationDB/fdb-record-layer/issues/#1915)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/CursorStreamingMode.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/CursorStreamingMode.java
@@ -32,5 +32,12 @@ public enum CursorStreamingMode {
     /** The client will process records one-at-a-time. */
     ITERATOR,
     /** The client will load all records immediately, such as with {@link RecordCursor#asList}. */
-    WANT_ALL
+    WANT_ALL,
+    /** Advanced. Transfer data in batches small enough to not be much more expensive than reading individual rows,
+     * to minimize cost if iteration stops early */
+    SMALL,
+    /** Advanced. Transfer data in batches sized in between small and large */
+    MEDIUM,
+    /** Advanced. Transfer data in batches large enough to be, in a high-concurrency environment, nearly as efficient as possible */
+    LARGE
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -252,8 +252,15 @@ public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements Bas
 
             final int limit = scanProperties.getExecuteProperties().getReturnedRowLimit();
             final StreamingMode streamingMode;
-            if (scanProperties.getCursorStreamingMode() == CursorStreamingMode.ITERATOR) {
+            CursorStreamingMode propertiesStreamingMode = scanProperties.getCursorStreamingMode();
+            if (propertiesStreamingMode == CursorStreamingMode.ITERATOR) {
                 streamingMode = StreamingMode.ITERATOR;
+            } else if (propertiesStreamingMode == CursorStreamingMode.LARGE) {
+                streamingMode = StreamingMode.LARGE;
+            } else if (propertiesStreamingMode == CursorStreamingMode.MEDIUM) {
+                streamingMode = StreamingMode.MEDIUM;
+            } else if (propertiesStreamingMode == CursorStreamingMode.SMALL) {
+                streamingMode = StreamingMode.SMALL;
             } else if (limit == ReadTransaction.ROW_LIMIT_UNLIMITED) {
                 streamingMode = StreamingMode.WANT_ALL;
             } else {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.record.CursorStreamingMode;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 
@@ -83,8 +85,8 @@ class RemoteFetchSplitRecordsTest extends RemoteFetchTestBase {
     }
 
     @ParameterizedTest(name = "indexPrefetchManySplitRecordTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
-    @EnumSource()
-    void indexPrefetchManySplitRecordTest(IndexFetchMethod useIndexPrefetch) throws Exception {
+    @MethodSource("fetchMethodAndStreamMode")
+    void indexPrefetchManySplitRecordTest(IndexFetchMethod useIndexPrefetch, CursorStreamingMode streamingMode) throws Exception {
         // TODO: This test actually runs the API in a way that returns results that are too large: Over 50MB
         // FDB will fix the issue to limit the bytes returned and then this test would need to adjust accordingly.
         int numTransactions = 8;
@@ -96,7 +98,7 @@ class RemoteFetchSplitRecordsTest extends RemoteFetchTestBase {
         }
         RecordQueryPlan plan = plan(NUM_VALUES_LARGER_THAN_1000_REVERSE, useIndexPrefetch);
 
-        executeAndVerifyData(plan, numRecordsPerTransaction * numTransactions, (rec, i) -> {
+        executeAndVerifyData(plan, null, serializableWithStreamingMode(streamingMode), numRecordsPerTransaction * numTransactions, (rec, i) -> {
             int primaryKey = 200 + i;
             String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
             int numValue = 2000 - i;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.record.CursorStreamingMode;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -124,10 +126,10 @@ class RemoteFetchTest extends RemoteFetchTestBase {
      * @param useIndexPrefetch the fetch method mode to use
      */
     @ParameterizedTest(name = "indexPrefetchPrimaryKeyIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
-    @EnumSource()
-    void indexPrefetchPrimaryKeyIndexTest(IndexFetchMethod useIndexPrefetch) throws Exception {
+    @MethodSource("fetchMethodAndStreamMode")
+    void indexPrefetchPrimaryKeyIndexTest(IndexFetchMethod useIndexPrefetch, CursorStreamingMode streamingMode) throws Exception {
         RecordQueryPlan plan = plan(PRIMARY_KEY_EQUAL, useIndexPrefetch);
-        executeAndVerifyData(plan, 1, (rec, i) -> {
+        executeAndVerifyData(plan, null, serializableWithStreamingMode(streamingMode), 1, (rec, i) -> {
             int primaryKey = 1;
             String strValue = ((primaryKey % 2) == 0) ? "even" : "odd";
             int numValue = 1000 - primaryKey;
@@ -137,10 +139,11 @@ class RemoteFetchTest extends RemoteFetchTestBase {
     }
 
     @ParameterizedTest(name = "indexPrefetchComplexIndexTest(" + ARGUMENTS_WITH_NAMES_PLACEHOLDER + ")")
-    @EnumSource()
-    void indexPrefetchComplexIndexTest(IndexFetchMethod useIndexPrefetch) throws Exception {
+    @MethodSource("fetchMethodAndStreamMode")
+    void indexPrefetchComplexIndexTest(IndexFetchMethod useIndexPrefetch, CursorStreamingMode streamingMode) throws Exception {
         RecordQueryPlan plan = plan(STR_VALUE_EVEN, useIndexPrefetch);
-        executeAndVerifyData(plan, 50, (rec, i) -> {
+        // Pass in every supported streaming mode. The result should not change.
+        executeAndVerifyData(plan, null, serializableWithStreamingMode(streamingMode), 50, (rec, i) -> {
             int primaryKey = i * 2;
             int numValue = 1000 - primaryKey;
             assertRecord(rec, primaryKey, "even", numValue, "MySimpleRecord$str_value_indexed", "even", primaryKey); // we are filtering out all odd entries, so count*2 are the keys of the even ones


### PR DESCRIPTION
Add support for LARGE, MEDIUM, and SMALL cursor streaming modes. These are only used if specifically set by the API users and should not change the default behavior.
