### PR TITLE
Resolves #1942: Make unrolled deletes the default record delete behavior

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,7 +24,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Unrolled record deletes (introduced in [3.3.309.0](#333090) are now on by default [(Issue #1942)](https://github.com/FoundationDB/fdb-record-layer/issues/1942)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
@@ -42,7 +42,7 @@ public final class FDBRecordStoreProperties {
      * more efficient if the underlying FDB storage engine can more efficiently handle single-key clears.
      */
     public static final RecordLayerPropertyKey<Boolean> UNROLL_SINGLE_RECORD_DELETES = RecordLayerPropertyKey.booleanPropertyKey(
-            "com.apple.foundationdb.record.recordstore.unroll_single_record_deletes", false);
+            "com.apple.foundationdb.record.recordstore.unroll_single_record_deletes", true);
 
     private FDBRecordStoreProperties() {
         throw new RecordCoreException("should not instantiate class of static prop");


### PR DESCRIPTION
This changes the default value in the property controlling whether record deletes are unrolled. Adopters can still opt into the old behavior by setting the property value, though most use cases should be fine with the new default. At some point in the future, we can consider deprecating the property and always unrolling record deletes if we wish.

This resolves #1942.