### PR TITLE
Resolve #1984: Log store timer metrics during indexer progress log message

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,7 +23,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Adds store timer metrics to the indexer progress metrics message [(Issue #1984)](https://github.com/FoundationDB/fdb-record-layer/issues/1984)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestHelpers.java
@@ -68,27 +68,28 @@ public class TestHelpers {
         };
     }
 
-    public static void assertLogs(Class<?> loggingClass, Pattern pattern, Callable<?> callable) {
-        assertLogs(loggingClass.getName(), pattern, callable);
+    public static List<String> assertLogs(Class<?> loggingClass, Pattern pattern, Callable<?> callable) {
+        return assertLogs(loggingClass.getName(), pattern, callable);
     }
 
-    public static void assertLogs(String loggerName, Pattern pattern, Callable<?> callable) {
+    public static List<String> assertLogs(String loggerName, Pattern pattern, Callable<?> callable) {
         MatchingAppender appender = new MatchingAppender(UUID.randomUUID().toString(), pattern);
-        assertLogs(loggerName, appender, callable);
+        return assertLogs(loggerName, appender, callable);
     }
 
-    public static void assertLogs(Class<?> loggingClass, String messagePrefix, Callable<?> callable) {
-        assertLogs(loggingClass.getName(), messagePrefix, callable);
+    public static List<String> assertLogs(Class<?> loggingClass, String messagePrefix, Callable<?> callable) {
+        return assertLogs(loggingClass.getName(), messagePrefix, callable);
     }
 
-    public static void assertLogs(String loggerName, String messagePrefix, Callable<?> callable) {
+    public static List<String> assertLogs(String loggerName, String messagePrefix, Callable<?> callable) {
         MatchingAppender appender = new MatchingAppender(UUID.randomUUID().toString(), messagePrefix);
-        assertLogs(loggerName, appender, callable);
+        return assertLogs(loggerName, appender, callable);
     }
 
-    private static void assertLogs(String loggerName, MatchingAppender appender, Callable<?> callable) {
+    private static List<String> assertLogs(String loggerName, MatchingAppender appender, Callable<?> callable) {
         callAndMonitorLogging(loggerName, appender, callable);
         assertTrue(appender.matched(), () -> "No messages were logged matching [" + appender + "]");
+        return appender.getMatchedEvents();
     }
 
     public static void assertDidNotLog(Class<?> loggingClass, Pattern pattern, Callable<?> callable) {
@@ -309,7 +310,7 @@ public class TestHelpers {
         @Nullable
         private final String messagePrefix;
 
-        private List<LogEvent> matchedEvents = new ArrayList<>();
+        private final List<String> matchedEvents = new ArrayList<>();
 
         protected MatchingAppender(@Nonnull String name, @Nonnull Pattern pattern) {
             super(name, null, null, true, null);
@@ -328,15 +329,15 @@ public class TestHelpers {
         }
 
         @Nonnull
-        public List<LogEvent> getMatchedEvents() {
+        public List<String> getMatchedEvents() {
             return matchedEvents;
         }
 
         @Override
-        public void append(@Nonnull LogEvent event) {
+        public synchronized void append(@Nonnull LogEvent event) {
             if ((pattern != null && pattern.matcher(event.getMessage().getFormattedMessage()).matches())
                     || (messagePrefix != null && event.getMessage().getFormattedMessage().startsWith(messagePrefix)))  {
-                matchedEvents.add(event);
+                matchedEvents.add(event.getMessage().getFormattedMessage());
             }
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -38,6 +38,7 @@ import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.tuple.Pair;
@@ -55,6 +56,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -66,6 +69,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -81,6 +85,25 @@ import static org.junit.jupiter.api.Assertions.fail;
  * build full indexes. ({@link #testConfigLoader()} does use a such API but it is not necessary.)
  */
 public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
+    private static final Pattern BATCH_GRV_PATTERN = eventCountPattern(FDBStoreTimer.Events.BATCH_GET_READ_VERSION);
+    private static final Pattern SCAN_RECORDS_PATTERN = eventCountPattern(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED);
+    private static final Pattern BUILD_RANGES_PATTERN = eventCountPattern(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT);
+
+    private static Pattern eventCountPattern(StoreTimer.Event event) {
+        return Pattern.compile(".*" + event.logKeyWithSuffix("_count") + "=\"(\\d+)\".*");
+    }
+
+    private static int extractCount(Pattern pattern, String logEvent) {
+        Matcher matcher = pattern.matcher(logEvent);
+        assertTrue(matcher.matches(), () -> String.format("expected \"%s\" to have pattern \"%s\"", logEvent, pattern));
+        return Integer.parseInt(matcher.group(1));
+    }
+
+    private static void assertAbsent(Pattern pattern, String logEvent) {
+        Matcher matcher = pattern.matcher(logEvent);
+        assertFalse(matcher.matches(), () -> String.format("did not expect \"%s\" to have pattern \"%s\"", logEvent, pattern));
+    }
+
     @Test
     @SuppressWarnings("deprecation")
     public void buildEndpointIdempotency() {
@@ -1054,6 +1077,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
 
     @Test
     public void testLogInterval() {
+        final int limit = 20;
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 50).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2((int)val + 1).build()
         ).collect(Collectors.toList());
@@ -1067,10 +1091,11 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         Index index = new Index("newIndex", field("num_value_2").ungrouped(), IndexTypes.SUM);
         FDBRecordStoreTestBase.RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
         openSimpleMetaData(hook);
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(index)
                 .setProgressLogIntervalMillis(10)
-                .setLimit(20)
+                .setLimit(limit)
+                .setTimer(null)
                 .setConfigLoader(old -> {
                     // Ensure that time limit is exceeded
                     try {
@@ -1081,11 +1106,16 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                     return old;
                 })
                 .build()) {
-            TestHelpers.assertLogs(IndexingBase.class, "Indexer: Built Range",
+            List<String> events = TestHelpers.assertLogs(IndexingBase.class, "Indexer: Built Range",
                     () -> {
                         indexer.buildIndex();
                         return null;
                     });
+            events.forEach(logEvent -> {
+                assertAbsent(BATCH_GRV_PATTERN, logEvent);
+                assertAbsent(BUILD_RANGES_PATTERN, logEvent);
+                assertAbsent(SCAN_RECORDS_PATTERN, logEvent);
+            });
         }
 
         // test with zero interval (always log)
@@ -1094,10 +1124,12 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             recordStore.markIndexDisabled(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(index)
+                .setTimer(timer)
                 .setProgressLogIntervalMillis(0)
-                .setLimit(20)
+                .setLimit(limit)
                 .setConfigLoader(old -> {
                     // Ensure that time limit is exceeded
                     try {
@@ -1108,11 +1140,19 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                     return old;
                 })
                 .build()) {
-            TestHelpers.assertLogs(IndexingBase.class, "Indexer: Built Range",
+            List<String> events = TestHelpers.assertLogs(IndexingBase.class, "Indexer: Built Range",
                     () -> {
                         indexer.buildIndex();
                         return null;
                     });
+            events.forEach(logEvent -> {
+                int batchGRVs = extractCount(BATCH_GRV_PATTERN, logEvent);
+                int buildRanges = extractCount(BUILD_RANGES_PATTERN, logEvent);
+                assertThat(buildRanges, lessThanOrEqualTo(batchGRVs));
+                assertEquals(1, buildRanges, () -> String.format("expected only 1 build range in \"%s\"", logEvent));
+                int scannedRecords = extractCount(SCAN_RECORDS_PATTERN, logEvent);
+                assertThat(String.format("expected only %d records scanned in \"%s\"", limit, logEvent), scannedRecords, lessThanOrEqualTo(limit));
+            });
         }
 
         // test with negative interval (never log)
@@ -1121,8 +1161,8 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             recordStore.markIndexDisabled(index).join();
             context.commit();
         }
-        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
-                .setDatabase(fdb).setMetaData(metaData).setIndex(index).setSubspace(subspace)
+        try (OnlineIndexer indexer = newIndexerBuilder()
+                .setIndex(index)
                 .setProgressLogIntervalMillis(-1)
                 .setLimit(20)
                 .setConfigLoader(old -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -1129,9 +1129,9 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                         return null;
                     });
             events.forEach(logEvent -> {
-                int batchGRVs = TestHelpers.extractCount(BATCH_GRV_PATTERN, logEvent);
+                int batchReadVersions = TestHelpers.extractCount(BATCH_GRV_PATTERN, logEvent);
                 int buildRanges = TestHelpers.extractCount(BUILD_RANGES_PATTERN, logEvent);
-                assertThat(buildRanges, lessThanOrEqualTo(batchGRVs));
+                assertThat(buildRanges, lessThanOrEqualTo(batchReadVersions));
                 assertEquals(1, buildRanges, () -> String.format("expected only 1 build range in \"%s\"", logEvent));
                 int scannedRecords = TestHelpers.extractCount(SCAN_RECORDS_PATTERN, logEvent);
                 assertThat(String.format("expected only %d records scanned in \"%s\"", limit, logEvent), scannedRecords, lessThanOrEqualTo(limit));


### PR DESCRIPTION
This adds the store timer metrics to the progress log message that is logged during an index build so that we can have insight into what the performance of a build is while it is going on.

This resolves #1984.