### PR TITLE
Delegate accumulator finalisation to children in RCV.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
@@ -282,12 +282,12 @@ public class RecordConstructorValue implements Value, AggregateValue, CreatesDyn
     @Override
     public Accumulator createAccumulator(final @Nonnull TypeRepository typeRepository) {
         return new Accumulator() {
-            List<Accumulator> childAccumulators = null;
+
+            @Nonnull
+            private final List<Accumulator> childAccumulators = buildAccumulators();
+
             @Override
             public void accumulate(@Nullable final Object currentObject) {
-                if (childAccumulators == null) {
-                    childAccumulators = buildAccumulators();
-                }
                 if (currentObject == null) {
                     childAccumulators.forEach(childAccumulator -> childAccumulator.accumulate(null));
                 } else {
@@ -304,10 +304,6 @@ public class RecordConstructorValue implements Value, AggregateValue, CreatesDyn
             @Nonnull
             @Override
             public Object finish() {
-                if (childAccumulators == null) {
-                    childAccumulators = buildAccumulators();
-                }
-
                 final var resultMessageBuilder = newMessageBuilderForType(typeRepository);
                 final var descriptorForType = resultMessageBuilder.getDescriptorForType();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
@@ -286,12 +286,7 @@ public class RecordConstructorValue implements Value, AggregateValue, CreatesDyn
             @Override
             public void accumulate(@Nullable final Object currentObject) {
                 if (childAccumulators == null) {
-                    final ImmutableList.Builder<Accumulator> childAccumulatorsBuilder = ImmutableList.builder();
-                    for (final var child : getChildren()) {
-                        Verify.verify(child instanceof AggregateValue);
-                        childAccumulatorsBuilder.add(((AggregateValue)child).createAccumulator(typeRepository));
-                    }
-                    childAccumulators = childAccumulatorsBuilder.build();
+                    childAccumulators = buildAccumulators();
                 }
                 if (currentObject == null) {
                     childAccumulators.forEach(childAccumulator -> childAccumulator.accumulate(null));
@@ -306,11 +301,11 @@ public class RecordConstructorValue implements Value, AggregateValue, CreatesDyn
                 }
             }
 
-            @Nullable
+            @Nonnull
             @Override
             public Object finish() {
                 if (childAccumulators == null) {
-                    return null;
+                    childAccumulators = buildAccumulators();
                 }
 
                 final var resultMessageBuilder = newMessageBuilderForType(typeRepository);
@@ -328,6 +323,16 @@ public class RecordConstructorValue implements Value, AggregateValue, CreatesDyn
                 }
 
                 return resultMessageBuilder.build();
+            }
+
+            @Nonnull
+            private List<Accumulator> buildAccumulators() {
+                final ImmutableList.Builder<Accumulator> childAccumulatorsBuilder = ImmutableList.builder();
+                for (final var child : getChildren()) {
+                    Verify.verify(child instanceof AggregateValue);
+                    childAccumulatorsBuilder.add(((AggregateValue)child).createAccumulator(typeRepository));
+                }
+                return childAccumulatorsBuilder.build();
             }
         };
     }


### PR DESCRIPTION
This allows the children accumulators in `RecordConstructorValue` to finalise their group instead of prematurely return `null`, this allows some special accumulator semantics to kick in such as `count()` (which returns `0` instead of `null` in case of empty group).

Fixes #1950.