### PR TITLE
Resolves #1995: Instrument RangeSet operations during index builds

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Additional instrumentaiton of the `RangeSet` is added to account for time spent during index builds  [(Issue #1995)](https://github.com/FoundationDB/fdb-record-layer/issues/1995)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.ReadTransactionContext;
+import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.TransactionContext;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.subspace.Subspace;
@@ -603,15 +604,22 @@ public class RangeSet {
     }
 
     /**
-     * Clears the subspace used by this RangeSet instance. This will delete the records of any
-     * data used by this set.
+     * Clears the subspace used by this RangeSet instance. This will remove all ranges from this set.
+     * @param tr transaction with which to run the operation
+     */
+    public void clear(@Nonnull Transaction tr) {
+        tr.clear(subspace.range());
+    }
+
+    /**
+     * Clears the subspace used by this RangeSet instance. This will remove all ranges from this set.
      * @param tc transaction or database in which to run operation
      * @return a future that is completed when the range has been cleared
      */
     @Nonnull
     public CompletableFuture<Void> clear(@Nonnull TransactionContext tc) {
         return tc.runAsync(tr -> {
-            tr.clear(subspace.range());
+            clear(tr);
             return AsyncUtil.DONE;
         });
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -33,7 +33,6 @@ import com.apple.foundationdb.async.AsyncIterator;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.CloseableAsyncIterator;
 import com.apple.foundationdb.async.MoreAsyncUtil;
-import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.AggregateFunctionNotSupportedException;
 import com.apple.foundationdb.record.ByteScanLimiter;
 import com.apple.foundationdb.record.CursorStreamingMode;
@@ -79,6 +78,7 @@ import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.DynamicMessageRecordSerializer;
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
+import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.storestate.FDBRecordStoreStateCache;
 import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
@@ -2834,22 +2834,21 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             Transaction tr = context.ensureActive();
             CompletableFuture<Boolean> future = tr.get(indexKey).thenCompose(previous -> {
                 if (previous == null) {
-                    RangeSet indexRangeSet = new RangeSet(indexRangeSubspace(getRecordMetaData().getIndex(indexName)));
-                    return indexRangeSet.isEmpty(tr)
-                            .thenCompose(isEmpty -> {
-                                if (isEmpty) {
-                                    // For readable indexes, we have an optimization where the range set is cleared out
-                                    // after the index is build to avoid carrying extra meta-data about the index range
-                                    // set. However, when we mark an index as write-only, we want to preserve the record
-                                    // that the index was completely built (if the range set was empty, i.e., cleared)
-                                    return indexRangeSet.insertRange(tr, null, null);
-                                } else {
-                                    return AsyncUtil.READY_FALSE;
-                                }
-                            }).thenApply(ignore -> {
-                                updateIndexState(indexName, indexKey, indexState);
-                                return true;
-                            });
+                    IndexingRangeSet indexRangeSet = IndexingRangeSet.forIndexBuild(this, getRecordMetaData().getIndex(indexName));
+                    return indexRangeSet.isEmptyAsync().thenCompose(empty -> {
+                        if (empty) {
+                            // For readable indexes, we have an optimization where the range set is cleared out
+                            // after the index is build to avoid carrying extra meta-data about the index range
+                            // set. However, when we mark an index as write-only, we want to preserve the record
+                            // that the index was completely built (if the range set was empty, i.e., cleared)
+                            return indexRangeSet.insertRangeAsync(null, null);
+                        } else {
+                            return AsyncUtil.READY_FALSE;
+                        }
+                    }).thenApply(ignore -> {
+                        updateIndexState(indexName, indexKey, indexState);
+                        return true;
+                    });
                 } else if (!Tuple.fromBytes(previous).get(0).equals(indexState.code())) {
                     updateIndexState(indexName, indexKey, indexState);
                     return AsyncUtil.READY_TRUE;
@@ -2949,16 +2948,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         if (!getRecordMetaData().hasIndex(index.getName())) {
             throw new MetaDataException("Index " + index.getName() + " does not exist in meta-data.");
         }
-        Transaction tr = ensureContextActive();
-        RangeSet rangeSet = new RangeSet(indexRangeSubspace(index));
-        AsyncIterator<Range> missingRangeIterator = rangeSet.missingRanges(tr, null, null, 1).iterator();
-        return missingRangeIterator.onHasNext().thenApply(hasFirst -> {
-            if (hasFirst) {
-                return Optional.of(missingRangeIterator.next());
-            } else {
-                return Optional.empty();
-            }
-        });
+        IndexingRangeSet rangeSet = IndexingRangeSet.forIndexBuild(this, index);
+        return rangeSet.firstMissingRangeAsync().thenApply(Optional::ofNullable);
     }
 
     /**
@@ -3112,7 +3103,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 throw wrapped;
             } else {
                 updateIndexState(index.getName(), indexKey, IndexState.READABLE);
-                clearReadableIndexBuildData(ensureContextActive(), index);
+                clearReadableIndexBuildData(index);
                 return true;
             }
         });
@@ -4274,7 +4265,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         Transaction tr = ensureContextActive();
         tr.clear(Range.startsWith(indexSubspace(index).pack())); // startsWith to handle ungrouped aggregate indexes
         tr.clear(indexSecondarySubspace(index).range());
-        tr.clear(indexRangeSubspace(index).range());
+        IndexingRangeSet.forIndexBuild(this, index).clear();
         if (index.isUnique()) {
             tr.clear(indexUniquenessViolationsSubspace(index).range());
         }
@@ -4311,17 +4302,16 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         }
     }
 
-    private void clearReadableIndexBuildData(Transaction tr, Index index) {
-        tr.clear(indexRangeSubspace(index).range());
+    private void clearReadableIndexBuildData(Index index) {
+        IndexingRangeSet.forIndexBuild(this, index).clear();
     }
 
     @SuppressWarnings("PMD.CloseResource")
     public void vacuumReadableIndexesBuildData() {
-        Transaction tr = ensureContextActive();
         Map<Index, IndexState> indexStates = getAllIndexStates(); // also adds state to read conflicts
         for (Map.Entry<Index, IndexState> entry : indexStates.entrySet()) {
             if (entry.getValue().equals(IndexState.READABLE)) {
-                clearReadableIndexBuildData(tr, entry.getKey());
+                clearReadableIndexBuildData(entry.getKey());
             }
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -165,6 +165,17 @@ public class FDBStoreTimer extends StoreTimer {
         /** The amount of time spent delayed during index builds. This is injected by the indexing process to avoid overwhelming the database server. */
         INDEXER_DELAY("indexer delay"),
 
+        /** The amount of time spent inserting ranges into a {@link com.apple.foundationdb.async.RangeSet}. */
+        RANGE_SET_INSERT("insert into range set"),
+        /** The amount of time listing missing ranges from a {@link com.google.common.collect.RangeSet}. */
+        RANGE_SET_LIST_MISSING("list missing ranges from range set"),
+        /** The amount of time finding the first missing range from a {@link com.google.common.collect.RangeSet}. */
+        RANGE_SET_FIND_FIRST_MISSING("find first missing range from range set"),
+        /** The amount of time checking if a {@link com.google.common.collect.RangeSet} contains a specific key. */
+        RANGE_SET_CONTAINS("range set contains key"),
+        /** The amount of time checking if a {@link com.google.common.collect.RangeSet} is empty. */
+        RANGE_SET_IS_EMPTY("range set is empty"),
+
         /** The amount of time spent clearing the space taken by an index that has been removed from the meta-data. */
         REMOVE_FORMER_INDEX("remove former index"),
         /** The amount of time spent counting records for the deprecated record count key. */
@@ -535,6 +546,8 @@ public class FDBStoreTimer extends StoreTimer {
         REVERSE_DIR_PERSISTENT_CACHE_MISS_COUNT("number of persistent cache misses", false),
         /** The number of reverse directory cache hits.  */
         REVERSE_DIR_PERSISTENT_CACHE_HIT_COUNT("number of persistent cache hits", false),
+        /** The number of times an {@link com.apple.foundationdb.async.RangeSet} is cleared. */
+        RANGE_SET_CLEAR("range set clears", false),
         /** The number of query plans that use a covering index. */
         PLAN_COVERING_INDEX("number of covering index plans", false),
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan}. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -21,10 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 
-import com.apple.foundationdb.Range;
-import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.async.AsyncIterator;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.ExecuteProperties;
@@ -43,6 +40,7 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
@@ -147,23 +145,20 @@ public class IndexingScrubMissing extends IndexingBase {
         validateOrThrowEx(IndexTypes.VALUE.equals(index.getType()) || scrubbingPolicy.ignoreIndexTypeCheck(), "scrubbed index is not a VALUE index");
         validateOrThrowEx(store.getIndexState(index) == IndexState.READABLE, "scrubbed index is not readable");
 
-        RangeSet rangeSet = new RangeSet(indexScrubRecordsRangeSubspace(store, index));
-        AsyncIterator<Range> ranges = rangeSet.missingRanges(store.ensureContextActive()).iterator();
 
         final ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder()
                 .setIsolationLevel(IsolationLevel.SNAPSHOT)
                 .setReturnedRowLimit(getLimit() + 1); // always respectLimit in this path; +1 allows a continuation item
         final ScanProperties scanProperties = new ScanProperties(executeProperties.build());
 
-        return ranges.onHasNext().thenCompose(hasNext -> {
-            if (Boolean.FALSE.equals(hasNext)) {
+        final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingRecords(store, index);
+        return rangeSet.firstMissingRangeAsync().thenCompose(range -> {
+            if (range == null) {
                 // Here: no more missing ranges - all done
                 // To avoid stale metadata, we'll keep the scrubbed-ranges indicator empty until the next scrub call.
-                Transaction tr = store.getContext().ensureActive();
-                tr.clear(indexScrubRecordsRangeSubspace(store, index).range());
+                rangeSet.clear();
                 return AsyncUtil.READY_FALSE;
             }
-            final Range range = ranges.next();
             final Tuple rangeStart = RangeSet.isFirstKey(range.begin) ? null : Tuple.fromBytes(range.begin);
             final Tuple rangeEnd = RangeSet.isFinalKey(range.end) ? null : Tuple.fromBytes(range.end);
             final TupleRange tupleRange = TupleRange.between(rangeStart, rangeEnd);
@@ -179,7 +174,7 @@ public class IndexingScrubMissing extends IndexingBase {
                     .thenApply(vignore -> hasMore.get() ?
                                           lastResult.get().get().getPrimaryKey() :
                                           rangeEnd)
-                    .thenCompose(cont -> rangeSet.insertRange(store.ensureContextActive(), packOrNull(rangeStart), packOrNull(cont), true)
+                    .thenCompose(cont -> rangeSet.insertRangeAsync(packOrNull(rangeStart), packOrNull(cont), true)
                             .thenApply(ignore -> {
                                 if ( scanLimit > 0 ) {
                                     scanCounter += recordsScanned.get();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
-import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.CursorStreamingMode;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
@@ -67,6 +66,7 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexPrefetchRangeKey
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanBounds;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanRange;
 import com.apple.foundationdb.record.provider.foundationdb.KeyValueCursor;
+import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
 import com.apple.foundationdb.record.query.QueryToKeyMatcher;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
@@ -739,8 +739,8 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
     @Override
     @Nonnull
     public CompletableFuture<Boolean> addedRangeWithKey(@Nonnull Tuple primaryKey) {
-        RangeSet rangeSet = new RangeSet(state.store.indexRangeSubspace(state.index));
-        return rangeSet.contains(state.transaction, primaryKey.pack());
+        IndexingRangeSet rangeSet = IndexingRangeSet.forIndexBuild(state.store, state.index);
+        return rangeSet.containsAsync(primaryKey.pack());
     }
 
     protected static boolean canDeleteWhere(@Nonnull IndexMaintainerState state, @Nonnull QueryToKeyMatcher.Match match, @Nonnull Key.Evaluated evaluated) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
@@ -1,0 +1,248 @@
+/*
+ * IndexingRangeSet.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.indexing;
+
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.ReadTransaction;
+import com.apple.foundationdb.TransactionContext;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.AsyncIterator;
+import com.apple.foundationdb.async.RangeSet;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.IndexingBase;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Wrapper around a {@link RangeSet} class that binds the class with a specific transaction. This then
+ * exposes a subset of methods from the {@link RangeSet} class and executes them with the given transaction.
+ * In general, Record Layer callers should prefer this class to using a {@link RangeSet} directly because
+ * this methods are instrumented using the {@link FDBRecordContext}'s {@link FDBStoreTimer}.
+ */
+@API(API.Status.INTERNAL)
+public class IndexingRangeSet {
+    @Nonnull
+    private final FDBRecordContext context;
+    @Nonnull
+    private final RangeSet rangeSet;
+
+    private IndexingRangeSet(@Nonnull FDBRecordContext context, @Nonnull RangeSet rangeSet) {
+        this.context = context;
+        this.rangeSet = rangeSet;
+    }
+
+    /**
+     * Returns whether the set is empty. This returns {@code false} if any range has been inserted
+     * into the set and {@code true} otherwise.
+     *
+     * @return a future that returns whether or not the set is empty
+     */
+    @Nonnull
+    public CompletableFuture<Boolean> isEmptyAsync() {
+        long startTime = System.nanoTime();
+        return context.instrument(FDBStoreTimer.Events.RANGE_SET_IS_EMPTY,
+                rangeSet.isEmpty(context.ensureActive()), startTime);
+    }
+
+    /**
+     * Clear the range set of all ranges. This will clear out the subspace backing this range set.
+     */
+    public void clear() {
+        rangeSet.clear(context.ensureActive());
+        context.increment(FDBStoreTimer.Counts.RANGE_SET_CLEAR);
+    }
+
+    /**
+     * Determine if a key is in a range that has been inserted into the range set.
+     *
+     * @param key the key search for in the set
+     *
+     * @return a future that will either be {@code true} or {@code false} depending on
+     * whether a range containing the key has been inserted
+     *
+     * @see RangeSet#contains(TransactionContext, byte[])
+     */
+    @Nonnull
+    public CompletableFuture<Boolean> containsAsync(@Nonnull byte[] key) {
+        long startTime = System.nanoTime();
+        return context.instrument(FDBStoreTimer.Events.RANGE_SET_CONTAINS,
+                rangeSet.contains(context.ensureActive(), key), startTime);
+    }
+
+    /**
+     * Return the first missing range in the set. This behaves like {@link #firstMissingRangeAsync(byte[], byte[])},
+     * but it operates on the whole range set.
+     *
+     * @return a future that will contain the first missing range or {@code null} if the set is complete
+     *
+     * @see #firstMissingRangeAsync(byte[], byte[])
+     * @see RangeSet#missingRanges(ReadTransaction)
+     */
+    @Nonnull
+    public CompletableFuture<Range> firstMissingRangeAsync() {
+        return firstMissingRangeAsync(null, null);
+    }
+
+    /**
+     * Find the first missing range between {@code begin} and {@code end}. This finds the first range of keys
+     * that are not in the set yet where the begin endpoint is greater than or equal to {@code begin} and the
+     * end endpoint is less than or equal to {@code end}. If no such range exists, then this will return a future
+     * containing {@code null}.
+     *
+     * @param begin the inclusive begin endpoint or {@code null} to indicate the beginning
+     * @param end the exclusive end endpoint or {@code null} to indicate the end
+     *
+     * @return a future that will either contain the first
+     *
+     * @see RangeSet#missingRanges(ReadTransaction, byte[], byte[])
+     */
+    @Nonnull
+    public CompletableFuture<Range> firstMissingRangeAsync(@Nullable byte[] begin, @Nullable byte[] end) {
+        final long startTime = System.nanoTime();
+        final AsyncIterator<Range> ranges = rangeSet.missingRanges(context.ensureActive(), begin, end, 1).iterator();
+        CompletableFuture<Range> future = ranges.onHasNext().thenApply(hasNext -> {
+            if (hasNext) {
+                return ranges.next();
+            } else {
+                return null;
+            }
+        });
+        return context.instrument(FDBStoreTimer.Events.RANGE_SET_FIND_FIRST_MISSING, future, startTime);
+    }
+
+    /**
+     * Get all missing ranges.
+     *
+     * @return a future containing a list of missing ranges
+     *
+     * @see #listMissingRangesAsync(byte[], byte[])
+     */
+    @Nonnull
+    public CompletableFuture<List<Range>> listMissingRangesAsync() {
+        return listMissingRangesAsync(null, null);
+    }
+
+    /**
+     * Get all missing ranges within the given boundaries.
+     *
+     * @param begin the inclusive begin endpoint or {@code null} to indicate the beginning
+     * @param end the exclusive end endpoint or {@code null} to indicate the end
+     *
+     * @return a future containing a list of missing ranges within the given boundaries
+     *
+     * @see RangeSet#missingRanges(ReadTransaction, byte[], byte[])
+     */
+    @Nonnull
+    public CompletableFuture<List<Range>> listMissingRangesAsync(@Nullable byte[] begin, @Nullable byte[] end) {
+        final long startTime = System.nanoTime();
+        CompletableFuture<List<Range>> future = rangeSet.missingRanges(context.ensureActive(), begin, end)
+                .asList();
+        return context.instrument(FDBStoreTimer.Events.RANGE_SET_LIST_MISSING, future, startTime);
+    }
+
+    /**
+     * Insert a range into the range set.
+     *
+     * @param begin the inclusive begin endpoint or {@code null} to indicate the beginning
+     * @param end the exclusive end endpoint or {@code null} to indicate the end
+     *
+     * @return future that is {@code true} if there were modifications to the set and {@code false} otherwise
+     *
+     * @see RangeSet#insertRange(TransactionContext, byte[], byte[])
+     */
+    @Nonnull
+    public CompletableFuture<Boolean> insertRangeAsync(@Nullable byte[] begin, @Nullable byte[] end) {
+        return insertRangeAsync(begin, end, false);
+    }
+
+    /**
+     * Insert a range into the range set. If {@code requiresEmpty} is set to {@code true}, then this
+     * will only actually change the database if the range in the database was initially empty. See
+     * {@link RangeSet#insertRange(TransactionContext, Range, boolean)} for more details.
+     *
+     * @param begin the inclusive begin endpoint or {@code null} to indicate the beginning
+     * @param end the exclusive end endpoint or {@code null} to indicate the end
+     * @param requireEmpty whether the range should only be inserted if the range was initially empty
+     *
+     * @return future that is {@code true} if there were modifications to the set and {@code false} otherwise
+     *
+     * @see RangeSet#insertRange(TransactionContext, byte[], byte[], boolean)
+     */
+    @Nonnull
+    public CompletableFuture<Boolean> insertRangeAsync(@Nullable byte[] begin, @Nullable byte[] end, boolean requireEmpty) {
+        final long startTime = System.nanoTime();
+        return context.instrument(FDBStoreTimer.Events.RANGE_SET_INSERT,
+                rangeSet.insertRange(context.ensureActive(), begin, end, requireEmpty), startTime);
+    }
+
+    /**
+     * Create a range set for an index's build. The indexing machinery should update this range set as ranges
+     * from the index are built.
+     *
+     * @param store the record store associated with the index build
+     * @param index the index being built
+     *
+     * @return a {@code WrappedRangeSet} for an index build of a specific store
+     */
+    @Nonnull
+    public static IndexingRangeSet forIndexBuild(@Nonnull FDBRecordStore store, @Nonnull Index index) {
+        RangeSet rangeSet = new RangeSet(store.indexRangeSubspace(index));
+        return new IndexingRangeSet(store.getRecordContext(), rangeSet);
+    }
+
+    /**
+     * Create a range set for scrubbing the entries of an index. This is used by the index scrubber to
+     * track how much of a given index has been scrubbed when looking for corruption such as dangling entries
+     * (that is, index entries that no longer correspond to any record).
+     *
+     * @param store the record store associated with the index build
+     * @param index the index being built
+     *
+     * @return a {@code WrappedRangeSet} for scrubbing the index's entries
+     */
+    @Nonnull
+    public static IndexingRangeSet forScrubbingIndex(@Nonnull FDBRecordStore store, @Nonnull Index index) {
+        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubIndexRangeSubspace(store, index));
+        return new IndexingRangeSet(store.getRecordContext(), rangeSet);
+    }
+
+    /**
+     * Create a range set for scrubbing the records of an index. This is used by the index scrubber to
+     * track how much of the records have been scrubbed when looking for corruption such as missing entries
+     * (that is, records that should have associated index entries in the index but do not).
+     *
+     * @param store the record store associated with the index build
+     * @param index the index being built
+     *
+     * @return a {@code WrappedRangeSet} for scrubbing the index's records
+     */
+    @Nonnull
+    public static IndexingRangeSet forScrubbingRecords(@Nonnull FDBRecordStore store, @Nonnull Index index) {
+        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubRecordsRangeSubspace(store, index));
+        return new IndexingRangeSet(store.getRecordContext(), rangeSet);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/package-info.java
@@ -1,0 +1,40 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes used during index builds. These classes are used when building or rebuilding an index on an existing
+ * store with existing data. This is intended to be an internal package of classes that adopters should not
+ * need to consume directly. Adopters should go through the
+ * {@link com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer OnlineIndexer} API to orchestrate
+ * builds.
+ *
+ * <p>
+ * This should not be confused with {@link com.apple.foundationdb.record.provider.foundationdb.indexes}, which
+ * contains implementations of the different index maintainers, which are used to index new records as they are
+ * written (and remove old index entries are records are deleted).
+ * </p>
+ *
+ * <p>
+ * There are additional classes that are currently in {@link com.apple.foundationdb.record.provider.foundationdb}
+ * that should probably be moved into this package, such as
+ * {@link com.apple.foundationdb.record.provider.foundationdb.IndexingBase IndexingBase} and its subclasses.
+ * </p>
+ */
+package com.apple.foundationdb.record.provider.foundationdb.indexing;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.Range;
-import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
@@ -42,6 +41,7 @@ import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
@@ -521,8 +521,8 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
                     .stream()
                     .findAny()
                     .orElseGet(() -> fail("no indexes defined in meta-data"));
-            new RangeSet(store.indexRangeSubspace(foundIndex))
-                    .insertRange(context.ensureActive(), null, null)
+            IndexingRangeSet.forIndexBuild(store, foundIndex)
+                    .insertRangeAsync(null, null)
                     .get();
 
             // re-delete the header


### PR DESCRIPTION
This adds additional metrics for the `RangeSet` class. This refactors access of the class so that it goes through a wrapping object, which associates a `RangeSet` with a particular `FDBRecordContext`. That context is then used to supply the transaction for the range set, but it also is used to instrument operations of this new wrapper class so that we have timing information for `RangeSet` operations during an index build.
    
This resolves #1995.