### PR TITLE
Fixes #2002: "EMPTY_SCANS" metric double counts empty ranges if hasNext() called multiple times

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `EMPTY_SCANS` metric is no double counts scans that call `hasNext` multiple times after completing an empty range scan [(Issue #2002)](https://github.com/FoundationDB/fdb-record-layer/issues/2002)
 * **Performance** Additional instrumentaiton of the `RangeSet` is added to account for time spent during index builds  [(Issue #1995)](https://github.com/FoundationDB/fdb-record-layer/issues/1995)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** The `EMPTY_SCANS` metric is no double counts scans that call `hasNext` multiple times after completing an empty range scan [(Issue #2002)](https://github.com/FoundationDB/fdb-record-layer/issues/2002)
+* **Bug fix** The `EMPTY_SCANS` metric no longer double counts empty scans that call `hasNext` multiple times [(Issue #2002)](https://github.com/FoundationDB/fdb-record-layer/issues/2002)
 * **Performance** Additional instrumentaiton of the `RangeSet` is added to account for time spent during index builds  [(Issue #1995)](https://github.com/FoundationDB/fdb-record-layer/issues/1995)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimerTest.java
@@ -74,7 +74,7 @@ public class FDBStoreTimerTest {
     ExecuteProperties ep;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         fdb = FDBDatabaseFactory.instance().getDatabase();
         context = fdb.openContext();
         setupBaseData();
@@ -83,13 +83,13 @@ public class FDBStoreTimerTest {
     }
 
     @AfterEach
-    public void teardown() throws Exception {
+    void teardown() {
         context.close();
         fdb.close();
     }
 
     @Test
-    public void counterDifferenceTest() {
+    void counterDifferenceTest() {
         RecordCursor<KeyValue> kvc = KeyValueCursor.Builder.withSubspace(subspace).setContext(context).setScanProperties(ScanProperties.FORWARD_SCAN).setRange(TupleRange.ALL).build();
 
         // see the timer counts from some onNext calls
@@ -131,7 +131,7 @@ public class FDBStoreTimerTest {
     }
 
     @Test
-    public void timeoutCounterDifferenceTest() {
+    void timeoutCounterDifferenceTest() {
         RecordCursor<KeyValue> kvc = KeyValueCursor.Builder.withSubspace(subspace).setContext(context).setScanProperties(ScanProperties.FORWARD_SCAN).setRange(TupleRange.ALL).build();
 
         FDBStoreTimer latestTimer = context.getTimer();
@@ -174,9 +174,8 @@ public class FDBStoreTimerTest {
     }
 
     @Test
-    public void timerConstraintChecks() {
-
-        // invalid to substract a snapshot timer from a timer that has been reset after the snapshot was taken
+    void timerConstraintChecks() {
+        // invalid to subtract a snapshot timer from a timer that has been reset after the snapshot was taken
         FDBStoreTimer latestTimer = context.getTimer();
         final StoreTimerSnapshot savedTimer;
         savedTimer = StoreTimerSnapshot.from(latestTimer);
@@ -189,7 +188,7 @@ public class FDBStoreTimerTest {
     }
 
     @Test
-    public void unchangedMetricsExcludedFromSnapshotDifference() {
+    void unchangedMetricsExcludedFromSnapshotDifference() {
         StoreTimer timer = new FDBStoreTimer();
 
         timer.increment(FDBStoreTimer.Counts.CREATE_RECORD_STORE);
@@ -212,7 +211,7 @@ public class FDBStoreTimerTest {
     }
 
     @Test
-    public void newMetricsAddedToSnapshotDifference() {
+    void newMetricsAddedToSnapshotDifference() {
         StoreTimer timer = new FDBStoreTimer();
 
         timer.increment(FDBStoreTimer.Counts.DELETE_RECORD_KEY);
@@ -254,7 +253,7 @@ public class FDBStoreTimerTest {
     }
 
     @Test
-    public void logKeyTest() {
+    void logKeyTest() {
         // If log key has not been specified, 'logKey()' should return then '.name()' of the enum.
         assertEquals(TestEvent.EVENT_WITH_SHORT_NAME.logKey(), "event_with_short_name");
 
@@ -263,7 +262,7 @@ public class FDBStoreTimerTest {
     }
 
     @Test
-    public void testAggregateMetrics() {
+    void testAggregateMetrics() {
         FDBStoreTimer storeTimer = new FDBStoreTimer();
 
         // I don't want this test to fail if new aggregates are added, but do want to verify that the
@@ -287,7 +286,7 @@ public class FDBStoreTimerTest {
     }
 
     @Test
-    public void testLowLevelIoMetrics() {
+    void testLowLevelIoMetrics() {
         final FDBStoreTimer timer = new FDBStoreTimer();
         try (FDBRecordContext context = fdb.openContext(null, timer)) {
             Transaction tr = context.ensureActive();
@@ -377,23 +376,64 @@ public class FDBStoreTimerTest {
             assertFalse(iterable.iterator().onHasNext().get());
             assertEquals(3L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
 
+            final AsyncIterator<KeyValue> itr1 = iterable.iterator();
+            assertFalse(itr1.hasNext()); // Should increment EMPTY_SCANS
+            assertFalse(itr1.hasNext()); // Should not double-count the same empty scan
+            assertEquals(4L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
+
             // Set a key in the range. From now on, the counter shouldn't get incremented
             tr.set(subspace.pack(Tuple.from(1L, "foo")), Tuple.from("bar").pack());
             final AsyncIterable<KeyValue> iterable2 = tr.getRange(subspace.pack(1L), subspace.pack(2L));
             assertThat(iterable2.asList().get(), hasSize(1));
-            assertEquals(3L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
+            assertEquals(4L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
 
             final AsyncIterator<KeyValue> itr2a = iterable2.iterator();
             assertTrue(itr2a.hasNext());
             assertEquals(Tuple.from("bar"), Tuple.fromBytes(itr2a.next().getValue()));
             assertFalse(itr2a.hasNext());
-            assertEquals(3L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
+            assertEquals(4L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
 
             final AsyncIterator<KeyValue> itr2b = iterable2.iterator();
             assertTrue(itr2b.onHasNext().get());
             assertEquals(Tuple.from("bar"), Tuple.fromBytes(itr2b.next().getValue()));
             assertFalse(itr2b.onHasNext().get());
-            assertEquals(3L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
+            assertEquals(4L, timer.getCount(FDBStoreTimer.Counts.EMPTY_SCANS));
+        }
+    }
+
+    @Test
+    void testReadsDoNotCountUntilStarted() throws ExecutionException, InterruptedException {
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (FDBRecordContext context = fdb.openContext(null, timer)) {
+            Transaction tr = context.ensureActive();
+            final AsyncIterable<KeyValue> iterable = tr.getRange(subspace.range());
+
+            // Calling getRange does not start a read yet, so the timers shouldn't have started
+            assertEquals(0, timer.getCount(FDBStoreTimer.Counts.READS));
+            assertEquals(0, timer.getCount(FDBStoreTimer.Counts.RANGE_READS));
+
+            // Run the read and validate metrics are updated
+            iterable.asList().get();
+            assertEquals(1, timer.getCount(FDBStoreTimer.Counts.READS));
+            assertEquals(1, timer.getCount(FDBStoreTimer.Counts.RANGE_READS));
+
+            // Creating an iterator does start the read, so make sure the reads metrics are updated
+            final AsyncIterator<KeyValue> iterator = iterable.iterator();
+            assertEquals(2, timer.getCount(FDBStoreTimer.Counts.READS));
+            assertEquals(2, timer.getCount(FDBStoreTimer.Counts.RANGE_READS));
+
+            // Moving an iterator forward does not count as another read
+            iterator.next();
+            assertEquals(2, timer.getCount(FDBStoreTimer.Counts.READS));
+            assertEquals(2, timer.getCount(FDBStoreTimer.Counts.RANGE_READS));
+
+            // Creating a new iterator starts a new read
+            final AsyncIterator<KeyValue> iterator2 = iterable.iterator();
+            assertEquals(3, timer.getCount(FDBStoreTimer.Counts.READS));
+            assertEquals(3, timer.getCount(FDBStoreTimer.Counts.RANGE_READS));
+
+            iterator.cancel();
+            iterator2.cancel();
         }
     }
 
@@ -444,6 +484,4 @@ public class FDBStoreTimerTest {
             return null;
         });
     }
-
-
 }


### PR DESCRIPTION
At the end of a range scan, it is legal to call `hasNext()` mutliple times. The old code would allow `hasNext()` to be called multiple times, and then it would increment the `EMPTY_SCANS` counter each time, which could result in the metric appearing the exceed the `RANGE_READS` metric. This also fixes another way in which `RANGE_READS` could be undercounted, as it is legal to start multiple `AsyncIterator`s from one `AsyncIterable`, though I don't think we actually do that within the Record Layer. Those two fixes together should ensure that `EMPTY_SCANS` is never higher than `RANGE_READS`.

This fixes #2002.