### PR TITLE
Fixes #2015: ValueIndexExpansionVisitor does not handle when primary key subsumed by index key

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Cascades planner no longer trips over `VALUE` indexes which contain all fields in the primary key [(Issue #2015)](https://github.com/FoundationDB/fdb-record-layer/issues/2015)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** OnlineIndexer: make stamp operations public [(Issue #2027)](https://github.com/FoundationDB/fdb-record-layer/issues/2027)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
@@ -196,6 +196,9 @@ public class ValueIndexExpansionVisitor extends KeyExpressionExpansionVisitor im
         }
         final var trimmedPrimaryKeyComponents = new ArrayList<>(primaryKey.normalizeKeyForPositions());
         index.trimPrimaryKey(trimmedPrimaryKeyComponents);
+        if (trimmedPrimaryKeyComponents.isEmpty()) {
+            return rootExpression;
+        }
         final var fullKeyListBuilder = ImmutableList.<KeyExpression>builder();
         fullKeyListBuilder.add(rootExpression);
         fullKeyListBuilder.addAll(trimmedPrimaryKeyComponents);


### PR DESCRIPTION
This adds a check while adding the primary key fields to the root expression so that if the primary key is entirely contained within the index expression and therefore doesn't need to be added to the key expression. There's a new test of the planner that fails without this fix, as the new planner needs to consider an expression of that kind. The test also runs under the old planner, which succeeded before and after this fix.

This fixes #2015.