### PR TITLE
Resolves #1970: Add instrumentation of empty scans

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** A new counter, `EMPTY_SCANS`, tracks how many empty range reads are executed [(Issue #1970)](https://github.com/FoundationDB/fdb-record-layer/issues/1970)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Refactor KeyValueCursor to allow extension [(Issue #1957)](https://github.com/FoundationDB/fdb-record-layer/issues/1957)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -687,6 +687,8 @@ public class FDBStoreTimer extends StoreTimer {
         COMMIT_UNKNOWN("commit unknown", false),
         /** Count failed due to transaction_too_large. */
         TRANSACTION_TOO_LARGE("transaction too large", false),
+        /** Count the number of scans executed that returned no data. */
+        EMPTY_SCANS("empty scans", false),
         ;
 
         private final String title;


### PR DESCRIPTION
This adds a counter of empty scans that gets incremented during empty range reads. This can then be used to track how many reads are returning zero results from a given workload.

This resolves #1970.