### PR TITLE
Resolves #1993: Add store timer metrics for retry and indexing delays

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,7 +24,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Adds store timer metrics to the indexer progress metrics message [(Issue #1984)](https://github.com/FoundationDB/fdb-record-layer/issues/1984)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Instrumentation is added for delays inserted during retries and index builds [(Issue #1993)](https://github.com/FoundationDB/fdb-record-layer/issues/1993)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
@@ -222,6 +222,9 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
                         LOGGER.warn(message.toString(), e);
                     }
                     CompletableFuture<Void> future = delay.delay();
+                    if (getTimer() != null) {
+                        future = getTimer().instrument(FDBStoreTimer.Events.RETRY_DELAY, future, executor);
+                    }
                     addFutureToCompleteExceptionally(future);
                     return future.thenApply(vignore -> {
                         currAttempt++;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -162,6 +162,8 @@ public class FDBStoreTimer extends StoreTimer {
         REBUILD_INDEX_EXPLICIT("rebuild index by an explicit request"),
         /** The amount of time spent rebuilding an index during a test. */
         REBUILD_INDEX_TEST("rebuild index during test"),
+        /** The amount of time spent delayed during index builds. This is injected by the indexing process to avoid overwhelming the database server. */
+        INDEXER_DELAY("indexer delay"),
 
         /** The amount of time spent clearing the space taken by an index that has been removed from the meta-data. */
         REMOVE_FORMER_INDEX("remove former index"),
@@ -224,6 +226,8 @@ public class FDBStoreTimer extends StoreTimer {
         TIME_WINDOW_LEADERBOARD_GET_SUB_DIRECTORY("leaderboard get sub-directory"),
         /** The amount of time spent in {@link com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowLeaderboardSaveSubDirectory}. */
         TIME_WINDOW_LEADERBOARD_SAVE_SUB_DIRECTORY("leaderboard save sub-directory"),
+        /** The amount of time spent during backoff delay on retryable errors in {@link FDBDatabase#run}. */
+        RETRY_DELAY("retry delay"),
         /** The total number of timeouts that have happened during asyncToSync and their durations. */
         TIMEOUTS("timeouts"),
         /** Total number and duration of commits. */
@@ -415,7 +419,7 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_LOCATABLE_RESOLVER_COMPUTE_DIGEST("wait for computing directory layer digest"),
         /** Wait for {@link com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverMappingReplicator} to copy a directory layer. */
         WAIT_LOCATABLE_RESOLVER_MAPPING_COPY("wait for copying contents of directory layer"),
-        /** Wait for a backoff delay on retryable error in {@link FDBDatabase#run}. */
+        /** Wait for a backoff delay on retryable errors in {@link FDBDatabase#run}. */
         WAIT_RETRY_DELAY("wait for retry delay"),
         /** Wait for statistics to be collected. */
         WAIT_COLLECT_STATISTICS("wait for statistics to be collected of a record store or index"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -608,7 +608,12 @@ public abstract class IndexingBase {
         }
 
         validateTimeLimit(toWait);
-        return MoreAsyncUtil.delayedFuture(toWait, TimeUnit.MILLISECONDS).thenApply(vignore3 -> true);
+
+        CompletableFuture<Boolean> delay = MoreAsyncUtil.delayedFuture(toWait, TimeUnit.MILLISECONDS).thenApply(vignore3 -> true);
+        if (getRunner().getTimer() != null) {
+            delay = getRunner().getTimer().instrument(FDBStoreTimer.Events.INDEXER_DELAY, delay, getRunner().getExecutor());
+        }
+        return delay;
     }
 
     private void validateTimeLimit(int toWait) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -241,7 +241,12 @@ public class IndexingThrottle {
                             message.addKeysAndValues(onlineIndexerLogMessageKeyValues);
                             LOGGER.warn(message.toString(), e);
                         }
-                        return delay.delay().thenApply(vignore3 -> true);
+                        CompletableFuture<Boolean> delayedContinue = delay.delay().thenApply(vignore3 -> true);
+                        if (common.getRunner().getTimer() != null) {
+                            delayedContinue = common.getRunner().getTimer().instrument(FDBStoreTimer.Events.RETRY_DELAY,
+                                    delayedContinue, common.getRunner().getExecutor());
+                        }
+                        return delayedContinue;
                     } else {
                         return completeExceptionally(ret, e, onlineIndexerLogMessageKeyValues);
                     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This class mantains a delay that should be used when retrying transactional operations that have failed due to
+ * This class maintains a delay that should be used when retrying transactional operations that have failed due to
  * something retriable.
  * <p>
  *     The goal here is to avoid making the situation worse when the system is overloaded, by backing off.


### PR DESCRIPTION
This adds metrics recording the amount of time that is spent during retries and indexing during delays. There was already a `WAIT_RETRY_DELAY` metric, but nothing that captured the event in asynchronous contexts, so I added `Event`s for `RETRY_DELAY` and `INDEXER_DELAY`, and then added instrumentation for those hooks. I also looked into testing, but testing that these events are hit is actually kind of difficult. I tried to add a test to `FDBDatabaseRunnerTest` that asserted on the metrics, but it was difficult to write one that was both reliable and actually asserted on anything, because the values for the counters can be legitimately zero if there isn't any actual delaying going on. Giving that this is just some metrics, the most important thing would seem to be making sure that it doesn't cause NPEs, which I think our tests already cover in that they set the `timer` to `null` in some runs.

This resolves #1993.