### PR TITLE
Resolve #2013: Online Indexing: Add transaction time quota and initia…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,8 +26,9 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Make Index.options immutable. This replaces the internal data structure of Index.options with an immutable map so that a user cannot call getOptions().put()[(Issue #2016)](https://github.com/FoundationDB/fdb-record-layer/issues/2016)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)*
+* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Online Indexing: Add transaction time quota and initial scanned records limit [(Issue #2013)](https://github.com/FoundationDB/fdb-record-layer/issues/2013)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -24,12 +24,10 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
-import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IndexState;
-import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordMetaData;
@@ -146,11 +144,7 @@ public class IndexingScrubDangling extends IndexingBase {
         validateOrThrowEx(IndexTypes.VALUE.equals(index.getType()) || scrubbingPolicy.ignoreIndexTypeCheck(), "scrubbed index is not a VALUE index");
         validateOrThrowEx(store.getIndexState(index) == IndexState.READABLE, "scrubbed index is not readable");
 
-        final ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder()
-                .setIsolationLevel(IsolationLevel.SNAPSHOT)
-                .setReturnedRowLimit(getLimit() + 1); // always respectLimit in this path; +1 allows a continuation item
-        final ScanProperties scanProperties = new ScanProperties(executeProperties.build());
-
+        final ScanProperties scanProperties = scanPropertiesWithLimits(true);
         final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingIndex(store, index);
         return rangeSet.firstMissingRangeAsync().thenCompose(range -> {
             if (range == null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -108,16 +108,16 @@ public class IndexingThrottle {
 
     private synchronized void loadConfig() {
         if (common.loadConfig()) {
-            final int initialLimit = common.config.getInitialLimit();
-            if (limit > initialLimit) {
+            final int maxLimit = common.config.getMaxLimit();
+            if (limit > maxLimit) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info(
-                            KeyValueLogMessage.build("Decreasing the limit to the new initial limit.",
+                            KeyValueLogMessage.build("Decreasing the limit to the new max limit.",
                                     LogMessageKeys.INDEX_NAME, common.getTargetIndexesNames(),
                                     LogMessageKeys.LIMIT, limit,
-                                    LogMessageKeys.MAX_LIMIT, initialLimit).toString());
+                                    LogMessageKeys.MAX_LIMIT, maxLimit).toString());
                 }
-                limit = initialLimit;
+                limit = maxLimit;
             }
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -79,7 +79,7 @@ public class IndexingThrottle {
 
     IndexingThrottle(@Nonnull IndexingCommon common, IndexState expectedIndexState) {
         this.common = common;
-        this.limit = common.config.getMaxLimit();
+        this.limit = common.config.getInitialLimit();
         this.expectedIndexState = expectedIndexState;
     }
 
@@ -108,16 +108,16 @@ public class IndexingThrottle {
 
     private synchronized void loadConfig() {
         if (common.loadConfig()) {
-            final int maxLimit = common.config.getMaxLimit();
-            if (limit > maxLimit) {
+            final int initialLimit = common.config.getInitialLimit();
+            if (limit > initialLimit) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info(
-                            KeyValueLogMessage.build("Decreasing the limit to the new maxLimit.",
+                            KeyValueLogMessage.build("Decreasing the limit to the new initial limit.",
                                     LogMessageKeys.INDEX_NAME, common.getTargetIndexesNames(),
                                     LogMessageKeys.LIMIT, limit,
-                                    LogMessageKeys.MAX_LIMIT, maxLimit).toString());
+                                    LogMessageKeys.MAX_LIMIT, initialLimit).toString());
                 }
-                limit = maxLimit;
+                limit = initialLimit;
             }
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -907,8 +907,9 @@ public class OnlineIndexScrubber implements AutoCloseable {
          */
         public OnlineIndexScrubber build() {
             validate();
-            OnlineIndexer.Config conf = new OnlineIndexer.Config(limit, maxRetries, recordsPerSecond,
-                    progressLogIntervalMillis, increaseLimitAfter, maxWriteLimitBytes, OnlineIndexer.Config.UNLIMITED_TIME);
+            OnlineIndexer.Config conf = new OnlineIndexer.Config(limit, limit, maxRetries, recordsPerSecond,
+                    progressLogIntervalMillis, increaseLimitAfter, maxWriteLimitBytes,
+                    OnlineIndexer.Config.UNLIMITED_TIME, OnlineIndexer.Config.UNLIMITED_TIME);
             if (scrubbingPolicyBuilder != null) {
                 scrubbingPolicy = scrubbingPolicyBuilder.build();
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -885,23 +885,27 @@ public class OnlineIndexer implements AutoCloseable {
     @API(API.Status.UNSTABLE)
     public static class Config {
         private final int maxLimit;
+        private final int initialLimit;
         private final int maxWriteLimitBytes;
         private final int maxRetries;
         private final int recordsPerSecond;
         private final long progressLogIntervalMillis;
         private final int increaseLimitAfter;
         private final long timeLimitMilliseconds;
+        private final long transactionTimeQuotaMilliseconds;
         public static final long UNLIMITED_TIME = 0;
 
-        Config(int maxLimit, int maxRetries, int recordsPerSecond, long progressLogIntervalMillis, int increaseLimitAfter,
-                   int maxWriteLimitBytes, long timeLimitMilliseconds) {
+        Config(int maxLimit, int initialLimit, int maxRetries, int recordsPerSecond, long progressLogIntervalMillis, int increaseLimitAfter,
+                   int maxWriteLimitBytes, long timeLimitMilliseconds, long transactionTimeQuotaMilliseconds) {
             this.maxLimit = maxLimit;
+            this.initialLimit = initialLimit > 0 && initialLimit < maxLimit ? initialLimit : maxLimit;
             this.maxRetries = maxRetries;
             this.recordsPerSecond = recordsPerSecond;
             this.progressLogIntervalMillis = progressLogIntervalMillis;
             this.increaseLimitAfter = increaseLimitAfter;
             this.maxWriteLimitBytes = maxWriteLimitBytes;
             this.timeLimitMilliseconds = timeLimitMilliseconds;
+            this.transactionTimeQuotaMilliseconds = transactionTimeQuotaMilliseconds;
         }
 
         /**
@@ -910,6 +914,14 @@ public class OnlineIndexer implements AutoCloseable {
          */
         public int getMaxLimit() {
             return maxLimit;
+        }
+
+        /**
+         * Get the initial number of records to process in one transaction.
+         * @return the initial number of records to process in one transaction
+         */
+        public int getInitialLimit() {
+            return initialLimit;
         }
 
         /**
@@ -950,7 +962,7 @@ public class OnlineIndexer implements AutoCloseable {
 
         /**
          * Stop scanning if the write size (bytes) becomes bigger that this value.
-         * @return the write size
+         * @return max write quota for a single transaction
          */
         public long getMaxWriteLimitBytes() {
             return maxWriteLimitBytes;
@@ -962,6 +974,14 @@ public class OnlineIndexer implements AutoCloseable {
          */
         public long getTimeLimitMilliseconds() {
             return timeLimitMilliseconds;
+        }
+
+        /**
+         * Get the time quota for a single transaction.
+         * @return the time quota for a single transaction
+         */
+        public long getTransactionTimeQuotaMilliseconds() {
+            return transactionTimeQuotaMilliseconds;
         }
 
         @Nonnull
@@ -977,12 +997,14 @@ public class OnlineIndexer implements AutoCloseable {
         public Builder toBuilder() {
             return Config.newBuilder()
                     .setMaxLimit(this.maxLimit)
+                    .setInitialLimit(this.initialLimit)
                     .setWriteLimitBytes(this.maxWriteLimitBytes)
                     .setIncreaseLimitAfter(this.increaseLimitAfter)
                     .setProgressLogIntervalMillis(this.progressLogIntervalMillis)
                     .setRecordsPerSecond(this.recordsPerSecond)
                     .setMaxRetries(this.maxRetries)
-                    .setTimeLimitMilliseconds(timeLimitMilliseconds);
+                    .setTimeLimitMilliseconds(timeLimitMilliseconds)
+                    .setTransactionTimeQuotaMilliseconds(this.transactionTimeQuotaMilliseconds);
         }
 
         /**
@@ -992,12 +1014,14 @@ public class OnlineIndexer implements AutoCloseable {
         @API(API.Status.UNSTABLE)
         public static class Builder {
             private int maxLimit = DEFAULT_LIMIT;
+            private int initialLimit = 0;
             private int maxWriteLimitBytes = DEFAULT_WRITE_LIMIT_BYTES;
             private int maxRetries = DEFAULT_MAX_RETRIES;
             private int recordsPerSecond = DEFAULT_RECORDS_PER_SECOND;
             private long progressLogIntervalMillis = DEFAULT_PROGRESS_LOG_INTERVAL;
             private int increaseLimitAfter = DO_NOT_RE_INCREASE_LIMIT;
             private long timeLimitMilliseconds = UNLIMITED_TIME;
+            private long transactionTimeQuotaMilliseconds = UNLIMITED_TIME;
 
             protected Builder() {
 
@@ -1005,7 +1029,6 @@ public class OnlineIndexer implements AutoCloseable {
 
             /**
              * Set the maximum number of records to process in one transaction.
-             *
              * The default limit is {@link #DEFAULT_LIMIT} = {@value #DEFAULT_LIMIT}.
              * @param limit the maximum number of records to process in one transaction
              * @return this builder
@@ -1017,8 +1040,20 @@ public class OnlineIndexer implements AutoCloseable {
             }
 
             /**
+             * Set the initial number of records to process in one transaction. This can be useful to avoid
+             * starting the indexing with the maximum limit (set by {@link #setMaxLimit(int)}), which may cause timeouts.
+             * The default initial limit is {@link #DEFAULT_LIMIT} = {@value #DEFAULT_LIMIT}.
+             * @param limit the initial number of records to process in one transaction
+             * @return this builder
+             */
+            @Nonnull
+            public Builder setInitialLimit(int limit) {
+                this.initialLimit = limit;
+                return this;
+            }
+
+            /**
              * Set the maximum transaction size in a single transaction.
-             *
              * The default limit is {@link #DEFAULT_WRITE_LIMIT_BYTES} = {@value #DEFAULT_WRITE_LIMIT_BYTES}.
              * @param limit the approximate maximum write size in one transaction
              * @return this builder
@@ -1091,10 +1126,26 @@ public class OnlineIndexer implements AutoCloseable {
              */
             @Nonnull
             public Builder setTimeLimitMilliseconds(long timeLimitMilliseconds) {
-                if (timeLimitMilliseconds < UNLIMITED_TIME) {
+                if (timeLimitMilliseconds < 0) {
                     timeLimitMilliseconds = UNLIMITED_TIME;
                 }
                 this.timeLimitMilliseconds = timeLimitMilliseconds;
+                return this;
+            }
+
+            /**
+             * Set the time quota for a single transaction. If this quota is exceeds, the indexer will commit the
+             * transaction and start a new one. This can be useful to avoid timeouts while scanning a high number of records
+             * in each transaction.
+             * A non-positive value (default) implies unlimited quota.
+             * Note that this quota, if reached, will be exceeded by an Order(1) overhead time. Keeping some margins might be
+             * a good idea.
+             * @param timeQuotaMilliseconds the time limit in milliseconds
+             * @return this builder
+             */
+            @Nonnull
+            public Builder setTransactionTimeQuotaMilliseconds(long timeQuotaMilliseconds) {
+                this.transactionTimeQuotaMilliseconds = timeQuotaMilliseconds;
                 return this;
             }
 
@@ -1104,8 +1155,8 @@ public class OnlineIndexer implements AutoCloseable {
              */
             @Nonnull
             public Config build() {
-                return new Config(maxLimit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter,
-                        maxWriteLimitBytes, timeLimitMilliseconds);
+                return new Config(maxLimit, initialLimit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter,
+                        maxWriteLimitBytes, timeLimitMilliseconds, transactionTimeQuotaMilliseconds);
             }
         }
     }
@@ -1138,6 +1189,7 @@ public class OnlineIndexer implements AutoCloseable {
         @Nullable
         private UnaryOperator<Config> configLoader = null;
         private int limit = DEFAULT_LIMIT;
+        private int initialLimit = 0;
         private int maxWriteLimitBytes = DEFAULT_WRITE_LIMIT_BYTES;
         private int maxRetries = DEFAULT_MAX_RETRIES;
         private int recordsPerSecond = DEFAULT_RECORDS_PER_SECOND;
@@ -1149,6 +1201,7 @@ public class OnlineIndexer implements AutoCloseable {
         private boolean useSynchronizedSession = true;
         private long leaseLengthMillis = DEFAULT_LEASE_LENGTH_MILLIS;
         private long timeLimitMilliseconds = 0;
+        private long transactionTimeQuotaMilliseconds = 0;
 
         protected Builder() {
         }
@@ -1379,6 +1432,19 @@ public class OnlineIndexer implements AutoCloseable {
         }
 
         /**
+         * Set the initial number of records to process in one transaction. This can be useful to avoid
+         * starting the indexing with the max limit (set by {@link #setLimit(int)}), which may cause timeouts.
+         * a non-positive value (default) or a value that is bigger than the max limit will initial the limit at the max limit.
+         * @param limit the initial number of records to process in one transaction
+         * @return this builder
+         */
+        @Nonnull
+        public Builder setInitialLimit(int limit) {
+            this.initialLimit = limit;
+            return this;
+        }
+
+        /**
          * Get the approximate maximum transaction write size. Note that the actual write size might be up to one
          * record bigger than this value - transactions started as part of the index build will be committed after
          * they exceed this size, and a new transaction will be started.
@@ -1391,8 +1457,8 @@ public class OnlineIndexer implements AutoCloseable {
         /**
          * Set the approximate maximum transaction write size. Note that the actual size might be up to one record
          * bigger than this value - transactions started as part of the index build will be committed after
-         * they exceed this size, and a new transaction will be started.
-         * he default limit is {@link #DEFAULT_WRITE_LIMIT_BYTES} = {@value #DEFAULT_WRITE_LIMIT_BYTES}.
+         * they exceed this size, and a new transaction will be started. A non-positive value implies unlimited.
+         * the default limit is {@link #DEFAULT_WRITE_LIMIT_BYTES} = {@value #DEFAULT_WRITE_LIMIT_BYTES}.
          * @param max the desired max write size
          * @return this builder
          */
@@ -1918,6 +1984,22 @@ public class OnlineIndexer implements AutoCloseable {
         }
 
         /**
+         * Set the time quota for a single transaction. If this quota is exceeds, the indexer will commit the
+         * transaction and start a new one. This can be useful to avoid timeouts while scanning a high number of records
+         * in each transaction.
+         * A non-positive value (default) implies unlimited quota.
+         * Note that this quota, if reached, will be exceeded by an Order(1) overhead time. Keeping some margins might be
+         * a good idea.
+         * @param timeQuotaMilliseconds the time limit in milliseconds
+         * @return this builder
+         */
+        @Nonnull
+        public Builder setTransactionTimeQuotaMilliseconds(long timeQuotaMilliseconds) {
+            this.transactionTimeQuotaMilliseconds = timeQuotaMilliseconds;
+            return this;
+        }
+
+        /**
          * Add an {@link IndexingPolicy} policy. If set, this policy will determine how the index should be
          * built.
          * For backward compatibility, the use of deprecated {@link #indexStatePrecondition} may override some policy values.
@@ -1954,8 +2036,8 @@ public class OnlineIndexer implements AutoCloseable {
         public OnlineIndexer build() {
             determineIndexingPolicy();
             validate();
-            Config conf = new Config(limit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter,
-                    maxWriteLimitBytes, timeLimitMilliseconds);
+            Config conf = new Config(limit, initialLimit, maxRetries, recordsPerSecond, progressLogIntervalMillis, increaseLimitAfter,
+                    maxWriteLimitBytes, timeLimitMilliseconds, transactionTimeQuotaMilliseconds);
             return new OnlineIndexer(runner, recordStoreBuilder, targetIndexes, recordTypes,
                     configLoader, conf,
                     useSynchronizedSession, leaseLengthMillis, trackProgress, indexingPolicy);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -194,7 +194,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         openSimpleMetaData(hook);
         disableAll(indexes);
         try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes, timer)
-                .setTransactionTimeQuotaMilliseconds(1)
+                .setTransactionTimeLimitMilliseconds(1)
                 .build()) {
             indexBuilder.buildIndex(true);
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -902,6 +902,26 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
     }
 
     @Test
+    void testConfigLoaderInitialLimit() throws Exception {
+        final Index index = new Index("newIndex", field("num_value_unique"));
+        populateData(40);
+
+        final FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+
+        openSimpleMetaData(hook);
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (OnlineIndexer indexBuilder = newIndexerBuilder(index, timer)
+                .setInitialLimit(4)
+                .setLimit(10000)
+                .setConfigLoader(old -> old)
+                .build()) {
+            indexBuilder.buildIndex();
+        }
+        assertEquals(10, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
+    }
+
+    @Test
     public void testOnlineIndexerBuilderWriteLimitBytes() throws Exception {
         int numRecords = 127;
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, numRecords).mapToObj( val ->

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -905,19 +905,17 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
     void testConfigLoaderInitialLimit() throws Exception {
         final Index index = new Index("newIndex", field("num_value_unique"));
         populateData(40);
-
         final FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
-
-        openSimpleMetaData(hook);
-
         final FDBStoreTimer timer = new FDBStoreTimer();
+        openSimpleMetaData(hook);
         try (OnlineIndexer indexBuilder = newIndexerBuilder(index, timer)
                 .setInitialLimit(4)
+                .setIncreaseLimitAfter(100) // high enough to keep the initial limit
                 .setLimit(10000)
-                .setConfigLoader(old -> old)
                 .build()) {
             indexBuilder.buildIndex();
         }
+        // Ensure that 40 records were scanned in 10 separate ranges (of 4 records each - the initial limit)
         assertEquals(10, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -36,8 +36,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -55,7 +53,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag(Tags.RequiresFDB)
 public abstract class OnlineIndexerTest extends FDBTestBase {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerTest.class);
 
     RecordMetaData metaData;
     RecordQueryPlanner planner;


### PR DESCRIPTION
…l scanned records limit

   Add two new values to OnlineIndexer.Config:
   1. A transaction time quota
   2. An initial scanned records limit value (separated from the max limit)