### PR TITLE
Fixes #2010: StoreSubTimer missing add override

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `StoreSubTimer` class now forwards metrics to an underlying timer when `add` is called, which previously could cause metrics reported only on commit to disappear entirely [(Issue #2010)](https://github.com/FoundationDB/fdb-record-layer/issues/2010)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreSubTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/StoreSubTimer.java
@@ -57,4 +57,12 @@ public class StoreSubTimer extends StoreTimer {
         }
         super.increment(event, amount);
     }
+
+    @Override
+    public void add(final StoreTimer other) {
+        if (underlying != null) {
+            underlying.add(other);
+        }
+        super.add(other);
+    }
 }


### PR DESCRIPTION
This adds an override to the `StoreSubTimer` class so that `.add(StoreTimer)` now adds the metrics from the passed in store timer both to its own counters but also to the counters of the underlying timer. This type of timer is constructed when a `TransactionListener` is specified:

https://github.com/FoundationDB/fdb-record-layer/blob/7677bc45a3aea3b5e11b3c582f2e90ee4788db04/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java#L755-L757

With the old `.add(StoreTimer)` implementation, if such a `StoreSubTimer` was used, then the delayed metrics would get added to the `StoreSubTimer`, but not to its underlying timer, which means that these metrics would appear to be gone from the the underlying timer in their entirety. This change now ensures that the metrics are passed along as expected, and the test added would have previously failed (reporting 0 for the writes and bytes written in the underlying timer).

Note that a potentially similar issue exists with `reset()`, which on a `StoreSubTimer` currently only resets the wrapper timer and not the underlying. Arguably, though, this is what the user could want, if the idea is that a `StoreSubTimer` can be reset multiple times without affecting the underlying timer. So, I've left it as is for now, though it's something we may need to reconsider.

This fixes #2010.