### PR TITLE
Add support for `int32` in record metadata `Value`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,6 +18,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Add support for `int32` in record metadata `Value` [(Issue #2091)](https://github.com/FoundationDB/fdb-record-layer/issues/2091)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
@@ -151,6 +151,10 @@ public class LiteralKeyExpression<T> extends BaseKeyExpression implements AtomKe
             ++found;
             value = proto.getBytesValue().toByteArray();
         }
+        if (proto.hasIntValue()) {
+            ++found;
+            value = proto.getIntValue();
+        }
         if (found == 0) {
             ++found;
         }
@@ -167,7 +171,9 @@ public class LiteralKeyExpression<T> extends BaseKeyExpression implements AtomKe
         if (value instanceof Double) {
             builder.setDoubleValue((Double) value);
         } else if (value instanceof Float) {
-            builder.setFloatValue((Float) value);
+            builder.setFloatValue((Float)value);
+        } else if (value instanceof Integer) {
+            builder.setIntValue((Integer)value);
         } else if (value instanceof Number) {
             builder.setLongValue(((Number) value).longValue());
         } else if (value instanceof Boolean) {

--- a/fdb-record-layer-core/src/main/proto/record_metadata.proto
+++ b/fdb-record-layer-core/src/main/proto/record_metadata.proto
@@ -160,6 +160,7 @@ message Value {
   optional bool bool_value = 4;
   optional string string_value = 5;
   optional bytes bytes_value = 6;
+  optional int32 int_value = 7;
 }
 
 message Function {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataProtoTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataProtoTest.java
@@ -50,7 +50,6 @@ import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredica
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -60,7 +59,6 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataProtoTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataProtoTest.java
@@ -41,11 +41,26 @@ import com.apple.foundationdb.record.TestRecordsWithHeaderProto;
 import com.apple.foundationdb.record.TestRecordsWithUnionProto;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.LiteralKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.OrPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import javax.annotation.Nonnull;
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -55,7 +70,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -356,5 +373,52 @@ public class MetaDataProtoTest {
         Index maxRecNoGrouped = metaData.getIndex("MaxRecNoGrouped");
         assertTrue(maxRecNoGrouped.getRootExpression() instanceof GroupingKeyExpression, "should have Grouping");
         assertEquals(1, ((GroupingKeyExpression)maxRecNoGrouped.getRootExpression()).getGroupedCount());
+    }
+
+    private static class ArgumentProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ExtensionContext context) throws Exception {
+            return Stream.of(Arguments.of("double parameter", 10.10d, 12, 12d),
+                    Arguments.of("float parameter", 11.11f, 13.13f),
+                    Arguments.of("long parameter", 42L, 44L),
+                    Arguments.of("int parameter", 32, 34),
+                    Arguments.of("string parameter", "foo", "bar"),
+                    Arguments.of("byte[] parameter", new byte[] {0xA, (byte)0xFF}, new byte[] {0xB}),
+                    Arguments.of("boolean parameter", false, true));
+        }
+    }
+
+    @ParameterizedTest(name = "[{0}] with parameter1 = {1} and parameter2 = {2}")
+    @ArgumentsSource(ArgumentProvider.class)
+    void serdeIndexPredicateWorksCorrectly(@Nonnull final String description, @Nonnull final Object expectedParameter1, @Nonnull final Object expectedParameter2) {
+        final var recordType = Type.Record.fromDescriptor(TestRecords1Proto.MySimpleRecord.getDescriptor());
+        final var numValue2 = FieldValue.ofFieldName(QuantifiedObjectValue.of(Quantifier.current(), recordType), "num_value_2");
+        final var range = OrPredicate.or(List.of(
+                // predicates here are semantically incorrect (e.g. comparing num_value_2 of type INT with STRING).
+                // but this is only for testing SerDe, so probably ok.
+                new ValuePredicate(numValue2, new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN, expectedParameter1)),
+                new ValuePredicate(numValue2, new Comparisons.SimpleComparison(Comparisons.Type.LESS_THAN, expectedParameter2))
+        ));
+        final var proto = RecordMetaDataProto.Index.newBuilder()
+                .setName("SparseIndex")
+                .addRecordType("MySimpleRecord")
+                .setType(IndexTypes.VALUE)
+                .setRootExpression(field("num_value_2").toKeyExpression())
+                .setPredicate(IndexPredicate.fromQueryPredicate(range).toProto())
+                .build();
+        final var actualParameter1 = proto.getPredicate().getOrPredicate().getChildren(0).getValuePredicate().getComparison().getSimpleComparison().getOperand();
+        final var actualParameter2 = proto.getPredicate().getOrPredicate().getChildren(1).getValuePredicate().getComparison().getSimpleComparison().getOperand();
+
+        if (expectedParameter1.getClass().isArray()) {
+            final var actualParam1Array = LiteralKeyExpression.fromProtoValue(actualParameter1);
+            assertTrue(actualParam1Array != null && actualParam1Array.getClass().equals(byte[].class));
+            final var actualParam2Array = LiteralKeyExpression.fromProtoValue(actualParameter2);
+            assertTrue(actualParam2Array != null && actualParam2Array.getClass().equals(byte[].class));
+            assertArrayEquals((byte[])expectedParameter1, (byte[])actualParam1Array);
+            assertArrayEquals((byte[])expectedParameter2, (byte[])actualParam2Array);
+        } else {
+            assertEquals(expectedParameter1, LiteralKeyExpression.fromProtoValue(actualParameter1));
+            assertEquals(expectedParameter2, LiteralKeyExpression.fromProtoValue(actualParameter2));
+        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpressionTest.java
@@ -48,6 +48,10 @@ public class LiteralKeyExpressionTest {
                 100L,
                 Long.MIN_VALUE,
                 Long.MAX_VALUE,
+                5,
+                -10,
+                Integer.MIN_VALUE,
+                Integer.MAX_VALUE,
                 true,
                 false,
                 "a string",
@@ -57,10 +61,6 @@ public class LiteralKeyExpressionTest {
                 TextSamples.YIDDISH,
                 "\n",
                 byteArray);
-    }
-
-    private static Stream<Integer> incorrectIntegerValues() {
-        return Stream.of(5, -10, Integer.MAX_VALUE, Integer.MIN_VALUE);
     }
 
     @ParameterizedTest
@@ -79,24 +79,6 @@ public class LiteralKeyExpressionTest {
             assertEquals(value, parsedViaProto.getValue());
             assertEquals(value, parsedViaBytes.getValue());
         }
-    }
-
-    @ParameterizedTest
-    @MethodSource("incorrectIntegerValues")
-    public void incorrectIntegerSerializationTest(@Nonnull Integer value) throws InvalidProtocolBufferException {
-        final LiteralKeyExpression<?> keyExpression = Key.Expressions.value(value);
-        final LiteralKeyExpression<?> parsedViaProto = LiteralKeyExpression.fromProto(keyExpression.toProto());
-        final LiteralKeyExpression<?> parsedViaBytes = LiteralKeyExpression.fromProto(
-                RecordMetaDataProto.Value.parseFrom(keyExpression.toProto().toByteArray()));
-        assertEquals(value, keyExpression.getValue());
-        assertEquals(keyExpression, parsedViaProto); // Comparison uses proto objects so both sides have Longs.
-
-        // Integer values are cast to Long before serializing so they are deserialized as Longs.
-        assertNotEquals(value, parsedViaProto.getValue());
-        assertNotEquals(value, parsedViaBytes.getValue());
-        // Values (as integers) are correct.
-        assertEquals(value.intValue(), ((Long) parsedViaProto.getValue()).intValue());
-        assertEquals(value.intValue(), ((Long) parsedViaBytes.getValue()).intValue());
     }
 
     @Test


### PR DESCRIPTION
Currently decimal values are treated as `int64`, this could silently change the semantics of an `IndexPredicate` with a `SimpleComparison` that has an operand of type `Integer` as it is widening it into `long`.

This adds support for `int32`, it also adds a unit test that verifies that the serialisation / deserialisation of comparison parameters yield identical results. it fixes #2091 and unblocks https://github.com/FoundationDB/fdb-record-layer/pull/2070.