### PR TITLE
Resolves #2052: Unnecessary recount of records on new stores

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** An unnecessary recount of records on new stores with a record count key has been removed [(Issue #2052)](https://github.com/FoundationDB/fdb-record-layer/issues/2052)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -4323,15 +4323,21 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                                        @Nonnull RecordMetaDataProto.DataStoreInfo.Builder info,
                                                        @Nonnull List<CompletableFuture<Void>> work,
                                                        int oldFormatVersion) {
+        boolean existingStore = oldFormatVersion > 0;
         KeyExpression countKeyExpression = metaData.getRecordCountKey();
+
         boolean rebuildRecordCounts =
-                (oldFormatVersion > 0 && oldFormatVersion < RECORD_COUNT_ADDED_FORMAT_VERSION) ||
-                        (countKeyExpression != null && formatVersion >= RECORD_COUNT_KEY_ADDED_FORMAT_VERSION &&
-                                (!info.hasRecordCountKey() || !KeyExpression.fromProto(info.getRecordCountKey()).equals(countKeyExpression)));
+                (existingStore && oldFormatVersion < RECORD_COUNT_ADDED_FORMAT_VERSION)
+                || (countKeyExpression != null && formatVersion >= RECORD_COUNT_KEY_ADDED_FORMAT_VERSION &&
+                        (!info.hasRecordCountKey() || !KeyExpression.fromProto(info.getRecordCountKey()).equals(countKeyExpression)))
+                || (countKeyExpression == null && info.hasRecordCountKey());
+
         if (rebuildRecordCounts) {
             // We want to clear all record counts.
-            final Transaction tr = ensureContextActive();
-            tr.clear(getSubspace().range(Tuple.from(RECORD_COUNT_KEY)));
+            if (existingStore) {
+                final Transaction tr = ensureContextActive();
+                tr.clear(getSubspace().range(Tuple.from(RECORD_COUNT_KEY)));
+            }
 
             // Set the new record count key if we have one.
             if (formatVersion >= RECORD_COUNT_KEY_ADDED_FORMAT_VERSION) {
@@ -4343,7 +4349,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             }
 
             // Add the record rebuild job.
-            addRebuildRecordCountsJob(work);
+            if (existingStore) {
+                addRebuildRecordCountsJob(work);
+            }
         }
         return rebuildRecordCounts;
     }


### PR DESCRIPTION
This adjusts the logic for handling the record count key so that on new stores, it doesn't have to recount the records. This isn't necessary because with a new store, the store is empty and thus the count key space can be defaulted to having no entries (that is, implicit zeroes for each entry). This also removes an extraneous clear range when the record count key doesn't need to be persisted.

This resolves #2052.