### PR TITLE
Resolve #1961: Indexing: Throw PartlyBuiltException when appropriate

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Indexing: Throw PartlyBuiltException when appropriate [(Issue #1961)](https://github.com/FoundationDB/fdb-record-layer/issues/1961)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -917,6 +917,10 @@ public abstract class IndexingBase {
             super(msg, keyValues);
             this.savedStamp = savedStamp;
         }
+
+        public IndexBuildProto.IndexBuildIndexingStamp getSavedStamp() {
+            return savedStamp;
+        }
     }
 
     public static PartlyBuiltException getAPartlyBuildExceptionIfApplicable(@Nullable Throwable ex) {


### PR DESCRIPTION
  This exception provides the caller extra information about the existing indexing method.