### PR TITLE
More of #1907: Sorting and comparing nested fields get confused

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Sorting and comparing nested fields get confused [(Issue #1907)](https://github.com/FoundationDB/fdb-record-layer/issues/1907)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
Another nested sorting test case that worked at 52b44e4af3decafd6c4398dbcb3ae58eae1e98ed but regressed.

Need to account for a multi-column index child that matches the sort once equalities are skipped.