### PR TITLE
Resolve #2027: OnlineIndexer: make stamp operations public

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** OnlineIndexer: make stamp operations public [(Issue #2027)](https://github.com/FoundationDB/fdb-record-layer/issues/2027)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -819,7 +819,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @return a map of target indexes and their "indexing stamps".
      */
     @API(API.Status.EXPERIMENTAL)
-    Map<String, IndexBuildProto.IndexBuildIndexingStamp> queryIndexingStamps() {
+    public Map<String, IndexBuildProto.IndexBuildIndexingStamp> queryIndexingStamps() {
         return indexingStamp(IndexingBase.IndexingStampOperation.QUERY, null, null);
     }
 
@@ -831,7 +831,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @return a map of target indexes and their "indexing stamps" before the change.
      */
     @API(API.Status.EXPERIMENTAL)
-    Map<String, IndexBuildProto.IndexBuildIndexingStamp> blockIndexBuilds(@Nullable String id, @Nullable Long ttlSeconds)  {
+    public Map<String, IndexBuildProto.IndexBuildIndexingStamp> blockIndexBuilds(@Nullable String id, @Nullable Long ttlSeconds)  {
         return indexingStamp(IndexingBase.IndexingStampOperation.BLOCK, id, ttlSeconds);
     }
 
@@ -842,7 +842,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @return  a map of target indexes and their "indexing stamps" before the change.
      */
     @API(API.Status.EXPERIMENTAL)
-    Map<String, IndexBuildProto.IndexBuildIndexingStamp> unblockIndexBuilds(@Nullable String id) {
+    public Map<String, IndexBuildProto.IndexBuildIndexingStamp> unblockIndexBuilds(@Nullable String id) {
         return indexingStamp(IndexingBase.IndexingStampOperation.UNBLOCK, id, null);
     }
 


### PR DESCRIPTION
To let use external callers make stamp operations, declare the next functions pubic:
queryIndexingStamps
blockIndexBuilds
unblockIndexBuilds