### PR TITLE
Fix bad error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ atlassian-ide-plugin.xml
 .idea/jarRepositories.xml
 .idea/shelf
 
+# VSCode specific files/directories
+.vscode
+**/bin
+
 # Eclipse specific files/directories
 .classpath
 .project

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
@@ -23,7 +23,7 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.PlanHashable;
-import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.lucene.search.LuceneOptimizedQueryParser;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
@@ -83,7 +83,7 @@ public class LuceneQuerySearchClause extends LuceneQueryClause {
         try {
             return parser.parse(searchString);
         } catch (Exception ioe) {
-            throw new RecordCoreArgumentException("Unable to parse search given for query", ioe);
+            throw new RecordCoreException("Unable to parse search given for query", ioe);
         }
     }
 


### PR DESCRIPTION
We accidentally used the wrong error type in the LuceneQuerySearchClause, so the error was getting replaced with a construction error.

While I was at it, I added some .gitignores to avoid accidentally committing VSCode folders