### PR TITLE
Resolves #1967: Consider alternative mechanism of loading records which favors gets over scans

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Add optional mechanism for loading records via single-key gets instead of a scan [(Issue #1967)](https://github.com/FoundationDB/fdb-record-layer/issues/1967)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
@@ -44,6 +44,25 @@ public final class FDBRecordStoreProperties {
     public static final RecordLayerPropertyKey<Boolean> UNROLL_SINGLE_RECORD_DELETES = RecordLayerPropertyKey.booleanPropertyKey(
             "com.apple.foundationdb.record.recordstore.unroll_single_record_deletes", true);
 
+    /**
+     * Whether {@linkplain com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore#loadRecord(Tuple) loading a record}
+     * should use multiple single-key gets instead of a single scan. This option may help latencies and storage server
+     * throughput on certain workloads when running with an LSM-based FDB storage engine. Note that records are stored
+     * across multiple keys in the Record Layer to support
+     * {@linkplain com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion versionstamps} and records
+     * larger than the {@linkplain com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore#VALUE_SIZE_LIMIT max value size}.
+     * Those keys are stored contiguously, and so they can be scanned with a single small range read, but if the data
+     * are stored on an LSM, then the single scan may be less efficient than multiple gets.
+     *
+     * <p>
+     * At the moment, this option is not recommended except during performance testing. Adopters should verify whether
+     * this change increases their measured performance on their workload before using.
+     * </p>
+     */
+    @API(API.Status.EXPERIMENTAL)
+    public static final RecordLayerPropertyKey<Boolean> LOAD_RECORDS_VIA_GETS = RecordLayerPropertyKey.booleanPropertyKey(
+            "com.apple.foundationdb.record.recordstore.load_records_via_gets", true);
+
     private FDBRecordStoreProperties() {
         throw new RecordCoreException("should not instantiate class of static prop");
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -322,7 +322,7 @@ public class SplitHelper {
         final byte[] unsplitKey = recordSubspace.pack(UNSPLIT_RECORD);
         final byte[] startSplitKey = recordSubspace.pack(START_SPLIT_RECORD);
 
-        // Cover the whole record range in a singe read conflict range to decrease size of final commit request
+        // Cover the whole record range in a single read conflict range to decrease size of final commit request
         // (when compared to having individual read conflicts keys added for each key read)
         final Range recordRange = recordSubspace.range();
         tr.addReadConflictRangeIfNotSnapshot(recordRange.begin, recordRange.end);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -142,6 +142,13 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
             path.deleteAllData(context);
             return null;
         });
+
+        // Reset these indexes added and last modified versions, which can be updated during tests.
+        // For example, adding the indexes to a RecordMetaDataBuilder can update these fields
+        COUNT_INDEX.setAddedVersion(0);
+        COUNT_INDEX.setLastModifiedVersion(0);
+        COUNT_UPDATES_INDEX.setAddedVersion(0);
+        COUNT_UPDATES_INDEX.setLastModifiedVersion(0);
     }
 
     @AfterEach

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -38,9 +38,9 @@ import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLaye
 import com.apple.foundationdb.record.query.plan.PlannableIndexTypes;
 import com.apple.foundationdb.record.query.plan.QueryPlanner;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
-import com.apple.foundationdb.record.query.plan.debug.DebuggerWithSymbolTables;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
+import com.apple.foundationdb.record.query.plan.debug.DebuggerWithSymbolTables;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
@@ -109,21 +109,30 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
     }
 
     public FDBRecordContext openContext() {
-        return openContext(RecordLayerPropertyStorage.newBuilder());
+        return openContext(RecordLayerPropertyStorage.getEmptyInstance());
     }
 
-    public FDBRecordContext openContext(@Nonnull final RecordLayerPropertyStorage.Builder propsBuilder) {
-        final FDBRecordContextConfig config = contextConfig(propsBuilder).build();
+    public FDBRecordContext openContext(@Nonnull final RecordLayerPropertyStorage props) {
+        return openContext(props.toBuilder());
+    }
+
+    public FDBRecordContext openContext(@Nonnull final RecordLayerPropertyStorage.Builder props) {
+        final FDBRecordContextConfig config = contextConfig(props).build();
         return fdb.openContext(config);
     }
 
-    protected FDBRecordContextConfig.Builder contextConfig(@Nonnull final RecordLayerPropertyStorage.Builder propsBuilder) {
+    private FDBRecordContextConfig.Builder contextConfig(@Nonnull final RecordLayerPropertyStorage.Builder props) {
         return FDBRecordContextConfig.newBuilder()
                 .setTimer(timer)
                 .setMdcContext(ImmutableMap.of("uuid", UUID.randomUUID().toString()))
                 .setTrackOpen(true)
                 .setSaveOpenStackTrace(true)
-                .setRecordContextProperties(propsBuilder.build());
+                .setRecordContextProperties(addDefaultProps(props).build());
+    }
+
+    // By default, do not set any props by default, but leave open for sub-classes to extend
+    protected RecordLayerPropertyStorage.Builder addDefaultProps(RecordLayerPropertyStorage.Builder props) {
+        return props;
     }
 
     @BeforeEach

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
@@ -125,21 +125,6 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
         }
     }
 
-    public static Stream<Pair<Boolean, Boolean>> splitAndSuffixArgs() {
-        // Note that splitLongRecords="true" && omitUnsplitSuffix="true" is not valid
-        return Stream.of(false, true).flatMap(splitLongRecords ->
-                (splitLongRecords ? Stream.of(false) : Stream.of(false, true)).map(omitUnsplitSuffix ->
-                        Pair.of(splitLongRecords, omitUnsplitSuffix)));
-    }
-
-    @Nonnull
-    public static Stream<Arguments> splitSuffixAndUnrollArgs() {
-        // Note that splitLongRecords="true" && omitUnsplitSuffix="true" is not valid
-        return splitAndSuffixArgs().flatMap(splitAndSuffix ->
-                        Stream.of(false, true).map(unrollSingleRecordDeletes ->
-                                Arguments.of(splitAndSuffix.getLeft(), splitAndSuffix.getRight(), unrollSingleRecordDeletes)));
-    }
-
     static class SplitHelperTestConfig {
         private final boolean splitLongRecords;
         private final boolean omitUnsplitSuffix;
@@ -728,13 +713,6 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
     private FDBRawRecord loadWithSplit(@Nonnull FDBRecordContext context, @Nonnull Tuple key, SplitHelperTestConfig testConfig,
                                        @Nullable FDBStoredSizes expectedSizes, @Nullable byte[] expectedContents) {
         return loadWithSplit(context, key, testConfig, expectedSizes, expectedContents, null);
-    }
-
-    private static Stream<Arguments> loadWithSplit() {
-        return splitAndSuffixArgs().flatMap(splitAndSuffix ->
-                Stream.of(false, true).flatMap(unroll ->
-                        Stream.of(false, true).map(loadViaGets ->
-                                Arguments.of(splitAndSuffix.getLeft(), splitAndSuffix.getRight(), unroll, loadViaGets))));
     }
 
     @MethodSource("testConfigs")

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -40,7 +40,6 @@ import com.apple.foundationdb.record.provider.common.text.TextSamples;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
@@ -222,8 +221,9 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     @Override
-    protected FDBRecordContextConfig.Builder contextConfig(@Nonnull final RecordLayerPropertyStorage.Builder propsBuilder) {
-        return super.contextConfig(propsBuilder.addProp(LuceneRecordContextProperties.LUCENE_EXECUTOR_SERVICE, (Supplier<ExecutorService>)() -> executorService));
+    protected RecordLayerPropertyStorage.Builder addDefaultProps(final RecordLayerPropertyStorage.Builder props) {
+        return super.addDefaultProps(props)
+                .addProp(LuceneRecordContextProperties.LUCENE_EXECUTOR_SERVICE, (Supplier<ExecutorService>)() -> executorService);
     }
 
     protected void openRecordStoreWithNgramIndex(FDBRecordContext context, boolean edgesOnly, int minSize, int maxSize) {
@@ -269,7 +269,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         hook.apply(metaDataBuilder);
         recordStore = getStoreBuilder(context, metaDataBuilder.getRecordMetaData())
                 .setSerializer(TextIndexTestUtils.COMPRESSING_SERIALIZER)
-                .uncheckedOpen();
+                .createOrOpen();
         setupPlanner(null);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -50,7 +50,6 @@ import com.apple.foundationdb.record.provider.common.text.TextSamples;
 import com.apple.foundationdb.record.provider.foundationdb.FDBIndexedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
@@ -348,8 +347,9 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Override
-    protected FDBRecordContextConfig.Builder contextConfig(@Nonnull final RecordLayerPropertyStorage.Builder propsBuilder) {
-        return super.contextConfig(propsBuilder.addProp(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED, true));
+    protected RecordLayerPropertyStorage.Builder addDefaultProps(final RecordLayerPropertyStorage.Builder props) {
+        return super.addDefaultProps(props)
+                .addProp(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED, true);
     }
 
     private LuceneScanBounds fullTextSearch(Index index, String search) {


### PR DESCRIPTION
This adds a property-controlled method for reading single records from FDB. It issues multiple single-key gets instead of one scan (for reasons detailed in #1967). This is off by default, because it is expected that this will perform worse on B-tree based storage engines (including the default SSD storage engine), and it is highly experimental. But once in, users can adjust this configuration to configure how reads are orchestrated in their own experiments.

This resolves #1967.