### PR TITLE
Use Index predicate when appropriate 

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Use Index.predicate as an index maintenance filter when appropriate [(Issue #2069)](https://github.com/FoundationDB/fdb-record-layer/issues/2069)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -139,6 +139,10 @@ public class FDBStoreTimer extends StoreTimer {
         DELETE_RECORD("delete record"),
         // TODO: Are these index maintenance related ones really DetailEvents?
         /** The amount of time spent maintaining an index when the entire record is skipped by the {@link IndexMaintenanceFilter}. */
+        SKIP_INDEX_RECORD_BY_PREDICATE("skip index record by index predicates"),
+        /** The amount of time spent at index predicates when an entry is skipped by the {@link IndexMaintenanceFilter}. */
+        USE_INDEX_RECORD_BY_PREDICATE("use index record by index predicates"),
+        /** The amount of time spent at index predicates when an entry is used by the {@link IndexMaintenanceFilter}. */
         SKIP_INDEX_RECORD("skip index record"),
         /** The amount of time spent maintaining an index when an entry is skipped by the {@link IndexMaintenanceFilter}. */
         SKIP_INDEX_ENTRY("skip index entry"),


### PR DESCRIPTION
FDBRecodStore is currently using a predefined IndexMaintenanceFilter as filter (defaulted to IndexMaintenanceFilter.NORMAL).
With the new Index.predicate field, change the logic to be:

If the user had explicitly set his own IndexMaintenanceFilter, use it.
Else if the index predicate was defined, use it.
Else use IndexMaintenanceFilter.NORMAL.