### PR TITLE
Mutual indexing: smarter ANY iteration - skip fragments that produce rangeSet conflicts

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Mutual indexing - better handle final iteration conflicts [(Issue #2082)](https://github.com/FoundationDB/fdb-record-layer/issues/2082)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -651,6 +651,18 @@ public class FDBStoreTimer extends StoreTimer {
         /** The number of {@link OnlineIndexer} range scans terminated after hitting the size limit. */
         ONLINE_INDEX_BUILDER_RANGES_BY_SIZE("number of indexer iterations terminated by write limit", false),
         /** The number of missing index entries detected by the online scrubber. */
+        ONLINE_INDEX_BUILDER_RANGES_BY_TIME("number of indexer iterations terminated by time limit", false),
+        /** The number of {@link OnlineIndexer} range scans terminated after hitting the time limit. */
+        MUTUAL_INDEXER_FULL_START("counter: start indexing a 'FULL' fragment", false),
+        /** {@link IndexingMutuallyByRecords} counter: start indexing a 'FULL' fragment. */
+        MUTUAL_INDEXER_FULL_DONE("counter: done indexing a 'FULL' fragment", false),
+        /** {@link IndexingMutuallyByRecords} counter: done indexing a 'FULL' fragment. */
+        MUTUAL_INDEXER_ANY_START("counter: start indexing an 'ANY' fragment", false),
+        /** {@link IndexingMutuallyByRecords} counter: start indexing an 'ANY' fragment. */
+        MUTUAL_INDEXER_ANY_DONE("counter: done indexing an 'ANY' fragment", false),
+        /** {@link IndexingMutuallyByRecords} counter: done indexing an 'ANY' fragment. */
+        MUTUAL_INDEXER_ANY_JUMP("counter: had conflicts while indexing an 'ANY' fragment, jump ahead", false),
+        /** {@link IndexingMutuallyByRecords} counter: had conflicts while indexing an 'ANY' fragment, jump ahead. */
         INDEX_SCRUBBER_MISSING_ENTRIES("number of missing index entries detected by online scrubber", false),
         /** The number of dangling index entries detected by online scrubber. */
         INDEX_SCRUBBER_DANGLING_ENTRIES("number of dangling index entries detected by online scrubber", false),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -653,6 +653,8 @@ public class FDBStoreTimer extends StoreTimer {
         /** The number of missing index entries detected by the online scrubber. */
         ONLINE_INDEX_BUILDER_RANGES_BY_TIME("number of indexer iterations terminated by time limit", false),
         /** The number of {@link OnlineIndexer} range scans terminated after hitting the time limit. */
+        ONLINE_INDEX_BUILDER_RANGES_BY_DEPLETION("number of indexer iterations terminated by cursor's range depletion", false),
+        /** The number of {@link OnlineIndexer} range scans terminated after hitting the cursor's range depletion. */
         MUTUAL_INDEXER_FULL_START("counter: start indexing a 'FULL' fragment", false),
         /** {@link IndexingMutuallyByRecords} counter: start indexing a 'FULL' fragment. */
         MUTUAL_INDEXER_FULL_DONE("counter: done indexing a 'FULL' fragment", false),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -802,6 +802,7 @@ public abstract class IndexingBase {
                     final CompletableFuture<Void> updateMaintainer = updateMaintainerBuilder(store, rec);
                     if (isExhausted) {
                         // we've just processed the last item
+                        timerIncrement(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_DEPLETION);
                         hasMore.set(false);
                         return updateMaintainer.thenApply(vignore -> false);
                     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -662,9 +662,8 @@ public abstract class IndexingBase {
     }
 
     public <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
-                                                          boolean limitControl,
                                                           @Nullable List<Object> additionalLogMessageKeyValues) {
-        return throttle.buildCommitRetryAsync(buildFunction, limitControl, additionalLogMessageKeyValues);
+        return throttle.buildCommitRetryAsync(buildFunction, additionalLogMessageKeyValues);
     }
 
     protected static void timerIncrement(@Nullable FDBStoreTimer timer, FDBStoreTimer.Counts event) {
@@ -902,7 +901,6 @@ public abstract class IndexingBase {
 
         return AsyncUtil.whileTrue(() ->
                     buildCommitRetryAsync(iterateRange,
-                            true,
                             additionalLogMessageKeyValues)
                             .handle((hasMore, ex) -> {
                                 if (ex == null) {
@@ -963,14 +961,8 @@ public abstract class IndexingBase {
     @Nonnull
     <R> CompletableFuture<R> throttledRunAsync(@Nonnull final Function<FDBRecordStore, CompletableFuture<R>> function,
                                                @Nonnull final BiFunction<R, Throwable, Pair<R, Throwable>> handlePostTransaction,
-                                               @Nullable final BiConsumer<FDBException, List<Object>> handleLessenWork,
                                                @Nullable final List<Object> additionalLogMessageKeyValues) {
-        return throttle.throttledRunAsync(function, handlePostTransaction, handleLessenWork, additionalLogMessageKeyValues);
-    }
-
-    void decreaseLimit(@Nonnull FDBException fdbException,
-                       @Nullable List<Object> additionalLogMessageKeyValues) {
-        throttle.decreaseLimit(fdbException, additionalLogMessageKeyValues);
+        return throttle.throttledRunAsync(function, handlePostTransaction, additionalLogMessageKeyValues);
     }
 
     protected void validateOrThrowEx(boolean isValid, @Nonnull String msg) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
@@ -211,7 +211,7 @@ public class IndexingByRecords extends IndexingBase {
     @Nonnull
     public CompletableFuture<TupleRange> buildEndpoints() {
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildEndpoints");
-        return buildCommitRetryAsync(this::buildEndpoints, false, additionalLogMessageKeyValues);
+        return buildCommitRetryAsync(this::buildEndpoints, additionalLogMessageKeyValues);
     }
 
     // Builds a range within a single transaction. It will look for the missing ranges within the given range and build those while
@@ -460,7 +460,6 @@ public class IndexingByRecords extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return buildCommitRetryAsync((store, recordsScanned) -> buildUnbuiltRange(store, start, end, recordsScanned),
-                true,
                 additionalLogMessageKeyValues);
     }
 
@@ -471,7 +470,6 @@ public class IndexingByRecords extends IndexingBase {
                 LogMessageKeys.RANGE_START, start,
                 LogMessageKeys.RANGE_END, end);
         return buildCommitRetryAsync((store, recordsScanned) -> buildUnbuiltRange(store, start, end, recordsScanned),
-                true,
                 additionalLogMessageKeyValues);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -141,7 +141,7 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
                             insertRanges(targetRangeSets, null, rangeStart),
                                     insertRanges(targetRangeSets, rangeEnd, null))
                             .thenApply(ignore -> null);
-                }, false, null);
+                }, null);
 
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex",
                 LogMessageKeys.RANGE_START, rangeStart,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -310,7 +310,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
                                     insertRanges(targetRangeSets, null, rangeStart),
                                     insertRanges(targetRangeSets, rangeEnd, null))
                             .thenApply(ignore -> null);
-                }, false, null);
+                }, null);
 
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "mutualMultiTargetIndex-wrapper",
                 LogMessageKeys.RANGE_START, rangeStart,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -375,15 +375,16 @@ public class IndexingMutuallyByRecords extends IndexingBase {
             Range rangeToBuild = isFull ?
                                  fullyUnBuiltRange(missingRanges, fragmentRange) :
                                  partlyUnBuiltRange(missingRanges, fragmentRange);
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info(KeyValueLogMessage.build("range to build",
-                                LogMessageKeys.SCAN_TYPE, fragmentIterationType,
-                                LogMessageKeys.RANGE, rangeToBuild,
-                                LogMessageKeys.ORIGINAL_RANGE, fragmentRange)
-                        .addKeysAndValues(fragmentLogMessageKeyValues())
-                        .toString());
-            }
+
             if (rangeToBuild != null && !anyJumperSaysJump(rangeToBuild)) {
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info(KeyValueLogMessage.build("fragment/range to build",
+                                    LogMessageKeys.SCAN_TYPE, fragmentIterationType,
+                                    LogMessageKeys.RANGE, rangeToBuild,
+                                    LogMessageKeys.ORIGINAL_RANGE, fragmentRange)
+                            .addKeysAndValues(fragmentLogMessageKeyValues())
+                            .toString());
+                }
                 timerIncrement(isFull ?
                                FDBStoreTimer.Counts.MUTUAL_INDEXER_FULL_START :
                                FDBStoreTimer.Counts.MUTUAL_INDEXER_ANY_START);
@@ -536,11 +537,13 @@ public class IndexingMutuallyByRecords extends IndexingBase {
         }
     }
 
-    // anyJumper:
-    //  During the ANY iteration, we wish to avoid cases of two indexers competing on the same fragment.
-    //  It is done by recording the exception and the fragment info, then - during the next iteration:
-    //      If at the same fragment, same range: re-throw
-    //      If at the same fragment, different range: jump to the next fragment
+    /**
+     * anyJumper algo:
+     *  During the ANY iteration, we wish to avoid cases of two indexers competing on the same fragment.
+     *  It is done by recording the exception and the fragment info, then - during the next iteration:
+     *      If at the same fragment, same range: re-throw
+     *      If at the same fragment, different range: jump to the next fragment
+     */
     boolean anyJumperSaysJump(Range rangeToBuild) {
         if (anyJumperEx == null || fragmentIterationType != FragmentIterationType.ANY) {
             return false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -191,8 +191,7 @@ public class IndexingScrubDangling extends IndexingBase {
         if (! indexResult.hasStoredRecord() ) {
             // Here: Oh, No! this index is dangling!
             danglingCount.incrementAndGet();
-            final FDBStoreTimer timer = getRunner().getTimer();
-            timerIncrement(timer, FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES);
+            timerIncrement(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES);
             final IndexEntry indexEntry = indexResult.getIndexEntry();
             final Tuple valueKey = indexEntry.getKey();
             final byte[] keyBytes = store.indexSubspace(common.getIndex()).pack(valueKey);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -223,8 +223,7 @@ public class IndexingScrubMissing extends IndexingBase {
                                 .toString());
                     }
                     missingCount.incrementAndGet();
-                    final FDBStoreTimer timer = getRunner().getTimer();
-                    timerIncrement(timer, FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES);
+                    timerIncrement(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES);
                     if (scrubbingPolicy.allowRepair()) {
                         // record to be indexed
                         return rec;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -40,11 +40,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -73,7 +73,7 @@ public class IndexingThrottle {
             FDBError.TRANSACTION_TOO_LARGE.code()));
 
     /**
-     * The number of successful transactions in a row as called by {@link #throttledRunAsync(Function, BiFunction, List)}.
+     * The number of successful transactions in a row as called by {@link #throttledRunAsync(Function, BiFunction, Function, List)}.
      */
     private int successCount = 0;
 
@@ -84,6 +84,7 @@ public class IndexingThrottle {
     }
 
     public <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
+                                                          @Nullable final Function<FDBException, Optional<R>> shouldReturnQuietly,
                                                           @Nullable List<Object> additionalLogMessageKeyValues) {
         AtomicLong recordsScanned = new AtomicLong(0);
         return throttledRunAsync(store -> buildFunction.apply(store, recordsScanned),
@@ -98,6 +99,7 @@ public class IndexingThrottle {
                     }
                     return Pair.of(result, exception);
                 },
+                shouldReturnQuietly,
                 additionalLogMessageKeyValues
         );
     }
@@ -181,6 +183,7 @@ public class IndexingThrottle {
     @Nonnull
     <R> CompletableFuture<R> throttledRunAsync(@Nonnull final Function<FDBRecordStore, CompletableFuture<R>> function,
                                                @Nonnull final BiFunction<R, Throwable, Pair<R, Throwable>> handlePostTransaction,
+                                               @Nullable final Function<FDBException, Optional<R>> shouldReturnQuietly,
                                                @Nullable final List<Object> additionalLogMessageKeyValues) {
         List<Object> onlineIndexerLogMessageKeyValues = new ArrayList<>(Arrays.asList(
                 LogMessageKeys.INDEX_NAME, common.getTargetIndexesNames(),
@@ -218,32 +221,41 @@ public class IndexingThrottle {
                 return function.apply(store);
             }), handlePostTransaction, onlineIndexerLogMessageKeyValues).handle((value, e) -> {
                 if (e == null) {
+                    // Here: success path - also the common path (or so we hope)
                     ret.complete(value);
                     return AsyncUtil.READY_FALSE;
-                } else {
-                    int currTries = tries.getAndIncrement();
-                    FDBException fdbE = getFDBException(e);
-                    if (currTries < common.config.getMaxRetries() && fdbE != null && lessenWorkCodes.contains(fdbE.getCode())) {
-                        decreaseLimit(fdbE, onlineIndexerLogMessageKeyValues);
-                        if (LOGGER.isWarnEnabled()) {
-                            final KeyValueLogMessage message = KeyValueLogMessage.build("Retrying Runner Exception",
-                                    LogMessageKeys.INDEXER_CURR_RETRY, currTries,
-                                    LogMessageKeys.INDEXER_MAX_RETRIES, common.config.getMaxRetries(),
-                                    LogMessageKeys.DELAY, delay.getNextDelayMillis(),
-                                    LogMessageKeys.LIMIT, limit);
-                            message.addKeysAndValues(onlineIndexerLogMessageKeyValues);
-                            LOGGER.warn(message.toString(), e);
-                        }
-                        CompletableFuture<Boolean> delayedContinue = delay.delay().thenApply(vignore3 -> true);
-                        if (common.getRunner().getTimer() != null) {
-                            delayedContinue = common.getRunner().getTimer().instrument(FDBStoreTimer.Events.RETRY_DELAY,
-                                    delayedContinue, common.getRunner().getExecutor());
-                        }
-                        return delayedContinue;
-                    } else {
-                        return completeExceptionally(ret, e, onlineIndexerLogMessageKeyValues);
+                }
+                FDBException fdbE = getFDBException(e);
+                if (shouldReturnQuietly != null) {
+                    Optional<R> retVal = shouldReturnQuietly.apply(fdbE);
+                    if (retVal.isPresent()) {
+                        // Here: handle a special case: would the caller wish us to quietly return?
+                        ret.complete(retVal.get());
+                        return AsyncUtil.READY_FALSE;
                     }
                 }
+                int currTries = tries.getAndIncrement();
+                if (currTries >= common.config.getMaxRetries() || fdbE == null || !lessenWorkCodes.contains(fdbE.getCode())) {
+                    // Here: should not retry. Or no more retries.
+                    return completeExceptionally(ret, e, onlineIndexerLogMessageKeyValues);
+                }
+                // Here: decrease limit, log, delay continue
+                decreaseLimit(fdbE, onlineIndexerLogMessageKeyValues);
+                if (LOGGER.isWarnEnabled()) {
+                    final KeyValueLogMessage message = KeyValueLogMessage.build("Retrying Runner Exception",
+                            LogMessageKeys.INDEXER_CURR_RETRY, currTries,
+                            LogMessageKeys.INDEXER_MAX_RETRIES, common.config.getMaxRetries(),
+                            LogMessageKeys.DELAY, delay.getNextDelayMillis(),
+                            LogMessageKeys.LIMIT, limit);
+                    message.addKeysAndValues(onlineIndexerLogMessageKeyValues);
+                    LOGGER.warn(message.toString(), e);
+                }
+                CompletableFuture<Boolean> delayedContinue = delay.delay().thenApply(vignore3 -> true);
+                if (common.getRunner().getTimer() != null) {
+                    delayedContinue = common.getRunner().getTimer().instrument(FDBStoreTimer.Events.RETRY_DELAY,
+                            delayedContinue, common.getRunner().getExecutor());
+                }
+                return delayedContinue;
             }).thenCompose(Function.identity());
         }, common.getRunner().getExecutor()).whenComplete((vignore, e) -> {
             if (e != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -229,7 +229,8 @@ public class IndexingThrottle {
                 if (shouldReturnQuietly != null) {
                     Optional<R> retVal = shouldReturnQuietly.apply(fdbE);
                     if (retVal.isPresent()) {
-                        // Here: handle a special case: would the caller wish us to quietly return?
+                        // Here: a non-empty answer signals to return this <R> value rather than handling the exception.
+                        // This is useful when the caller wishes to handle this exception itself.
                         ret.complete(retVal.get());
                         return AsyncUtil.READY_FALSE;
                     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.FDBException;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
@@ -59,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -415,7 +415,7 @@ public class OnlineIndexer implements AutoCloseable {
 
     /**
      * Get the current number of records to process in one transaction.
-     * This may go up or down while {@link #throttledRunAsync(Function, BiFunction, BiConsumer, List)} is running, if there are failures committing or
+     * This may go up or down while {@link #throttledRunAsync(Function, BiFunction, List)} is running, if there are failures committing or
      * repeated successes.
      * @return the current number of records to process in one transaction
      */
@@ -444,8 +444,6 @@ public class OnlineIndexer implements AutoCloseable {
      * @param handlePostTransaction after the transaction is committed, or fails to commit, this function is called with
      * the result or exception respectively. This handler should return a new pair with either the result to return from
      * {@code runAsync} or an exception to be checked whether {@code retriable} should be retried.
-     * @param handleLessenWork if it there is too much work to be done in a single transaction, this function is called
-     * with the FDB exception and additional logging. It should make necessary adjustments to lessen the work.
      * @param additionalLogMessageKeyValues additional key/value pairs to be included in logs
      * @param <R> return type of function to run
      */
@@ -453,24 +451,16 @@ public class OnlineIndexer implements AutoCloseable {
     @VisibleForTesting
     <R> CompletableFuture<R> throttledRunAsync(@Nonnull final Function<FDBRecordStore, CompletableFuture<R>> function,
                                                @Nonnull final BiFunction<R, Throwable, Pair<R, Throwable>> handlePostTransaction,
-                                               @Nullable final BiConsumer<FDBException, List<Object>> handleLessenWork,
                                                @Nullable final List<Object> additionalLogMessageKeyValues) {
         // test only
-        return getIndexer().throttledRunAsync(function, handlePostTransaction, handleLessenWork, additionalLogMessageKeyValues);
+        return getIndexer().throttledRunAsync(function, handlePostTransaction, additionalLogMessageKeyValues);
     }
 
     @VisibleForTesting
     <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
                                                    @Nullable List<Object> additionalLogMessageKeyValues) {
         // test only
-        return getIndexer().buildCommitRetryAsync(buildFunction, true, additionalLogMessageKeyValues);
-    }
-
-    @VisibleForTesting
-    void decreaseLimit(@Nonnull FDBException fdbException,
-                       @Nullable List<Object> additionalLogMessageKeyValues) {
-        // test only
-        getIndexer().decreaseLimit(fdbException, additionalLogMessageKeyValues);
+        return getIndexer().buildCommitRetryAsync(buildFunction, additionalLogMessageKeyValues);
     }
 
     @VisibleForTesting

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -201,7 +201,6 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        // cannot predict exactly how many times the transaction time quota will be reached, but surely more than 0
         assertTrue(0 < timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_DEPLETION));
         assertReadable(indexes);
         assertAllValidated(indexes);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -202,7 +202,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         // cannot predict exactly how many times the transaction time quota will be reached, but surely more than 0
-        assertTrue(0 < timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_SIZE));
+        assertTrue(0 < timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_DEPLETION));
         assertReadable(indexes);
         assertAllValidated(indexes);
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -201,7 +201,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         range.parallel().forEach(ignore -> {
             try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes, timer)
                     .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
-                            .setMutualIndexingBoundaries(boundaries) // no boundaries mean self detection - which will be no boundaries
+                            .setMutualIndexingBoundaries(boundaries)
                             .build())
                     .setLimit(7)
                     .setMaxAttempts(2)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -1322,8 +1322,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         }
 
         // After unblocking, finish building
-        IntStream.rangeClosed(0, 3).parallel()
-                .forEach(ignore -> oneThreadIndexing(indexes, timer, boundariesList));
+        oneThreadIndexing(indexes, timer, boundariesList);
 
         // Validate
         assertReadable(indexes);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -135,6 +135,48 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         assertAllValidated(indexes);
     }
 
+    @Test
+    void testMutualIndexingNoBoundariesMultiIndexers() {
+        // Let multi threads build all the indexes - boundaries will be detected automatically - which means (null, null) because the data set will be too small to have multiple shards in fdb
+        // Note that some of the indexers should get conflicts, which should trigger the anyJumper mechanism. This test asserts that some indexers jump and abort at the third iteration.
+        final FDBStoreTimer timer = new FDBStoreTimer();
+
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE));
+        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+
+        long numRecords = 180;
+        populateData(numRecords);
+
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+
+        IntStream range = IntStream.rangeClosed(0, 7);
+        AtomicInteger count = new AtomicInteger(0);
+        range.parallel().forEach(ignore -> {
+            try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes, timer)
+                    .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                            .setMutualIndexing() // no boundaries mean self detection - which will be no boundaries
+                            .build())
+                    .setLimit(7)
+                    .setMaxAttempts(2)
+                    .setMaxRetries(2)
+                    .build()) {
+                try {
+                    indexBuilder.buildIndex(true);
+                } catch (RecordCoreException ex) {
+                    assertTrue(ex.getMessage().contains("Mutual indexing failure - third iteration"));
+                    count.incrementAndGet();
+                }
+            }
+        });
+        assertReadable(indexes);
+        assertAllValidated(indexes);
+        assertTrue(count.get() > 1);
+    }
+
     @ParameterizedTest
     @CsvSource({
             // single threads:

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -177,6 +177,49 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         assertTrue(count.get() > 1);
     }
 
+    @Test
+    void testMutualIndexingMultiBoundariesMultiIndexers() {
+        // Let multi threads build all the indexes
+        // Note that some of the indexers should get conflicts, which should trigger the anyJumper mechanism. This test asserts that some indexers jump and abort at the third iteration.
+        final FDBStoreTimer timer = new FDBStoreTimer();
+
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE));
+        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+
+        long numRecords = 200;
+        populateData(numRecords);
+
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+
+        final List<Tuple> boundaries = getBoundariesList(numRecords, 40);
+        IntStream range = IntStream.rangeClosed(0, 7);
+        AtomicInteger count = new AtomicInteger(0);
+        range.parallel().forEach(ignore -> {
+            try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes, timer)
+                    .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                            .setMutualIndexingBoundaries(boundaries) // no boundaries mean self detection - which will be no boundaries
+                            .build())
+                    .setLimit(7)
+                    .setMaxAttempts(2)
+                    .setMaxRetries(2)
+                    .build()) {
+                try {
+                    indexBuilder.buildIndex(true);
+                } catch (RecordCoreException ex) {
+                    assertTrue(ex.getMessage().contains("Mutual indexing failure - third iteration"));
+                    count.incrementAndGet();
+                }
+            }
+        });
+        assertReadable(indexes);
+        assertAllValidated(indexes);
+        assertTrue(count.get() > 0);
+    }
+
     @ParameterizedTest
     @CsvSource({
             // single threads:

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -460,7 +460,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
     }
 
     private <R> CompletableFuture<R> runAndHandleLessenWorkCodes(OnlineIndexer indexBuilder, @Nonnull Function<FDBRecordStore, CompletableFuture<R>> function) {
-        return indexBuilder.throttledRunAsync(function, Pair::of, indexBuilder::decreaseLimit, null);
+        return indexBuilder.throttledRunAsync(function, Pair::of, null);
     }
 
     @Test


### PR DESCRIPTION
Implement `anyJumper` 
During the ANY iteration: 
  If `throttledRunAsync` gets an exception, the mutual indexer will store it and return quietly 
  Then, during the next outer iteration:
        If at the same fragment, same range: re-throw (as the problem was not related to a rangeSet conflicts)
        If at the same fragment, different range: jump to the next fragment
