### PR TITLE
Resolves #1998: Delay publishing commit-dependent metrics until after commit

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Metrics that are dependent on transaction commit will only be recorded after its associated transaction is successfully committed [(Issue #1998)](https://github.com/FoundationDB/fdb-record-layer/issues/1998)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -163,8 +163,9 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @SuppressWarnings("PMD.CloseResource")
     protected FDBRecordContext(@Nonnull FDBDatabase fdb,
                                @Nonnull Transaction transaction,
-                               @Nonnull FDBRecordContextConfig config) {
-        super(fdb, transaction, config.getTimer());
+                               @Nonnull FDBRecordContextConfig config,
+                               @Nullable FDBStoreTimer delayedTimer) {
+        super(fdb, transaction, config.getTimer(), delayedTimer);
         this.transactionCreateTime = System.currentTimeMillis();
         this.localVersion = new AtomicInteger(0);
         this.localVersionCache = new ConcurrentSkipListMap<>(ByteArrayUtil::compareUnsigned);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCache.java
@@ -179,8 +179,7 @@ public class FDBReverseDirectoryCache {
     @Nonnull
     @SuppressWarnings({"squid:S2095", "PMD.CloseResource"}) // Don't realize that the context is closed in the returned future
     public CompletableFuture<Optional<String>> getInReverseDirectoryCacheSubspace(@Nullable FDBStoreTimer timer, @Nonnull ScopedValue<Long> scopedReverseDirectoryKey) {
-        FDBRecordContext context = fdb.openContext();
-        context.setTimer(timer);
+        FDBRecordContext context = fdb.openContext(null, timer);
         return getReverseCacheSubspace(scopedReverseDirectoryKey.getScope())
                 .thenCompose(subspace -> getFromSubspace(context, subspace, scopedReverseDirectoryKey))
                 .whenComplete((result, exception) -> context.close());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -482,11 +482,11 @@ public class FDBStoreTimer extends StoreTimer {
         /** The number of times the store state cache was unable to return a cached result. */
         STORE_STATE_CACHE_MISS("store info cache miss", false),
         /** The number of record key-value pairs saved. */
-        SAVE_RECORD_KEY("number of record keys saved", false),
+        SAVE_RECORD_KEY("number of record keys saved", false, null, true),
         /** The size of keys for record key-value pairs saved. */
-        SAVE_RECORD_KEY_BYTES("number of record key bytes saved", true),
+        SAVE_RECORD_KEY_BYTES("number of record key bytes saved", true, null, true),
         /** The size of values for record key-value pairs saved. */
-        SAVE_RECORD_VALUE_BYTES("number of record value bytes saved", true),
+        SAVE_RECORD_VALUE_BYTES("number of record value bytes saved", true, null, true),
         /** The number of entries (e.g., key-value pairs or text index entries) loaded by a scan. */
         LOAD_SCAN_ENTRY("number of entries loaded by some scan", false),
         /** The number of key-value pairs loaded by a range scan. */
@@ -500,11 +500,11 @@ public class FDBStoreTimer extends StoreTimer {
         /** The size of values for record key-value pairs loaded. */
         LOAD_RECORD_VALUE_BYTES("number of record value bytes loaded", true),
         /** The number of index key-value pairs saved. */
-        SAVE_INDEX_KEY("number of index keys saved", false),
+        SAVE_INDEX_KEY("number of index keys saved", false, null, true),
         /** The size of keys for index key-value pairs saved. */
-        SAVE_INDEX_KEY_BYTES("number of index key bytes saved", true),
+        SAVE_INDEX_KEY_BYTES("number of index key bytes saved", true, null, true),
         /** The size of values for index key-value pairs saved. */
-        SAVE_INDEX_VALUE_BYTES("number of index value bytes saved", true),
+        SAVE_INDEX_VALUE_BYTES("number of index value bytes saved", true, null, true),
         /** The number of index key-value pairs loaded. */
         LOAD_INDEX_KEY("number of index keys loaded", false),
         /** The size of keys for index key-value pairs loaded. */
@@ -518,19 +518,19 @@ public class FDBStoreTimer extends StoreTimer {
         /** The size of values for index state key-value pairs loaded. */
         LOAD_STORE_STATE_VALUE_BYTES("number of store state value bytes loaded", true),
         /** The number of record key-value pairs deleted. */
-        DELETE_RECORD_KEY("number of record keys deleted", false),
+        DELETE_RECORD_KEY("number of record keys deleted", false, null, true),
         /** The size of keys for record key-value pairs deleted. */
-        DELETE_RECORD_KEY_BYTES("number of record key bytes deleted", true),
+        DELETE_RECORD_KEY_BYTES("number of record key bytes deleted", true, null, true),
         /** The size of values for record key-value pairs deleted. */
-        DELETE_RECORD_VALUE_BYTES("number of record value bytes deleted", true),
+        DELETE_RECORD_VALUE_BYTES("number of record value bytes deleted", true, null, true),
         /** The number of index key-value pairs deleted. */
-        DELETE_INDEX_KEY("number of index keys deleted", false),
+        DELETE_INDEX_KEY("number of index keys deleted", false, null, true),
         /** The size of keys for index key-value pairs deleted. */
-        DELETE_INDEX_KEY_BYTES("number of index key bytes deleted", true),
+        DELETE_INDEX_KEY_BYTES("number of index key bytes deleted", true, null, true),
         /** The size of values for index key-value pairs deleted. */
-        DELETE_INDEX_VALUE_BYTES("number of index value bytes deleted", true),
+        DELETE_INDEX_VALUE_BYTES("number of index value bytes deleted", true, null, true),
         /** The previous size of values for record key-value pairs that are updated. */
-        REPLACE_RECORD_VALUE_BYTES("number of record value bytes replaced", true),
+        REPLACE_RECORD_VALUE_BYTES("number of record value bytes replaced", true, null, true),
         /** The number of reverse directory cache misses.  */
         REVERSE_DIR_PERSISTENT_CACHE_MISS_COUNT("number of persistent cache misses", false),
         /** The number of reverse directory cache hits.  */
@@ -648,7 +648,7 @@ public class FDBStoreTimer extends StoreTimer {
         /** The number of times that an index entry does not point to a valid record. */
         BAD_INDEX_ENTRY("number of occurrences of bad index entries", false),
         /** The number of record keys repaired by {@link FDBRecordStore#repairRecordKeys(byte[], com.apple.foundationdb.record.ScanProperties)}. */
-        REPAIR_RECORD_KEY("repair record key", false),
+        REPAIR_RECORD_KEY("repair record key", false, null, true),
         /** The number of record keys with an invalid split suffix found by {@link FDBRecordStore#repairRecordKeys(byte[], com.apple.foundationdb.record.ScanProperties)}. */
         INVALID_SPLIT_SUFFIX("invalid split suffix", false),
         /** The number of record keys with an incorrect length found by {@link FDBRecordStore#repairRecordKeys(byte[], com.apple.foundationdb.record.ScanProperties)}. */
@@ -658,7 +658,7 @@ public class FDBStoreTimer extends StoreTimer {
         /** The number of bytes read. */
         BYTES_READ("bytes read", true),
         /** The number of bytes written, not including deletes. */
-        BYTES_WRITTEN("bytes written", true),
+        BYTES_WRITTEN("bytes written", true, null, true),
         /** Total number of read (get) operations. */
         READS("reads", false),
         /** Total number of range read (get) operations. */
@@ -666,13 +666,13 @@ public class FDBStoreTimer extends StoreTimer {
         /** Total number of remote fetch (get) operations. */
         REMOTE_FETCH("remote fetch reads", false),
         /** Total number of write operations. */
-        WRITES("writes", false),
+        WRITES("writes", false, null, true),
         /** Total number of delete (clear) operations. */
-        DELETES("deletes", false),
+        DELETES("deletes", false, null, true),
         /** Total number of range delete (clear) operations. */
-        RANGE_DELETES("range deletes", false),
+        RANGE_DELETES("range deletes", false, null, true),
         /** Total number of mutation operations. */
-        MUTATIONS("mutations", false),
+        MUTATIONS("mutations", false, null, true),
         /** JNI Calls.*/
         JNI_CALLS("jni calls", false),
         /**Bytes read.*/
@@ -698,20 +698,27 @@ public class FDBStoreTimer extends StoreTimer {
         private final String title;
         private final boolean isSize;
         private final String logKey;
+        private final boolean delayedUntilCommit;
 
-        Counts(String title, boolean isSize, String logKey) {
+        Counts(String title, boolean isSize, String logKey, boolean delayedUntilCommit) {
             this.title = title;
             this.isSize = isSize;
             this.logKey = (logKey != null) ? logKey : Count.super.logKey();
+            this.delayedUntilCommit = delayedUntilCommit;
         }
 
         Counts(String title, boolean isSize) {
-            this(title, isSize, null);
+            this(title, isSize, null, false);
         }
 
         @Override
         public String title() {
             return title;
+        }
+
+        @Override
+        public boolean isDelayedUntilCommit() {
+            return delayedUntilCommit;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/InstrumentedReadTransaction.java
@@ -69,6 +69,18 @@ abstract class InstrumentedReadTransaction<T extends ReadTransaction> implements
 
     protected final boolean enableAssertions;
 
+    /**
+     * Create a new transaction wrapping an existing {@link ReadTransaction}. This will then use the
+     * given timers to instrument the transaction's operations. Note that the main {@code timer} may be
+     * shared between multiple transactions, but the {@code delayedTimer} should be solely used by this
+     * transaction.
+     *
+     * @param timer the main timer to use for most events
+     * @param delayedTimer the timer to use for events that are marked as {@linkplain StoreTimer.Event#isDelayedUntilCommit() delayed until commit}
+     * @param underlying the underlying {@link ReadTransaction} to wrap
+     * @param enableAssertions whether operations should validate their inputs and throw {@link com.apple.foundationdb.record.RecordCoreException}s
+     *     if constaints like maximum key or value size are exceeded
+     */
     public InstrumentedReadTransaction(@Nullable StoreTimer timer, @Nullable StoreTimer delayedTimer, @Nonnull T underlying, boolean enableAssertions) {
         this.timer = timer;
         this.delayedTimer = delayedTimer;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/ScopedInterningLayer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/layers/interning/ScopedInterningLayer.java
@@ -136,8 +136,7 @@ public class ScopedInterningLayer extends LocatableResolver {
     @Override
     @SuppressWarnings("PMD.CloseResource")
     protected CompletableFuture<Optional<String>> readReverse(FDBStoreTimer timer, Long value) {
-        FDBRecordContext context = database.openContext();
-        context.setTimer(timer);
+        FDBRecordContext context = database.openContext(null, timer);
         return readReverse(context, value)
                 .whenComplete((ignored, th) -> context.close());
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStorePerformanceTest.java
@@ -239,8 +239,7 @@ public class FDBRecordStorePerformanceTest extends FDBTestBase {
         if (parameters.parallelCount == 0) {
             final Function<FDBRecordStore, CompletableFuture<?>> singleTest = test.apply(parameters.startValue);
             for (int j = 0; j < parameters.repeatCount; j++) {
-                try (FDBRecordContext context = fdb.openContext()) {
-                    context.setTimer(timer);
+                try (FDBRecordContext context = fdb.openContext(null, timer)) {
                     if (databaseParameters.disableReadYourWrites) {
                         context.ensureActive().options().setReadYourWritesDisable();
                     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreRepairTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreRepairTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -273,12 +274,13 @@ public class FDBRecordStoreRepairTest extends FDBRecordStoreTestBase {
             openUnsplitRecordStore(context, hook);
             assertNull(recordStore.repairRecordKeys(null, ScanProperties.FORWARD_SCAN, isDryRun).get(),
                     "Did not expect a continuation!");
+            context.commit();
 
-            assertEquals(repairedKeys, context.getTimer().getCount(FDBStoreTimer.Counts.REPAIR_RECORD_KEY));
-            assertEquals(invalidKeyLengths, context.getTimer().getCount(FDBStoreTimer.Counts.INVALID_KEY_LENGTH));
-            assertEquals(invalidSplitSuffixes, context.getTimer().getCount(FDBStoreTimer.Counts.INVALID_SPLIT_SUFFIX));
-
-            commit(context);
+            final FDBStoreTimer timer = Objects.requireNonNull(context.getTimer());
+            assertEquals(repairedKeys, timer.getCount(FDBStoreTimer.Counts.REPAIR_RECORD_KEY));
+            assertEquals(invalidKeyLengths, timer.getCount(FDBStoreTimer.Counts.INVALID_KEY_LENGTH));
+            assertEquals(invalidSplitSuffixes, timer.getCount(FDBStoreTimer.Counts.INVALID_SPLIT_SUFFIX));
+            timer.reset();
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBReverseDirectoryCacheTest.java
@@ -99,9 +99,7 @@ public class FDBReverseDirectoryCacheTest extends FDBTestBase {
     }
 
     private FDBRecordContext openContext() {
-        FDBRecordContext context = fdb.openContext();
-        context.setTimer(timer);
-        return context;
+        return fdb.openContext(null, timer);
     }
 
     private void commit(FDBRecordContext context) {
@@ -412,8 +410,7 @@ public class FDBReverseDirectoryCacheTest extends FDBTestBase {
         runParallelCodeOnEmptyDB(parallelism,
                 () -> {
                     if (preInitReverseDirectoryCache) {
-                        try (final FDBRecordContext context = fdb.openContext()) {
-                            context.setTimer(timer);
+                        try (final FDBRecordContext context = fdb.openContext(null, timer)) {
                             context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE,
                                     globalScope.resolve(context.getTimer(), "something totally different"));
                         }
@@ -422,8 +419,7 @@ public class FDBReverseDirectoryCacheTest extends FDBTestBase {
                 lock -> {
                     final String name = "chi_" + Math.abs(new Random().nextLong());
                     FDBDatabase fdb = getFdb.get();
-                    try (final FDBRecordContext context = fdb.openContext()) {
-                        context.setTimer(timer);
+                    try (final FDBRecordContext context = fdb.openContext(null, timer)) {
                         lock.acquire();
                         context.asyncToSync(FDBStoreTimer.Waits.WAIT_DIRECTORY_RESOLVE,
                                 CompletableFuture.allOf(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
@@ -403,7 +403,7 @@ public class FDBStoreTimerTest {
             assertEquals(0, timer.getCount(FDBStoreTimer.Counts.WRITES));
             assertEquals(0, timer.getCount(FDBStoreTimer.Counts.BYTES_WRITTEN));
 
-            // Only commit the event transactions (note: i += 2, not i++)
+            // Only commit half the transactions (note: i += 2, not i++)
             for (int i = 0; i < contextCount; i += 2) {
                 contexts.get(i).commit();
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
@@ -77,10 +77,9 @@ public class FDBStoreTimerTest {
     @BeforeEach
     public void setup() throws Exception {
         fdb = FDBDatabaseFactory.instance().getDatabase();
-        context = fdb.openContext();
-        setupBaseData();
         FDBStoreTimer timer = new FDBStoreTimer();
-        context.setTimer(timer);
+        context = fdb.openContext(null, timer);
+        setupBaseData();
     }
 
     @AfterEach

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
@@ -1152,17 +1152,19 @@ public class VersionIndexTest extends FDBTestBase {
                 // We leave the version if it's stored with the record
                 assertEquals(version, newVersion);
             }
+            // The legacy version space should be empty now, either because it was deleted or because the version was
+            // never there
+            assertFalse(context.ensureActive().getRange(recordStore.getLegacyVersionSubspace().range()).iterator().hasNext());
+            context.commit();
+
             // There should be 4 range deletes per former index, plus 1 for the version space, if required.
             // This assert may need to change if additional indexes subspaces are created
-            long rangeDeletes = recordStore.getTimer().getCount(FDBStoreTimer.Counts.RANGE_DELETES);
+            long rangeDeletes = context.getTimer().getCount(FDBStoreTimer.Counts.RANGE_DELETES);
             if (inLegacyVersionSpace) {
                 assertEquals(9L, rangeDeletes);
             } else {
                 assertEquals(8L, rangeDeletes);
             }
-            // The legacy version space should be empty now, either because it was deleted or because the version was
-            // never there
-            assertFalse(context.ensureActive().getRange(recordStore.getLegacyVersionSubspace().range()).iterator().hasNext());
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/ExtendedDirectoryLayerTest.java
@@ -309,8 +309,7 @@ class ExtendedDirectoryLayerTest extends LocatableResolverTest {
     @Test
     public void testSetMappingDoesNotScanDirectoryKeySpace() {
         FDBStoreTimer timer = new FDBStoreTimer();
-        try (FDBRecordContext context = database.openContext()) {
-            context.setTimer(timer);
+        try (FDBRecordContext context = database.openContext(null, timer)) {
             for (long i = 0; i < 10; i++) {
                 globalScope.setMapping(context, "some-key-" + i, i).join();
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -127,9 +127,7 @@ public class LeaderboardIndexTest extends FDBTestBase {
     }
 
     protected FDBRecordContext openContext() {
-        FDBRecordContext context = fdb.openContext();
-        context.setTimer(metrics);
-        return context;
+        return fdb.openContext(null, metrics);
     }
 
     public static final int TEN_UNITS = 2;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
@@ -554,9 +554,6 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
 
             // Load the record store state into the cache.
             try (FDBRecordContext context1 = testContext.getCachedContext(fdb, storeBuilder); FDBRecordContext context2 = testContext.getCachedContext(fdb, storeBuilder)) {
-                context1.setTimer(new FDBStoreTimer());
-                context2.setTimer(new FDBStoreTimer());
-
                 FDBRecordStore recordStore1 = storeBuilder.copyBuilder()
                         .setContext(context1)
                         .setMetaDataProvider(metaData1)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
@@ -125,9 +125,7 @@ public class SyntheticRecordPlannerTest {
     private FDBRecordStore.Builder recordStoreBuilder;
 
     private FDBRecordContext openContext() {
-        FDBRecordContext context = fdb.openContext();
-        context.setTimer(timer);
-        return context;
+        return fdb.openContext(null, timer);
     }
 
     private QueryPlanner setupPlanner(@Nonnull FDBRecordStore recordStore, @Nullable PlannableIndexTypes indexTypes) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -169,13 +169,13 @@ public class LuceneEvents {
         /** Total number of bytes that were attempted to be written (not necessarily committed) for file references in the FDBDirectory. */
         LUCENE_WRITE_FILE_REFERENCE_SIZE("lucene write file reference size", true),
         /** Count of writeData calls in FDBDirectory. */
-        LUCENE_WRITE_CALL("lucene index writes", false),
-        /** Total number of bytes that were attempted to be written (not necessarily committed) to the FDBDirectory.*/
-        LUCENE_WRITE_SIZE("lucene index size", true),
+        LUCENE_WRITE_CALL("lucene index writes", false, null, true),
+        /** Total number of bytes that were written to the FDBDirectory.*/
+        LUCENE_WRITE_SIZE("lucene index size", true, null, true),
         /** The number of block reads that occur against the FDBDirectory.*/
         LUCENE_BLOCK_READS("lucene block reads", false),
-        /** Time to write a file references in Lucene's FDBDirectory.*/
-        LUCENE_WRITE_FILE_REFERENCE("lucene write file reference" , false),
+        /** Number of file references written in Lucene's FDBDirectory.*/
+        LUCENE_WRITE_FILE_REFERENCE("lucene write file reference" , false, null, true),
         /** Matched documents returned from lucene index reader scans. **/
         LUCENE_SCAN_MATCHED_DOCUMENTS("lucene scan matched documents", false),
         /** Matched auto complete suggestions returned from lucene auto complete suggestion lookup. **/
@@ -193,15 +193,17 @@ public class LuceneEvents {
         private final String title;
         private final boolean isSize;
         private final String logKey;
+        private final boolean delayedUntilCommit;
 
-        Counts(String title, boolean isSize, String logKey) {
+        Counts(String title, boolean isSize, String logKey, boolean delayedUntilCommit) {
             this.title = title;
             this.isSize = isSize;
             this.logKey = (logKey != null) ? logKey : StoreTimer.Count.super.logKey();
+            this.delayedUntilCommit = delayedUntilCommit;
         }
 
         Counts(String title, boolean isSize) {
-            this(title, isSize, null);
+            this(title, isSize, null, false);
         }
 
         @Override
@@ -213,6 +215,11 @@ public class LuceneEvents {
         @Nonnull
         public String logKey() {
             return this.logKey;
+        }
+
+        @Override
+        public boolean isDelayedUntilCommit() {
+            return delayedUntilCommit;
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -145,6 +145,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         assertNotNull(directory.readBlock("testReference2",
                 directory.getFDBLuceneFileReferenceAsync("testReference2"), 1).get(), "seek data should exist");
 
+        directory.getContext().commit();
         assertCorrectMetricCount(LuceneEvents.Counts.LUCENE_WRITE_SIZE, LuceneSerializer.encode(data, true, false).length);
         assertCorrectMetricCount(LuceneEvents.Counts.LUCENE_WRITE_CALL, 1);
     }


### PR DESCRIPTION
This allows `FDBStoreTimer.Event`s to mark themselves as delayed until commit, in which case the context won't increment/record them initially, and they'll only get added to the base timer once the transaction has successfully committed. This is done by having the record context keep track of two timers, one of which is from the user and is updated immediately and the other of which is created by the context and stores these delayed metrics. Once the commit happens, the data from the delayed timer are added to the other timer.

I'd initially wanted this to be done with a single timer, which would then encapsulate the dispatching between the two timers. I think with a slightly different class hierarchy (such as a single `StoreTimer` interface with various implementations arranged to support composability), this could be done. However, because this uses inheritance instead of composition, it would have been a bit clunky and ultimately error prone.

This resolves #1998.