### PR TITLE
Resolve #2022: Mutual indexing: the list of missing ranges should be …

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Mutual indexing: the list of missing ranges should be fetched in snapshot resolution [(Issue #2022)](https://github.com/FoundationDB/fdb-record-layer/issues/2022)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -338,7 +338,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
         }
         validateSameMetadataOrThrow(store);
         IndexingRangeSet rangeSet = IndexingRangeSet.forIndexBuild(store, common.getPrimaryIndex());
-        return rangeSet.listMissingRangesAsync().thenCompose(missingRanges ->
+        return rangeSet.listMissingRangesSnapshotAsync().thenCompose(missingRanges ->
                 buildNextRangeOnly(sortAndSquash(missingRanges), subspaceProvider, subspace));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
@@ -165,6 +165,20 @@ public class IndexingRangeSet {
     }
 
     /**
+     * Get all missing ranges in a snapshot resolution. This function can be used to avoid adding all the missing ranges
+     * to the transaction's conflict list.
+     *
+     * @return a future containing a full list of all missing range.
+     */
+    @Nonnull
+    public CompletableFuture<List<Range>> listMissingRangesSnapshotAsync() {
+        final long startTime = System.nanoTime();
+        CompletableFuture<List<Range>> future = rangeSet.missingRanges(context.ensureActive().snapshot(), null, null)
+                .asList();
+        return context.instrument(FDBStoreTimer.Events.RANGE_SET_LIST_MISSING, future, startTime);
+    }
+
+    /**
      * Insert a range into the range set.
      *
      * @param begin the inclusive begin endpoint or {@code null} to indicate the beginning


### PR DESCRIPTION
…fetched in snapshot resolution. 

When fetching the list of missing ranges, the whole range is being added to the transaction's conflict list - which restricts mutual indexing to a ridiculously bad performance. 