### PR TITLE
Change how the binding name is constructed for functions …

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
@@ -86,7 +86,7 @@ public class QueryRecordFunctionWithComparison implements ComponentWithCompariso
 
     @Override
     public String getName() {
-        return function.toString();
+        return function.getName();
     }
 
     @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexTest.java
@@ -1327,7 +1327,7 @@ class RankIndexTest extends FDBRecordStoreQueryTestBase {
         RecordQueryPlan plan = planner.plan(query);
         assertThat(plan, inValues(equalTo(Arrays.asList(0L, 2L)), scoreForRank(
                 containsInAnyOrder(
-                        hasToString("__rank_0 = BasicRankedRecord$score.score_for_rank($__in_rank(Field { 'score' None} group 1)__0)")),
+                        hasToString("__rank_0 = BasicRankedRecord$score.score_for_rank($__in_rank__0)")),
                 fetch(filter(rankComparisonFor("score", Comparisons.Type.EQUALS, "__rank_0"),
                         coveringIndexScan(indexScan(allOf(indexName("rank_by_gender"), bounds(hasTupleString("([M, null],[M, 1]]"))))))))));
 
@@ -1356,7 +1356,7 @@ class RankIndexTest extends FDBRecordStoreQueryTestBase {
                 containsInAnyOrder(
                         hasToString("__rank_0 = BasicRankedRecord$score.score_for_rank_else_skip(3)")),
                 fetch(filter(rankComparisonFor("score", Comparisons.Type.LESS_THAN, "__rank_0"),
-                        coveringIndexScan(indexScan(allOf(indexName("rank_by_gender"), bounds(hasTupleString("[EQUALS M, EQUALS $__in_rank([Field { 'gender' None}, Field { 'score' None}] group 1)__0]"))))))))));
+                        coveringIndexScan(indexScan(allOf(indexName("rank_by_gender"), bounds(hasTupleString("[EQUALS M, EQUALS $__in_rank__0]"))))))))));
 
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
@@ -1152,15 +1152,15 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                                 .in(ls)))
                 .build();
 
-        // Index(rank_by_string [EQUALS str0, EQUALS $__in_rank([Field { 'str_value_indexed' None}, Field { 'num_value_2' None}] group 1)__0] BY_RANK) WHERE __in_rank([Field { 'str_value_indexed' None}, Field { 'num_value_2' None}] group 1)__0 IN [1, 3, 5]
+        // Index(rank_by_string [EQUALS str0, EQUALS $__in_rank__0] BY_RANK) WHERE __in_rank__0 IN [1, 3, 5]
         RecordQueryPlan plan = planner.plan(query);
         assertMatchesExactly(plan,
                 inValuesJoinPlan(
                         indexPlan().where(indexName("rank_by_string")).and(RecordQueryPlanMatchers.indexScanType(IndexScanType.BY_RANK))
                 ).where(inValuesList(equalsObject(ls))));
-        assertEquals(-778840248, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
-        assertEquals(-1474202802, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(2030164999, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(-1804746094, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
+        assertEquals(268875332, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(-521724163, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         List<Long> recNos = new ArrayList<>();
         querySimpleRecordStore(recordMetaDataHook, plan, EvaluationContext::empty,
                 record -> recNos.add(record.getRecNo()),
@@ -1185,15 +1185,15 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
                 .setFilter(Query.rank("num_value_2").in(ls))
                 .build();
 
-        // Index(rank [EQUALS $__in_rank(Field { 'num_value_2' None} group 1)__0] BY_RANK) WHERE __in_rank(Field { 'num_value_2' None} group 1)__0 IN [1, 3, 5]
+        // Index(rank [EQUALS $__in_rank__0] BY_RANK) WHERE __in_rank__0 IN [1, 3, 5]
         RecordQueryPlan plan = planner.plan(query);
         assertMatchesExactly(plan,
                 inValuesJoinPlan(
                         indexPlan().where(indexName("rank")).and(RecordQueryPlanMatchers.indexScanType(IndexScanType.BY_RANK))
                 ).where(inValuesList(equalsObject(ls))));
-        assertEquals(1518925028, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
-        assertEquals(-1422629447, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
-        assertEquals(-1422660327, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+        assertEquals(1334377108, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
+        assertEquals(1071050249, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(1071019369, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
         List<Long> recNos = new ArrayList<>();
         querySimpleRecordStore(recordMetaDataHook, plan, EvaluationContext::empty,
                 record -> recNos.add(record.getRecNo()),


### PR DESCRIPTION
… to not have all the arguments.

It just makes the plan summary harder to read.
A unique suffix is already added; this is just meant to give some sense of what the binding is for and the function name is good enough for that.