### PR TITLE
Improve covering field path computation …

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Improve covering field path computation for the case where a normalized field still takes up more than position [(Issue #2085)](https://github.com/FoundationDB/fdb-record-layer/issues/2085)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/AvailableFields.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/AvailableFields.java
@@ -133,16 +133,17 @@ public class AvailableFields {
 
         // KEYs -- from the index's definition
         final IndexKeyValueToPartialRecord.Builder builder = IndexKeyValueToPartialRecord.newBuilder(recordType);
-        for (int i = 0; i < keyFields.size(); i++) {
-            KeyExpression keyField = keyFields.get(i);
-            FieldData fieldData = constrainFieldData(recordType, constituentNameToPathMap, keyField, ImmutableIntArray.of(i));
+        int keyPosition = 0;
+        for (KeyExpression keyField : keyFields) {
+            FieldData fieldData = constrainFieldData(recordType, constituentNameToPathMap, keyField, ImmutableIntArray.of(keyPosition));
             if (!nonStoredFields.contains(keyField) && !keyField.createsDuplicates() && addCoveringField(keyField, fieldData, builder)) {
                 fields.put(keyField, fieldData);
             }
+            keyPosition += keyField.getColumnSize();
         }
         if (commonPrimaryKey != null) {
             // KEYs -- from the primary key
-            fields.putAll(getPrimaryKeyFieldMap(recordType, index, commonPrimaryKey, keyFields.size(), nonStoredFields, constituentNameToPathMap, builder));
+            fields.putAll(getPrimaryKeyFieldMap(recordType, index, commonPrimaryKey, keyPosition, nonStoredFields, constituentNameToPathMap, builder));
         }
         for (int i = 0; i < valueFields.size(); i++) {
             KeyExpression valueField = valueFields.get(i);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -1899,7 +1899,7 @@ public class RecordQueryPlanner implements QueryPlanner {
         final IndexKeyValueToPartialRecord.TupleSource source;
         final int index;
 
-        int i = keyFields.indexOf(requiredExpr);
+        int i = keyFieldPosition(requiredExpr, keyFields);
         if (i >= 0) {
             source = IndexKeyValueToPartialRecord.TupleSource.KEY;
             index = i;
@@ -1913,6 +1913,17 @@ public class RecordQueryPlanner implements QueryPlanner {
             }
         }
         return AvailableFields.addCoveringField(requiredExpr, AvailableFields.FieldData.ofUnconditional(source, ImmutableIntArray.of(index)), builder);
+    }
+
+    private static int keyFieldPosition(final @Nonnull KeyExpression requiredExpr, final @Nonnull List<KeyExpression> keyFields) {
+        int position = 0;
+        for (KeyExpression keyField : keyFields) {
+            if (keyField.equals(requiredExpr)) {
+                return position;
+            }
+            position += keyField.getColumnSize();
+        }
+        return -1;
     }
 
     private static class PlanContext {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
+import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordMetaData;
@@ -30,18 +31,24 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.QueryableKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRuleSet;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
+import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
@@ -50,6 +57,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,6 +69,7 @@ import static com.apple.foundationdb.record.TestHelpers.assertDiscardedNone;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.keyWithValue;
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.unbounded;
@@ -79,6 +89,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.scanComparisons;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.startsWith;
@@ -894,4 +905,110 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
         assertEquals(284123809, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
         assertEquals(994460375, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
     }
+
+    @Test
+    void coveringWideFunctionKey() throws Exception {
+        final Index nonFlattenedIndex = new Index("nonFlattenedIndex", concat(
+                field("num_value_2"),
+                function("non_flattened", concatenateFields("num_value_3_indexed", "str_value_indexed"))
+        ));
+        final RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", nonFlattenedIndex);
+        complexQuerySetup(hook);
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType("MySimpleRecord")
+                .setFilter(Query.field("num_value_2").greaterThanOrEquals(1))
+                .setRequiredResults(List.of(field("num_value_2")))
+                .build();
+        final RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher =
+                coveringIndexPlan()
+                        .where(indexPlanOf(indexPlan().where(indexName(nonFlattenedIndex.getName())).and(scanComparisons(range("[[1],>")))));
+        assertMatchesExactly(plan, planMatcher);
+        
+        assertEquals(782401607, plan.planHash(PlanHashable.PlanHashKind.LEGACY));
+        assertEquals(-1308646683, plan.planHash(PlanHashable.PlanHashKind.FOR_CONTINUATION));
+        assertEquals(-597350078, plan.planHash(PlanHashable.PlanHashKind.STRUCTURAL_WITHOUT_LITERALS));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            int i = 0;
+            try (RecordCursorIterator<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(Objects.requireNonNull(plan)).asIterator()) {
+                while (cursor.hasNext()) {
+                    FDBQueriedRecord<Message> rec = cursor.next();
+                    TestRecords1Proto.MySimpleRecord.Builder myrec = TestRecords1Proto.MySimpleRecord.newBuilder();
+                    myrec.mergeFrom(Objects.requireNonNull(rec).getRecord());
+                    assertThat(myrec.getNumValue2(), greaterThanOrEqualTo(1));
+                    i++;
+                }
+            }
+            assertEquals(66, i);
+            assertDiscardedNone(context);
+        }
+    }
+
+    /**
+     * Function registry for {@link NonFlattenedFunction}.
+     */
+    @AutoService(FunctionKeyExpression.Factory.class)
+    public static class TestFunctionRegistry implements FunctionKeyExpression.Factory {
+        @Nonnull
+        @Override
+        public List<FunctionKeyExpression.Builder> getBuilders() {
+            return Collections.singletonList(new FunctionKeyExpression.BiFunctionBuilder("non_flattened",
+                    NonFlattenedFunction::new));
+        }
+    }
+
+    private static class NonFlattenedFunction extends FunctionKeyExpression implements QueryableKeyExpression {
+        private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("NonFlattened-Function");
+
+        public NonFlattenedFunction(@Nonnull String name, @Nonnull KeyExpression arguments) {
+            super(name, arguments);
+        }
+
+        @Override
+        public int getMinArguments() {
+            return 0;
+        }
+
+        @Override
+        public int getMaxArguments() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Nonnull
+        @Override
+        public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable FDBRecord<M> record,
+                                                                        @Nullable Message message,
+                                                                        @Nonnull Key.Evaluated arguments) {
+            return Collections.singletonList(arguments);
+        }
+
+        @Override
+        public boolean createsDuplicates() {
+            return getArguments().createsDuplicates();
+        }
+
+        @Override
+        public int getColumnSize() {
+            return getArguments().getColumnSize();
+        }
+
+        @Nonnull
+        @Override
+        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+            throw new UnsupportedOperationException("not supported");
+        }
+
+        @Override
+        public int planHash(@Nonnull final PlanHashable.PlanHashKind hashKind) {
+            return super.basePlanHash(hashKind, BASE_HASH);
+        }
+
+        @Override
+        public int queryHash(@Nonnull final QueryHashKind hashKind) {
+            return super.baseQueryHash(hashKind, BASE_HASH);
+        }
+    }
 }
+


### PR DESCRIPTION
… for the case where a normalized field still takes up more than position.

Fixes #2085: Covering fields are off when one isn't exactly one column wide.