### PR TITLE
Adjusting RecordCoreArgumentException so that we can pass wrapped exceptions correctly

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCoreArgumentException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordCoreArgumentException.java
@@ -31,11 +31,11 @@ import javax.annotation.Nonnull;
 public class RecordCoreArgumentException extends RecordCoreException {
     private static final long serialVersionUID = 1;
 
-    public RecordCoreArgumentException(@Nonnull String msg, @Nonnull Object ... keyValue) {
+    public RecordCoreArgumentException(@Nonnull String msg, @Nonnull Object... keyValue) {
         super(msg, keyValue);
     }
 
-    public RecordCoreArgumentException(@Nonnull String msg, @Nonnull IllegalArgumentException cause) {
+    public RecordCoreArgumentException(@Nonnull String msg, @Nonnull Throwable cause) {
         super(msg, cause);
     }
 }


### PR DESCRIPTION
Not doing this was resulting in an error in the lucene module which was attempting to treat syntax errors as argument exceptions. It's possible that there is a more appropriate error for that within Lucene, but this change will at least mean that we don't lose the wrapped exception by accidentally triggering an "Unbalanced key/value" exception to be thrown at creation time.