### PR TITLE
Support `bitset_contains` in Lucene query

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -14,6 +14,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 <!--
 // begin next release
 ### NEXT_RELEASE
+* **Feature** Supports bitset_contains in Lucene query
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -32,7 +32,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.NumericUtils;
@@ -41,14 +40,14 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * This version assumes longs--want to switch based on Point type (either long or int) as future work
+ * This version assumes longs--want to switch based on Point type (either long or int) as future work.
  */
 public class BitSetQuery extends Query {
 
     private final String field;
     private final long bitMask;
 
-    public BitSetQuery(final String field,final long bitMask) {
+    public BitSetQuery(final String field, long bitMask) {
         this.field = field;
         this.bitMask = bitMask;
     }
@@ -163,19 +162,19 @@ public class BitSetQuery extends Query {
             public ScorerSupplier scorerSupplier(final LeafReaderContext context) throws IOException {
                 LeafReader reader = context.reader();
                 PointValues values = reader.getPointValues(field);
-                if(values == null){
-                    //no docs in this segment
+                if (values == null) {
+                    // no docs in this segment
                     return null;
                 }
                 Weight weight = this;
 
-                //TODO(Bfines) decide if we need to check index dimensions here
-//                        if (values.getNumIndexDimensions() != numDims) {
-//                            throw new IllegalArgumentException("field=\"" + field + "\" was indexed with numIndexDimensions=" + values.getNumIndexDimensions() + " but this query has numDims=" + numDims);
-//                        }
-//                        if (bytesPerDim != values.getBytesPerDimension()) {
-//                            throw new IllegalArgumentException("field=\"" + field + "\" was indexed with bytesPerDim=" + values.getBytesPerDimension() + " but this query has bytesPerDim=" + bytesPerDim);
-//                        }
+                // TODO(Bfines) decide if we need to check index dimensions here
+                // if (values.getNumIndexDimensions() != numDims) {
+                //     throw new IllegalArgumentException("field=\"" + field + "\" was indexed with numIndexDimensions=" + values.getNumIndexDimensions() + " but this query has numDims=" + numDims);
+                // }
+                // if (bytesPerDim != values.getBytesPerDimension()) {
+                //     throw new IllegalArgumentException("field=\"" + field + "\" was indexed with bytesPerDim=" + values.getBytesPerDimension() + " but this query has bytesPerDim=" + bytesPerDim);
+                // }
 
                 return new ScorerSupplier() {
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -1,0 +1,214 @@
+/*
+ * BitSetQuery.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.query;
+
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.NumericUtils;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * This version assumes longs--want to switch based on Point type (either long or int) as future work
+ */
+public class BitSetQuery extends Query {
+
+    private final String field;
+    private final long bitMask;
+
+    public BitSetQuery(final String field,final long bitMask) {
+        this.field = field;
+        this.bitMask = bitMask;
+    }
+
+    @Override
+    public String toString(final String field) {
+        return "BITSET-MASK(" + Long.toBinaryString(bitMask) + ")";
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return sameClassAs(obj) &&
+               equalsTo(getClass().cast(obj));
+    }
+
+    private boolean equalsTo(BitSetQuery query) {
+        return Objects.equals(bitMask, query.bitMask);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * classHash() + Long.hashCode(bitMask);
+    }
+
+    @Override
+    public Weight createWeight(final IndexSearcher searcher, final ScoreMode scoreMode, final float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+
+            private boolean matches(byte[] bitSet) {
+                return (NumericUtils.sortableBytesToLong(bitSet, 0) & bitMask) == bitMask;
+            }
+
+            private PointValues.IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {
+                return new PointValues.IntersectVisitor() {
+
+                    DocIdSetBuilder.BulkAdder adder;
+
+                    @Override
+                    public void grow(int count) {
+                        adder = result.grow(count);
+                    }
+
+                    @Override
+                    public void visit(int docID) {
+                        adder.add(docID);
+                    }
+
+                    @Override
+                    public void visit(int docID, byte[] packedValue) {
+                        if (matches(packedValue)) {
+                            visit(docID);
+                        }
+                    }
+
+                    @Override
+                    public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+                        if (matches(packedValue)) {
+                            int docID;
+                            while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                                visit(docID);
+                            }
+                        }
+                    }
+
+                    @Override
+                    public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                        return PointValues.Relation.CELL_INSIDE_QUERY;
+                    }
+                };
+            }
+
+            private PointValues.IntersectVisitor getInverseIntersectVisitor(FixedBitSet result, int[] cost) {
+                return new PointValues.IntersectVisitor() {
+
+                    @Override
+                    public void visit(int docID) {
+                        result.clear(docID);
+                        cost[0]--;
+                    }
+
+                    @Override
+                    public void visit(int docID, byte[] packedValue) {
+                        if (!matches(packedValue)) {
+                            visit(docID);
+                        }
+                    }
+
+                    @Override
+                    public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+                        if (!matches(packedValue)) {
+                            int docID;
+                            while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                                visit(docID);
+                            }
+                        }
+                    }
+
+                    @Override
+                    public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                        return PointValues.Relation.CELL_INSIDE_QUERY;
+                    }
+                };
+            }
+
+            @Override
+            public ScorerSupplier scorerSupplier(final LeafReaderContext context) throws IOException {
+                LeafReader reader = context.reader();
+                PointValues values = reader.getPointValues(field);
+                if(values == null){
+                    //no docs in this segment
+                    return null;
+                }
+                Weight weight = this;
+
+                //TODO(Bfines) decide if we need to check index dimensions here
+//                        if (values.getNumIndexDimensions() != numDims) {
+//                            throw new IllegalArgumentException("field=\"" + field + "\" was indexed with numIndexDimensions=" + values.getNumIndexDimensions() + " but this query has numDims=" + numDims);
+//                        }
+//                        if (bytesPerDim != values.getBytesPerDimension()) {
+//                            throw new IllegalArgumentException("field=\"" + field + "\" was indexed with bytesPerDim=" + values.getBytesPerDimension() + " but this query has bytesPerDim=" + bytesPerDim);
+//                        }
+
+                return new ScorerSupplier() {
+
+                    final DocIdSetBuilder result = new DocIdSetBuilder(reader.maxDoc(), values, field);
+                    final PointValues.IntersectVisitor visitor = getIntersectVisitor(result);
+                    long cost = -1;
+
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        values.intersect(visitor);
+                        DocIdSetIterator iterator = result.build().iterator();
+                        return new ConstantScoreScorer(weight, score(), scoreMode, iterator);
+                    }
+
+                    @Override
+                    public long cost() {
+                        if (cost == -1) {
+                            // Computing the cost may be expensive, so only do it if necessary
+                            cost = values.estimateDocCount(visitor);
+                            assert cost >= 0;
+                        }
+                        return cost;
+                    }
+                };
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                ScorerSupplier scorerSupplier = scorerSupplier(context);
+                if (scorerSupplier == null) {
+                    return null;
+                }
+                return scorerSupplier.get(Long.MAX_VALUE);
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return true;
+            }
+        };
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -108,6 +108,7 @@ public class BitSetQuery extends Query {
                         }
                     }
 
+                    @SuppressWarnings("PMD.AssignmentInOperand")
                     @Override
                     public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
                         if (matches(packedValue)) {
@@ -142,6 +143,7 @@ public class BitSetQuery extends Query {
                     }
 
                     @Override
+                    @SuppressWarnings("PMD.AssignmentInOperand")
                     public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
                         if (!matches(packedValue)) {
                             int docID;
@@ -158,6 +160,7 @@ public class BitSetQuery extends Query {
                 };
             }
 
+            @SuppressWarnings("PMD.CloseResource")
             @Override
             public ScorerSupplier scorerSupplier(final LeafReaderContext context) throws IOException {
                 LeafReader reader = context.reader();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene.query;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PointValues;
@@ -58,6 +59,7 @@ public class BitSetQuery extends Query {
     }
 
     @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     public boolean equals(final Object obj) {
         return sameClassAs(obj) &&
                equalsTo(getClass().cast(obj));

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -66,12 +66,14 @@ public class BitSetQuery extends Query {
     }
 
     private boolean equalsTo(BitSetQuery query) {
-        return Objects.equals(bitMask, query.bitMask);
+        return Objects.equals(bitMask, query.bitMask) && Objects.equals(field, query.field);
     }
 
     @Override
     public int hashCode() {
-        return 31 * classHash() + Long.hashCode(bitMask);
+        int hash = classHash();
+        hash = 31 * hash + field.hashCode();
+        return 31 * hash + Long.hashCode(bitMask);
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -78,7 +78,13 @@ public class BitSetQuery extends Query {
         return new ConstantScoreWeight(this, boost) {
 
             private boolean matches(byte[] bitSet) {
-                return (NumericUtils.sortableBytesToLong(bitSet, 0) & bitMask) == bitMask;
+                if (bitMask == 0L) {
+                    //if bitMask is 0, actually applying the mask will always return 0, regardless of the actual value,
+                    // so we just check if any bits are set instead
+                    return NumericUtils.sortableBytesToLong(bitSet, 0) == 0;
+                } else {
+                    return (NumericUtils.sortableBytesToLong(bitSet, 0) & bitMask) == bitMask;
+                }
             }
 
             private PointValues.IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {
@@ -115,7 +121,7 @@ public class BitSetQuery extends Query {
 
                     @Override
                     public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-                        return PointValues.Relation.CELL_INSIDE_QUERY;
+                        return PointValues.Relation.CELL_CROSSES_QUERY;
                     }
                 };
             }
@@ -148,7 +154,7 @@ public class BitSetQuery extends Query {
 
                     @Override
                     public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-                        return PointValues.Relation.CELL_INSIDE_QUERY;
+                        return PointValues.Relation.CELL_CROSSES_QUERY;
                     }
                 };
             }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -81,13 +81,7 @@ public class BitSetQuery extends Query {
         return new ConstantScoreWeight(this, boost) {
 
             private boolean matches(byte[] bitSet) {
-                if (bitMask == 0L) {
-                    //if bitMask is 0, actually applying the mask will always return 0, regardless of the actual value,
-                    // so we just check if any bits are set instead
-                    return NumericUtils.sortableBytesToLong(bitSet, 0) == 0;
-                } else {
-                    return (NumericUtils.sortableBytesToLong(bitSet, 0) & bitMask) == bitMask;
-                }
+                return (NumericUtils.sortableBytesToLong(bitSet, 0) & bitMask) == bitMask;
             }
 
             private PointValues.IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common classes for handling bitsets.
+ */
+package com.apple.foundationdb.record.lucene.query;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
@@ -20,12 +20,14 @@
 
 package com.apple.foundationdb.record.lucene.search;
 
+import com.apple.foundationdb.record.lucene.query.BitSetQuery;
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.Token;
 import org.apache.lucene.queryparser.flexible.core.messages.QueryParserMessages;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.search.MultiPhraseQuery;
@@ -50,14 +52,42 @@ public interface ConfigAwareQueryParser {
     @Nonnull
     Query constructFieldWithoutPointsConfig(String field, String queryText, boolean quoted) throws ParseException;
 
+    @Nonnull
+    Token nextToken();
+
     @SuppressWarnings("PMD.PreserveStackTrace") //it isn't possible with Lucene's exception API
     @Nonnull
-    default Query attemptConstructFieldQueryWithPointsConfig(final String field, final String queryText, final boolean quoted) throws ParseException {
+    default Query attemptConstructFieldQueryWithPointsConfig(final String field, String queryText, final boolean quoted) throws ParseException {
         final var pointsConfig = getPointsConfig();
         PointsConfig cfg = pointsConfig.get(field);
         if (cfg == null) {
             return constructFieldWithoutPointsConfig(field, queryText, quoted);
         }
+
+        /*
+         * Look for BITSET_CONTAINS function. If it is there, read the mask to get the number,
+         * and then create a BITSET query operator.
+         */
+        boolean isBitset = false;
+        if (queryText.equalsIgnoreCase("BITSET_CONTAINS")) {
+            //look for the next token
+            if (!"(".equals(nextToken().toString())) {
+                throw new ParseException("Missing ( from BITSET_CONTAINS");
+            }
+            Token nextToken = nextToken(); //this should be the actual value
+            String bitMaskStr = nextToken.toString();
+            isBitset = true;
+            queryText = bitMaskStr;
+            //check for a ), in order to consume it. If it's not there, throw a Parse Exception
+            if (!")".equals(nextToken().toString())) {
+                throw new ParseException("Missing ) from BITSET_CONTAINS");
+            }
+
+            if (!Long.class.equals(cfg.getType())) {
+                throw new ParseException("Cannot parse a BITSET_CONTAINS on a non-long data type");
+            }
+        }
+
         //parse the text as the correct type and convert it to a query
 
         if (cfg instanceof BooleanPointsConfig) {
@@ -81,7 +111,11 @@ public interface ConfigAwareQueryParser {
         if (Integer.class.equals(cfg.getType())) {
             return IntPoint.newExactQuery(field, point.intValue());
         } else if (Long.class.equals(cfg.getType())) {
-            return LongPoint.newExactQuery(field, point.longValue());
+            if (isBitset) {
+                return new BitSetQuery(field, point.longValue());
+            } else {
+                return LongPoint.newExactQuery(field, point.longValue());
+            }
         } else if (Double.class.equals(cfg.getType())) {
             return DoublePoint.newExactQuery(field, point.doubleValue());
         } else if (Float.class.equals(cfg.getType())) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
@@ -69,7 +69,7 @@ public interface ConfigAwareQueryParser {
          * Look for BITSET_CONTAINS function. If it is there, read the mask to get the number,
          * and then create a BITSET query operator.
          */
-        if (queryText.equalsIgnoreCase("BITSET_CONTAINS")) {
+        if ("BITSET_CONTAINS".equalsIgnoreCase(queryText)) {
             return constructBitSetQuery(field);
         }
 
@@ -107,6 +107,7 @@ public interface ConfigAwareQueryParser {
     }
 
     @Nonnull
+    @SuppressWarnings("PMD.PreserveStackTrace") //it isn't possible with Lucene's exception API
     private Query constructBitSetQuery(@Nonnull final String field) throws ParseException {
         //look for the next token
         if (!"(".equals(nextToken().toString())) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldQueryParser.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene.search;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.Token;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
@@ -113,5 +114,11 @@ public class LuceneOptimizedMultiFieldQueryParser extends MultiFieldQueryParser 
     @Override
     public Query constructRangeQueryWithoutPointsConfig(final @Nonnull String field, final @Nonnull String part1, final @Nonnull String part2, final boolean startInclusive, final boolean endInclusive) throws ParseException {
         return super.getRangeQuery(field, part1, part2, startInclusive, endInclusive);
+    }
+
+    @Nonnull
+    @Override
+    public final Token nextToken() {
+        return getNextToken();
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedQueryParser.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene.search;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.queryparser.classic.Token;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanNearQuery;
@@ -78,5 +79,11 @@ public class LuceneOptimizedQueryParser extends QueryParser implements ConfigAwa
     @Override
     public Query constructRangeQueryWithoutPointsConfig(final @Nonnull String field, final @Nonnull String part1, final @Nonnull String part2, final boolean startInclusive, final boolean endInclusive) throws ParseException {
         return getRangeQuery(field, part1, part2, startInclusive, endInclusive);
+    }
+
+    @Nonnull
+    @Override
+    public final Token nextToken() {
+        return getNextToken();
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -84,9 +84,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -589,7 +589,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
 
     private static Stream<Arguments> bitsetParams() {
         return Stream.of(
-                Arguments.of(0b0, List.of()),
+                Arguments.of(0b0, List.of(1623L, 1547L)),
                 Arguments.of(0b100, List.of(1623L)),
                 Arguments.of(0b10, List.of(1547L)),
                 Arguments.of(0b1000, List.of(1623L, 1547L)),
@@ -630,7 +630,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
 
     private static Stream<Arguments> bitsetOrParams() {
         return Stream.of(
-                Arguments.of(0b0, 0b0, List.of()),
+                Arguments.of(0b0, 0b0, List.of(1623L, 1547L)),
                 Arguments.of(0b100, 0b1, List.of(1623L)),
                 Arguments.of(0b10, 0b1, List.of(1547L)),
                 Arguments.of(0b1000, 0b1000, List.of(1623L, 1547L)),

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -82,6 +82,11 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -95,6 +100,7 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.group;
 import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.query;
@@ -580,6 +586,34 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                     recordStore.scanIndex(TEXT_AND_NUMBER_INDEX, fullTextSearch(TEXT_AND_NUMBER_INDEX, "\"propose a Vision\" AND group:[" + Long.MIN_VALUE + " TO " + Long.MIN_VALUE + "}"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(TEXT_AND_NUMBER_INDEX), context, "_0.cfs", true);
+        }
+    }
+
+    private static Stream<Arguments> bitsetParams() {
+        return Stream.of(
+                Arguments.of(0b0, List.of()),
+                Arguments.of(0b100, List.of(1623L)),
+                Arguments.of(0b10, List.of(1547L)),
+                Arguments.of(0b1000, List.of(1623L, 1547L)),
+                Arguments.of(0b110, List.of()),
+                Arguments.of(0b11000, List.of(1623L, 1547L)),
+                Arguments.of(0b1100, List.of(1623L))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("bitsetParams")
+    void bitset(int mask, List<Long> expectedResult) {
+        /*
+         * Check that a range query returns empty if you feed it a range that is logically empty (i.e. (Long.MAX_VALUE,...)
+         */
+        try (FDBRecordContext context = openContext()) {
+            rebuildIndexMetaData(context, SIMPLE_DOC, TEXT_AND_NUMBER_INDEX);
+            recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 0b11100));
+            recordStore.saveRecord(createSimpleDocument(1547L, ENGINEER_JOKE, 0b11010));
+
+            assertIndexEntryPrimaryKeys(expectedResult,
+                    recordStore.scanIndex(TEXT_AND_NUMBER_INDEX, fullTextSearch(TEXT_AND_NUMBER_INDEX, "\"propose a Vision\" AND BITSET_CONTAINS(group, " + mask + ")"), null, ScanProperties.FORWARD_SCAN));
         }
     }
 


### PR DESCRIPTION
Original comment as in #2048:

> This introduces a BITSET_CONTAINS function to the lucene query language:
>
> `flag:BITSET_CONTAINS(mask)`
> This returns true if the mask is wholly contained in flag.

This mainly copies #2046 and #2048 removing all dependencies on parser integration work.