### PR TITLE
Resolve  #1957: Create base class for KeyValueCursor and Builder, use with IndexPrefetchRangeKeyValueCursor

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Refactor KeyValueCursor to allow extension [(Issue #1957)](https://github.com/FoundationDB/fdb-record-layer/issues/1957)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.MappedKeyValue;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncIterator;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.MappedKeyValue;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncIterator;
 import com.apple.foundationdb.record.cursors.CursorLimitManager;
@@ -36,9 +37,9 @@ import javax.annotation.Nonnull;
  * the record for a particular index entry.
  */
 @API(API.Status.EXPERIMENTAL)
-public class IndexPrefetchRangeKeyValueCursor extends KeyValueCursorBase {
+public class IndexPrefetchRangeKeyValueCursor extends KeyValueCursorBase<MappedKeyValue> {
     private IndexPrefetchRangeKeyValueCursor(@Nonnull final FDBRecordContext context,
-                                             @Nonnull final AsyncIterator<KeyValue> iterator,
+                                             @Nonnull final AsyncIterator<MappedKeyValue> iterator,
                                              int prefixLength,
                                              @Nonnull final CursorLimitManager limitManager,
                                              int valuesLimit) {
@@ -67,10 +68,10 @@ public class IndexPrefetchRangeKeyValueCursor extends KeyValueCursorBase {
         @SuppressWarnings("unchecked")
         public IndexPrefetchRangeKeyValueCursor build() {
             prepare();
-            AsyncIterator<? extends KeyValue> iterator = getTransaction()
+            AsyncIterator<MappedKeyValue> iterator = getTransaction()
                     .getMappedRange(getBegin(), getEnd(), mapper, getLimit(), isReverse(), getStreamingMode())
                     .iterator();
-            return new IndexPrefetchRangeKeyValueCursor(getContext(), (AsyncIterator<KeyValue>)iterator, getPrefixLength(), getLimitManager(), getValuesLimit());
+            return new IndexPrefetchRangeKeyValueCursor(getContext(), iterator, getPrefixLength(), getLimitManager(), getValuesLimit());
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
@@ -64,7 +64,6 @@ public class IndexPrefetchRangeKeyValueCursor extends KeyValueCursorBase<MappedK
         }
 
 
-        @SuppressWarnings("unchecked")
         public IndexPrefetchRangeKeyValueCursor build() {
             prepare();
             AsyncIterator<MappedKeyValue> iterator = getTransaction()
@@ -74,7 +73,7 @@ public class IndexPrefetchRangeKeyValueCursor extends KeyValueCursorBase<MappedK
         }
 
         @Override
-        protected Builder getThis() {
+        protected Builder self() {
             return this;
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -21,155 +21,25 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.KeySelector;
 import com.apple.foundationdb.KeyValue;
-import com.apple.foundationdb.Range;
-import com.apple.foundationdb.ReadTransaction;
-import com.apple.foundationdb.StreamingMode;
 import com.apple.foundationdb.async.AsyncIterator;
-import com.apple.foundationdb.record.CursorStreamingMode;
-import com.apple.foundationdb.record.EndpointType;
-import com.apple.foundationdb.record.KeyRange;
-import com.apple.foundationdb.record.RecordCoreException;
-import com.apple.foundationdb.record.RecordCursorContinuation;
-import com.apple.foundationdb.record.RecordCursorResult;
-import com.apple.foundationdb.record.ScanProperties;
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
-import com.apple.foundationdb.record.TupleRange;
-import com.apple.foundationdb.record.cursors.AsyncIteratorCursor;
-import com.apple.foundationdb.record.cursors.BaseCursor;
 import com.apple.foundationdb.record.cursors.CursorLimitManager;
 import com.apple.foundationdb.subspace.Subspace;
-import com.apple.foundationdb.tuple.Tuple;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The basic cursor for scanning ranges of the FDB database.
  */
 @API(API.Status.MAINTAINED)
-public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements BaseCursor<KeyValue> {
-    @Nonnull
-    private final FDBRecordContext context;
-    private final int prefixLength;
-    @Nonnull
-    private final CursorLimitManager limitManager;
-    private int valuesLimit;
-    // the pointer may be mutated, but the actual array must never be mutated or continuations will break
-    @Nullable
-    private byte[] lastKey;
+public class KeyValueCursor extends KeyValueCursorBase {
 
-    protected KeyValueCursor(@Nonnull final FDBRecordContext context,
+    private KeyValueCursor(@Nonnull final FDBRecordContext context,
                              @Nonnull final AsyncIterator<KeyValue> iterator,
                              int prefixLength,
                              @Nonnull final CursorLimitManager limitManager,
                              int valuesLimit) {
-        super(context.getExecutor(), iterator);
-
-        this.context = context;
-        this.prefixLength = prefixLength;
-        this.limitManager = limitManager;
-        this.valuesLimit = valuesLimit;
-
-        context.instrument(FDBStoreTimer.DetailEvents.GET_SCAN_RANGE_RAW_FIRST_CHUNK, iterator.onHasNext());
-    }
-
-    @Nonnull
-    @Override
-    public CompletableFuture<RecordCursorResult<KeyValue>> onNext() {
-        if (nextResult != null && !nextResult.hasNext()) {
-            // This guard is needed to guarantee that if onNext is called multiple times after the cursor has
-            // returned a result without a value, then the same NoNextReason is returned each time. Without this guard,
-            // one might return SCAN_LIMIT_REACHED (for example) after returning a result with SOURCE_EXHAUSTED because
-            // of the tryRecordScan check.
-            return CompletableFuture.completedFuture(nextResult);
-        } else if (limitManager.tryRecordScan()) {
-            return iterator.onHasNext().thenApply(hasNext -> {
-                if (hasNext) {
-                    KeyValue kv = iterator.next();
-                    if (context != null) {
-                        context.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
-                        context.increment(FDBStoreTimer.Counts.LOAD_KEY_VALUE);
-                    }
-                    limitManager.reportScannedBytes(kv.getKey().length + kv.getValue().length);
-                    // Note that this mutates the pointer and NOT the array.
-                    // If the value of lastKey is mutated, the Continuation class will break.
-                    lastKey = kv.getKey();
-                    valuesSeen++;
-                    nextResult = RecordCursorResult.withNextValue(kv, continuationHelper());
-                } else if (valuesSeen >= valuesLimit) {
-                    // Source iterator hit limit that we passed down.
-                    nextResult = RecordCursorResult.withoutNextValue(continuationHelper(), NoNextReason.RETURN_LIMIT_REACHED);
-                } else {
-                    // Source iterator is exhausted.
-                    nextResult = RecordCursorResult.exhausted();
-                }
-                return nextResult;
-            });
-        } else { // a limit must have been exceeded
-            final Optional<NoNextReason> stoppedReason = limitManager.getStoppedReason();
-            if (!stoppedReason.isPresent()) {
-                throw new RecordCoreException("limit manager stopped KeyValueCursor but did not report a reason");
-            }
-            nextResult = RecordCursorResult.withoutNextValue(continuationHelper(), stoppedReason.get());
-            return CompletableFuture.completedFuture(nextResult);
-        }
-    }
-
-    @Override
-    @Nonnull
-    public RecordCursorResult<KeyValue> getNext() {
-        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, onNext());
-    }
-
-    @Nonnull
-    private RecordCursorContinuation continuationHelper() {
-        return new Continuation(lastKey, prefixLength);
-    }
-
-    private static class Continuation implements RecordCursorContinuation {
-        @Nullable
-        private final byte[] lastKey;
-        private final int prefixLength;
-
-        public Continuation(@Nullable final byte[] lastKey, final int prefixLength) {
-            // Note that doing this without a full copy is dangerous if the array is ever mutated.
-            // Currently, this never happens and the only thing that changes is which array lastKey points to.
-            // However, if logic in KeyValueCursor or KeyValue changes, this could break continuations.
-            // To resolve it, we could resort to doing a full copy here, although that's somewhat expensive.
-            this.lastKey = lastKey;
-            this.prefixLength = prefixLength;
-        }
-
-        @Override
-        public boolean isEnd() {
-            return lastKey == null;
-        }
-
-        @Nonnull
-        @Override
-        public ByteString toByteString() {
-            if (lastKey == null) {
-                return ByteString.EMPTY;
-            }
-            ByteString base = ZeroCopyByteString.wrap(lastKey);
-            return base.substring(prefixLength, lastKey.length);
-        }
-
-        @Nullable
-        @Override
-        public byte[] toBytes() {
-            if (lastKey == null) {
-                return null;
-            }
-            return Arrays.copyOfRange(lastKey, prefixLength, lastKey.length);
-        }
+        super(context, iterator, prefixLength, limitManager, valuesLimit);
     }
 
     /**
@@ -185,194 +55,34 @@ public class KeyValueCursor extends AsyncIteratorCursor<KeyValue> implements Bas
      * </code></pre>
      */
     @API(API.Status.MAINTAINED)
-    public static class Builder {
-        private FDBRecordContext context = null;
-        private final Subspace subspace;
-        private byte[] continuation = null;
-        private ScanProperties scanProperties = null;
-        private byte[] lowBytes = null;
-        private byte[] highBytes = null;
-        private EndpointType lowEndpoint = null;
-        private EndpointType highEndpoint = null;
+    public static class Builder extends KeyValueCursorBase.Builder<Builder> {
 
         protected Builder(@Nonnull Subspace subspace) {
-            this.subspace = subspace;
+            super(subspace);
         }
 
+        /*
+         * This will be deprecated: Use the {@link #newBuilder(Subspace)} instead
+         */
         public static Builder withSubspace(@Nonnull Subspace subspace) {
             return new Builder(subspace);
         }
 
-        @SuppressWarnings("unchecked")
-        public KeyValueCursor build() throws RecordCoreException {
-            if (subspace == null) {
-                throw new RecordCoreException("record subspace must be supplied");
-            }
-
-            if (context == null) {
-                throw new RecordCoreException("record context must be supplied");
-            }
-
-            if (scanProperties == null) {
-                throw new RecordCoreException("record scanProperties must be supplied");
-            }
-
-            if (lowBytes == null) {
-                lowBytes = subspace.pack();
-            }
-            if (highBytes == null) {
-                highBytes = subspace.pack();
-            }
-            if (lowEndpoint == null) {
-                lowEndpoint = EndpointType.TREE_START;
-            }
-            if (highEndpoint == null) {
-                highEndpoint = EndpointType.TREE_END;
-            }
-
-            // Handle the continuation and then turn the endpoints into one byte array on the
-            // left (inclusive) and another on the right (exclusive).
-            int prefixLength = calculatePrefixLength();
-
-            final boolean reverse = scanProperties.isReverse();
-            if (continuation != null) {
-                final byte[] continuationBytes = new byte[prefixLength + continuation.length];
-                System.arraycopy(lowBytes, 0, continuationBytes, 0, prefixLength);
-                System.arraycopy(continuation, 0, continuationBytes, prefixLength, continuation.length);
-                if (reverse) {
-                    highBytes = continuationBytes;
-                    highEndpoint = EndpointType.CONTINUATION;
-                } else {
-                    lowBytes = continuationBytes;
-                    lowEndpoint = EndpointType.CONTINUATION;
-                }
-            }
-            final Range byteRange = TupleRange.toRange(lowBytes, highBytes, lowEndpoint, highEndpoint);
-            lowBytes = byteRange.begin;
-            highBytes = byteRange.end;
-
-            // Begin the scan with the new arrays
-            KeySelector begin = KeySelector.firstGreaterOrEqual(lowBytes);
-            KeySelector end = KeySelector.firstGreaterOrEqual(highBytes);
-            if (scanProperties.getExecuteProperties().getSkip() > 0) {
-                if (reverse) {
-                    end = end.add(- scanProperties.getExecuteProperties().getSkip());
-                } else {
-                    begin = begin.add(scanProperties.getExecuteProperties().getSkip());
-                }
-            }
-
-            final int limit = scanProperties.getExecuteProperties().getReturnedRowLimit();
-            final StreamingMode streamingMode;
-            CursorStreamingMode propertiesStreamingMode = scanProperties.getCursorStreamingMode();
-            if (propertiesStreamingMode == CursorStreamingMode.ITERATOR) {
-                streamingMode = StreamingMode.ITERATOR;
-            } else if (propertiesStreamingMode == CursorStreamingMode.LARGE) {
-                streamingMode = StreamingMode.LARGE;
-            } else if (propertiesStreamingMode == CursorStreamingMode.MEDIUM) {
-                streamingMode = StreamingMode.MEDIUM;
-            } else if (propertiesStreamingMode == CursorStreamingMode.SMALL) {
-                streamingMode = StreamingMode.SMALL;
-            } else if (limit == ReadTransaction.ROW_LIMIT_UNLIMITED) {
-                streamingMode = StreamingMode.WANT_ALL;
-            } else {
-                streamingMode = StreamingMode.EXACT;
-            }
-
-            final AsyncIterator<? extends KeyValue> iterator;
-            ReadTransaction transaction = context.readTransaction(scanProperties.getExecuteProperties().getIsolationLevel().isSnapshot());
-            iterator = scanRange(transaction, begin, end, limit, reverse, streamingMode);
-
-            final CursorLimitManager limitManager = new CursorLimitManager(context, scanProperties);
-            final int valuesLimit = scanProperties.getExecuteProperties().getReturnedRowLimitOrMax();
-
-            return new KeyValueCursor(context, (AsyncIterator<KeyValue>)iterator, prefixLength, limitManager, valuesLimit);
+        public static Builder newBuilder(@Nonnull Subspace subspace) {
+            return new Builder(subspace);
         }
 
-        public Builder setContext(FDBRecordContext context) {
-            this.context = context;
-            return this;
-        }
-
-        @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
-        public Builder setContinuation(@Nullable byte[] continuation) {
-            this.continuation = continuation;
-            return this;
-        }
-
-        public Builder setScanProperties(@Nonnull ScanProperties scanProperties) {
-            this.scanProperties = scanProperties;
-            return this;
-        }
-
-        public Builder setRange(@Nonnull KeyRange range) {
-            setLow(range.getLowKey(), range.getLowEndpoint());
-            setHigh(range.getHighKey(), range.getHighEndpoint());
-            return this;
-        }
-
-        public Builder setRange(@Nonnull TupleRange range) {
-            setLow(range.getLow(), range.getLowEndpoint());
-            setHigh(range.getHigh(), range.getHighEndpoint());
-            return this;
-        }
-
-        public Builder setLow(@Nullable Tuple low, @Nonnull EndpointType lowEndpoint) {
-            return setLow(low != null ? subspace.pack(low) : subspace.pack(), lowEndpoint);
-        }
-
-        @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
-        public Builder setLow(@Nonnull byte[] lowBytes, @Nonnull EndpointType lowEndpoint) {
-            this.lowBytes = lowBytes;
-            this.lowEndpoint = lowEndpoint;
-            return this;
-        }
-
-        public Builder setHigh(@Nullable Tuple high, @Nonnull EndpointType highEndpoint) {
-            return setHigh(high != null ? subspace.pack(high) : subspace.pack(), highEndpoint);
-        }
-
-        @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
-        public Builder setHigh(@Nonnull byte[] highBytes, @Nonnull EndpointType highEndpoint) {
-            this.highBytes = highBytes;
-            this.highEndpoint = highEndpoint;
-            return this;
-        }
-
-        /**
-         * Perform the actual operation that generates the cursor that scans the range.
-         * @param transaction the transaction to operate on
-         * @param begin the start of the scan range
-         * @param end the end of the scan range
-         * @param limit the scan limit
-         * @param reverse whether the scan is in reverse order
-         * @param streamingMode the streaming mode
-         * @return an iterator over the range or key/values from the DB
-         */
-        @SuppressWarnings("java:S1452")
-        protected AsyncIterator<? extends KeyValue> scanRange(@Nonnull ReadTransaction transaction,
-                                                    @Nonnull KeySelector begin,
-                                                    @Nonnull KeySelector end,
-                                                    int limit, boolean reverse,
-                                                    @Nonnull StreamingMode streamingMode) {
-            return transaction
-                    .getRange(begin, end, limit, reverse, streamingMode)
+        public KeyValueCursor build() {
+            prepare();
+            final AsyncIterator<KeyValue> iterator = getTransaction()
+                    .getRange(getBegin(), getEnd(), getLimit(), isReverse(), getStreamingMode())
                     .iterator();
+            return new KeyValueCursor(getContext(), iterator, getPrefixLength(), getLimitManager(), getValuesLimit());
         }
 
-        /**
-         * Calculate the key prefix length for the returned values. This will be used to derive the primary key used in
-         * the calculated continuation.
-         * @return the length of the key prefix
-         */
-        protected int calculatePrefixLength() {
-            int prefixLength = subspace.pack().length;
-            while ((prefixLength < lowBytes.length) &&
-                   (prefixLength < highBytes.length) &&
-                   (lowBytes[prefixLength] == highBytes[prefixLength])) {
-                prefixLength++;
-            }
-            return prefixLength;
+        @Override
+        protected Builder getThis() {
+            return this;
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -81,7 +81,7 @@ public class KeyValueCursor extends KeyValueCursorBase<KeyValue> {
         }
 
         @Override
-        protected Builder getThis() {
+        protected Builder self() {
             return this;
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursor.java
@@ -32,7 +32,7 @@ import javax.annotation.Nonnull;
  * The basic cursor for scanning ranges of the FDB database.
  */
 @API(API.Status.MAINTAINED)
-public class KeyValueCursor extends KeyValueCursorBase {
+public class KeyValueCursor extends KeyValueCursorBase<KeyValue> {
 
     private KeyValueCursor(@Nonnull final FDBRecordContext context,
                              @Nonnull final AsyncIterator<KeyValue> iterator,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -177,7 +177,7 @@ public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIterat
      * A builder for {@link KeyValueCursorBase}.
      * @param <T> the type of the concrete subclass of the builder
      * This follows a pattern for nested builder class, hence is generic, so that subclasses can pass in their type (and
-     * implement {@link #getThis()}) to return the subclass builder correct type.
+     * implement {@link #self()}) to return the subclass builder correct type.
      *
      * <pre><code>
      * KeyValueCursorSubclass.Builder.withSubspace(subspace)
@@ -284,54 +284,54 @@ public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIterat
 
         public T setContext(FDBRecordContext context) {
             this.context = context;
-            return getThis();
+            return self();
         }
 
         @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
         public T setContinuation(@Nullable byte[] continuation) {
             this.continuation = continuation;
-            return getThis();
+            return self();
         }
 
         public T setScanProperties(@Nonnull ScanProperties scanProperties) {
             this.scanProperties = scanProperties;
-            return getThis();
+            return self();
         }
 
         public T setRange(@Nonnull KeyRange range) {
             setLow(range.getLowKey(), range.getLowEndpoint());
             setHigh(range.getHighKey(), range.getHighEndpoint());
-            return getThis();
+            return self();
         }
 
         public T setRange(@Nonnull TupleRange range) {
             setLow(range.getLow(), range.getLowEndpoint());
             setHigh(range.getHigh(), range.getHighEndpoint());
-            return getThis();
+            return self();
         }
 
         public T setLow(@Nullable Tuple low, @Nonnull EndpointType lowEndpoint) {
             setLow(low != null ? subspace.pack(low) : subspace.pack(), lowEndpoint);
-            return getThis();
+            return self();
         }
 
         @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
         public T setLow(@Nonnull byte[] lowBytes, @Nonnull EndpointType lowEndpoint) {
             this.lowBytes = lowBytes;
             this.lowEndpoint = lowEndpoint;
-            return getThis();
+            return self();
         }
 
         public T setHigh(@Nullable Tuple high, @Nonnull EndpointType highEndpoint) {
             setHigh(high != null ? subspace.pack(high) : subspace.pack(), highEndpoint);
-            return getThis();
+            return self();
         }
 
         @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
         public T setHigh(@Nonnull byte[] highBytes, @Nonnull EndpointType highEndpoint) {
             this.highBytes = highBytes;
             this.highEndpoint = highEndpoint;
-            return getThis();
+            return self();
         }
 
         /**
@@ -405,6 +405,12 @@ public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIterat
             }
         }
 
-        protected abstract T getThis();
+        /**
+         * {@code Self} pattern is used to return the appropriate THIS for the builder {@code set*} methods. In order to
+         * be able to string set methods together where some are implemented by a superclass, the self() method returns
+         * this with the subclass type.
+         * @return this object from the subclass
+         */
+        protected abstract T self();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -1,0 +1,407 @@
+/*
+ * KeyValueCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.KeySelector;
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.StreamingMode;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.async.AsyncIterator;
+import com.apple.foundationdb.record.CursorStreamingMode;
+import com.apple.foundationdb.record.EndpointType;
+import com.apple.foundationdb.record.KeyRange;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.cursors.AsyncIteratorCursor;
+import com.apple.foundationdb.record.cursors.BaseCursor;
+import com.apple.foundationdb.record.cursors.CursorLimitManager;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyByteString;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The base class for cursors scanning ranges of the FDB database.
+ */
+@API(API.Status.MAINTAINED)
+public abstract class KeyValueCursorBase extends AsyncIteratorCursor<KeyValue> implements BaseCursor<KeyValue> {
+    @Nonnull
+    private final FDBRecordContext context;
+    private final int prefixLength;
+    @Nonnull
+    private final CursorLimitManager limitManager;
+    private int valuesLimit;
+    // the pointer may be mutated, but the actual array must never be mutated or continuations will break
+    @Nullable
+    private byte[] lastKey;
+
+    protected KeyValueCursorBase(@Nonnull final FDBRecordContext context,
+                                 @Nonnull final AsyncIterator<KeyValue> iterator,
+                                 int prefixLength,
+                                 @Nonnull final CursorLimitManager limitManager,
+                                 int valuesLimit) {
+        super(context.getExecutor(), iterator);
+
+        this.context = context;
+        this.prefixLength = prefixLength;
+        this.limitManager = limitManager;
+        this.valuesLimit = valuesLimit;
+
+        context.instrument(FDBStoreTimer.DetailEvents.GET_SCAN_RANGE_RAW_FIRST_CHUNK, iterator.onHasNext());
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<RecordCursorResult<KeyValue>> onNext() {
+        if (nextResult != null && !nextResult.hasNext()) {
+            // This guard is needed to guarantee that if onNext is called multiple times after the cursor has
+            // returned a result without a value, then the same NoNextReason is returned each time. Without this guard,
+            // one might return SCAN_LIMIT_REACHED (for example) after returning a result with SOURCE_EXHAUSTED because
+            // of the tryRecordScan check.
+            return CompletableFuture.completedFuture(nextResult);
+        } else if (limitManager.tryRecordScan()) {
+            return iterator.onHasNext().thenApply(hasNext -> {
+                if (hasNext) {
+                    KeyValue kv = iterator.next();
+                    if (context != null) {
+                        context.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
+                        context.increment(FDBStoreTimer.Counts.LOAD_KEY_VALUE);
+                    }
+                    limitManager.reportScannedBytes(kv.getKey().length + kv.getValue().length);
+                    // Note that this mutates the pointer and NOT the array.
+                    // If the value of lastKey is mutated, the Continuation class will break.
+                    lastKey = kv.getKey();
+                    valuesSeen++;
+                    nextResult = RecordCursorResult.withNextValue(kv, continuationHelper());
+                } else if (valuesSeen >= valuesLimit) {
+                    // Source iterator hit limit that we passed down.
+                    nextResult = RecordCursorResult.withoutNextValue(continuationHelper(), NoNextReason.RETURN_LIMIT_REACHED);
+                } else {
+                    // Source iterator is exhausted.
+                    nextResult = RecordCursorResult.exhausted();
+                }
+                return nextResult;
+            });
+        } else { // a limit must have been exceeded
+            final Optional<NoNextReason> stoppedReason = limitManager.getStoppedReason();
+            if (!stoppedReason.isPresent()) {
+                throw new RecordCoreException("limit manager stopped KeyValueCursor but did not report a reason");
+            }
+            nextResult = RecordCursorResult.withoutNextValue(continuationHelper(), stoppedReason.get());
+            return CompletableFuture.completedFuture(nextResult);
+        }
+    }
+
+    @Override
+    @Nonnull
+    public RecordCursorResult<KeyValue> getNext() {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, onNext());
+    }
+
+    @Nonnull
+    private RecordCursorContinuation continuationHelper() {
+        return new Continuation(lastKey, prefixLength);
+    }
+
+    private static class Continuation implements RecordCursorContinuation {
+        @Nullable
+        private final byte[] lastKey;
+        private final int prefixLength;
+
+        public Continuation(@Nullable final byte[] lastKey, final int prefixLength) {
+            // Note that doing this without a full copy is dangerous if the array is ever mutated.
+            // Currently, this never happens and the only thing that changes is which array lastKey points to.
+            // However, if logic in KeyValueCursor or KeyValue changes, this could break continuations.
+            // To resolve it, we could resort to doing a full copy here, although that's somewhat expensive.
+            this.lastKey = lastKey;
+            this.prefixLength = prefixLength;
+        }
+
+        @Override
+        public boolean isEnd() {
+            return lastKey == null;
+        }
+
+        @Nonnull
+        @Override
+        public ByteString toByteString() {
+            if (lastKey == null) {
+                return ByteString.EMPTY;
+            }
+            ByteString base = ZeroCopyByteString.wrap(lastKey);
+            return base.substring(prefixLength, lastKey.length);
+        }
+
+        @Nullable
+        @Override
+        public byte[] toBytes() {
+            if (lastKey == null) {
+                return null;
+            }
+            return Arrays.copyOfRange(lastKey, prefixLength, lastKey.length);
+        }
+    }
+
+    /**
+     * A builder for {@link KeyValueCursorBase}.
+     * @param <T> the type of the concrete subclass of the builder
+     * This follows a pattern for nested builder class, hence is generic, so that subclasses can pass in their type (and
+     * implement {@link #getThis()}) to return the subclass builder correct type.
+     *
+     * <pre><code>
+     * KeyValueCursorSubclass.Builder.withSubspace(subspace)
+     *                     .setContext(context)
+     *                     .setRange(TupleRange.ALL)
+     *                     .setContinuation(null)
+     *                     .setScanProperties(ScanProperties.FORWARD_SCAN)
+     *                     .build()
+     * </code></pre>
+     */
+    @API(API.Status.MAINTAINED)
+    public abstract static class Builder<T extends Builder<T>> {
+
+        private int prefixLength;
+
+        private FDBRecordContext context = null;
+        private final Subspace subspace;
+        private byte[] continuation = null;
+        private ScanProperties scanProperties = null;
+        private byte[] lowBytes = null;
+        private byte[] highBytes = null;
+        private EndpointType lowEndpoint = null;
+        private EndpointType highEndpoint = null;
+        private ReadTransaction transaction;
+        private CursorLimitManager limitManager;
+        private int valuesLimit;
+        private int limit;
+        private boolean reverse;
+        private StreamingMode streamingMode;
+        private KeySelector begin;
+        private KeySelector end;
+
+        protected Builder(@Nonnull Subspace subspace) {
+            this.subspace = subspace;
+        }
+
+        /**
+         * Called by subclasses to perform chacks and initialize all the required properties needed to construct cursors.
+         */
+        protected void prepare() {
+            if (subspace == null) {
+                throw new RecordCoreException("record subspace must be supplied");
+            }
+
+            if (context == null) {
+                throw new RecordCoreException("record context must be supplied");
+            }
+
+            if (scanProperties == null) {
+                throw new RecordCoreException("record scanProperties must be supplied");
+            }
+
+            if (lowBytes == null) {
+                lowBytes = subspace.pack();
+            }
+            if (highBytes == null) {
+                highBytes = subspace.pack();
+            }
+            if (lowEndpoint == null) {
+                lowEndpoint = EndpointType.TREE_START;
+            }
+            if (highEndpoint == null) {
+                highEndpoint = EndpointType.TREE_END;
+            }
+
+            // Handle the continuation and then turn the endpoints into one byte array on the
+            // left (inclusive) and another on the right (exclusive).
+            prefixLength = calculatePrefixLength();
+
+            reverse = scanProperties.isReverse();
+            if (continuation != null) {
+                final byte[] continuationBytes = new byte[prefixLength + continuation.length];
+                System.arraycopy(lowBytes, 0, continuationBytes, 0, prefixLength);
+                System.arraycopy(continuation, 0, continuationBytes, prefixLength, continuation.length);
+                if (reverse) {
+                    highBytes = continuationBytes;
+                    highEndpoint = EndpointType.CONTINUATION;
+                } else {
+                    lowBytes = continuationBytes;
+                    lowEndpoint = EndpointType.CONTINUATION;
+                }
+            }
+            final Range byteRange = TupleRange.toRange(lowBytes, highBytes, lowEndpoint, highEndpoint);
+            lowBytes = byteRange.begin;
+            highBytes = byteRange.end;
+
+            // Begin the scan with the new arrays
+            begin = KeySelector.firstGreaterOrEqual(lowBytes);
+            end = KeySelector.firstGreaterOrEqual(highBytes);
+            if (scanProperties.getExecuteProperties().getSkip() > 0) {
+                if (reverse) {
+                    end = end.add(- scanProperties.getExecuteProperties().getSkip());
+                } else {
+                    begin = begin.add(scanProperties.getExecuteProperties().getSkip());
+                }
+            }
+
+            limit = scanProperties.getExecuteProperties().getReturnedRowLimit();
+            CursorStreamingMode propertiesStreamingMode = scanProperties.getCursorStreamingMode();
+            if (propertiesStreamingMode == CursorStreamingMode.ITERATOR) {
+                streamingMode = StreamingMode.ITERATOR;
+            } else if (propertiesStreamingMode == CursorStreamingMode.LARGE) {
+                streamingMode = StreamingMode.LARGE;
+            } else if (propertiesStreamingMode == CursorStreamingMode.MEDIUM) {
+                streamingMode = StreamingMode.MEDIUM;
+            } else if (propertiesStreamingMode == CursorStreamingMode.SMALL) {
+                streamingMode = StreamingMode.SMALL;
+            } else if (limit == ReadTransaction.ROW_LIMIT_UNLIMITED) {
+                streamingMode = StreamingMode.WANT_ALL;
+            } else {
+                streamingMode = StreamingMode.EXACT;
+            }
+
+            transaction = context.readTransaction(scanProperties.getExecuteProperties().getIsolationLevel().isSnapshot());
+            limitManager = new CursorLimitManager(context, scanProperties);
+            valuesLimit = scanProperties.getExecuteProperties().getReturnedRowLimitOrMax();
+        }
+
+        public T setContext(FDBRecordContext context) {
+            this.context = context;
+            return getThis();
+        }
+
+        @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
+        public T setContinuation(@Nullable byte[] continuation) {
+            this.continuation = continuation;
+            return getThis();
+        }
+
+        public T setScanProperties(@Nonnull ScanProperties scanProperties) {
+            this.scanProperties = scanProperties;
+            return getThis();
+        }
+
+        public T setRange(@Nonnull KeyRange range) {
+            setLow(range.getLowKey(), range.getLowEndpoint());
+            setHigh(range.getHighKey(), range.getHighEndpoint());
+            return getThis();
+        }
+
+        public T setRange(@Nonnull TupleRange range) {
+            setLow(range.getLow(), range.getLowEndpoint());
+            setHigh(range.getHigh(), range.getHighEndpoint());
+            return getThis();
+        }
+
+        public T setLow(@Nullable Tuple low, @Nonnull EndpointType lowEndpoint) {
+            setLow(low != null ? subspace.pack(low) : subspace.pack(), lowEndpoint);
+            return getThis();
+        }
+
+        @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
+        public T setLow(@Nonnull byte[] lowBytes, @Nonnull EndpointType lowEndpoint) {
+            this.lowBytes = lowBytes;
+            this.lowEndpoint = lowEndpoint;
+            return getThis();
+        }
+
+        public T setHigh(@Nullable Tuple high, @Nonnull EndpointType highEndpoint) {
+            setHigh(high != null ? subspace.pack(high) : subspace.pack(), highEndpoint);
+            return getThis();
+        }
+
+        @SpotBugsSuppressWarnings(value = "EI2", justification = "copies are expensive")
+        public T setHigh(@Nonnull byte[] highBytes, @Nonnull EndpointType highEndpoint) {
+            this.highBytes = highBytes;
+            this.highEndpoint = highEndpoint;
+            return getThis();
+        }
+
+        /**
+         * Calculate the key prefix length for the returned values. This will be used to derive the primary key used in
+         * the calculated continuation.
+         * @return the length of the key prefix
+         */
+        protected int calculatePrefixLength() {
+            int prefixLength = subspace.pack().length;
+            while ((prefixLength < lowBytes.length) &&
+                   (prefixLength < highBytes.length) &&
+                   (lowBytes[prefixLength] == highBytes[prefixLength])) {
+                prefixLength++;
+            }
+            return prefixLength;
+        }
+
+        public FDBRecordContext getContext() {
+            return context;
+        }
+
+        public int getLimit() {
+            return limit;
+        }
+
+        public int getPrefixLength() {
+            return prefixLength;
+        }
+
+        public ReadTransaction getTransaction() {
+            return transaction;
+        }
+
+        public CursorLimitManager getLimitManager() {
+            return limitManager;
+        }
+
+        public int getValuesLimit() {
+            return valuesLimit;
+        }
+
+        public boolean isReverse() {
+            return reverse;
+        }
+
+        public StreamingMode getStreamingMode() {
+            return streamingMode;
+        }
+
+        public KeySelector getBegin() {
+            return begin;
+        }
+
+        public KeySelector getEnd() {
+            return end;
+        }
+
+        protected abstract T getThis();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -52,10 +52,10 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * The base class for cursors scanning ranges of the FDB database.
- * @param <Kv> the type of the KeyValue that this cursor iterates over
+ * @param <K> the type of the KeyValue that this cursor iterates over
  */
 @API(API.Status.MAINTAINED)
-public abstract class KeyValueCursorBase<Kv extends KeyValue> extends AsyncIteratorCursor<Kv> implements BaseCursor<Kv> {
+public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIteratorCursor<K> implements BaseCursor<K> {
     @Nonnull
     private final FDBRecordContext context;
     private final int prefixLength;
@@ -67,7 +67,7 @@ public abstract class KeyValueCursorBase<Kv extends KeyValue> extends AsyncItera
     private byte[] lastKey;
 
     protected KeyValueCursorBase(@Nonnull final FDBRecordContext context,
-                                 @Nonnull final AsyncIterator<Kv> iterator,
+                                 @Nonnull final AsyncIterator<K> iterator,
                                  int prefixLength,
                                  @Nonnull final CursorLimitManager limitManager,
                                  int valuesLimit) {
@@ -83,7 +83,7 @@ public abstract class KeyValueCursorBase<Kv extends KeyValue> extends AsyncItera
 
     @Nonnull
     @Override
-    public CompletableFuture<RecordCursorResult<Kv>> onNext() {
+    public CompletableFuture<RecordCursorResult<K>> onNext() {
         if (nextResult != null && !nextResult.hasNext()) {
             // This guard is needed to guarantee that if onNext is called multiple times after the cursor has
             // returned a result without a value, then the same NoNextReason is returned each time. Without this guard,
@@ -93,7 +93,7 @@ public abstract class KeyValueCursorBase<Kv extends KeyValue> extends AsyncItera
         } else if (limitManager.tryRecordScan()) {
             return iterator.onHasNext().thenApply(hasNext -> {
                 if (hasNext) {
-                    Kv kv = iterator.next();
+                    K kv = iterator.next();
                     if (context != null) {
                         context.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
                         context.increment(FDBStoreTimer.Counts.LOAD_KEY_VALUE);
@@ -125,7 +125,7 @@ public abstract class KeyValueCursorBase<Kv extends KeyValue> extends AsyncItera
 
     @Override
     @Nonnull
-    public RecordCursorResult<Kv> getNext() {
+    public RecordCursorResult<K> getNext() {
         return context.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, onNext());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -192,7 +192,6 @@ public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIterat
     public abstract static class Builder<T extends Builder<T>> {
 
         private int prefixLength;
-
         private FDBRecordContext context = null;
         private final Subspace subspace;
         private byte[] continuation = null;
@@ -276,20 +275,7 @@ public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIterat
             }
 
             limit = scanProperties.getExecuteProperties().getReturnedRowLimit();
-            CursorStreamingMode propertiesStreamingMode = scanProperties.getCursorStreamingMode();
-            if (propertiesStreamingMode == CursorStreamingMode.ITERATOR) {
-                streamingMode = StreamingMode.ITERATOR;
-            } else if (propertiesStreamingMode == CursorStreamingMode.LARGE) {
-                streamingMode = StreamingMode.LARGE;
-            } else if (propertiesStreamingMode == CursorStreamingMode.MEDIUM) {
-                streamingMode = StreamingMode.MEDIUM;
-            } else if (propertiesStreamingMode == CursorStreamingMode.SMALL) {
-                streamingMode = StreamingMode.SMALL;
-            } else if (limit == ReadTransaction.ROW_LIMIT_UNLIMITED) {
-                streamingMode = StreamingMode.WANT_ALL;
-            } else {
-                streamingMode = StreamingMode.EXACT;
-            }
+            streamingMode = calcStreamingMode(scanProperties.getCursorStreamingMode(), limit);
 
             transaction = context.readTransaction(scanProperties.getExecuteProperties().getIsolationLevel().isSnapshot());
             limitManager = new CursorLimitManager(context, scanProperties);
@@ -401,6 +387,22 @@ public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIterat
 
         public KeySelector getEnd() {
             return end;
+        }
+
+        private StreamingMode calcStreamingMode(final CursorStreamingMode propertiesStreamingMode, final int limit) {
+            if (propertiesStreamingMode == CursorStreamingMode.ITERATOR) {
+                return StreamingMode.ITERATOR;
+            } else if (propertiesStreamingMode == CursorStreamingMode.LARGE) {
+                return StreamingMode.LARGE;
+            } else if (propertiesStreamingMode == CursorStreamingMode.MEDIUM) {
+                return StreamingMode.MEDIUM;
+            } else if (propertiesStreamingMode == CursorStreamingMode.SMALL) {
+                return StreamingMode.SMALL;
+            } else if (limit == ReadTransaction.ROW_LIMIT_UNLIMITED) {
+                return StreamingMode.WANT_ALL;
+            } else {
+                return StreamingMode.EXACT;
+            }
         }
 
         protected abstract T getThis();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -52,9 +52,10 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * The base class for cursors scanning ranges of the FDB database.
+ * @param <Kv> the type of the KeyValue that this cursor iterates over
  */
 @API(API.Status.MAINTAINED)
-public abstract class KeyValueCursorBase<KV extends KeyValue> extends AsyncIteratorCursor<KV> implements BaseCursor<KV> {
+public abstract class KeyValueCursorBase<Kv extends KeyValue> extends AsyncIteratorCursor<Kv> implements BaseCursor<Kv> {
     @Nonnull
     private final FDBRecordContext context;
     private final int prefixLength;
@@ -66,7 +67,7 @@ public abstract class KeyValueCursorBase<KV extends KeyValue> extends AsyncItera
     private byte[] lastKey;
 
     protected KeyValueCursorBase(@Nonnull final FDBRecordContext context,
-                                 @Nonnull final AsyncIterator<KV> iterator,
+                                 @Nonnull final AsyncIterator<Kv> iterator,
                                  int prefixLength,
                                  @Nonnull final CursorLimitManager limitManager,
                                  int valuesLimit) {
@@ -82,7 +83,7 @@ public abstract class KeyValueCursorBase<KV extends KeyValue> extends AsyncItera
 
     @Nonnull
     @Override
-    public CompletableFuture<RecordCursorResult<KV>> onNext() {
+    public CompletableFuture<RecordCursorResult<Kv>> onNext() {
         if (nextResult != null && !nextResult.hasNext()) {
             // This guard is needed to guarantee that if onNext is called multiple times after the cursor has
             // returned a result without a value, then the same NoNextReason is returned each time. Without this guard,
@@ -92,7 +93,7 @@ public abstract class KeyValueCursorBase<KV extends KeyValue> extends AsyncItera
         } else if (limitManager.tryRecordScan()) {
             return iterator.onHasNext().thenApply(hasNext -> {
                 if (hasNext) {
-                    KV kv = iterator.next();
+                    Kv kv = iterator.next();
                     if (context != null) {
                         context.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
                         context.increment(FDBStoreTimer.Counts.LOAD_KEY_VALUE);
@@ -124,7 +125,7 @@ public abstract class KeyValueCursorBase<KV extends KeyValue> extends AsyncItera
 
     @Override
     @Nonnull
-    public RecordCursorResult<KV> getNext() {
+    public RecordCursorResult<Kv> getNext() {
         return context.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, onNext());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -97,7 +97,7 @@ public abstract class KeyValueCursorBase extends AsyncIteratorCursor<KeyValue> i
                         context.increment(FDBStoreTimer.Counts.LOAD_SCAN_ENTRY);
                         context.increment(FDBStoreTimer.Counts.LOAD_KEY_VALUE);
                     }
-                    limitManager.reportScannedBytes(kv.getKey().length + kv.getValue().length);
+                    limitManager.reportScannedBytes((long)kv.getKey().length + (long)kv.getValue().length);
                     // Note that this mutates the pointer and NOT the array.
                     // If the value of lastKey is mutated, the Continuation class will break.
                     lastKey = kv.getKey();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
@@ -287,6 +287,7 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
                 inRange ? update(oldRecord, newRecord) : AsyncUtil.DONE);
     }
 
+    @SuppressWarnings("java:S3776") // Trying to simplify this method cognitive complexity seems to make it harder to follow
     private <M extends Message> CompletableFuture<Void> updateWriteOnlyByIndex(@Nonnull Index sourceIndex, @Nullable final FDBIndexableRecord<M> oldRecord, @Nullable final FDBIndexableRecord<M> newRecord) {
         IndexMaintainer sourceIndexMaintainer = state.store.getIndexMaintainer(sourceIndex);
         Tuple oldEntryKey = evaluateSingletonIndexKey(sourceIndex, sourceIndexMaintainer, oldRecord);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
@@ -159,15 +159,13 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
         }
         IndexScanRange scanRange = (IndexScanRange)scanBounds;
         Tuple mapper = createRemoteFetchMapper(commonPrimaryKeyLength);
-        final RecordCursor<KeyValue> keyValues = IndexPrefetchRangeKeyValueCursor.Builder.newBuilder(state.indexSubspace, mapper.pack())
+        final RecordCursor<MappedKeyValue> keyValues = IndexPrefetchRangeKeyValueCursor.Builder.newBuilder(state.indexSubspace, mapper.pack())
                 .setContext(state.context)
                 .setRange(scanRange.getScanRange())
                 .setContinuation(continuation)
                 .setScanProperties(scanProperties)
                 .build();
-        // Hard cast - Not ideal but likely needed to avoid complex implementation of specific cursor
-        RecordCursor<MappedKeyValue> mappedResults = keyValues.map(MappedKeyValue.class::cast);
-        return mappedResults.map(this::unpackRemoteFetchRecord);
+        return keyValues.map(this::unpackRemoteFetchRecord);
     }
 
     /**


### PR DESCRIPTION
This is clearing some technical debt from the original remote fetch implementation. One of the PR comments was to implement a base class for KeyValueCursor and extend it for the base KeyValueCursor and the RemoteFetch variant.
A few other fixes were made in support of SonarQube errors, but the overall logic should not have changed.