### PR TITLE
Resolves #1974: Cascades Aggregate index plan matching ignores predicates

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,6 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Cascades Aggregate index plan matching ignores predicates [(Issue #1974)](https://github.com/FoundationDB/fdb-record-layer/issues/1974)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
@@ -270,11 +270,11 @@ public class GroupByExpression implements RelationalExpressionWithChildren, Inte
         final Optional<Compensation> childCompensation = matchInfo.getChildPartialMatch(quantifier)
                                 .map(childPartialMatch -> childPartialMatch.compensate(boundParameterPrefixMap));
 
-        if (childCompensation.isPresent() && (childCompensation.get().isImpossible() || !childCompensation.get().canBeDeferred())) {
+        if (childCompensation.isPresent() && (childCompensation.get().isImpossible() || childCompensation.get().isNeeded())) {
             return Compensation.impossibleCompensation();
         }
 
-        return childCompensation.orElse(Compensation.NO_COMPENSATION);
+        return Compensation.noCompensation();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
@@ -260,11 +260,7 @@ public class GroupByExpression implements RelationalExpressionWithChildren, Inte
     public Compensation compensate(@Nonnull final PartialMatch partialMatch,
                                    @Nonnull final Map<CorrelationIdentifier, ComparisonRange> boundParameterPrefixMap) {
         final var matchInfo = partialMatch.getMatchInfo();
-
-        final var quantifiers = getQuantifiers();
-
-        Verify.verify(quantifiers.size() == 1);
-        final var quantifier = quantifiers.get(0);
+        final var quantifier = Iterables.getOnlyElement(getQuantifiers());
 
         // if the match requires, for the moment, any, compensation, we reject it.
         final Optional<Compensation> childCompensation = matchInfo.getChildPartialMatch(quantifier)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.query.plan.plans.InParameterSource;
 import com.apple.foundationdb.record.query.plan.plans.InSource;
 import com.apple.foundationdb.record.query.plan.plans.InValuesSource;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAbstractDataModificationPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
@@ -75,6 +76,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.AnyMatcher.any;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.CollectionMatcher.empty;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.all;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.ofTypeOwning;
@@ -644,6 +646,11 @@ public class RecordQueryPlanMatchers {
         return typedWithDownstream(RecordQueryStreamingAggregationPlan.class,
                 Extractor.of(RecordQueryStreamingAggregationPlan::getGroupingValue, name -> "grouping(" + name + ")"),
                 downstream);
+    }
+
+    @Nonnull
+    public static BindingMatcher<RecordQueryAggregateIndexPlan> aggregateIndexPlan() {
+        return childrenPlans(RecordQueryAggregateIndexPlan.class, empty());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -76,7 +76,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.AnyMatcher.any;
-import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.CollectionMatcher.empty;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.all;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.ofTypeOwning;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -650,7 +650,7 @@ public class RecordQueryPlanMatchers {
 
     @Nonnull
     public static BindingMatcher<RecordQueryAggregateIndexPlan> aggregateIndexPlan() {
-        return childrenPlans(RecordQueryAggregateIndexPlan.class, empty());
+        return ofTypeOwning(RecordQueryAggregateIndexPlan.class, CollectionMatcher.empty());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
@@ -160,7 +160,7 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
     }
 
     @Nonnull
-    private GroupExpressionRef<RelationalExpression> constructGroupByPlan(boolean withPredicate) {
+    private GroupExpressionRef<RelationalExpression> constructGroupByPlan(final boolean withPredicate) {
         final var cascadesPlanner = (CascadesPlanner)planner;
         final var allRecordTypes = ImmutableSet.of("MySimpleRecord", "MyOtherRecord");
         var qun =
@@ -232,7 +232,7 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    protected void setupHookAndAddData(boolean addIndex, boolean addAggregateIndex) throws Exception {
+    protected void setupHookAndAddData(final boolean addIndex, final boolean addAggregateIndex) throws Exception {
         try (FDBRecordContext context = openContext()) {
             FDBRecordStoreTestBase.RecordMetaDataHook hook = (metaDataBuilder) -> {
                 complexQuerySetupHook().apply(metaDataBuilder);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
@@ -22,10 +22,13 @@ package com.apple.foundationdb.record.provider.foundationdb.query;
 
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.Column;
@@ -39,6 +42,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSort
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
@@ -58,7 +62,9 @@ import java.util.Optional;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.aggregateIndexPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.aggregations;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.anyPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.groupings;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.mapPlan;
@@ -75,10 +81,10 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
 
     @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
     public void testSimpleGroupBy() throws Exception {
-        setupHookAndAddData(true);
+        setupHookAndAddData(true, false);
         final var cascadesPlanner = (CascadesPlanner)planner;
         final var plan = cascadesPlanner.planGraph(
-                this::constructGroupByPlan,
+                () -> constructGroupByPlan(false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
                 false,
@@ -96,18 +102,32 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
 
     @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
     public void attemptToPlanGroupByWithoutCompatiblySortedIndexFails() throws Exception {
-        setupHookAndAddData(false);
+        setupHookAndAddData(false, false);
         final var cascadesPlanner = (CascadesPlanner)planner;
         Assertions.assertThrows(RecordCoreException.class, () -> cascadesPlanner.planGraph(
-                this::constructGroupByPlan,
+                () -> constructGroupByPlan(false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
                 false,
                 ParameterRelationshipGraph.empty()), "Cascades planner could not plan query");
     }
 
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    public void testAggregateIndexPlanning() throws Exception {
+        setupHookAndAddData(false, true);
+        final var cascadesPlanner = (CascadesPlanner)planner;
+        final var plan = cascadesPlanner.planGraph(
+                () -> constructGroupByPlan(false),
+                Optional.empty(),
+                IndexQueryabilityFilter.TRUE,
+                false,
+                ParameterRelationshipGraph.empty());
+
+        assertMatchesExactly(plan, aggregateIndexPlan());
+    }
+
     @Nonnull
-    private GroupExpressionRef<RelationalExpression> constructGroupByPlan() {
+    private GroupExpressionRef<RelationalExpression> constructGroupByPlan(boolean withPredicate) {
         final var cascadesPlanner = (CascadesPlanner)planner;
         final var allRecordTypes = ImmutableSet.of("MySimpleRecord", "MyOtherRecord");
         var qun =
@@ -140,6 +160,11 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
             final var col2 = Column.of(Type.Record.Field.of(quantifiedValue.getResultType(), Optional.of(qun.getAlias().getId())), quantifiedValue);
 
             selectBuilder.addQuantifier(qun).addAllResultColumns(List.of(col1, col2));
+
+            if (withPredicate) {
+                selectBuilder.addPredicate(new ValuePredicate(num2Value, new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN_OR_EQUALS, 42)));
+            }
+
             qun = Quantifier.forEach(GroupExpressionRef.of(selectBuilder.build().buildSelect()));
         }
 
@@ -174,12 +199,15 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    protected void setupHookAndAddData(boolean addIndex) throws Exception {
+    protected void setupHookAndAddData(boolean addIndex, boolean addAggregateIndex) throws Exception {
         try (FDBRecordContext context = openContext()) {
             FDBRecordStoreTestBase.RecordMetaDataHook hook = (metaDataBuilder) -> {
                 complexQuerySetupHook().apply(metaDataBuilder);
                 if (addIndex) {
                     metaDataBuilder.addIndex("MySimpleRecord", "MySimpleRecord$num_value_2", field("num_value_2"));
+                }
+                if (addAggregateIndex) {
+                    metaDataBuilder.addIndex("MySimpleRecord", new Index("AggIndex", field("num_value_3_indexed").groupBy(field("num_value_2")), IndexTypes.SUM));
                 }
             };
             openSimpleRecordStore(context, hook);


### PR DESCRIPTION
This fixes compensation logic in `GroupByExpression` such that if the underlying quantifier has any compensation requirements it will return an impossible compensation effectively causing the (aggregate) index match candidate to disqualify if the query has any predicates in the select-where part requiring compensation.

This resolves #1974.