### PR TITLE
Resolves #2089: Cascades planner should support queries on record version

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Record versions are now queryable by the Cascades planner, including mathcing on version indexes [(Issue #2089)](https://github.com/FoundationDB/fdb-record-layer/issues/2089)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/VersionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/VersionKeyExpression.java
@@ -108,7 +108,7 @@ public class VersionKeyExpression extends BaseKeyExpression implements AtomKeyEx
     @Nonnull
     @Override
     public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
-        return new VersionValue();
+        return new VersionValue(baseAlias);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
@@ -186,7 +186,7 @@ public class QueryRecordFunctionWithComparison implements ComponentWithCompariso
 
             return GraphExpansion.ofExists(rankComparisonQuantifier);
         } else if (function instanceof StoreRecordFunction<?> && FunctionNames.VERSION.equals(function.getName())) {
-            VersionValue versionValue = new VersionValue(baseQuantifier.getAlias());
+            final VersionValue versionValue = new VersionValue(baseQuantifier.getAlias());
             return GraphExpansion.builder()
                     .addPredicate(new ValuePredicate(versionValue, comparison))
                     .build();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryRecordFunctionWithComparison.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordFunction;
 import com.apple.foundationdb.record.metadata.IndexRecordFunction;
+import com.apple.foundationdb.record.metadata.StoreRecordFunction;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
@@ -38,6 +39,7 @@ import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredica
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.RankValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.VersionValue;
 import com.apple.foundationdb.record.util.HashUtils;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Descriptors;
@@ -183,6 +185,11 @@ public class QueryRecordFunctionWithComparison implements ComponentWithCompariso
             }
 
             return GraphExpansion.ofExists(rankComparisonQuantifier);
+        } else if (function instanceof StoreRecordFunction<?> && FunctionNames.VERSION.equals(function.getName())) {
+            VersionValue versionValue = new VersionValue(baseQuantifier.getAlias());
+            return GraphExpansion.builder()
+                    .addPredicate(new ValuePredicate(versionValue, comparison))
+                    .build();
         }
 
         throw new UnsupportedOperationException();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -273,6 +273,7 @@ public interface MatchCandidate {
 
         switch (indexType) {
             case IndexTypes.VALUE:
+            case IndexTypes.VERSION:
                 expandIndexMatchCandidate(index,
                     availableRecordTypeNames,
                     availableRecordTypes,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PromoteValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PromoteValue.java
@@ -56,8 +56,7 @@ public class PromoteValue implements ValueWithChild {
                     Pair.of(Type.TypeCode.INT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Integer)in),
                     Pair.of(Type.TypeCode.LONG, Type.TypeCode.FLOAT), (descriptor, in) -> Float.valueOf((Long)in),
                     Pair.of(Type.TypeCode.LONG, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Long)in),
-                    Pair.of(Type.TypeCode.FLOAT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Float)in)
-            );
+                    Pair.of(Type.TypeCode.FLOAT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Float)in));
     /**
      * The hash value of this expression.
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PromoteValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PromoteValue.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.MessageHelpers;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
@@ -39,7 +38,6 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -58,10 +56,8 @@ public class PromoteValue implements ValueWithChild {
                     Pair.of(Type.TypeCode.INT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Integer)in),
                     Pair.of(Type.TypeCode.LONG, Type.TypeCode.FLOAT), (descriptor, in) -> Float.valueOf((Long)in),
                     Pair.of(Type.TypeCode.LONG, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Long)in),
-                    Pair.of(Type.TypeCode.FLOAT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Float)in),
-                    Pair.of(Type.TypeCode.STRING, Type.TypeCode.VERSION), (descriptor, in) -> FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) in)),
-                    Pair.of(Type.TypeCode.STRING, Type.TypeCode.BYTES), (descriptor, in) -> Base64.getDecoder().decode((String) in),
-                    Pair.of(Type.TypeCode.BYTES, Type.TypeCode.VERSION), (descriptor, in) -> FDBRecordVersion.fromBytes((byte[]) in));
+                    Pair.of(Type.TypeCode.FLOAT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Float)in)
+            );
     /**
      * The hash value of this expression.
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PromoteValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PromoteValue.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.MessageHelpers;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
@@ -38,6 +39,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -56,7 +58,10 @@ public class PromoteValue implements ValueWithChild {
                     Pair.of(Type.TypeCode.INT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Integer)in),
                     Pair.of(Type.TypeCode.LONG, Type.TypeCode.FLOAT), (descriptor, in) -> Float.valueOf((Long)in),
                     Pair.of(Type.TypeCode.LONG, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Long)in),
-                    Pair.of(Type.TypeCode.FLOAT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Float)in));
+                    Pair.of(Type.TypeCode.FLOAT, Type.TypeCode.DOUBLE), (descriptor, in) -> Double.valueOf((Float)in),
+                    Pair.of(Type.TypeCode.STRING, Type.TypeCode.VERSION), (descriptor, in) -> FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) in)),
+                    Pair.of(Type.TypeCode.STRING, Type.TypeCode.BYTES), (descriptor, in) -> Base64.getDecoder().decode((String) in),
+                    Pair.of(Type.TypeCode.BYTES, Type.TypeCode.VERSION), (descriptor, in) -> FDBRecordVersion.fromBytes((byte[]) in));
     /**
      * The hash value of this expression.
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScanWithFetchMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScanWithFetchMatchCandidate.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 
 import javax.annotation.Nonnull;
@@ -41,6 +43,12 @@ public interface ScanWithFetchMatchCandidate extends WithPrimaryKeyMatchCandidat
                                                  @Nonnull final CorrelationIdentifier sourceAlias,
                                                  @Nonnull final CorrelationIdentifier targetAlias,
                                                  @Nonnull final Iterable<? extends Value> providedValuesFromIndex) {
+        if (!(toBePushedValue instanceof FieldValue || toBePushedValue instanceof RecordConstructorValue)) {
+            // At the moment, we can only push field and record value operations through fetches. Once this is fixed,
+            // we can expand the list of push-able values
+            return Optional.empty();
+        }
+
         final AliasMap equivalenceMap = AliasMap.of(sourceAlias, baseAlias);
         final AliasMap toTargetAliasMap = AliasMap.of(sourceAlias, targetAlias);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
@@ -58,7 +58,7 @@ public class ValueIndexExpansionVisitor extends KeyExpressionExpansionVisitor im
     private final List<RecordType> queriedRecordTypes;
 
     public ValueIndexExpansionVisitor(@Nonnull Index index, @Nonnull Collection<RecordType> queriedRecordTypes) {
-        Preconditions.checkArgument(IndexTypes.VALUE.equals(index.getType()) || IndexTypes.RANK.equals(index.getType()));
+        Preconditions.checkArgument(IndexTypes.VALUE.equals(index.getType()) || IndexTypes.VERSION.equals(index.getType()) || IndexTypes.RANK.equals(index.getType()));
         this.index = index;
         this.queriedRecordTypes = ImmutableList.copyOf(queriedRecordTypes);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ValueMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ValueMatchers.java
@@ -154,6 +154,6 @@ public class ValueMatchers {
 
     @Nonnull
     public static BindingMatcher<VersionValue> versionValue() {
-        return typedWithDownstream(VersionValue.class, Extractor.identity(), anyValue());
+        return typed(VersionValue.class);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ValueMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ValueMatchers.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregati
 import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.StreamableAggregateValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.cascades.values.VersionValue;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
@@ -149,5 +150,10 @@ public class ValueMatchers {
         return typedWithDownstream(StreamableAggregateValue.class,
                 Extractor.of(StreamableAggregateValue::getChildren, name -> "children(" + name + ")"),
                 downstreamValues);
+    }
+
+    @Nonnull
+    public static BindingMatcher<VersionValue> versionValue() {
+        return typedWithDownstream(VersionValue.class, Extractor.identity(), anyValue());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughFilterRule.java
@@ -22,9 +22,9 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
-import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.ReferencedFieldsConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.ReferencedFieldsConstraint.ReferencedFields;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughSelectRule.java
@@ -22,9 +22,9 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
-import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.ReferencedFieldsConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.ReferencedFieldsConstraint.ReferencedFields;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.typing;
 
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.Narrowable;
 import com.apple.foundationdb.record.query.plan.cascades.NullableArrayTypeUtils;
@@ -640,6 +641,7 @@ public interface Type extends Narrowable<Type> {
         INT(Integer.class, FieldDescriptorProto.Type.TYPE_INT32, true, true),
         LONG(Long.class, FieldDescriptorProto.Type.TYPE_INT64, true, true),
         STRING(String.class, FieldDescriptorProto.Type.TYPE_STRING, true, false),
+        VERSION(FDBRecordVersion.class, FieldDescriptorProto.Type.TYPE_BYTES, true, false),
         ENUM(Enum.class, FieldDescriptorProto.Type.TYPE_ENUM, false, false),
         RECORD(Message.class, null, false, false),
         ARRAY(List.class, null, false, false),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
@@ -144,11 +144,11 @@ public class FieldValue implements ValueWithChild {
         // If the last step in the field path is an array that is also nullable, then we need to unwrap the value
         // wrapper.
         //
-        return wrapPrimitive(getResultType(), NullableArrayTypeUtils.unwrapIfArray(fieldValue, getResultType()));
+        return unwrapPrimitive(getResultType(), NullableArrayTypeUtils.unwrapIfArray(fieldValue, getResultType()));
     }
 
     @Nullable
-    private static Object wrapPrimitive(@Nonnull Type type, @Nullable Object fieldValue) {
+    private static Object unwrapPrimitive(@Nonnull Type type, @Nullable Object fieldValue) {
         if (fieldValue == null) {
             return null;
         }
@@ -158,7 +158,7 @@ public class FieldValue implements ValueWithChild {
             Type elementType = Objects.requireNonNull(((Type.Array)type).getElementType());
             List<Object> returnList = new ArrayList<>(list.size());
             for (Object elem : list) {
-                returnList.add(wrapPrimitive(elementType, elem));
+                returnList.add(unwrapPrimitive(elementType, elem));
             }
             return returnList;
         } else if (type.getTypeCode() == Type.TypeCode.VERSION) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordTypeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordTypeValue.java
@@ -102,8 +102,8 @@ public class RecordTypeValue implements QuantifiedValue {
 
     @Override
     public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
-        if (otherValue instanceof QuantifiedObjectValue) {
-            return getAlias().equals(((QuantifiedObjectValue)otherValue).getAlias());
+        if (otherValue instanceof QuantifiedValue) {
+            return getAlias().equals(((QuantifiedValue)otherValue).getAlias());
         }
         return false;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
@@ -51,7 +51,6 @@ import org.apache.commons.lang3.tuple.Triple;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -468,7 +467,6 @@ public class RelOpValue implements BooleanValue {
         // TODO think about equality epsilon for floating-point types.
         EQ_BU(Comparisons.Type.EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_BB(Comparisons.Type.EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.BOOLEAN, (l, r) -> (boolean)l == (boolean)r),
-        EQ_BV(Comparisons.Type.EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).equals(r)),
         EQ_IU(Comparisons.Type.EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_II(Comparisons.Type.EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l == (int)r),
         EQ_IL(Comparisons.Type.EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l == (long)r),
@@ -499,7 +497,6 @@ public class RelOpValue implements BooleanValue {
         // EQ_SD(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         EQ_SU(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_SS(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> l.equals(r)), // TODO: locale-aware comparison
-        EQ_SV(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).equals(r)),
         EQ_UU(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_UB(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         EQ_UI(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -509,13 +506,10 @@ public class RelOpValue implements BooleanValue {
         EQ_US(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
         EQ_UV(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         EQ_VU(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        EQ_VB(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> l.equals(FDBRecordVersion.fromBytes((byte[]) r, false))),
-        EQ_VS(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> l.equals(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false))),
         EQ_VV(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, Object::equals),
 
         NEQ_BU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         NEQ_BB(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.BOOLEAN, (l, r) -> (boolean)l != (boolean)r),
-        NEQ_BV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> !(FDBRecordVersion.fromBytes((byte[]) l)).equals(r)),
         NEQ_IU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         NEQ_II(Comparisons.Type.NOT_EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l != (int)r),
         NEQ_IL(Comparisons.Type.NOT_EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l != (long)r),
@@ -547,20 +541,16 @@ public class RelOpValue implements BooleanValue {
         NEQ_SU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         NEQ_SS(Comparisons.Type.NOT_EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> !l.equals(r)), // TODO: locale-aware comparison
         NEQ_UU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        NEQ_SV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> !(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).equals(r)),
         NEQ_UB(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         NEQ_UI(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
         NEQ_UL(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.LONG, (l, r) -> null),
         NEQ_UF(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         NEQ_UD(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
-        NEQ_UV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         NEQ_US(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        NEQ_UV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         NEQ_VU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        NEQ_VB(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> !l.equals(FDBRecordVersion.fromBytes((byte[]) r, false))),
-        NEQ_VS(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> !l.equals(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false))),
         NEQ_VV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> !l.equals(r)),
 
-        LT_BV(Comparisons.Type.LESS_THAN, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) < 0),
         LT_IU(Comparisons.Type.LESS_THAN, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LT_II(Comparisons.Type.LESS_THAN, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l < (int)r),
         LT_IL(Comparisons.Type.LESS_THAN, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l < (long)r),
@@ -591,7 +581,6 @@ public class RelOpValue implements BooleanValue {
         // LT_SD(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         LT_SU(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LT_SS(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) < 0), // TODO: locale-aware comparison
-        LT_SV(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) < 0),
         LT_UU(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LT_UB(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         LT_UI(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -601,11 +590,8 @@ public class RelOpValue implements BooleanValue {
         LT_US(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
         LT_UV(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         LT_VU(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        LT_VB(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) < 0),
-        LT_VS(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) < 0),
         LT_VV(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) < 0),
 
-        LTE_BV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) <= 0),
         LTE_IU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LTE_II(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l <= (int)r),
         LTE_IL(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l <= (long)r),
@@ -636,7 +622,6 @@ public class RelOpValue implements BooleanValue {
         // LTE_SD(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         LTE_SU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LTE_SS(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) <= 0), // TODO: locale-aware comparison
-        LTE_SV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) <= 0),
         LTE_UU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LTE_UB(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         LTE_UI(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -646,11 +631,8 @@ public class RelOpValue implements BooleanValue {
         LTE_US(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
         LTE_UV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         LTE_VU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        LTE_VB(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) <= 0),
-        LTE_VS(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) <= 0),
         LTE_VV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) <= 0),
 
-        GT_BV(Comparisons.Type.GREATER_THAN, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) > 0),
         GT_IU(Comparisons.Type.GREATER_THAN, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GT_II(Comparisons.Type.GREATER_THAN, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l > (int)r),
         GT_IL(Comparisons.Type.GREATER_THAN, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l > (long)r),
@@ -681,7 +663,6 @@ public class RelOpValue implements BooleanValue {
         // GT_SD(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         GT_SU(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GT_SS(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) > 0), // TODO: locale-aware comparison
-        GT_SV(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) > 0),
         GT_UU(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GT_UB(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         GT_UI(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -691,11 +672,8 @@ public class RelOpValue implements BooleanValue {
         GT_US(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
         GT_UV(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         GT_VU(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        GT_VB(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) > 0),
-        GT_VS(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) > 0),
         GT_VV(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) > 0),
 
-        GTE_BV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) >= 0),
         GTE_IU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GTE_II(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l >= (int)r),
         GTE_IL(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l >= (long)r),
@@ -726,18 +704,15 @@ public class RelOpValue implements BooleanValue {
         // GTE_SD(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         GTE_SU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GTE_SS(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) >= 0), // TODO: locale-aware comparison
-        GTE_SV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) >= 0),
         GTE_UU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        GTE_UV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         GTE_UB(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         GTE_UI(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
         GTE_UL(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.LONG, (l, r) -> null),
         GTE_UF(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         GTE_UD(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
         GTE_US(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        GTE_UV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         GTE_VU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
-        GTE_VB(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) >= 0),
-        GTE_VS(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) >= 0),
         GTE_VV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) >= 0),
         ;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
@@ -50,6 +51,7 @@ import org.apache.commons.lang3.tuple.Triple;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -466,6 +468,7 @@ public class RelOpValue implements BooleanValue {
         // TODO think about equality epsilon for floating-point types.
         EQ_BU(Comparisons.Type.EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_BB(Comparisons.Type.EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.BOOLEAN, (l, r) -> (boolean)l == (boolean)r),
+        EQ_BV(Comparisons.Type.EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).equals(r)),
         EQ_IU(Comparisons.Type.EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_II(Comparisons.Type.EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l == (int)r),
         EQ_IL(Comparisons.Type.EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l == (long)r),
@@ -496,6 +499,7 @@ public class RelOpValue implements BooleanValue {
         // EQ_SD(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         EQ_SU(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_SS(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> l.equals(r)), // TODO: locale-aware comparison
+        EQ_SV(Comparisons.Type.EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).equals(r)),
         EQ_UU(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         EQ_UB(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         EQ_UI(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -503,9 +507,15 @@ public class RelOpValue implements BooleanValue {
         EQ_UF(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         EQ_UD(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
         EQ_US(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        EQ_UV(Comparisons.Type.EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
+        EQ_VU(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        EQ_VB(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> l.equals(FDBRecordVersion.fromBytes((byte[]) r, false))),
+        EQ_VS(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> l.equals(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false))),
+        EQ_VV(Comparisons.Type.EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, Object::equals),
 
         NEQ_BU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         NEQ_BB(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BOOLEAN, Type.TypeCode.BOOLEAN, (l, r) -> (boolean)l != (boolean)r),
+        NEQ_BV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> !(FDBRecordVersion.fromBytes((byte[]) l)).equals(r)),
         NEQ_IU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         NEQ_II(Comparisons.Type.NOT_EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l != (int)r),
         NEQ_IL(Comparisons.Type.NOT_EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l != (long)r),
@@ -537,13 +547,20 @@ public class RelOpValue implements BooleanValue {
         NEQ_SU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         NEQ_SS(Comparisons.Type.NOT_EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> !l.equals(r)), // TODO: locale-aware comparison
         NEQ_UU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        NEQ_SV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> !(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).equals(r)),
         NEQ_UB(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         NEQ_UI(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
         NEQ_UL(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.LONG, (l, r) -> null),
         NEQ_UF(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         NEQ_UD(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
+        NEQ_UV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         NEQ_US(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        NEQ_VU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        NEQ_VB(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> !l.equals(FDBRecordVersion.fromBytes((byte[]) r, false))),
+        NEQ_VS(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> !l.equals(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false))),
+        NEQ_VV(Comparisons.Type.NOT_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> !l.equals(r)),
 
+        LT_BV(Comparisons.Type.LESS_THAN, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) < 0),
         LT_IU(Comparisons.Type.LESS_THAN, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LT_II(Comparisons.Type.LESS_THAN, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l < (int)r),
         LT_IL(Comparisons.Type.LESS_THAN, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l < (long)r),
@@ -574,6 +591,7 @@ public class RelOpValue implements BooleanValue {
         // LT_SD(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         LT_SU(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LT_SS(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) < 0), // TODO: locale-aware comparison
+        LT_SV(Comparisons.Type.LESS_THAN, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) < 0),
         LT_UU(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LT_UB(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         LT_UI(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -581,7 +599,13 @@ public class RelOpValue implements BooleanValue {
         LT_UF(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         LT_UD(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
         LT_US(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        LT_UV(Comparisons.Type.LESS_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
+        LT_VU(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        LT_VB(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) < 0),
+        LT_VS(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) < 0),
+        LT_VV(Comparisons.Type.LESS_THAN, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) < 0),
 
+        LTE_BV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) <= 0),
         LTE_IU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LTE_II(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l <= (int)r),
         LTE_IL(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l <= (long)r),
@@ -612,6 +636,7 @@ public class RelOpValue implements BooleanValue {
         // LTE_SD(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         LTE_SU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LTE_SS(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) <= 0), // TODO: locale-aware comparison
+        LTE_SV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) <= 0),
         LTE_UU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         LTE_UB(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         LTE_UI(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -619,7 +644,13 @@ public class RelOpValue implements BooleanValue {
         LTE_UF(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         LTE_UD(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
         LTE_US(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        LTE_UV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
+        LTE_VU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        LTE_VB(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) <= 0),
+        LTE_VS(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) <= 0),
+        LTE_VV(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) <= 0),
 
+        GT_BV(Comparisons.Type.GREATER_THAN, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) > 0),
         GT_IU(Comparisons.Type.GREATER_THAN, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GT_II(Comparisons.Type.GREATER_THAN, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l > (int)r),
         GT_IL(Comparisons.Type.GREATER_THAN, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l > (long)r),
@@ -650,6 +681,7 @@ public class RelOpValue implements BooleanValue {
         // GT_SD(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         GT_SU(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GT_SS(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) > 0), // TODO: locale-aware comparison
+        GT_SV(Comparisons.Type.GREATER_THAN, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) > 0),
         GT_UU(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GT_UB(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         GT_UI(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
@@ -657,7 +689,13 @@ public class RelOpValue implements BooleanValue {
         GT_UF(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         GT_UD(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
         GT_US(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        GT_UV(Comparisons.Type.GREATER_THAN, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
+        GT_VU(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        GT_VB(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) > 0),
+        GT_VS(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) > 0),
+        GT_VV(Comparisons.Type.GREATER_THAN, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) > 0),
 
+        GTE_BV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes((byte[]) l, false)).compareTo((FDBRecordVersion) r) >= 0),
         GTE_IU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GTE_II(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.INT, (l, r) -> (int)l >= (int)r),
         GTE_IL(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.INT, Type.TypeCode.LONG, (l, r) -> (int)l >= (long)r),
@@ -688,13 +726,21 @@ public class RelOpValue implements BooleanValue {
         // GTE_SD(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.DOUBLE, (l, r) -> ??), // invalid
         GTE_SU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.UNKNOWN, (l, r) -> null),
         GTE_SS(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.STRING, (l, r) -> ((String)l).compareTo((String)r) >= 0), // TODO: locale-aware comparison
+        GTE_SV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.STRING, Type.TypeCode.VERSION, (l, r) -> (FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) l), false)).compareTo((FDBRecordVersion) r) >= 0),
         GTE_UU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        GTE_UV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.VERSION, (l, r) -> null),
         GTE_UB(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BOOLEAN, (l, r) -> null),
         GTE_UI(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.INT, (l, r) -> null),
         GTE_UL(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.LONG, (l, r) -> null),
         GTE_UF(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.FLOAT, (l, r) -> null),
         GTE_UD(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.DOUBLE, (l, r) -> null),
-        GTE_US(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null);
+        GTE_US(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.STRING, (l, r) -> null),
+        GTE_VU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        GTE_VB(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.BYTES, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes((byte[]) r, false)) >= 0),
+        GTE_VS(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.STRING, (l, r) -> ((FDBRecordVersion)l).compareTo(FDBRecordVersion.fromBytes(Base64.getDecoder().decode((String) r), false)) >= 0),
+        GTE_VV(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.VERSION, Type.TypeCode.VERSION, (l, r) -> ((FDBRecordVersion)l).compareTo((FDBRecordVersion) r) >= 0),
+        ;
+
         @Nonnull
         private final Comparisons.Type type;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
@@ -22,32 +22,87 @@ package com.apple.foundationdb.record.query.plan.cascades.values;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.Formatter;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
+import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * A value representing a version stamp.
  */
 @API(API.Status.EXPERIMENTAL)
-public class VersionValue implements LeafValue, Value.CompileTimeValue {
+public class VersionValue implements QuantifiedValue {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Version-Value");
 
-    public VersionValue() {
-        // explicit default constructor
+    @Nonnull
+    private final CorrelationIdentifier baseAlias;
+
+    public VersionValue(@Nonnull CorrelationIdentifier baseAlias) {
+        this.baseAlias = baseAlias;
+    }
+
+    @Override
+    public CorrelationIdentifier getAlias() {
+        return baseAlias;
+    }
+
+    @Nullable
+    @Override
+    public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context) {
+        QueryResult binding = (QueryResult) context.getBinding(baseAlias);
+        return binding.getQueriedRecordMaybe()
+                .map(FDBQueriedRecord::getStoredRecord)
+                .map(FDBStoredRecord::getVersion)
+                .orElse(null);
     }
 
     @Nonnull
     @Override
-    public Value replaceReferenceWithField(@Nonnull final FieldValue fieldValue) {
+    public Type getResultType() {
+        return Type.primitiveType(Type.TypeCode.VERSION);
+    }
+
+    @Nonnull
+    @Override
+    public String explain(@Nonnull final Formatter formatter) {
+        return toString();
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return "version(" + baseAlias.getId() + ")";
+    }
+
+    @Nonnull
+    @Override
+    public VersionValue rebaseLeaf(@Nonnull final CorrelationIdentifier targetAlias) {
+        return new VersionValue(targetAlias);
+    }
+
+    @Nonnull
+    @Override
+    public VersionValue replaceReferenceWithField(@Nonnull final FieldValue fieldValue) {
         return this;
     }
 
     @Override
     public boolean isFunctionallyDependentOn(@Nonnull final Value otherValue) {
-        return true;
+        if (otherValue instanceof QuantifiedValue) {
+            return getAlias().equals(((QuantifiedValue)otherValue).getAlias());
+        }
+        return false;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
@@ -80,7 +80,7 @@ public class VersionValue implements QuantifiedValue {
     @Nonnull
     @Override
     public String toString() {
-        return "version(" + baseAlias.getId() + ")";
+        return "version(" + baseAlias + ")";
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
@@ -25,9 +25,8 @@ import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
-import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
@@ -62,8 +61,7 @@ public class VersionValue implements QuantifiedValue {
     public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context) {
         QueryResult binding = (QueryResult) context.getBinding(baseAlias);
         return binding.getQueriedRecordMaybe()
-                .map(FDBQueriedRecord::getStoredRecord)
-                .map(FDBStoredRecord::getVersion)
+                .map(FDBRecord::getVersion)
                 .orElse(null);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBVersionsQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBVersionsQueryTest.java
@@ -1,0 +1,411 @@
+/*
+ * FDBVersionsQueryTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.query;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.TestRecords1Proto.MySimpleRecord;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
+import com.apple.foundationdb.record.provider.common.RecordSerializer;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTypedRecordStore;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Tag;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.version;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.bounds;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.filter;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.hasTupleString;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.indexScan;
+import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.unbounded;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests of queries involving predicates on {@link FDBRecordVersion}s. These tests are around to facilitate testing
+ * the planners' version queries, including things like making sure if the version is
+ * For additional tests, see {@link com.apple.foundationdb.record.provider.foundationdb.indexes.VersionIndexTest}.
+ */
+@Tag(Tags.RequiresFDB)
+public class FDBVersionsQueryTest extends FDBRecordStoreQueryTestBase {
+    private static final Index VERSION_INDEX = new Index("versionIndex", version(), IndexTypes.VERSION);
+    private static final Index VERSION_BY_NUM_VALUE_2_INDEX = new Index("versionByNumValue2Index", concat(field("num_value_2"), version()), IndexTypes.VERSION);
+
+    private static final RecordMetaDataHook VERSIONS_HOOK = metaDataBuilder -> {
+        metaDataBuilder.setStoreRecordVersions(true);
+
+        final RecordTypeBuilder simple = metaDataBuilder.getRecordType("MySimpleRecord");
+        metaDataBuilder.addIndex(simple, VERSION_INDEX);
+        metaDataBuilder.addIndex(simple, VERSION_BY_NUM_VALUE_2_INDEX);
+    };
+
+    private void openStore(FDBRecordContext context) {
+        openSimpleRecordStore(context, VERSIONS_HOOK);
+    }
+
+    @Nonnull
+    private FDBTypedRecordStore<MySimpleRecord> getNarrowedStore() {
+        RecordSerializer<Message> baseSerializer = recordStore.getSerializer();
+        return recordStore.getTypedRecordStore(new RecordSerializer<>() {
+            @Nonnull
+            @Override
+            public byte[] serialize(@Nonnull final RecordMetaData metaData, @Nonnull final RecordType recordType, @Nonnull final MySimpleRecord rec, @Nullable final StoreTimer timer) {
+                return baseSerializer.serialize(metaData, recordType, rec, timer);
+            }
+
+            @Nonnull
+            @Override
+            public MySimpleRecord deserialize(@Nonnull final RecordMetaData metaData, @Nonnull final Tuple primaryKey, @Nonnull final byte[] serialized, @Nullable final StoreTimer timer) {
+                Message msg = baseSerializer.deserialize(metaData, primaryKey, serialized, timer);
+
+                if (!msg.getDescriptorForType().equals(MySimpleRecord.getDescriptor())) {
+                    throw new RecordCoreException("invalid type to deserialize");
+                }
+                return MySimpleRecord.newBuilder().mergeFrom(msg).build();
+            }
+
+            @Nonnull
+            @Override
+            public RecordSerializer<Message> widen() {
+                return baseSerializer.widen();
+            }
+        });
+    }
+
+    @Nonnull
+    private List<FDBStoredRecord<MySimpleRecord>> populateRecords() {
+        List<FDBStoredRecord<MySimpleRecord>> saved = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            try (FDBRecordContext context = openContext()) {
+                openStore(context);
+                FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+                List<FDBStoredRecord<MySimpleRecord>> savedInTransaction = new ArrayList<>();
+                for (int j = 0; j < 10; j++) {
+                    MySimpleRecord record = MySimpleRecord.newBuilder()
+                            .setRecNo(j * 100 + i)
+                            .setStrValueIndexed(j % 2 == 0 ? "even" : "odd")
+                            .setNumValue2(j % 3)
+                            .setNumValue3Indexed(j)
+                            .setNumValueUnique(i * 100 + j)
+                            .build();
+
+                    savedInTransaction.add(typedStore.saveRecord(record));
+                }
+
+                context.commit();
+                byte[] globalVersion = context.getVersionStamp();
+                savedInTransaction.forEach(rec -> saved.add(rec.withCommittedVersion(globalVersion)));
+            }
+        }
+        return saved;
+    }
+
+    @DualPlannerTest
+    void orderByVersion() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setSort(version())
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, indexScan(allOf(indexName(VERSION_INDEX.getName()), unbounded())));
+
+            List<FDBQueriedRecord<MySimpleRecord>> queried = typedStore.executeQuery(plan)
+                    .asList()
+                    .join();
+            assertThat(queried, hasSize(records.size()));
+            assertInVersionOrder(queried);
+        }
+    }
+
+    @DualPlannerTest
+    void orderByVersionWithSelectiveResults() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setRequiredResults(List.of(field("rec_no"), version()))
+                    .setSort(version())
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, indexScan(allOf(indexName(VERSION_INDEX.getName()), unbounded())));
+
+            List<FDBQueriedRecord<MySimpleRecord>> queried = typedStore.executeQuery(plan)
+                    .asList()
+                    .join();
+            assertThat(queried, hasSize(records.size()));
+            assertInVersionOrder(queried);
+        }
+    }
+
+    @DualPlannerTest
+    void filterByVersion() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            FDBRecordVersion versionForQuery = records.get(records.size() / 2).getVersion();
+            assertNotNull(versionForQuery);
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.version().greaterThan(versionForQuery))
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, indexScan(allOf(indexName(VERSION_INDEX.getName()), bounds(hasTupleString("([" + versionForQuery.toVersionstamp(false) + "],>")))));
+            List<FDBStoredRecord<MySimpleRecord>> queried = typedStore.executeQuery(plan)
+                    .map(FDBQueriedRecord::getStoredRecord)
+                    .asList()
+                    .join();
+
+            List<FDBStoredRecord<MySimpleRecord>> expected = records.stream()
+                    .filter(rec -> {
+                        FDBRecordVersion recordVersion = rec.getVersion();
+                        assertNotNull(recordVersion);
+                        return recordVersion.compareTo(versionForQuery) > 0;
+                    })
+                    .collect(Collectors.toList());
+            assertEquals(expected, queried);
+        }
+    }
+
+    @DualPlannerTest
+    void residualVersionFilter() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            FDBRecordVersion versionForQuery = records.get(records.size() / 2).getVersion();
+            assertNotNull(versionForQuery);
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.version().greaterThan(versionForQuery))
+                    .setSort(field("num_value_unique")) // use sort to force execution of predicate as a residual filter
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, filter(Query.version().greaterThan(versionForQuery), indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), unbounded()))));
+            List<FDBStoredRecord<MySimpleRecord>> queried = typedStore.executeQuery(plan)
+                    .map(FDBQueriedRecord::getStoredRecord)
+                    .asList()
+                    .join();
+
+            List<FDBStoredRecord<MySimpleRecord>> expected = records.stream()
+                    .filter(rec -> {
+                        FDBRecordVersion recordVersion = rec.getVersion();
+                        assertNotNull(recordVersion);
+                        return recordVersion.compareTo(versionForQuery) > 0;
+                    })
+                    .sorted(Comparator.comparingInt(rec -> rec.getRecord().getNumValueUnique()))
+                    .collect(Collectors.toList());
+            assertEquals(expected, queried);
+        }
+    }
+
+    @DualPlannerTest
+    void residualVersionFilterWithSelectiveResults() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            FDBRecordVersion versionForQuery = records.get(records.size() / 2).getVersion();
+            assertNotNull(versionForQuery);
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.version().greaterThan(versionForQuery))
+                    .setSort(field("num_value_unique")) // use sort to force execution of predicate as a residual filter
+                    .setRequiredResults(List.of(field("num_value_unique"), field("rec_no")))
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, filter(Query.version().greaterThan(versionForQuery), indexScan(allOf(indexName("MySimpleRecord$num_value_unique"), unbounded()))));
+            List<Long> queried = typedStore.executeQuery(plan)
+                    .map(rec -> rec.getRecord().getRecNo())
+                    .asList()
+                    .join();
+
+            List<Long> expected = records.stream()
+                    .filter(rec -> {
+                        FDBRecordVersion recordVersion = rec.getVersion();
+                        assertNotNull(recordVersion);
+                        return recordVersion.compareTo(versionForQuery) > 0;
+                    })
+                    .sorted(Comparator.comparingInt(rec -> rec.getRecord().getNumValueUnique()))
+                    .map(rec -> rec.getRecord().getRecNo())
+                    .collect(Collectors.toList());
+            assertEquals(expected, queried);
+        }
+    }
+
+    @DualPlannerTest
+    void sortAndFilterWithSingleIndex() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.field("num_value_2").equalsValue(1))
+                    .setSort(version())
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            assertThat(plan, indexScan(allOf(indexName(VERSION_BY_NUM_VALUE_2_INDEX.getName()), bounds(hasTupleString("[[1],[1]]")))));
+            List<FDBStoredRecord<MySimpleRecord>> queried = typedStore.executeQuery(plan)
+                    .map(FDBQueriedRecord::getStoredRecord)
+                    .asList()
+                    .join();
+            assertInVersionOrder(queried);
+
+            List<FDBStoredRecord<MySimpleRecord>> expected = records.stream()
+                    .filter(rec -> rec.getRecord().getNumValue2() == 1)
+                    .collect(Collectors.toList());
+            assertEquals(expected, queried);
+        }
+    }
+
+    @DualPlannerTest
+    void sortFilterOnVersionIndexEntries() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            FDBRecordVersion excludedVersion = records.stream()
+                    .filter(rec -> rec.getRecord().getNumValue2() == 1)
+                    .map(FDBStoredRecord::getVersion)
+                    .findAny()
+                    .get();
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.and(Query.field("num_value_2").equalsValue(1), Query.version().notEquals(excludedVersion)))
+                    .setSort(version())
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            // Should be able to push down version filter onto index the index entries when planner can better reason about version field
+            assertThat(plan, filter(Query.version().notEquals(excludedVersion), indexScan(allOf(indexName(VERSION_BY_NUM_VALUE_2_INDEX.getName()), bounds(hasTupleString("[[1],[1]]"))))));
+            List<FDBStoredRecord<MySimpleRecord>> queried = typedStore.executeQuery(plan)
+                    .map(FDBQueriedRecord::getStoredRecord)
+                    .asList()
+                    .join();
+            assertInVersionOrder(queried);
+
+            List<FDBStoredRecord<MySimpleRecord>> expected = records.stream()
+                    .filter(rec -> rec.getRecord().getNumValue2() == 1)
+                    .filter(rec -> rec.hasVersion() && !rec.getVersion().equals(excludedVersion))
+                    .collect(Collectors.toList());
+            assertEquals(expected, queried);
+        }
+    }
+
+    @DualPlannerTest
+    void requestVersionWhenQueryIsOnOtherFields() {
+        List<FDBStoredRecord<MySimpleRecord>> records = populateRecords();
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context);
+            FDBTypedRecordStore<MySimpleRecord> typedStore = getNarrowedStore();
+
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.field("str_value_indexed").equalsValue("even"))
+                    .setRequiredResults(List.of(field("rec_no"), version()))
+                    .build();
+
+            RecordQueryPlan plan = planner.plan(query);
+            // Should be able to push down version filter onto index the index entries when planner can better reason about version field
+            assertThat(plan, indexScan(allOf(indexName("MySimpleRecord$str_value_indexed"), bounds(hasTupleString("[[even],[even]]")))));
+            List<FDBStoredRecord<MySimpleRecord>> queried = typedStore.executeQuery(plan)
+                    .map(FDBQueriedRecord::getStoredRecord)
+                    .asList()
+                    .join();
+            assertTrue(queried.stream().allMatch(FDBRecord::hasVersion), "records should all have non-null versions");
+
+            List<FDBStoredRecord<MySimpleRecord>> expected = records.stream()
+                    .filter(rec -> rec.getRecord().getStrValueIndexed().equals("even"))
+                    .sorted(Comparator.comparing(FDBStoredRecord::getPrimaryKey))
+                    .collect(Collectors.toList());
+            assertEquals(expected, queried);
+        }
+    }
+
+    private static void assertInVersionOrder(List<? extends FDBRecord<?>> records) {
+        FDBRecordVersion lastVersion = null;
+        for (FDBRecord<?> record : records) {
+            FDBRecordVersion nextVersion = record.getVersion();
+            assertNotNull(nextVersion, () -> String.format("version for record with primary key %s should not be null", record.getPrimaryKey()));
+            if (lastVersion != null) {
+                assertThat(nextVersion, greaterThan(lastVersion));
+            }
+            lastVersion = nextVersion;
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
@@ -428,8 +428,10 @@ public class PlannerRepl implements Debugger {
                         });
             } else {
                 final Class<?> superClass = currentEventClass.getSuperclass();
-                if (Event.class.isAssignableFrom(superClass)) {
-                    resolutionQueue.push((Class<? extends Event>)superClass);
+                if (superClass != null) {
+                    if (Event.class.isAssignableFrom(superClass)) {
+                        resolutionQueue.push((Class<? extends Event>)superClass);
+                    }
                 }
                 final Class<?>[] interfaces = currentEventClass.getInterfaces();
                 for (final Class<?> anInterface : interfaces) {


### PR DESCRIPTION
Support for record versions and version indexes are added to the Cascades planner. This does a number of things:

1. A new primitive type, `VERSION`, is added to the type system. This type is used to represent an `FDBRecordVersion`, with some promotion rules to allow it to be compared to `byte[]` and `String` types. It is serialized to `bytes` when included as a field in a message (for example, when included as return type field in a QGM).
1. The existing `VersionValue` is modified to be evaluatble. It now takes a quanitifier and evaluates the version on the record backed by the quantifier.
1. Matching on `version` indexes is added to the index/query matching logic. As `version` indexes behave identically to `value` indexes during query time, this re-uses the matching logic for `value` indexes, with a small number of changes to allow `VersionValue`s to be flowed through. One problem that I hit is that covered index records do not carry their version, even if that was in the index entry, and so some of the logic to support covering index optimizations needed to be modified to stop the optimization from being applied. That is something that we should try to fix, though.

This resolves #2089.