### PR TITLE
Resolves #1980: Indexing typestamp: add query + flow control

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,6 +26,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Indexing typestamp: add query + flow control [(Issue #1980)](https://github.com/FoundationDB/fdb-record-layer/issues/1980)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -398,7 +398,7 @@ public class FDBStoreTimer extends StoreTimer {
         /** Wait for an {@link IndexOperation} to complete. */
         WAIT_INDEX_OPERATION("wait for index operation"),
         /** Wait for indexing type stamp operation. */
-        WAIT_INDEX_TYPESTAMP_OP("wait for indexing type stamp operation"),
+        WAIT_INDEX_TYPESTAMP_OPERATION("wait for indexing type stamp operation"),
         /** Wait for adding an index. */
         WAIT_ADD_INDEX("wait for adding an index"),
         /** Wait for dropping an index. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -397,6 +397,8 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_REVERSE_DIRECTORY_LOCATE("wait for finding reverse directory location"),
         /** Wait for an {@link IndexOperation} to complete. */
         WAIT_INDEX_OPERATION("wait for index operation"),
+        /** Wait for indexing type stamp operation. */
+        WAIT_INDEX_TYPESTAMP_OP("wait for indexing type stamp operation"),
         /** Wait for adding an index. */
         WAIT_ADD_INDEX("wait for adding an index"),
         /** Wait for dropping an index. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -55,7 +55,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -64,6 +63,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -1077,6 +1077,9 @@ public abstract class IndexingBase {
         }
 
         public static String stampToString(IndexBuildProto.IndexBuildIndexingStamp stamp) {
+            if (stamp == null) {
+                return "IndexingStamp(<null>)";
+            }
             final StringBuilder str = new StringBuilder("IndexingStamp(")
                     .append(stamp.getMethod())
                     .append(", target:")
@@ -1089,7 +1092,7 @@ public abstract class IndexingBase {
                 }
                 long expirationMillis = stamp.getBlockExpireEpochMilliSeconds();
                 if (expirationMillis > 0) {
-                    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-mm-dd_HH:mm:ss");
+                    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-mm-dd_HH:mm:ss", Locale.US);
                     Date expirationDate = new Date(expirationMillis);
                     str.append(", blockExpires{").append(sdf.format(expirationDate)).append("}");
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -463,7 +463,7 @@ public abstract class IndexingBase {
         return
             areSimilar(newStamp, savedStamp)
             ?
-            (!isTypeStampBlocked(savedStamp) || policy.shouldAllowUnblock(savedStamp.getBlockDescription()))
+            (!isTypeStampBlocked(savedStamp) || policy.shouldAllowUnblock(savedStamp.getBlockID()))
             :
             policy.shouldAllowTakeoverContinue() &&
                (newStamp.getMethod() == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS &&
@@ -988,14 +988,14 @@ public abstract class IndexingBase {
         if (op == OnlineIndexer.IndexingStampOperation.BLOCK) {
             builder.setBlock(true);
             if (id != null) {
-                builder.setBlockDescription(id);
+                builder.setBlockID(id);
             }
             if (timeoutSeconds != null && timeoutSeconds > 0) {
                 builder.setBlockExpireEpochSeconds((int)(System.currentTimeMillis() / 1000) + timeoutSeconds);
             }
         }
         if (op == OnlineIndexer.IndexingStampOperation.UNBLOCK &&
-                (id == null || id.isEmpty() || id.equals(stamp.getBlockDescription()))) {
+                (id == null || id.isEmpty() || id.equals(stamp.getBlockID()))) {
             builder.setBlock(false);
         }
         store.saveIndexingTypeStamp(index, builder.build());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -312,7 +312,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
                             .thenApply(ignore -> null);
                 }, false, null);
 
-        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex",
+        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "mutualMultiTargetIndex",
                 LogMessageKeys.RANGE_START, rangeStart,
                 LogMessageKeys.RANGE_END, rangeEnd);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -2263,7 +2263,7 @@ public class OnlineIndexer implements AutoCloseable {
             private DesiredAction ifReadable = DesiredAction.CONTINUE;
             private boolean doAllowUniqueuPendingState = false;
             private boolean doAllowTakeoverContinue = false;
-            private long checkIndexingStampFrequency = 0;
+            private long checkIndexingStampFrequency = 60_000;
             private boolean useMutualIndexing = false;
             private List<Tuple> useMutualIndexingBoundaries = null;
             private boolean allowUnblock = false;
@@ -2426,8 +2426,7 @@ public class OnlineIndexer implements AutoCloseable {
 
             /**
              * During indexing, the indexer can check the current indexing stamp and throw an exception if it had changed.
-             * This can be useful if there is a high probability of another indexing process taking over or a deliberate
-             * attempt to pause the indexing process by applying {TODO: add link}
+             * This may happen if another indexing type takes over or by an indexing block (see {@link #indexingStamp}).
              * The argument may be:
              *  * -1: never check
              *  *  0: check during every transaction
@@ -2494,7 +2493,7 @@ public class OnlineIndexer implements AutoCloseable {
             }
 
             /**
-             * If the index is partly built and blocked, control if allowed to unblock and continue.
+             * If the index is partly built and blocked, allowed (or disallow) unblocking before indexing.
              * @param allowUnblock if true, unblock (if blocked) and continue.
              * @param allowUnblockId if non-null and non-empty, unblock only if the indexing stamp's id matches it. Will not continue if not blocked.
              * @return this builder
@@ -2507,7 +2506,7 @@ public class OnlineIndexer implements AutoCloseable {
             }
 
             /**
-             * Call {@link #setAllowUnblock(boolean, String)} will null id.
+             * Call {@link #setAllowUnblock(boolean, String)} without block-id.
              * @param allowUnblock if true, allow unblock and continue
              * @return this builder
              */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -820,7 +819,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @return a map of target indexes and their "indexing stamps".
      */
     @API(API.Status.EXPERIMENTAL)
-    AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> queryIndexingStamps() {
+    Map<String, IndexBuildProto.IndexBuildIndexingStamp> queryIndexingStamps() {
         return indexingStamp(IndexingBase.IndexingStampOperation.QUERY, null, null);
     }
 
@@ -832,7 +831,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @return a map of target indexes and their "indexing stamps" before the change.
      */
     @API(API.Status.EXPERIMENTAL)
-    AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> blockIndexBuilds(@Nullable String id, @Nullable Long ttlSeconds)  {
+    Map<String, IndexBuildProto.IndexBuildIndexingStamp> blockIndexBuilds(@Nullable String id, @Nullable Long ttlSeconds)  {
         return indexingStamp(IndexingBase.IndexingStampOperation.BLOCK, id, ttlSeconds);
     }
 
@@ -843,14 +842,14 @@ public class OnlineIndexer implements AutoCloseable {
      * @return  a map of target indexes and their "indexing stamps" before the change.
      */
     @API(API.Status.EXPERIMENTAL)
-    AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> unblockIndexBuilds(@Nullable String id) {
+    Map<String, IndexBuildProto.IndexBuildIndexingStamp> unblockIndexBuilds(@Nullable String id) {
         return indexingStamp(IndexingBase.IndexingStampOperation.UNBLOCK, id, null);
     }
 
-    private AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> indexingStamp(@Nullable IndexingBase.IndexingStampOperation op, @Nullable String id, @Nullable Long ttlSeconds) {
+    private Map<String, IndexBuildProto.IndexBuildIndexingStamp> indexingStamp(@Nullable IndexingBase.IndexingStampOperation op, @Nullable String id, @Nullable Long ttlSeconds) {
         // any indexer will do
         return asyncToSync(FDBStoreTimer.Waits.WAIT_INDEX_TYPESTAMP_OPERATION,
-                getIndexer().indexingStamp(op, id, ttlSeconds));
+                getIndexer().performIndexingStampOperation(op, id, ttlSeconds));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -2242,8 +2242,13 @@ public class OnlineIndexer implements AutoCloseable {
          * (See {@link Builder#allowTakeoverContinue(boolean)}).
          * @return true if allowed
          */
-        public boolean shouldAllowTakeoverContinue() {
-            return allowTakeoverContinue;
+        public boolean shouldAllowTakeoverContinue(IndexBuildProto.IndexBuildIndexingStamp.Method newMethod,
+                                                   IndexBuildProto.IndexBuildIndexingStamp.Method oldMethod) {
+            return allowTakeoverContinue &&
+                   // Takeover is allowed only in certain cases
+                   (newMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS &&
+                    (oldMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS ||
+                     oldMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.MUTUAL_BY_RECORDS));
         }
 
 

--- a/fdb-record-layer-core/src/main/proto/index_build.proto
+++ b/fdb-record-layer-core/src/main/proto/index_build.proto
@@ -34,6 +34,7 @@ message IndexBuildIndexingStamp {
     SCRUB_REPAIR = 3;  // while readable, verify index validity. Repair if needed.
     MULTI_TARGET_BY_RECORDS = 4; // scan records, build multiple target indexes
     MUTUAL_BY_RECORDS = 5; // scan records, build multiple target indexes, while allowing multiple indexer processes
+    NONE = 6; // return this stamp in query when null - never to be written in the DB
   };
   optional Method method = 1;
   optional bytes source_index_subspace_key = 2; // relevant only with BY_INDEX method
@@ -41,7 +42,7 @@ message IndexBuildIndexingStamp {
   repeated string targetIndex = 4; // (Only with MULTI_TARGET & MUTUAL) list of target indexes sorted alphabetically
                                    // the first item is used as the primary index
   optional bool block = 5; // if true and unexpired, indexing may not be continued
-  optional uint32 blockExpireEpochSeconds = 6; // if non zero, the block expiration time in seconds since epoch
+  optional uint64 blockExpireEpochMilliSeconds = 6; // if non zero, the block expiration time in milliseconds since epoch
   optional string blockID = 7; // optional, a short string that describes the reason for the block.
  }
 

--- a/fdb-record-layer-core/src/main/proto/index_build.proto
+++ b/fdb-record-layer-core/src/main/proto/index_build.proto
@@ -38,11 +38,11 @@ message IndexBuildIndexingStamp {
   optional Method method = 1;
   optional bytes source_index_subspace_key = 2; // relevant only with BY_INDEX method
   optional int32 source_index_last_modified_version = 3; // only with BY_INDEX method
-  repeated string targetIndex = 4; //only with *_MULTI_TARGET: list of target indexes sorted alphabetically
+  repeated string targetIndex = 4; // (Only with MULTI_TARGET & MUTUAL) list of target indexes sorted alphabetically
                                    // the first item is used as the primary index
   optional bool block = 5; // if true and unexpired, indexing may not be continued
-  optional uint32 blockExpireEpochSeconds = 6; // if non zero, the date in seconds since epoch to invalidated pause
-  optional string blockDescription = 7; // optional, info only - allow adding a string describing the reason for the pause.
+  optional uint32 blockExpireEpochSeconds = 6; // if non zero, the block expiration time in seconds since epoch
+  optional string blockID = 7; // optional, a short string that describes the reason for the block.
  }
 
 

--- a/fdb-record-layer-core/src/main/proto/index_build.proto
+++ b/fdb-record-layer-core/src/main/proto/index_build.proto
@@ -40,6 +40,9 @@ message IndexBuildIndexingStamp {
   optional int32 source_index_last_modified_version = 3; // only with BY_INDEX method
   repeated string targetIndex = 4; //only with *_MULTI_TARGET: list of target indexes sorted alphabetically
                                    // the first item is used as the primary index
+  optional bool block = 5; // if true and unexpired, indexing may not be continued
+  optional uint32 blockExpireEpochSeconds = 6; // if non zero, the date in seconds since epoch to invalidated pause
+  optional string blockDescription = 7; // optional, info only - allow adding a string describing the reason for the pause.
  }
 
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -32,8 +32,8 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
-import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1144,7 +1144,7 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setIndex(targetIndex)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.blockIndexBuilds(luka, 10L);
             String indexName = targetIndex.getName();
             final IndexBuildProto.IndexBuildIndexingStamp stamp = stampMap.get(indexName);
@@ -1158,7 +1158,7 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setIndex(targetIndex)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.queryIndexingStamps();
             String indexName = targetIndex.getName();
             final IndexBuildProto.IndexBuildIndexingStamp stamp = stampMap.get(indexName);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -1161,7 +1161,7 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
             final IndexBuildProto.IndexBuildIndexingStamp stamp = stampMap.get(indexName);
             assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.BY_INDEX, stamp.getMethod());
             assertTrue(stamp.getBlock());
-            assertEquals(luka, stamp.getBlockDescription());
+            assertEquals(luka, stamp.getBlockID());
             assertTrue(stamp.getBlockExpireEpochSeconds() > (System.currentTimeMillis() / 1000));
             assertTrue(stamp.getBlockExpireEpochSeconds() < 20 + (System.currentTimeMillis() / 1000));
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -1145,7 +1145,7 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 .setIndex(targetIndex)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionBlock(luka, 10L);
+                    indexer.blockIndexBuilds(luka, 10L);
             String indexName = targetIndex.getName();
             final IndexBuildProto.IndexBuildIndexingStamp stamp = stampMap.get(indexName);
             assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.BY_INDEX, stamp.getMethod());
@@ -1159,7 +1159,7 @@ public class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 .setIndex(targetIndex)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionQuery();
+                    indexer.queryIndexingStamps();
             String indexName = targetIndex.getName();
             final IndexBuildProto.IndexBuildIndexingStamp stamp = stampMap.get(indexName);
             assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.BY_INDEX, stamp.getMethod());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -829,7 +829,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                 assertTrue(stamp.getTargetIndexList().containsAll(indexNames));
                 assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS, stamp.getMethod());
                 assertTrue(stamp.getBlock());
-                assertEquals(luka, stamp.getBlockDescription());
+                assertEquals(luka, stamp.getBlockID());
                 assertTrue(stamp.getBlockExpireEpochSeconds() > (System.currentTimeMillis() / 1000));
                 assertTrue(stamp.getBlockExpireEpochSeconds() < 20 + (System.currentTimeMillis() / 1000));
             }
@@ -914,7 +914,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
             throw new RuntimeException(e);
         }
 
-        // 5. continue normally, the block should have expired
+        // 5. continue normally, the block should been have expired
         try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setTimer(timer)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -812,7 +812,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionBlock(luka, 10L);
+                    indexer.blockIndexBuilds(luka, 10L);
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {
@@ -830,7 +830,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionQuery();
+                    indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {
@@ -903,7 +903,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            indexer.indexingSessionBlock(luka, 2L);
+            indexer.blockIndexBuilds(luka, 2L);
         }
 
         // 3. fail continue without unblock

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -312,6 +312,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         buildIndexAndCrashHalfway(chunkSize, 2, timer, newIndexerBuilder()
                 .setIndex(indexAhead)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .checkIndexingStampFrequencyMilliseconds(0)
                         .allowTakeoverContinue()));
 
         // 3. assert mismatch type stamp

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -32,10 +32,10 @@ import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -811,7 +811,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.blockIndexBuilds(luka, 10L);
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
@@ -829,7 +829,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -289,7 +289,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         final FDBStoreTimer timer = new FDBStoreTimer();
         final int numRecords = 107;
-        final int chunkSize  = 17;
+        final int chunkSize  = 13;
 
         List<Index> indexes = new ArrayList<>();
         indexes.add(new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -1155,7 +1155,6 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // Continue with unblock, correct id
         openSimpleMetaData(hook);
-        openSimpleMetaData(hook);
         try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -929,6 +929,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         try (OnlineIndexer indexBuilder = newIndexerBuilder()
                 .setTargetIndexes(indexes)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .allowTakeoverContinue()
                         .setMutualIndexingBoundaries(boundaries))
                 .setLimit(1)
                 .setConfigLoader(old -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -1133,7 +1133,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 assertTrue(stamp.getTargetIndexList().containsAll(indexNames));
                 assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.MUTUAL_BY_RECORDS, stamp.getMethod());
                 assertTrue(stamp.getBlock());
-                assertEquals(luka, stamp.getBlockDescription());
+                assertEquals(luka, stamp.getBlockID());
                 assertTrue(stamp.getBlockExpireEpochSeconds() > (System.currentTimeMillis() / 1000));
                 assertTrue(stamp.getBlockExpireEpochSeconds() < 20 + (System.currentTimeMillis() / 1000));
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -47,12 +47,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -1036,7 +1036,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
@@ -1067,7 +1067,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.unblockIndexBuilds(null);
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
@@ -1095,7 +1095,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
@@ -1151,7 +1151,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
@@ -1241,7 +1241,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
@@ -1373,7 +1373,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
@@ -1404,7 +1404,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
+            final Map<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
                     indexer.unblockIndexBuilds(null);
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -1015,7 +1015,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                         .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                         .setTargetIndexes(indexes)
                         .build()) {
-                    indexer.indexingSessionBlock(null, 0L);
+                    indexer.blockIndexBuilds(null, 0L);
                 }
             } else {
                 oneThreadIndexingCrashHalfway(indexes, timer, boundariesList, 1);
@@ -1036,7 +1036,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionQuery();
+                    indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {
@@ -1067,7 +1067,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionUnblock(null);
+                    indexer.unblockIndexBuilds(null);
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {
@@ -1095,7 +1095,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionQuery();
+                    indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {
@@ -1141,7 +1141,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes)
                 .build()) {
-            indexer.indexingSessionBlock(luka, 10L);
+            indexer.blockIndexBuilds(luka, 10L);
         }
 
         // Test query, ensure blocked
@@ -1151,7 +1151,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionQuery();
+                    indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {
@@ -1231,7 +1231,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                 .setTargetIndexes(indexes.subList(1, 3))
                 .build()) {
-            indexer.indexingSessionBlock(luka, 10L);
+            indexer.blockIndexBuilds(luka, 10L);
         }
 
         // Test query, ensure blocked
@@ -1241,7 +1241,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionQuery();
+                    indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             IntStream.range(0, indexNames.size()).forEach(i -> {
@@ -1329,7 +1329,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                             .setDatabase(fdb).setMetaData(metaData).setSubspace(subspace)
                             .setTargetIndexes(indexes)
                             .build()) {
-                        indexer.indexingSessionBlock(null, 0L);
+                        indexer.blockIndexBuilds(null, 0L);
                     }
                     context.commit();
                 }
@@ -1373,7 +1373,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionQuery();
+                    indexer.queryIndexingStamps();
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {
@@ -1404,7 +1404,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 .setTargetIndexes(indexes)
                 .build()) {
             final AbstractMap<String, IndexBuildProto.IndexBuildIndexingStamp> stampMap =
-                    indexer.indexingSessionUnblock(null);
+                    indexer.unblockIndexBuilds(null);
             final List<String> indexNames = indexes.stream().map(Index::getName).collect(Collectors.toList());
             assertTrue(stampMap.keySet().containsAll(indexNames));
             for (String indexName : indexNames) {


### PR DESCRIPTION
Add indexing control flow. Allowing: 
1. Set frequency of checking the indexing stamp (never, always, or minimal time between checks) 
2. Throw an exception of the indexing stamp had changed 
3. Provide a way to query, block, and unblock the indexing stamp
4. Provide an option to unblock during indexing 
5. Provide an option to add a block id during block, that can be used for verification during unblock 
6. Provide a time-to-leave option to the indexing block 
