### PR TITLE
Resolves #2062: Expose transaction-scoped and read-only APIs from the LocatableResolver

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The `LocatableResolver` interface has been enhanced with read-only and transaction-scoped APIs [(Issue #2062)](https://github.com/FoundationDB/fdb-record-layer/issues/2062)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -114,6 +114,12 @@ public abstract class LocatableResolver {
         return database;
     }
 
+    private void validateDatabase(@Nonnull FDBRecordContext context) {
+        if (!context.getDatabase().equals(database)) {
+            throw new RecordCoreArgumentException("attempted to resolve value against incorrect database");
+        }
+    }
+
     @Nonnull
     private <T> CompletableFuture<T> runAsync(@Nullable FDBStoreTimer timer,
                                               @Nonnull Function<FDBRecordContext, CompletableFuture<T>> retriable,
@@ -159,6 +165,12 @@ public abstract class LocatableResolver {
                 runner.close();
             }
         }
+    }
+
+    private CompletableFuture<Cache<ScopedValue<String>, ResolverResult>> getDirectoryCache(@Nonnull FDBRecordContext context) {
+        validateDatabase(context);
+        return getVersion(context)
+                .thenApply(database::getDirectoryCache);
     }
 
     /**
@@ -350,15 +362,10 @@ public abstract class LocatableResolver {
     @API(API.Status.UNSTABLE)
     @Nonnull
     public CompletableFuture<ResolverResult> resolveWithMetadata(@Nonnull FDBRecordContext context, @Nonnull String name, @Nonnull ResolverCreateHooks hooks) {
-        if (!context.getDatabase().equals(database)) {
-            throw new RecordCoreArgumentException("attempted to resolve value against incorrect database");
-        }
-
         // check the version stored in the resolver state and compare it with what version the cache was created at
         // if we read a version that is ahead of whats stored in FDBDatabase we need to invalidate the cache in FDBDatabase
         // if the cache version in FDBDatabase is a future version we can trust the cache we get from getDirectoryCache
-        return getVersion(context)
-                .thenApply(database::getDirectoryCache)
+        return getDirectoryCache(context)
                 .thenCompose(directoryCache ->
                         resolveWithCache(context, wrap(name), directoryCache, hooks));
     }
@@ -462,6 +469,40 @@ public abstract class LocatableResolver {
         }).orElseThrow(() -> new NoSuchElementException("reverse lookup of " + wrap(value))));
     }
 
+    /**
+     * Lookup the String that maps to the provided value within the scope of the path that this object was constructed with.
+     * This will execute use the transaction provided to access the database, though the isolation is slightly
+     * relaxed as it may read data committed in other transactions, though it will only return uncommitted data
+     * from this transaction.
+     *
+     * @param context the transaction to use to look up the reverse mapping
+     * @param value the value of the mapping to lookup
+     * @return a future that will contain the name that maps to this value
+     * @throws NoSuchElementException if the value is not found
+     */
+    @Nonnull
+    public CompletableFuture<String> reverseLookupInTransaction(@Nonnull FDBRecordContext context,
+                                                                long value) {
+        final Cache<ScopedValue<Long>, String> inMemoryCache = database.getReverseDirectoryInMemoryCache();
+        final ScopedValue<Long> reverseCacheKey = wrap(value);
+        String cachedString = inMemoryCache.getIfPresent(reverseCacheKey);
+        if (cachedString != null) {
+            return CompletableFuture.completedFuture(cachedString);
+        }
+        return readReverse(context, value).thenApply(maybeKey -> {
+            if (maybeKey.isPresent()) {
+                String key = maybeKey.get();
+                context.addPostCommit(() -> {
+                    inMemoryCache.put(reverseCacheKey, key);
+                    return AsyncUtil.DONE;
+                });
+                return key;
+            } else {
+                throw new NoSuchElementException("reverse lookup of " + reverseCacheKey);
+            }
+        });
+    }
+
     private CompletableFuture<ResolverResult> resolveWithCache(@Nonnull FDBRecordContext context,
                                                                @Nonnull ScopedValue<String> scopedName,
                                                                @Nonnull Cache<ScopedValue<String>, ResolverResult> directoryCache,
@@ -481,6 +522,95 @@ public abstract class LocatableResolver {
             directoryCache.put(scopedName, fetched);
             return fetched;
         });
+    }
+
+    /**
+     * Read a value within the context of a single transaction. This will use the transaction passed in when
+     * reading from the database (unlike some of the methods in this class which will just use it as the
+     * basis of child transactions). If the name has not been previously inserted into the resolver, it
+     * will return {@code null}. Additionally, the isolation properties are somewhat relaxed, in that it can
+     * read values committed in other transactions (from the {@linkplain FDBDatabase#getDirectoryCache(int)
+     * directory cache}), though it won't return any uncommitted data.
+     *
+     * @param context the transaction to use to read from the database
+     * @param name the name to look up
+     * @return a future that contains the current {@link ResolverResult} for the given name or {@code null} if unset
+     */
+    @Nonnull
+    public CompletableFuture<ResolverResult> readInTransaction(@Nonnull FDBRecordContext context,
+                                                               @Nonnull String name) {
+        return getDirectoryCache(context).thenCompose(directoryCache -> {
+            ScopedValue<String> scopedName = wrap(name);
+            ResolverResult cachedValue = directoryCache.getIfPresent(scopedName);
+            if (cachedValue != null) {
+                return CompletableFuture.completedFuture(cachedValue);
+            }
+
+            return context.instrument(FDBStoreTimer.Events.DIRECTORY_READ, read(context, name)).thenApply(maybeResult -> {
+                ResolverResult result = maybeResult.orElse(null);
+                // If the value for this name was inserted in the same transaction, it is not safe to put the
+                // resolved value into the cache until the transaction commits. We don't really have a way
+                // of knowing if that's happened, so only add to the cache as a post-commit hook
+                addCachePostCommitIfNotError(context, directoryCache, name, result, null);
+                return result;
+            });
+        });
+    }
+
+    /**
+     * Allocate a new value within the context of a single transaction. This will use the transaction passed in when
+     * creating the resolver entry (unlike some of the methods in this class which will just use it as the
+     * basis of child transactions). It is the responsibility of the caller to ensure that an entry for this name has
+     * not been previously allocated (such as by calling {@link #readInTransaction(FDBRecordContext, String)}). This
+     * will return the new value that has been allocated.
+     *
+     * @param context the transaction to use to read from the database
+     * @param name the name to create a mapping for
+     * @param hooks hooks to run when inserting the name into the database
+     * @return a future that contains the current {@link ResolverResult} for the given name or {@code null} if unset
+     */
+    @Nonnull
+    public CompletableFuture<ResolverResult> createInTransaction(@Nonnull FDBRecordContext context,
+                                                                 @Nonnull String name,
+                                                                 @Nonnull ResolverCreateHooks hooks) {
+        return getDirectoryCache(context).thenCompose(directoryCache ->
+                createIfNotLocked(context, name, hooks).whenComplete((result, err) ->
+                        addCachePostCommitIfNotError(context, directoryCache, name, result, err)));
+    }
+
+    /**
+     * Update the mapping for a single value within the context of a single transaction. This will use the
+     * transaction passed in when saving the result to the database. This method can be used for things
+     * like copying data from one locatable resolver to another, but other methods like {@link #resolve(String)}
+     * or {@link #createInTransaction(FDBRecordContext, String, ResolverCreateHooks)} should generally
+     * be preferred.
+     *
+     * @param context the transaction to use to write to the database
+     * @param name the name to write a mapping for
+     * @param newResult the new resolver result to write into the database
+     * @return a future that will complete when the new mapping has been saved
+     */
+    @Nonnull
+    public CompletableFuture<Void> saveInTransaction(@Nonnull FDBRecordContext context,
+                                                     @Nonnull String name,
+                                                     @Nonnull ResolverResult newResult) {
+        return getDirectoryCache(context).thenCompose(directoryCache ->
+                setMapping(context, name, newResult).whenComplete((vignore, err) ->
+                        addCachePostCommitIfNotError(context, directoryCache, name, newResult, err)));
+    }
+
+    private void addCachePostCommitIfNotError(@Nonnull FDBRecordContext context,
+                                              @Nonnull Cache<ScopedValue<String>, ResolverResult> directoryCache,
+                                              @Nonnull String name,
+                                              @Nullable ResolverResult result,
+                                              @Nullable Throwable err) {
+        if (result != null && err == null) {
+            context.addPostCommit(() -> {
+                ScopedValue<String> scopedName = wrap(name);
+                directoryCache.put(scopedName, result);
+                return AsyncUtil.DONE;
+            });
+        }
     }
 
     private CompletableFuture<ResolverResult> readOrCreateValue(@Nonnull FDBRecordContext context,
@@ -534,7 +664,7 @@ public abstract class LocatableResolver {
     }
 
     @Nonnull
-    private CompletableFuture<ResolverStateProto.State> loadResolverState(@Nonnull FDBRecordContext context) {
+    public CompletableFuture<ResolverStateProto.State> loadResolverState(@Nonnull FDBRecordContext context) {
         // don't use a snapshot read, the lock state shouldn't change frequently but if it does we should
         // fail the transaction and should retry getting the value.
         return context.instrument(FDBStoreTimer.DetailEvents.RESOLVER_STATE_READ,
@@ -688,6 +818,28 @@ public abstract class LocatableResolver {
                 LogMessageKeys.RESOLVER_KEY, key);
     }
 
+    /**
+     * Update the resolver's state in the context of a single transaction. Most users should prefer
+     * methods like {@link #incrementVersion()} to update the state version or methods like
+     * {@link #retireLayer()} to update whether the resolver is locked.
+     *
+     * @param context the transaction to use to update the resolver's state
+     * @param newState the new state to write
+     * @return a future that will be completed when the new state has been written
+     */
+    @Nonnull
+    public CompletableFuture<Void> saveResolverState(@Nonnull final FDBRecordContext context, @Nonnull ResolverStateProto.State newState) {
+        return loadResolverState(context).thenCompose(oldState -> {
+            if (newState.equals(oldState)) {
+                return AsyncUtil.DONE;
+            }
+            if (oldState.getVersion() > newState.getVersion()) {
+                throw new RecordCoreArgumentException("resolver state version must monotonically increase");
+            }
+            return writeResolverState(context, newState);
+        });
+    }
+
     private CompletableFuture<Void> updateAndCommitResolverState(@Nonnull final StateMutation mutation) {
         return runAsync(null, context -> updateResolverState(context, mutation),
                 LogMessageKeys.TRANSACTION_NAME, "LocatableResolver::updateAndCommitResolverState",
@@ -696,17 +848,18 @@ public abstract class LocatableResolver {
     }
 
     private CompletableFuture<Void> updateResolverState(@Nonnull final FDBRecordContext context, @Nonnull final StateMutation mutation) {
+        return loadResolverState(context)
+                .thenApply(mutation::apply)
+                .thenCompose(newState -> writeResolverState(context, newState));
+    }
+
+    private CompletableFuture<Void> writeResolverState(@Nonnull final FDBRecordContext context, @Nonnull ResolverStateProto.State newState) {
         return getStateSubspaceAsync()
                 .thenApply(Subspace::getKey)
-                .thenCompose(stateKey ->
-                        context.ensureActive().get(stateKey)
-                                .thenApply(LocatableResolver::deserializeResolverState)
-                                .thenApply(state -> mutation.apply(state).toByteArray())
-                                .thenApply(bytes -> {
-                                    context.ensureActive().set(stateKey, bytes);
-                                    return null;
-                                })
-                );
+                .thenApply(stateKey -> {
+                    context.ensureActive().set(stateKey, newState.toByteArray());
+                    return null;
+                });
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -471,9 +471,10 @@ public abstract class LocatableResolver {
 
     /**
      * Lookup the String that maps to the provided value within the scope of the path that this object was constructed with.
-     * This will execute use the transaction provided to access the database, though the isolation is slightly
-     * relaxed as it may read data committed in other transactions, though it will only return uncommitted data
-     * from this transaction.
+     * This will execute using the transaction provided to access the database, though the isolation is relaxed
+     * compared to other operations. In particular, the semantics are closer to {@code READ_COMMITTED} in that it can
+     * read entries committed by transactions started after the transaction was created. However, the only uncommitted
+     * data it will return will be those that were created by the same transaction.
      *
      * @param context the transaction to use to look up the reverse mapping
      * @param value the value of the mapping to lookup
@@ -529,8 +530,9 @@ public abstract class LocatableResolver {
      * reading from the database (unlike some of the methods in this class which will just use it as the
      * basis of child transactions). If the name has not been previously inserted into the resolver, it
      * will return {@code null}. Additionally, the isolation properties are somewhat relaxed, in that it can
-     * read values committed in other transactions (from the {@linkplain FDBDatabase#getDirectoryCache(int)
-     * directory cache}), though it won't return any uncommitted data.
+     * read values committed by newer transactions (from the {@linkplain FDBDatabase#getDirectoryCache(int)
+     * directory cache}), though it won't return any uncommitted data except for entries that were created
+     * using the supplied transaction.
      *
      * @param context the transaction to use to read from the database
      * @param name the name to look up

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolver.java
@@ -580,27 +580,6 @@ public abstract class LocatableResolver {
                         addCachePostCommitIfNotError(context, directoryCache, name, result, err)));
     }
 
-    /**
-     * Update the mapping for a single value within the context of a single transaction. This will use the
-     * transaction passed in when saving the result to the database. This method can be used for things
-     * like copying data from one locatable resolver to another, but other methods like {@link #resolve(String)}
-     * or {@link #createInTransaction(FDBRecordContext, String, ResolverCreateHooks)} should generally
-     * be preferred.
-     *
-     * @param context the transaction to use to write to the database
-     * @param name the name to write a mapping for
-     * @param newResult the new resolver result to write into the database
-     * @return a future that will complete when the new mapping has been saved
-     */
-    @Nonnull
-    public CompletableFuture<Void> saveInTransaction(@Nonnull FDBRecordContext context,
-                                                     @Nonnull String name,
-                                                     @Nonnull ResolverResult newResult) {
-        return getDirectoryCache(context).thenCompose(directoryCache ->
-                setMapping(context, name, newResult).whenComplete((vignore, err) ->
-                        addCachePostCommitIfNotError(context, directoryCache, name, newResult, err)));
-    }
-
     private void addCachePostCommitIfNotError(@Nonnull FDBRecordContext context,
                                               @Nonnull Cache<ScopedValue<String>, ResolverResult> directoryCache,
                                               @Nonnull String name,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -1263,13 +1263,7 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         final ResolverResult committedResult;
         try (FDBRecordContext context = database.openContext()) {
             assertNull(globalScope.readInTransaction(context, key).join());
-            if (globalScope instanceof ScopedDirectoryLayer) {
-                // ScopedDirectoryLayers do not support saveInTransaction
-                committedResult = globalScope.createInTransaction(context, key, ResolverCreateHooks.getDefault()).join();
-            } else {
-                globalScope.saveInTransaction(context, key, uncommittedResult).join();
-                committedResult = uncommittedResult;
-            }
+            committedResult = globalScope.createInTransaction(context, key, ResolverCreateHooks.getDefault()).join();
             assertEquals(key, globalScope.reverseLookupInTransaction(context, committedResult.getValue()).join());
 
             context.commit();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -23,11 +23,14 @@ package com.apple.foundationdb.record.provider.foundationdb.keyspace;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.ResolverStateProto;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactoryImpl;
+import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
@@ -50,6 +53,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,6 +88,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -95,6 +100,8 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -121,6 +128,8 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         random = new Random(seed);
         globalScope = resolverFactory.getGlobalScope();
         database = resolverFactory.getDatabase();
+        // Loading the reverse directory cache can happen in a potentially conflicting transaction, so get it out of the way
+        database.getReverseDirectoryCache().waitUntilReadyForTesting();
     }
 
     @Test
@@ -954,6 +963,63 @@ public abstract class LocatableResolverTest extends FDBTestBase {
         }, is(0), 200, 10);
     }
 
+    @Test
+    void testUpdatingResolverStateDirectly() {
+        final ResolverStateProto.State newState;
+        try (FDBRecordContext context = database.openContext()) {
+            ResolverStateProto.State state = globalScope.loadResolverState(context).join();
+            assertNotNull(state);
+
+            int version = globalScope.getVersion(null).join();
+            assertEquals(state.getVersion(), version);
+
+            newState = state.toBuilder()
+                    .setVersion(state.getVersion() + 1)
+                    .setLock(ResolverStateProto.WriteLock.RETIRED)
+                    .build();
+            globalScope.saveResolverState(context, newState).join();
+            context.commit();
+        }
+
+        try (FDBRecordContext context = database.openContext()) {
+            ResolverStateProto.State state = globalScope.loadResolverState(context).join();
+            assertEquals(newState, state);
+
+            int potentiallyCachedVersion = globalScope.getVersion(null).join();
+            assertThat(potentiallyCachedVersion, either(equalTo(newState.getVersion())).or(equalTo(newState.getVersion() - 1)));
+            database.clearCaches();
+            assertEquals(newState.getVersion(), globalScope.getVersion(null).join());
+        }
+    }
+
+    @Test
+    void enforceResolverStateMonotonicity() {
+        int initialVersion = globalScope.getVersion(null).join();
+        try (FDBRecordContext context = database.openContext()) {
+            globalScope.saveResolverState(context, ResolverStateProto.State.newBuilder().setVersion(initialVersion + 10).build()).join();
+            context.commit();
+        }
+
+        try (FDBRecordContext context = database.openContext()) {
+            ResolverStateProto.State newState = ResolverStateProto.State.newBuilder()
+                    .setVersion(initialVersion + 5)
+                    .build();
+            CompletionException completionException = assertThrows(CompletionException.class, () -> globalScope.saveResolverState(context, newState).join());
+            assertNotNull(completionException.getCause());
+            assertThat(completionException.getCause(), instanceOf(RecordCoreArgumentException.class));
+            RecordCoreArgumentException argumentException = (RecordCoreArgumentException) completionException.getCause();
+            assertThat(argumentException, hasMessageContaining("resolver state version must monotonically increase"));
+            context.commit();
+        }
+
+        try (FDBRecordContext context = database.openContext()) {
+            assertEquals(initialVersion + 10, globalScope.loadResolverState(context).join().getVersion());
+            assertThat(globalScope.getVersion(null).join(), either(equalTo(initialVersion)).or(equalTo(initialVersion + 10)));
+            database.clearCaches();
+            assertEquals(initialVersion + 10, globalScope.getVersion(null).join());
+        }
+    }
+
     @SuppressWarnings("squid:S5778") // allow multiple calls in throws lambda
     @Test
     void testWriteSafetyCheck() {
@@ -1066,6 +1132,141 @@ public abstract class LocatableResolverTest extends FDBTestBase {
             assertThat("we can see the existing reverse mapping", globalScope.reverseLookup(context.getTimer(), value).join(), is("an-existing-mapping"));
             assertThat("we can see the existing reverse mapping", globalScope.reverseLookup(context, value).join(), is("an-existing-mapping"));
         }
+    }
+
+    @Test
+    void createAndReadInTransaction() {
+        final String key = "some_key";
+        ResolverResult result;
+        try (FDBRecordContext context = database.openContext()) {
+            assertNull(globalScope.readInTransaction(context, key).join());
+
+            result = globalScope.createInTransaction(context, key, ResolverCreateHooks.getDefault()).join();
+            assertEquals(result, globalScope.readInTransaction(context, key).join());
+            assertEquals(key, globalScope.reverseLookupInTransaction(context, result.getValue()).join());
+            context.commit();
+        }
+
+        try (FDBRecordContext context = database.openContext()) {
+            assertEquals(result, globalScope.resolveWithMetadata(context, key, ResolverCreateHooks.getDefault()).join());
+            assertEquals(key, globalScope.reverseLookup(context, result.getValue()).join());
+            database.clearCaches();
+            assertEquals(result, globalScope.resolveWithMetadata(context, key, ResolverCreateHooks.getDefault()).join());
+            assertEquals(key, globalScope.reverseLookup(context, result.getValue()).join());
+        }
+    }
+
+    @Test
+    void createInMultipleTransactions() {
+        final String key = "a_key_to_create";
+        final ResolverResult committedResult;
+        final List<FDBRecordContext> contexts = new ArrayList<>();
+        final Set<Long> otherValues = new HashSet<>();
+        try {
+            FDBRecordContext firstContext = database.openContext();
+            firstContext.getReadVersion();
+            contexts.add(firstContext);
+            for (int i = 0; i < 10; i++) {
+                FDBRecordContext nextContext = database.openContext();
+                nextContext.getReadVersion();
+                contexts.add(nextContext);
+            }
+
+            assertNull(globalScope.readInTransaction(firstContext, key).join());
+            String expectedMetadata;
+            ResolverCreateHooks firstCreateHooks;
+            if (globalScope instanceof ScopedDirectoryLayer) {
+                expectedMetadata = null;
+                firstCreateHooks = ResolverCreateHooks.getDefault();
+            } else {
+                expectedMetadata = "first transaction";
+                firstCreateHooks = new ResolverCreateHooks(DEFAULT_CHECK, ignore -> expectedMetadata.getBytes(StandardCharsets.UTF_8));
+            }
+            committedResult = globalScope.createInTransaction(firstContext, key, firstCreateHooks).join();
+            assertEquals(expectedMetadata, committedResult.getMetadata() == null ? null : new String(committedResult.getMetadata(), StandardCharsets.UTF_8));
+            assertEquals(key, globalScope.reverseLookupInTransaction(firstContext, committedResult.getValue()).join());
+
+            for (FDBRecordContext otherContext : contexts.subList(1, contexts.size())) {
+                assertNull(globalScope.readInTransaction(otherContext, key).join());
+                ResolverResult otherResult = globalScope.createInTransaction(otherContext, key, ResolverCreateHooks.getDefault()).join();
+                assertEquals(key, globalScope.reverseLookupInTransaction(otherContext, otherResult.getValue()).join());
+                otherValues.add(otherResult.getValue());
+            }
+
+            firstContext.commit();
+            for (FDBRecordContext otherContext : contexts.subList(1, contexts.size())) {
+                assertThrows(FDBExceptions.FDBStoreTransactionConflictException.class, otherContext::commit);
+            }
+        } finally {
+            contexts.forEach(FDBRecordContext::close);
+        }
+
+        try (FDBRecordContext context = database.openContext()) {
+            assertEquals(committedResult, globalScope.resolveWithMetadata(context, key, ResolverCreateHooks.getDefault()).join());
+            database.clearCaches();
+            assertEquals(committedResult, globalScope.resolveWithMetadata(context, key, ResolverCreateHooks.getDefault()).join());
+            otherValues.remove(committedResult.getValue());
+
+            for (Long otherValue : otherValues) {
+                CompletionException err = assertThrows(CompletionException.class, () -> globalScope.reverseLookup(context, otherValue).join());
+                assertNotNull(err.getCause());
+                assertThat(err.getCause(), instanceOf(NoSuchElementException.class));
+            }
+        }
+    }
+
+    @Test
+    void onlyCacheCommittedResults() {
+        final String key = "key_to_create_but_not_commit";
+        final ResolverResult uncommittedResult;
+        try (FDBRecordContext context = database.openContext()) {
+            uncommittedResult = globalScope.createInTransaction(context, key, ResolverCreateHooks.getDefault()).join();
+            assertNotNull(uncommittedResult);
+            assertEquals(key, globalScope.reverseLookupInTransaction(context, uncommittedResult.getValue()).join());
+            // do not commit
+        }
+
+        try (FDBRecordContext context = database.openContext()) {
+            assertNull(globalScope.readInTransaction(context, key).join());
+            ResolverResult intermediateResult = globalScope.createInTransaction(context, key, ResolverCreateHooks.getDefault()).join();
+            assertEquals(intermediateResult, globalScope.readInTransaction(context, key).join());
+            CompletionException reversLookupErr = assertThrows(CompletionException.class, () -> globalScope.reverseLookup(context, uncommittedResult.getValue()).join());
+            assertNotNull(reversLookupErr.getCause());
+            assertThat(reversLookupErr.getCause(), instanceOf(NoSuchElementException.class));
+            // do not commit
+        }
+
+        final ResolverResult committedResult;
+        try (FDBRecordContext context = database.openContext()) {
+            assertNull(globalScope.readInTransaction(context, key).join());
+            if (globalScope instanceof ScopedDirectoryLayer) {
+                // ScopedDirectoryLayers do not support saveInTransaction
+                committedResult = globalScope.createInTransaction(context, key, ResolverCreateHooks.getDefault()).join();
+            } else {
+                globalScope.saveInTransaction(context, key, uncommittedResult).join();
+                committedResult = uncommittedResult;
+            }
+            assertEquals(key, globalScope.reverseLookupInTransaction(context, committedResult.getValue()).join());
+
+            context.commit();
+        }
+
+        assertEquals(committedResult, database.getDirectoryCache(globalScope.getVersion(null).join())
+                .getIfPresent(globalScope.wrap(key)));
+        assertEquals(key, database.getReverseDirectoryInMemoryCache().getIfPresent(globalScope.wrap(committedResult.getValue())));
+        database.clearCaches();
+        assertNull(database.getDirectoryCache(globalScope.getVersion(null).join())
+                .getIfPresent(globalScope.wrap(key)));
+        assertNull(database.getReverseDirectoryInMemoryCache().getIfPresent(globalScope.wrap(committedResult.getValue())));
+
+        try (FDBRecordContext context = database.openContext()) {
+            assertEquals(committedResult, globalScope.readInTransaction(context, key).join());
+            assertEquals(key, globalScope.reverseLookupInTransaction(context, committedResult.getValue()).join());
+            context.commit();
+        }
+        assertEquals(committedResult, database.getDirectoryCache(globalScope.getVersion(null).join())
+                .getIfPresent(globalScope.wrap(key)));
+        assertEquals(key, database.getReverseDirectoryInMemoryCache().getIfPresent(globalScope.wrap(committedResult.getValue())));
     }
 
     @SuppressWarnings("squid:S5778") // allow multiple calls in throws lambda


### PR DESCRIPTION
New methods have been added to the `LocatableResolver` which accomplish the following:

1. A new "read" method allows the user to look at a mapping without creating one if it doesn't exist.
1. A transaction can be provided to read, create, or save a mapping. These methods have semantics that are more in line with the rest of the Record Layer's APIs.
1. Additional methods to directly read and update the full resolver state have been added. This can be useful if, for example, the user wants to both update the version and lock or unlock a locatable resolver.

These methods together make it possible to use a `LocatableResolver` in situations that are more in line with, say, a `RecordStore`.

This resolves #2062.