### PR TITLE
Resolves #1982: LOAD_RECORDS_VIA_GETS should default to false

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Default value of `LOAD_RECORDS_VIA_GETS` property reverted to `false` to match behavior prior to [3.3.327.0](#333270) [(Issue #1982)](https://github.com/FoundationDB/fdb-record-layer/issues/1982)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
@@ -61,7 +61,7 @@ public final class FDBRecordStoreProperties {
      */
     @API(API.Status.EXPERIMENTAL)
     public static final RecordLayerPropertyKey<Boolean> LOAD_RECORDS_VIA_GETS = RecordLayerPropertyKey.booleanPropertyKey(
-            "com.apple.foundationdb.record.recordstore.load_records_via_gets", true);
+            "com.apple.foundationdb.record.recordstore.load_records_via_gets", false);
 
     private FDBRecordStoreProperties() {
         throw new RecordCoreException("should not instantiate class of static prop");


### PR DESCRIPTION
This sets the default value of the `LOAD_RECORD_VIA_GETS` property to false. This reverts the default behavior to match what the behavior prior to 3.3.327.0 when the property was introduced. It was always the intention that this property would be off by default, and then adopters could experiment with it to see if it improved performance, but the default was set incorrectly in the initial commit.

This resolves #1982.