### PR TITLE
Resolves #2053: Default protoMajorVersion to 3 in build

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -51,18 +51,18 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.3/ba035118bc8bac37d7eff77700720999acd9986d/j2objc-annotations-1.3.jar" />
         </processorPath>
         <module name="fdb-record-layer.fdb-extensions.main" />
-        <module name="fdb-record-layer.fdb-record-layer-lucene.test" />
-        <module name="fdb-record-layer.fdb-record-layer-spatial.main" />
-        <module name="fdb-record-layer.fdb-record-layer-lucene.main" />
-        <module name="fdb-record-layer.fdb-record-layer-core.test" />
-        <module name="fdb-record-layer.fdb-record-layer-icu.main" />
+        <module name="fdb-record-layer.fdb-record-layer-lucene-pb3.main" />
+        <module name="fdb-record-layer.fdb-record-layer-core-pb3.test" />
+        <module name="fdb-record-layer.fdb-record-layer-spatial-pb3.main" />
+        <module name="fdb-record-layer.fdb-record-layer-icu-pb3.main" />
+        <module name="fdb-record-layer.fdb-record-layer-lucene-pb3.test" />
       </profile>
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
           <entry name="$PROJECT_DIR$/fdb-extensions/.out/libs/fdb-extensions-3.3-SNAPSHOT.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto.service/auto-service/1.0.1/c9779f7372192a96c957a3df1faeeabd07881085/auto-service-1.0.1.jar" />
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.foundationdb/fdb-java/7.1.14/a5ba547fd768293b9974f224850344c4e703cd72/fdb-java-7.1.14.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.foundationdb/fdb-java/7.1.26/4c9db13fe80d9a99a6cdbaefaa3e6c8c9b1d041e/fdb-java-7.1.26.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.squareup/javapoet/1.12.0/459ae6c796db7dcbc723f9536af2ce49d86c1a80/javapoet-1.12.0.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.auto/auto-common/1.2/ca270191fd7d2a7297da7c8f29184206df10c67d/auto-common-1.2.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/31.1-jre/60458f877d055d0c9114d9e1a2efb737b4bc282c/guava-31.1-jre.jar" />
@@ -75,7 +75,7 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.11.0/c5a0ace696d3f8b1c1d8cc036d8c03cc0cbe6b69/error_prone_annotations-2.11.0.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.3/ba035118bc8bac37d7eff77700720999acd9986d/j2objc-annotations-1.3.jar" />
         </processorPath>
-        <module name="fdb-record-layer.fdb-record-layer-core.main" />
+        <module name="fdb-record-layer.fdb-record-layer-core-pb3.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="11" />

--- a/build.gradle
+++ b/build.gradle
@@ -201,12 +201,13 @@ subprojects {
         if (System.getenv('PROTO_VERSION') != null) {
             protoMajorVersion = System.getenv('PROTO_VERSION')
         } else {
-            protoMajorVersion = '2'
+            protoMajorVersion = '3'
         }
         if (protoMajorVersion == "2") {
             protobufVersion = protobuf2Version
         } else if (protoMajorVersion == "3") {
             protobufVersion = protobuf3Version
+            setProperty('coreNotStrict', 'true')
         } else {
             throw new GradleException("Unknown protobuf major version: ${protoMajorVersion}")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,6 @@ subprojects {
             protobufVersion = protobuf2Version
         } else if (protoMajorVersion == "3") {
             protobufVersion = protobuf3Version
-            setProperty('coreNotStrict', 'true')
         } else {
             throw new GradleException("Unknown protobuf major version: ${protoMajorVersion}")
         }
@@ -260,6 +259,7 @@ subprojects {
     }
 
     apply from: rootProject.file('gradle/check.gradle')
+    apply from: rootProject.file('gradle/strict.gradle')
 
     if(System.getenv("DO_NOT_CHECK") != null) {
         task check(overwrite: true, dependsOn: quickCheck) { }

--- a/examples/examples.gradle
+++ b/examples/examples.gradle
@@ -19,9 +19,6 @@
  */
 
 apply from: rootProject.file('gradle/proto.gradle')
-if (!hasProperty('coreNotStrict')) {
-    apply from: rootProject.file('gradle/strict.gradle')
-}
 apply plugin: 'application'
 
 def coreProject = ":${ext.coreProjectName}"

--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-apply from: rootProject.file('gradle/strict.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
 
 dependencies {

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -21,11 +21,6 @@
 apply plugin: 'com.github.johnrengelman.shadow'
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
-// Necessary until deprecation warnings in generated proto code are fixed
-// See: https://github.com/protocolbuffers/protobuf/issues/7271
-if (!hasProperty('coreNotStrict')) {
-    apply from: rootProject.file('gradle/strict.gradle')
-}
 
 configurations {
     repl.extendsFrom testRuntimeOnly

--- a/fdb-record-layer-icu/fdb-record-layer-icu.gradle
+++ b/fdb-record-layer-icu/fdb-record-layer-icu.gradle
@@ -18,8 +18,6 @@
  * limitations under the License.
  */
 
-apply from: rootProject.file('gradle/strict.gradle')
-
 def coreProject = ":${ext.coreProjectName}"
 dependencies {
     api project(coreProject)

--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -20,13 +20,6 @@
 
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
-if (!hasProperty('coreNotStrict')) {
-    apply from: rootProject.file('gradle/strict.gradle')
-    tasks.withType(JavaCompile) {
-        // also generates redundant casts for bytes fields
-        options.compilerArgs += ["-Xlint:-cast"]
-    }
-}
 
 def coreProject = ":${ext.coreProjectName}"
 dependencies {
@@ -52,6 +45,28 @@ dependencies {
     testCompileOnly "com.google.auto.service:auto-service:undefined"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     testAnnotationProcessor "com.google.auto.service:auto-service:undefined"
+}
+
+if (protoMajorVersion == '2') {
+    protobuf {
+        generateProtoTasks {
+            all().each { task ->
+                task.doLast {
+                    task.outputs.getFiles().forEach {
+                        // Suppress redundant ByteString casting in proto-generated code in proto2
+                        ant.replace(dir: it, includes: "**/LuceneContinuationProto.java",
+                                token: "public int getSerializedSize() {\n",
+                                value: "@SuppressWarnings(\"cast\") public int getSerializedSize() {\n",
+                        )
+                        ant.replace(dir: it, includes: "**/LuceneContinuationProto.java",
+                                token: "public void writeTo(com.google.protobuf.CodedOutputStream output)\n",
+                                value: "@SuppressWarnings(\"cast\") public void writeTo(com.google.protobuf.CodedOutputStream output)\n",
+                        )
+                    }
+                }
+            }
+        }
+    }
 }
 
 def skipFDB = System.getenv('SKIP_FDB_TESTS') != null && System.getenv('SKIP_FDB_TESTS') == 'true'

--- a/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
+++ b/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
@@ -20,9 +20,6 @@
 
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
-if (!hasProperty('coreNotStrict')) {
-    apply from: rootProject.file('gradle/strict.gradle')
-}
 
 def coreProject = ":${ext.coreProjectName}"
 dependencies {

--- a/gradle/proto.gradle
+++ b/gradle/proto.gradle
@@ -69,6 +69,20 @@ protobuf {
                 task.addIncludeDir(files("${projectDir}/src/main/proto"))
                 task.addIncludeDir(files("${projectDir}/.out/extracted-include-protos/main"))
             }
+
+            if (protoMajorVersion == '3') {
+                // When generating from syntax = proto2 files, protoc can generate methods that reference
+                // the deprecated PARSER field. Suppress these warnings on generated code
+                // See: https://github.com/protocolbuffers/protobuf/issues/7271
+                task.doLast {
+                    task.outputs.getFiles().forEach {
+                        ant.replace(dir: it, includes: "**/*.java",
+                                token: "public static final class ",
+                                value: "@SuppressWarnings(\"deprecation\") public static final class ",
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,7 +48,7 @@ def protoMajorVersion
 if ( System.getenv('PROTO_VERSION') != null) {
     protoMajorVersion = System.getenv('PROTO_VERSION')
 } else {
-    protoMajorVersion = '2'
+    protoMajorVersion = '3'
 }
 if (protoMajorVersion != "2") {
     project(':fdb-record-layer-core').name = "fdb-record-layer-core-pb${protoMajorVersion}"


### PR DESCRIPTION
This updates the build script so that if one runs `./gradlew build` with no other arguments, it will build the proto3-based artifacts. If one sets the `PROTO_VERSION` to 2, it should still build the proto2-based artifacts, so this won't change the published artifacts, but it may affect flows of a developer working on the project.

This resolves #2053.