### PR TITLE
Resolves #1923: Avoid copying continuation byte arrays by using ByteString internally

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** The number of array copies when constructing continuations should be decreased by relying more on `ByteString` internally [(Issue #1923)](https://github.com/FoundationDB/fdb-record-layer/issues/1923)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteArrayContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/ByteArrayContinuation.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.annotation.API;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,7 +55,7 @@ public class ByteArrayContinuation implements RecordCursorContinuation {
     @Nonnull
     public ByteString toByteString() {
         if (byteString == null) {
-            byteString = ByteString.copyFrom(bytes);
+            byteString = ZeroCopyByteString.wrap(bytes);
         }
         return byteString;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorEndContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorEndContinuation.java
@@ -21,7 +21,9 @@
 package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.annotation.API;
+import com.google.protobuf.ByteString;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -33,6 +35,12 @@ public class RecordCursorEndContinuation implements RecordCursorContinuation {
     public static final RecordCursorContinuation END = new RecordCursorEndContinuation();
 
     private RecordCursorEndContinuation() {
+    }
+
+    @Nonnull
+    @Override
+    public ByteString toByteString() {
+        return ByteString.EMPTY;
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorStartContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCursorStartContinuation.java
@@ -21,7 +21,9 @@
 package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.annotation.API;
+import com.google.protobuf.ByteString;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -43,6 +45,12 @@ public class RecordCursorStartContinuation implements RecordCursorContinuation {
     @Override
     public boolean isEnd() {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    public ByteString toByteString() {
+        return ByteString.EMPTY;
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ChainedCursor.java
@@ -28,6 +28,8 @@ import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -258,6 +260,13 @@ public class ChainedCursor<T> implements BaseCursor<T> {
         public Continuation(@Nonnull Optional<T> lastValue, @Nonnull Function<T, byte[]> continuationEncoder) {
             this.lastValue = lastValue;
             this.continuationEncoder = continuationEncoder;
+        }
+
+        @Nonnull
+        @Override
+        public ByteString toByteString() {
+            byte[] bytes = toBytes();
+            return bytes == null ? ByteString.EMPTY : ZeroCopyByteString.wrap(bytes);
         }
 
         @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ListCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/ListCursor.java
@@ -25,11 +25,14 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
@@ -107,6 +110,15 @@ public class ListCursor<T> implements RecordCursor<T> {
             // cursor knows for certain that there is no more after that result, as in the ListCursor.
             // Concretely, this means that we really need a > here, rather than >=.
             return nextPosition > listSize;
+        }
+
+        @Nonnull
+        @Override
+        public ByteString toByteString() {
+            if (isEnd()) {
+                return ByteString.EMPTY;
+            }
+            return ZeroCopyByteString.wrap(Objects.requireNonNull(toBytes()));
         }
 
         @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RangeCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RangeCursor.java
@@ -25,10 +25,13 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -104,6 +107,15 @@ public class RangeCursor implements RecordCursor<Integer> {
             // cursor knows for certain that there is no more after that result, as in the ListCursor.
             // Concretely, this means that we really need a > here, rather than >=.
             return nextPosition > size;
+        }
+
+        @Nonnull
+        @Override
+        public ByteString toByteString() {
+            if (isEnd()) {
+                return ByteString.EMPTY;
+            }
+            return ZeroCopyByteString.wrap(Objects.requireNonNull(toBytes()));
         }
 
         @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -41,6 +41,8 @@ import com.apple.foundationdb.record.cursors.BaseCursor;
 import com.apple.foundationdb.record.cursors.CursorLimitManager;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -148,6 +150,16 @@ public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements Bas
         @Override
         public boolean isEnd() {
             return lastKey == null;
+        }
+
+        @Nonnull
+        @Override
+        public ByteString toByteString() {
+            if (lastKey == null) {
+                return ByteString.EMPTY;
+            }
+            ByteString base = ZeroCopyByteString.wrap(lastKey);
+            return base.substring(prefixLength, lastKey.length);
         }
 
         @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/BloomFilterCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/BloomFilterCursorContinuation.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.provider.foundationdb.cursors;
 
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -53,9 +52,9 @@ class BloomFilterCursorContinuation implements RecordCursorContinuation {
             if (childContinuation.isEnd()) {
                 builder.setExhausted(true);
             } else {
-                byte[] childBytes = childContinuation.toBytes();
-                if (childBytes != null) {
-                    builder.setContinuation(ZeroCopyByteString.wrap(childBytes));
+                ByteString childBytes = childContinuation.toByteString();
+                if (!childBytes.isEmpty()) {
+                    builder.setContinuation(childBytes);
                 }
             }
             if (bloomBytes != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ComparatorCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/ComparatorCursorContinuation.java
@@ -78,13 +78,13 @@ class ComparatorCursorContinuation extends MergeCursorContinuation<RecordCursorP
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
         } else {
-            byte[] asBytes = continuation.toBytes();
-            if (asBytes == null && !continuation.isEnd()) {
+            ByteString asBytes = continuation.toByteString();
+            if (asBytes.isEmpty() && !continuation.isEnd()) {
                 cursorState = START_PROTO;
             } else {
                 cursorState = RecordCursorProto.ComparatorContinuation.CursorState.newBuilder()
                         .setStarted(true)
-                        .setContinuation(ByteString.copyFrom(asBytes))
+                        .setContinuation(asBytes)
                         .build();
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/IntersectionCursorContinuation.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -60,26 +59,26 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
 
     @Override
     protected void setFirstChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
-        byte[] asBytes = continuation.toBytes();
-        if (asBytes == null && !continuation.isEnd()) { // first cursor has not started
+        ByteString asBytes = continuation.toByteString();
+        if (asBytes.isEmpty() && !continuation.isEnd()) { // first cursor has not started
             builder.setFirstStarted(false);
         } else {
             builder.setFirstStarted(true);
-            if (asBytes != null) {
-                builder.setFirstContinuation(ZeroCopyByteString.wrap(asBytes));
+            if (!asBytes.isEmpty()) {
+                builder.setFirstContinuation(asBytes);
             }
         }
     }
 
     @Override
     protected void setSecondChild(@Nonnull RecordCursorProto.IntersectionContinuation.Builder builder, @Nonnull RecordCursorContinuation continuation) {
-        byte[] asBytes = continuation.toBytes();
-        if (asBytes == null && !continuation.isEnd()) { // second cursor not started
+        ByteString asBytes = continuation.toByteString();
+        if (asBytes.isEmpty() && !continuation.isEnd()) { // second cursor not started
             builder.setSecondStarted(false);
         } else {
             builder.setSecondStarted(true);
-            if (asBytes != null) {
-                builder.setSecondContinuation(ZeroCopyByteString.wrap(asBytes));
+            if (!asBytes.isEmpty()) {
+                builder.setSecondContinuation(asBytes);
             }
         }
     }
@@ -90,13 +89,13 @@ class IntersectionCursorContinuation extends MergeCursorContinuation<RecordCurso
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
         } else {
-            byte[] asBytes = continuation.toBytes();
-            if (asBytes == null && !continuation.isEnd()) {
+            ByteString asBytes = continuation.toByteString();
+            if (asBytes.isEmpty() && !continuation.isEnd()) {
                 cursorState = START_PROTO;
             } else {
                 cursorState = RecordCursorProto.IntersectionContinuation.CursorState.newBuilder()
                         .setStarted(true)
-                        .setContinuation(ByteString.copyFrom(asBytes))
+                        .setContinuation(asBytes)
                         .build();
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/cursors/UnionCursorContinuation.java
@@ -30,8 +30,8 @@ import com.apple.foundationdb.record.RecordCursorStartContinuation;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -61,9 +61,9 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
         if (continuation.isEnd()) {
             builder.setFirstExhausted(true);
         } else {
-            final byte[] asBytes = continuation.toBytes();
-            if (asBytes != null) {
-                builder.setFirstContinuation(ZeroCopyByteString.wrap(asBytes));
+            final ByteString asBytes = continuation.toByteString();
+            if (!asBytes.isEmpty()) {
+                builder.setFirstContinuation(asBytes);
             }
         }
     }
@@ -73,9 +73,9 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
         if (continuation.isEnd()) {
             builder.setSecondExhausted(true);
         } else {
-            final byte[] asBytes = continuation.toBytes();
-            if (asBytes != null) {
-                builder.setSecondContinuation(ZeroCopyByteString.wrap(asBytes));
+            final ByteString asBytes = continuation.toByteString();
+            if (!asBytes.isEmpty()) {
+                builder.setSecondContinuation(asBytes);
             }
         }
     }
@@ -86,12 +86,12 @@ class UnionCursorContinuation extends MergeCursorContinuation<RecordCursorProto.
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
         } else {
-            final byte[] asBytes = continuation.toBytes();
-            if (asBytes == null) {
+            final ByteString asBytes = continuation.toByteString();
+            if (asBytes.isEmpty()) {
                 cursorState = START_PROTO;
             } else {
                 cursorState = RecordCursorProto.UnionContinuation.CursorState.newBuilder()
-                        .setContinuation(ZeroCopyByteString.wrap(asBytes))
+                        .setContinuation(asBytes)
                         .build();
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexContinuation.java
@@ -34,9 +34,9 @@ import com.apple.foundationdb.record.provider.foundationdb.cursors.MergeCursorCo
 import com.apple.foundationdb.record.provider.foundationdb.indexes.BitmapValueIndexMaintainer;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,12 +88,12 @@ class ComposedBitmapIndexContinuation extends MergeCursorContinuation<RecordCurs
         if (continuation.isEnd()) {
             cursorState = EXHAUSTED_PROTO;
         } else {
-            final byte[] asBytes = continuation.toBytes();
-            if (asBytes == null) {
+            final ByteString asBytes = continuation.toByteString();
+            if (asBytes.isEmpty()) {
                 cursorState = START_PROTO;
             } else {
                 cursorState = RecordCursorProto.ComposedBitmapIndexContinuation.CursorState.newBuilder()
-                        .setContinuation(ZeroCopyByteString.wrap(asBytes))
+                        .setContinuation(asBytes)
                         .build();
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySelectorPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySelectorPlan.java
@@ -280,6 +280,8 @@ public class RecordQuerySelectorPlan extends RecordQueryChooserPlanBase {
         @Nullable
         private ByteString innerContinuation = null;
         private boolean isEnd;
+        @Nullable
+        private RecordCursorProto.SelectorPlanContinuation cachedProto;
 
         public SelectorContinuation(byte[] rawBytes) {
             try {
@@ -308,17 +310,33 @@ public class RecordQuerySelectorPlan extends RecordQueryChooserPlanBase {
             }
         }
 
+        private RecordCursorProto.SelectorPlanContinuation toProto() {
+            if (cachedProto == null) {
+                cachedProto = RecordCursorProto.SelectorPlanContinuation.newBuilder()
+                        .setSelectedPlan(selectedPlanIndex)
+                        .setInnerContinuation(innerContinuation)
+                        .build();
+            }
+            return cachedProto;
+        }
+
+        @Nonnull
+        @Override
+        public ByteString toByteString() {
+            if (isEnd()) {
+                return ByteString.EMPTY;
+            } else {
+                return toProto().toByteString();
+            }
+        }
+
         @Nullable
         @Override
         public byte[] toBytes() {
             if (isEnd()) {
                 return null;
             } else {
-                RecordCursorProto.SelectorPlanContinuation continuation = RecordCursorProto.SelectorPlanContinuation.newBuilder()
-                        .setSelectedPlan(selectedPlanIndex)
-                        .setInnerContinuation(innerContinuation)
-                        .build();
-                return continuation.toByteArray();
+                return toProto().toByteArray();
             }
         }
 


### PR DESCRIPTION
This updates the logic in the `RecordCursorContinuation` objects to avoid serializing a continuation all the way to a `byte[]` if it is not necessary. For example, when constructing protobuf objects that back continuations, child continuations can be constructed by calling `.toByteString()` on the continuation and passing that to the protobuf builder instead of serializing all the to a `byte[]` and then wrapping it back in a `ByteString`. This also makes sure that (as much as possible) the cursor implementations are more efficient when constructing a `ByteString`. For example, for the proto-based continuations, it should be able to return `.toByteString()` on the protobuf object instead of serializing the _protobuf_ all the way to a `byte[]` and then wrapping it back up, which some implementations did previously.

Adopters who need a `ByteString` rather than a `byte[]` (for example, to pack the continuation into a protobuf) are also encouraged to switch to the newer method.

This resolves #1923. This also follows up from #1921, which introduced the zero copy `ByteString` to avoid copying immutable arrays.