### PR TITLE
Some improvements for Lucene queries against joined indexes

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
@@ -128,7 +128,13 @@ public class SortedRecordSerializer<M extends Message> {
 
         @Nullable
         @Override
-        public Map<String, FDBStoredRecord<? extends Message>> getConstituents() {
+        public FDBSyntheticRecord getSyntheticRecord() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public String getConstituentName() {
             return null;
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
@@ -134,6 +134,12 @@ public class SortedRecordSerializer<M extends Message> {
 
         @Nullable
         @Override
+        public FDBQueriedRecord<M> getConstituent(@Nonnull String constituentName) {
+            return null;
+        }
+
+        @Nullable
+        @Override
         public String getConstituentName() {
             return null;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
@@ -500,29 +500,29 @@ public class SyntheticRecordPlannerTest {
             //      returns items that should not be in the index anymore.
             //
             Assertions.assertEquals(3, join.size());
-            var simpleRecord = Verify.verifyNotNull(Verify.verifyNotNull(join.get(0).getConstituents()).get("simple")).getRecord();
-            Assertions.assertNull(Verify.verifyNotNull(join.get(0).getConstituents()).get("other"));
+            var simpleRecord = Verify.verifyNotNull(join.get(0).getConstituent("simple")).getRecord();
+            Assertions.assertNull(join.get(0).getConstituent("other"));
             Descriptors.Descriptor simpleDescriptor = simpleRecord.getDescriptorForType();
             Assertions.assertEquals(0L, simpleRecord.getField(simpleDescriptor.findFieldByName("rec_no")));
             Assertions.assertEquals("even", simpleRecord.getField(simpleDescriptor.findFieldByName("str_value")));
             Assertions.assertEquals(1001L, simpleRecord.getField(simpleDescriptor.findFieldByName("other_rec_no")));
 
-            simpleRecord = Verify.verifyNotNull(Verify.verifyNotNull(join.get(1).getConstituents()).get("simple")).getRecord();
+            simpleRecord = Verify.verifyNotNull(join.get(1).getConstituent("simple")).getRecord();
             simpleDescriptor = simpleRecord.getDescriptorForType();
             Assertions.assertEquals(0L, simpleRecord.getField(simpleDescriptor.findFieldByName("rec_no")));
             Assertions.assertEquals("even", simpleRecord.getField(simpleDescriptor.findFieldByName("str_value")));
             Assertions.assertEquals(1001L, simpleRecord.getField(simpleDescriptor.findFieldByName("other_rec_no")));
-            var otherRecord = Verify.verifyNotNull(Verify.verifyNotNull(join.get(1).getConstituents()).get("other")).getRecord();
+            var otherRecord = Verify.verifyNotNull(join.get(1).getConstituent("other")).getRecord();
             Descriptors.Descriptor otherDescriptor = otherRecord.getDescriptorForType();
             Assertions.assertEquals(1001L, otherRecord.getField(otherDescriptor.findFieldByName("rec_no")));
             Assertions.assertEquals(1, otherRecord.getField(otherDescriptor.findFieldByName("num_value_3")));
 
-            simpleRecord = Verify.verifyNotNull(Verify.verifyNotNull(join.get(2).getConstituents()).get("simple")).getRecord();
+            simpleRecord = Verify.verifyNotNull(join.get(2).getConstituent("simple")).getRecord();
             simpleDescriptor = simpleRecord.getDescriptorForType();
             Assertions.assertEquals(2L, simpleRecord.getField(simpleDescriptor.findFieldByName("rec_no")));
             Assertions.assertEquals("even", simpleRecord.getField(simpleDescriptor.findFieldByName("str_value")));
             Assertions.assertEquals(1003L, simpleRecord.getField(simpleDescriptor.findFieldByName("other_rec_no")));
-            Assertions.assertNull(Verify.verifyNotNull(join.get(2).getConstituents()).get("other"));
+            Assertions.assertNull(join.get(2).getConstituent("other"));
             
             // same query except setting required fields to get a covering scan
             query = RecordQuery.newBuilder()

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -463,7 +463,26 @@ public class LucenePlanner extends RecordQueryPlanner {
     private boolean validateIndexField(@Nonnull LucenePlanState state, @Nonnull String field) {
         // Can only check that the field name given corresponds to some top-level branch to an indexed field.
         for (LuceneIndexExpressions.DocumentFieldDerivation fieldDerivation : state.documentFields.values()) {
-            if (fieldDerivation.getRecordFieldPath().get(0).equals(field)) {
+            if (fieldMatchesPath(fieldDerivation, field)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean fieldMatchesPath(@Nonnull LuceneIndexExpressions.DocumentFieldDerivation fieldDerivation,
+                                     @Nonnull String field) {
+        StringBuilder path = null;
+        for (String pathElement : fieldDerivation.getRecordFieldPath()) {
+            if (path == null) {
+                path = new StringBuilder(pathElement);
+            } else {
+                path.append("_").append(pathElement);
+            }
+            if (path.length() > field.length()) {
+                break;
+            }
+            if (path.toString().equals(field)) {
                 return true;
             }
         }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -414,7 +414,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
             assertEquals(1, queriedRecordList.size());
             FDBQueriedRecord<Message> queriedRecord = queriedRecordList.get(0);
             
-            List<LuceneHighlighting.HighlightedTerm> highlightedTerms = LuceneHighlighting.highlightedTermsForMessage(queriedRecord);
+            List<LuceneHighlighting.HighlightedTerm> highlightedTerms = LuceneHighlighting.highlightedTermsForMessage(queriedRecord, null);
             assertEquals(1, highlightedTerms.size());
             LuceneHighlighting.HighlightedTerm highlightedTerm = highlightedTerms.get(0);
             assertEquals("text", highlightedTerm.getFieldName());


### PR DESCRIPTION
1. Allow longer field names for Lucene validation.
    In effect, any path prefix is accepted.
    The fields in the Lucene query component field list sometimes reflect more of the path, particularly with a Lucene join index.

2. Allow highlighting to work on a constituent record from a joined record Lucene index.
    For this we need the constituent field name and to adjust the index expression and terms map accordingly.

3. Generalize constituent handling around `FDBQueriedRecord` beyond just `getConstituents`.
    Can also get a particular constituent, which requires a little work in the case of covering.
    This adds some non-abstract methods, but there doesn't seem any philosophical objection to that.
