### PR TITLE
Expose version change info from FDBRecordStore

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Refactor KeyValueCursor to allow extension [(Issue #1957)](https://github.com/FoundationDB/fdb-record-layer/issues/1957)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Expose version change info from FDBRecordStore [(Issue #1965)](https://github.com/FoundationDB/fdb-record-layer/issues/1965)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Indexing: Throw PartlyBuiltException when appropriate [(Issue #1961)](https://github.com/FoundationDB/fdb-record-layer/issues/1961)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -354,11 +354,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * Get the provider for the record store's meta-data.
-     * @return the meta-data source to use
+     * Returns {@code true} if the RecordMetadata version is changed in the RecordStore. Alternatively, returns
+     * {@code false} if the version is either not checked (checkVersion() not called) or it is up-to-date.
+     * @return the versionChanged boolean
      */
     @Nonnull
-    public Boolean getVersionChanged() {
+    public boolean getVersionChanged() {
         return versionChanged;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -2031,7 +2031,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         }
         CompletableFuture<Boolean> result = storeHeaderFuture.thenCompose(storeHeader -> checkVersion(storeHeader, userVersionChecker));
         return context.instrument(FDBStoreTimer.Events.CHECK_VERSION, result).thenApply(versionChanged -> {
-            this.versionChanged |= versionChanged
+            this.versionChanged |= versionChanged;
             return versionChanged;
         });
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -2031,9 +2031,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         }
         CompletableFuture<Boolean> result = storeHeaderFuture.thenCompose(storeHeader -> checkVersion(storeHeader, userVersionChecker));
         return context.instrument(FDBStoreTimer.Events.CHECK_VERSION, result).thenApply(versionChanged -> {
-            if (!this.versionChanged && versionChanged) {
-                this.versionChanged = true;
-            }
+            this.versionChanged |= versionChanged
             return versionChanged;
         });
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -359,7 +359,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @return the versionChanged boolean
      */
     @Nonnull
-    public boolean getVersionChanged() {
+    public boolean isVersionChanged() {
         return versionChanged;
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -72,6 +72,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -118,6 +119,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
             FDBRecordStore recordStore = storeBuilder(context, metaDataBuilder).createOrOpen();
+            assertTrue(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -126,6 +128,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
 
             metaDataBuilder.addIndex("MySimpleRecord", newIndex);
             recordStore = recordStore.asBuilder().setMetaDataProvider(metaDataBuilder).open();
+            assertTrue(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -136,6 +139,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             final RecordMetaData staleMetaData = metaDataBuilder.getRecordMetaData();
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             recordStore = recordStore.asBuilder().setMetaDataProvider(metaDataBuilder).open();
+            assertTrue(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getDisabledIndexNames());
@@ -170,6 +174,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             FDBRecordStore recordStore = storeBuilder(context, origMetaData)
                     .setMetaDataStore(metaDataStore)
                     .createOrOpen();
+            assertTrue(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -182,6 +187,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             recordStore = storeBuilder(context, origMetaData)
                     .setMetaDataStore(metaDataStore)
                     .open();
+            assertTrue(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -194,6 +200,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             metaDataStore.saveRecordMetaData(metaDataBuilder.getRecordMetaData());
             recordStore = FDBRecordStore.newBuilder().setContext(context).setSubspace(expectedSubspace).setMetaDataStore(metaDataStore).open();
+            assertTrue(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getDisabledIndexNames());
@@ -213,6 +220,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
             FDBRecordStore recordStore = storeBuilder(context, metaDataBuilder).uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(metaDataBuilder.getVersion(), recordStore.getRecordMetaData().getVersion());
@@ -220,6 +228,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
 
             metaDataBuilder.addIndex("MySimpleRecord", newIndex);
             recordStore = recordStore.asBuilder().setMetaDataProvider(metaDataBuilder).uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -229,11 +238,13 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             final RecordMetaData staleMetaData = metaDataBuilder.getRecordMetaData();
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             recordStore = storeBuilder(context, metaDataBuilder).uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 2, recordStore.getRecordMetaData().getVersion());
 
             recordStore = recordStore.asBuilder().setMetaDataProvider(staleMetaData).uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -257,13 +268,14 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
 
             RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
             RecordMetaData origMetaData = metaDataBuilder.getRecordMetaData();
-            int version = origMetaData.getVersion();
 
             FDBRecordStore recordStore = storeBuilder(context, origMetaData)
                     .setMetaDataStore(metaDataStore)
                     .uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
+            int version = origMetaData.getVersion();
             assertEquals(version, recordStore.getRecordMetaData().getVersion());
 
             metaDataBuilder.addIndex("MySimpleRecord", newIndex);
@@ -273,6 +285,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             recordStore = FDBRecordStore.newBuilder().setContext(context).setSubspace(expectedSubspace)
                     .setMetaDataStore(metaDataStore).setMetaDataProvider(origMetaData)
                     .uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -285,6 +298,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             metaDataStore.saveAndSetCurrent(metaDataBuilder.getRecordMetaData().toProto()).join();
             recordStore = FDBRecordStore.newBuilder().setContext(context).setKeySpacePath(path).setMetaDataStore(metaDataStore).uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 2, recordStore.getRecordMetaData().getVersion());
@@ -292,6 +306,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             // The stale meta-data store uses the cached meta-data, hence the old version in the final assert
             recordStore = FDBRecordStore.newBuilder().setContext(context).setSubspace(expectedSubspace)
                     .setMetaDataStore(staleMetaDataStore).uncheckedOpen();
+            assertFalse(recordStore.getVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -825,6 +840,65 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             assertEquals(1, timer.getCount(FDBStoreTimer.Events.ESTIMATE_SIZE), "should have only checked the database for the size once");
             assertEquals(ImmutableSet.of(indexName1, indexName2), recordStore.getRecordStoreState().getDisabledIndexNames());
 
+            commit(context);
+        }
+    }
+
+    @Test
+    public void testVersionChangedFlagAfterOpening() {
+        KeySpacePath metaDataPath;
+        Subspace metaDataSubspace;
+        try (FDBRecordContext context = fdb.openContext()) {
+            metaDataPath = TestKeySpace.getKeyspacePath("record-test", "unit", "metadataStore");
+            metaDataSubspace = metaDataPath.toSubspace(context);
+            context.ensureActive().clear(Range.startsWith(metaDataSubspace.pack()));
+            context.commit();
+        }
+
+        // Test call getVersionChanged after unchecked opening a record store
+        try (FDBRecordContext context = fdb.openContext()) {
+            FDBRecordStore store = FDBRecordStore.newBuilder()
+                    .setContext(context)
+                    .setMetaDataProvider(simpleMetaData(NO_HOOK))
+                    .setKeySpacePath(path)
+                    .uncheckedOpen();
+            assertFalse(store.getVersionChanged());
+            commit(context);
+        }
+
+        // Test call getVersionChanged after creating a new store
+        var metadata = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
+        try (FDBRecordContext context = fdb.openContext()) {
+            FDBRecordStore store = FDBRecordStore.newBuilder()
+                    .setContext(context)
+                    .setMetaDataProvider(metadata)
+                    .setKeySpacePath(path)
+                    .createOrOpen();
+            assertTrue(store.getVersionChanged());
+            commit(context);
+        }
+
+        // Test call getVersionChanged after opening an already created store
+        try (FDBRecordContext context = fdb.openContext()) {
+            FDBRecordStore store = FDBRecordStore.newBuilder()
+                    .setContext(context)
+                    .setMetaDataProvider(metadata)
+                    .setKeySpacePath(path)
+                    .createOrOpen();
+            assertFalse(store.getVersionChanged());
+            commit(context);
+        }
+
+        // Test call getVersionChanged after opening an already created store with new version of metadata
+        Index newIndex = new Index("newIndex", concatenateFields("str_value_indexed", "num_value_3_indexed"));
+        metadata.addIndex("MySimpleRecord", newIndex);
+        try (FDBRecordContext context = fdb.openContext()) {
+            FDBRecordStore store = FDBRecordStore.newBuilder()
+                    .setContext(context)
+                    .setMetaDataProvider(metadata)
+                    .setKeySpacePath(path)
+                    .createOrOpen();
+            assertTrue(store.getVersionChanged());
             commit(context);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -120,7 +120,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
             FDBRecordStore recordStore = storeBuilder(context, metaDataBuilder).createOrOpen();
-            assertTrue(recordStore.getVersionChanged());
+            assertTrue(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -129,7 +129,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
 
             metaDataBuilder.addIndex("MySimpleRecord", newIndex);
             recordStore = recordStore.asBuilder().setMetaDataProvider(metaDataBuilder).open();
-            assertTrue(recordStore.getVersionChanged());
+            assertTrue(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -140,7 +140,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             final RecordMetaData staleMetaData = metaDataBuilder.getRecordMetaData();
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             recordStore = recordStore.asBuilder().setMetaDataProvider(metaDataBuilder).open();
-            assertTrue(recordStore.getVersionChanged());
+            assertTrue(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getDisabledIndexNames());
@@ -175,7 +175,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             FDBRecordStore recordStore = storeBuilder(context, origMetaData)
                     .setMetaDataStore(metaDataStore)
                     .createOrOpen();
-            assertTrue(recordStore.getVersionChanged());
+            assertTrue(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -188,7 +188,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             recordStore = storeBuilder(context, origMetaData)
                     .setMetaDataStore(metaDataStore)
                     .open();
-            assertTrue(recordStore.getVersionChanged());
+            assertTrue(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
@@ -201,7 +201,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             metaDataStore.saveRecordMetaData(metaDataBuilder.getRecordMetaData());
             recordStore = FDBRecordStore.newBuilder().setContext(context).setSubspace(expectedSubspace).setMetaDataStore(metaDataStore).open();
-            assertTrue(recordStore.getVersionChanged());
+            assertTrue(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertEquals(recordStore.getRecordStoreState(), recordStore.getRecordStoreState());
             assertEquals(Collections.singleton(newIndex2.getName()), recordStore.getRecordStoreState().getDisabledIndexNames());
@@ -221,7 +221,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
             FDBRecordStore recordStore = storeBuilder(context, metaDataBuilder).uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(metaDataBuilder.getVersion(), recordStore.getRecordMetaData().getVersion());
@@ -229,7 +229,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
 
             metaDataBuilder.addIndex("MySimpleRecord", newIndex);
             recordStore = recordStore.asBuilder().setMetaDataProvider(metaDataBuilder).uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -239,13 +239,13 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             final RecordMetaData staleMetaData = metaDataBuilder.getRecordMetaData();
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             recordStore = storeBuilder(context, metaDataBuilder).uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 2, recordStore.getRecordMetaData().getVersion());
 
             recordStore = recordStore.asBuilder().setMetaDataProvider(staleMetaData).uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -273,7 +273,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             FDBRecordStore recordStore = storeBuilder(context, origMetaData)
                     .setMetaDataStore(metaDataStore)
                     .uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             int version = origMetaData.getVersion();
@@ -286,7 +286,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             recordStore = FDBRecordStore.newBuilder().setContext(context).setSubspace(expectedSubspace)
                     .setMetaDataStore(metaDataStore).setMetaDataProvider(origMetaData)
                     .uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -299,7 +299,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             metaDataBuilder.addIndex("MySimpleRecord", newIndex2);
             metaDataStore.saveAndSetCurrent(metaDataBuilder.getRecordMetaData().toProto()).join();
             recordStore = FDBRecordStore.newBuilder().setContext(context).setKeySpacePath(path).setMetaDataStore(metaDataStore).uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 2, recordStore.getRecordMetaData().getVersion());
@@ -307,7 +307,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             // The stale meta-data store uses the cached meta-data, hence the old version in the final assert
             recordStore = FDBRecordStore.newBuilder().setContext(context).setSubspace(expectedSubspace)
                     .setMetaDataStore(staleMetaDataStore).uncheckedOpen();
-            assertFalse(recordStore.getVersionChanged());
+            assertFalse(recordStore.isVersionChanged());
             assertEquals(expectedSubspace, recordStore.getSubspace());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
             assertEquals(version + 1, recordStore.getRecordMetaData().getVersion());
@@ -865,7 +865,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
                     .setKeySpacePath(path)
                     .uncheckedOpen();
             // No updates to the storeHeader.
-            assertFalse(store.getVersionChanged());
+            assertFalse(store.isVersionChanged());
             commit(context);
         }
 
@@ -876,10 +876,10 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
                     .setMetaDataProvider(metadata)
                     .setKeySpacePath(path)
                     .uncheckedOpen();
-            assertFalse(store.getVersionChanged());
+            assertFalse(store.isVersionChanged());
             // Explicit call to checkVersion() sets the metadataVersion in the storeHeader.
             store.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_EXISTS).thenApply(changed -> {
-                assertTrue(store.getVersionChanged());
+                assertTrue(store.isVersionChanged());
                 return AsyncUtil.DONE;
             });
             commit(context);
@@ -895,7 +895,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
                     .setKeySpacePath(path)
                     .createOrOpen();
             // createOrOpen() calls the checkVersion() which bumps up the version.
-            assertTrue(store.getVersionChanged());
+            assertTrue(store.isVersionChanged());
             commit(context);
         }
 
@@ -907,7 +907,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
                     .setKeySpacePath(path)
                     .createOrOpen();
             // createOrOpen() calls the checkVersion() but the metadata is already up-to-date
-            assertFalse(store.getVersionChanged());
+            assertFalse(store.isVersionChanged());
             commit(context);
         }
 
@@ -921,10 +921,10 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
                     .setMetaDataProvider(metadata)
                     .setKeySpacePath(path)
                     .uncheckedOpen();
-            assertFalse(store.getVersionChanged());
+            assertFalse(store.isVersionChanged());
             // checkVersion() will bump up the version
             store.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.NONE).thenApply(changed -> {
-                assertTrue(store.getVersionChanged());
+                assertTrue(store.isVersionChanged());
                 return AsyncUtil.DONE;
             });
             commit(context);
@@ -939,13 +939,13 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
                     .setMetaDataProvider(metadata)
                     .setKeySpacePath(path)
                     .uncheckedOpen();
-            assertFalse(store.getVersionChanged());
+            assertFalse(store.isVersionChanged());
             // The checkVersion() will bump up the metadata version in the first iteration (i=0), while it won't have
             // any effect on the other following calls. However, getVersionChanged() should return true even if there
             // is change in one of the calls.
             for (var i = 0; i < 5; i++) {
                 store.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.NONE).thenApply(changed -> {
-                    assertTrue(store.getVersionChanged());
+                    assertTrue(store.isVersionChanged());
                     return AsyncUtil.DONE;
                 });
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -951,8 +951,6 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             }
             commit(context);
         }
-
-
     }
 
     @Nonnull


### PR DESCRIPTION
Adds a boolean flag `VersionChanged` to indicate if the version has been changed while creating/opening a new store. 

When a RecordStore is created via `createOrOpen()`, `create()` or `open()` methods in `FDBRecordStore.Builder`, the `checkVersion()` is called underneath to update the store versions to the newest possible values and returns a boolean value. `VersionChanged` persists this boolean value that can be retrieved from the `Builder` _after_ creating/opening a (new) store. 

The version changed info can therefore be made available anywhere the store is built.

fixes #1965 