### PR TITLE
Add internal Lucene analysers to store and sorted document fields

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistry.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistry.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.record.metadata.Index;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 
 /**
  * Registry for {@link AnalyzerChooser}s. This registry allows for full-text indexes to specify
@@ -39,4 +40,9 @@ import javax.annotation.Nonnull;
 public interface LuceneAnalyzerRegistry {
     @Nonnull
     LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull Index index, @Nonnull LuceneAnalyzerType type);
+
+    @Nonnull
+    LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull Index index,
+                                                                           @Nonnull LuceneAnalyzerType type,
+                                                                           @Nonnull Map<String, LuceneIndexExpressions.DocumentFieldDerivation> auxiliaryFieldInfo);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistry.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistry.java
@@ -38,8 +38,6 @@ import java.util.Map;
  */
 @SuppressWarnings("unused")
 public interface LuceneAnalyzerRegistry {
-    @Nonnull
-    LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull Index index, @Nonnull LuceneAnalyzerType type);
 
     @Nonnull
     LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull Index index,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.lucene.exact.ExactTokenAnalyzerFactory;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import org.apache.commons.lang3.tuple.Pair;
@@ -88,27 +89,61 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
 
     @Nonnull
     @Override
-    public LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull Index index, @Nonnull LuceneAnalyzerType type) {
+    public LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull final Index index, @Nonnull final LuceneAnalyzerType type) {
+        return getLuceneAnalyzerCombinationProvider(index, type, Map.of());
+    }
+
+    @Nonnull
+    @Override
+    public LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull final Index index,
+                                                                                  @Nonnull final LuceneAnalyzerType type,
+                                                                                  @Nonnull final Map<String, LuceneIndexExpressions.DocumentFieldDerivation> auxiliaryFieldInfo) {
         final String defaultAnalyzerName = index.getOption(type.getAnalyzerOptionKey());
         final String analyzerPerFieldName = index.getOption(type.getAnalyzerPerFieldOptionKey());
         Pair<AnalyzerChooser, AnalyzerChooser> defaultAnalyzerChooserPair = getAnalyzerChooser(index, defaultAnalyzerName, type);
 
-        if (analyzerPerFieldName == null) {
-            return new LuceneAnalyzerCombinationProvider(defaultAnalyzerChooserPair.getLeft(), defaultAnalyzerChooserPair.getRight(),
-                    null, null);
-        }
-
         Map<String, AnalyzerChooser> indexAnalyzerChooserPerFieldOverride = new TreeMap<>();
         Map<String, AnalyzerChooser> queryAnalyzerChooserPerFieldOverride = new TreeMap<>();
 
-        LuceneIndexOptions.parseKeyValuePairOptionValue(analyzerPerFieldName).forEach((fieldName, analyzerName) -> {
-            Pair<AnalyzerChooser, AnalyzerChooser> perFieldAnalyzerChooserPair = getAnalyzerChooser(index, analyzerName, type);
-            indexAnalyzerChooserPerFieldOverride.put(fieldName, perFieldAnalyzerChooserPair.getLeft());
-            queryAnalyzerChooserPerFieldOverride.put(fieldName, perFieldAnalyzerChooserPair.getRight());
+        if (analyzerPerFieldName != null) {
+            LuceneIndexOptions.parseKeyValuePairOptionValue(analyzerPerFieldName).forEach((fieldName, analyzerName) -> {
+                Pair<AnalyzerChooser, AnalyzerChooser> perFieldAnalyzerChooserPair = getAnalyzerChooser(index, analyzerName, type);
+                indexAnalyzerChooserPerFieldOverride.put(fieldName, perFieldAnalyzerChooserPair.getLeft());
+                queryAnalyzerChooserPerFieldOverride.put(fieldName, perFieldAnalyzerChooserPair.getRight());
+            });
+        }
+
+        auxiliaryFieldInfo.forEach((fieldName, fieldInfo) -> {
+            addPerFieldAnalyzerIfNecessary(indexAnalyzerChooserPerFieldOverride, fieldName, fieldInfo, index);
+            addPerFieldAnalyzerIfNecessary(queryAnalyzerChooserPerFieldOverride, fieldName, fieldInfo, index);
         });
 
         return new LuceneAnalyzerCombinationProvider(defaultAnalyzerChooserPair.getLeft(), defaultAnalyzerChooserPair.getRight(),
                 indexAnalyzerChooserPerFieldOverride, queryAnalyzerChooserPerFieldOverride);
+    }
+
+    private void addPerFieldAnalyzerIfNecessary(@Nonnull final Map<String, AnalyzerChooser> chooserPerFieldOverride,
+                                                @Nonnull final String fieldName,
+                                                @Nonnull final LuceneIndexExpressions.DocumentFieldDerivation fieldInfo,
+                                                @Nonnull final Index index) {
+        if (chooserPerFieldOverride.containsKey(fieldName)) {
+            // do not override already chosen field analyzer.
+            return;
+        }
+        if (isEligibleForNoOpAnalyzer(fieldInfo)) {
+            if (registry.isEmpty()
+                    || registry.get(LuceneAnalyzerType.FULL_TEXT) == null
+                    || registry.get(LuceneAnalyzerType.FULL_TEXT).get(ExactTokenAnalyzerFactory.NAME) == null) {
+                throw new MetaDataException("could not retrieve analyzer",
+                        LuceneLogMessageKeys.ANALYZER_NAME, ExactTokenAnalyzerFactory.NAME,
+                        LuceneLogMessageKeys.ANALYZER_TYPE, LuceneAnalyzerType.FULL_TEXT);
+            }
+            chooserPerFieldOverride.put(fieldName, registry.get(LuceneAnalyzerType.FULL_TEXT).get(ExactTokenAnalyzerFactory.NAME).getIndexAnalyzerChooser(index));
+        }
+    }
+
+    private static boolean isEligibleForNoOpAnalyzer(@Nonnull final LuceneIndexExpressions.DocumentFieldDerivation fieldInfo) {
+        return fieldInfo.isSorted() || fieldInfo.isStored();
     }
 
     private Pair<AnalyzerChooser, AnalyzerChooser> getAnalyzerChooser(@Nonnull Index index, @Nullable String analyzerName, @Nonnull LuceneAnalyzerType type) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.lucene.search.BooleanPointsConfig;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -172,6 +173,23 @@ public class LuceneIndexExpressions {
                     return null;
             }
         }
+    }
+
+    @Nonnull
+    public static Map<String, DocumentFieldDerivation> getDocumentFieldDerivations(@Nonnull final Index index, @Nonnull final RecordMetaData metadata) {
+        Map<String, LuceneIndexExpressions.DocumentFieldDerivation> combined = null;
+        for (RecordType recordType : metadata.recordTypesForIndex(index)) {
+            final var documentFields = getDocumentFieldDerivations(index.getRootExpression(), recordType.getDescriptor());
+            if (combined == null) {
+                combined = documentFields;
+            } else {
+                combined.putAll(documentFields);
+            }
+        }
+        if (combined == null) {
+            combined = Collections.emptyMap();
+        }
+        return combined;
     }
 
     /**

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -104,8 +104,9 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         super(state);
         this.executor = executor;
         this.directoryManager = FDBDirectoryManager.getManager(state);
-        this.indexAnalyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(state.index, LuceneAnalyzerType.FULL_TEXT);
-        this.autoCompleteQueryAnalyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(state.index, LuceneAnalyzerType.AUTO_COMPLETE);
+        final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(state.index, state.store.getRecordMetaData());
+        this.indexAnalyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(state.index, LuceneAnalyzerType.FULL_TEXT, fieldInfos);
+        this.autoCompleteQueryAnalyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(state.index, LuceneAnalyzerType.AUTO_COMPLETE, fieldInfos);
         this.autoCompleteEnabled = state.index.getBooleanOption(LuceneIndexOptions.AUTO_COMPLETE_ENABLED, false);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -126,7 +126,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         }
 
         LucenePlanState state = new LucenePlanState(index, groupingComparisons, filter);
-        getFieldDerivations(state);
+        state.documentFields = LuceneIndexExpressions.getDocumentFieldDerivations(index, metaData);
 
         QueryComponent queryComponent = state.groupingComparisons.isEmpty() ? state.filter : filterMask.getUnsatisfiedFilter();
         // Special scans like auto-complete cannot be combined with regular queries.
@@ -447,24 +447,6 @@ public class LucenePlanner extends RecordQueryPlanner {
             }
         }
         return comparison;
-    }
-
-    @Nonnull
-    private void getFieldDerivations(@Nonnull LucenePlanState state) {
-        Map<String, LuceneIndexExpressions.DocumentFieldDerivation> combined = null;
-        for (RecordType recordType : getRecordMetaData().recordTypesForIndex(state.index)) {
-            Map<String, LuceneIndexExpressions.DocumentFieldDerivation> documentFields =
-                    LuceneIndexExpressions.getDocumentFieldDerivations(state.index.getRootExpression(), recordType.getDescriptor());
-            if (combined == null) {
-                combined = documentFields;
-            } else {
-                combined.putAll(documentFields);
-            }
-        }
-        if (combined == null) {
-            combined = Collections.emptyMap();
-        }
-        state.documentFields = combined;
     }
 
     @Nullable

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
@@ -238,7 +238,8 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
                 case TEXT_CONTAINS_PHRASE:
                     // PhraseQuery will require tokenizing, so may as well just use parser.
                     try {
-                        final LuceneAnalyzerCombinationProvider analyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT);
+                        final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(index, store.getRecordMetaData());
+                        final LuceneAnalyzerCombinationProvider analyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT, fieldInfos);
                         final QueryParser parser = new QueryParser(field, analyzerSelector.provideQueryAnalyzer((String) comparand).getAnalyzer());
                         return parser.parse("\"" + comparand + "\"");
                     } catch (Exception ex) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryMultiFieldSearchClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryMultiFieldSearchClause.java
@@ -63,7 +63,8 @@ public class LuceneQueryMultiFieldSearchClause extends LuceneQueryClause {
 
     @Override
     public Query bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
-        final LuceneAnalyzerCombinationProvider analyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT);
+        final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(index, store.getRecordMetaData());
+        final LuceneAnalyzerCombinationProvider analyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT, fieldInfos);
         final String[] fieldNames = LuceneScanParameters.indexTextFields(index, store.getRecordMetaData()).toArray(new String[0]);
         final String searchString = isParameter ? (String)context.getBinding(search) : search;
         final Map<String, PointsConfig> pointsConfigMap = LuceneIndexExpressions.constructPointConfigMap(store, index);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
@@ -75,7 +75,8 @@ public class LuceneQuerySearchClause extends LuceneQueryClause {
 
     @Override
     public Query bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
-        final LuceneAnalyzerCombinationProvider analyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT);
+        final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(index, store.getRecordMetaData());
+        final LuceneAnalyzerCombinationProvider analyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT, fieldInfos);
         final String searchString = isParameter ? (String)context.getBinding(search) : search;
         final Map<String, PointsConfig> pointsConfigMap = LuceneIndexExpressions.constructPointConfigMap(store, index);
         final QueryParser parser = new LuceneOptimizedQueryParser(defaultField, analyzerSelector.provideQueryAnalyzer(searchString).getAnalyzer(), pointsConfigMap);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzer.java
@@ -1,0 +1,42 @@
+/*
+ * ExactTokenAnalyzer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.exact;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.util.CharTokenizer;
+
+/**
+ * Effectively a no-op analyzer.
+ */
+public class ExactTokenAnalyzer extends Analyzer {
+
+    private static class NoOpTokenizer extends CharTokenizer {
+        @Override
+        protected boolean isTokenChar(int inputCharacter) {
+            return !Character.isISOControl(inputCharacter);
+        }
+    }
+
+    @Override
+    protected TokenStreamComponents createComponents(String fieldName) {
+        return new TokenStreamComponents(new NoOpTokenizer());
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
@@ -36,7 +36,7 @@ import java.util.List;
 @AutoService(LuceneAnalyzerFactory.class)
 public class ExactTokenAnalyzerFactory implements LuceneAnalyzerFactory  {
 
-    public static final String NAME = "QUERY_ONLY_EXACT_ANALYZER_10";
+    public static final String NAME = "QUERY_ONLY_EXACT_ANALYZER";
 
     public static final String UNIQUE_NAME = "query_only_exact_analyzer";
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
@@ -1,0 +1,61 @@
+package com.apple.foundationdb.record.lucene.exact;
+
+import com.apple.foundationdb.record.lucene.AnalyzerChooser;
+import com.apple.foundationdb.record.lucene.LuceneAnalyzerFactory;
+import com.apple.foundationdb.record.lucene.LuceneAnalyzerType;
+import com.apple.foundationdb.record.lucene.LuceneAnalyzerWrapper;
+import com.apple.foundationdb.record.metadata.Index;
+import com.google.auto.service.AutoService;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Constructs a new instance of {@link ExactTokenAnalyzer}.
+ */
+@AutoService(LuceneAnalyzerFactory.class)
+public class ExactTokenAnalyzerFactory implements LuceneAnalyzerFactory  {
+
+    public static final String NAME = "QUERY_ONLY_EXACT_ANALYZER_10";
+
+    public static final String UNIQUE_NAME = "query_only_exact_analyzer";
+
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    public LuceneAnalyzerType getType() {
+        return LuceneAnalyzerType.FULL_TEXT;
+    }
+
+    @Nonnull
+    @Override
+    public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index ignored) {
+        return new AnalyzerChooser() {
+            @Nonnull
+            @Override
+            public LuceneAnalyzerWrapper chooseAnalyzer(@Nonnull List<String> ignored) {
+                return new LuceneAnalyzerWrapper(UNIQUE_NAME, new ExactTokenAnalyzer());
+            }
+        };
+    }
+
+    @Nonnull
+    @Override
+    public AnalyzerChooser getQueryAnalyzerChooser(@Nonnull Index ignored, @Nonnull AnalyzerChooser alsoIgnored) {
+        return new AnalyzerChooser() {
+            @Nonnull
+            @Override
+            public LuceneAnalyzerWrapper chooseAnalyzer(@Nonnull List<String> ignored) {
+                return new LuceneAnalyzerWrapper(UNIQUE_NAME, new ExactTokenAnalyzer());
+            }
+        };
+    }
+}
+
+

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
@@ -1,3 +1,23 @@
+/*
+ * ExactTokenAnalyzerFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.apple.foundationdb.record.lucene.exact;
 
 import com.apple.foundationdb.record.lucene.AnalyzerChooser;
@@ -57,5 +77,3 @@ public class ExactTokenAnalyzerFactory implements LuceneAnalyzerFactory  {
         };
     }
 }
-
-

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes for analyzing stored and sorted fields.
+ */
+package com.apple.foundationdb.record.lucene.exact;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryTest.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
 
@@ -46,9 +48,9 @@ public class LuceneAnalyzerRegistryTest {
                         LuceneIndexOptions.TEXT_SYNONYM_SET_NAME_OPTION, EnglishSynonymMapConfig.ExpandedEnglishSynonymMapConfig.CONFIG_NAME));
         // Assert the synonym analyzer is used for query analyzer for full-text search
         Assertions.assertEquals(SynonymAnalyzer.QueryOnlySynonymAnalyzerFactory.ANALYZER_FACTORY_NAME,
-                LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT).provideQueryAnalyzer("").getUniqueIdentifier());
+                LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT, Map.of()).provideQueryAnalyzer("").getUniqueIdentifier());
         // Assert the standard analyzer is used for query analyzer for auto-complete suggestions
         Assertions.assertEquals(LuceneAnalyzerWrapper.STANDARD_ANALYZER_NAME,
-                LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.AUTO_COMPLETE).provideQueryAnalyzer("").getUniqueIdentifier());
+                LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.AUTO_COMPLETE, Map.of()).provideQueryAnalyzer("").getUniqueIdentifier());
     }
 }


### PR DESCRIPTION
This fixes a problem with potentially parsing a Lucene query field predicate incorrectly if the field is stored or sorted. The issue is caused because the same text analyser, that is specified in the schema by the customer, is used to analyse the RHS of a stored field predicate which could lead to incorrect results.

When dealing with stored and sorted fields, the index maintainer will store their values as-is, therefore, when it is expected that a predicate on these fields gets the same treatments for its operands. This PR addresses this behaviour by doing the following changes:

* Implement a very simple no-op analyser, analyser factory, and tokeniser, that pass-through the analysed terms.
* In `LuceneAnalyzerRegistry`, add a overload of the method `getLuceneAnalyzerCombinationProvider` that accepts a third parameter which is an auxiliary mapping between each index field and its `DocumentFieldDerivation`.
* During the analysis of the index and creating its set of analysers, we examine the auxiliary map, and if feasible, add the above no-op analyser to each field that is stored or sorted.