### PR TITLE
Restore removed method and mark it for deprecation.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,6 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Restore a removed method from `CascadesPlanner` and mark it for deprecation [(Issue #2102)](https://github.com/FoundationDB/fdb-record-layer/issues/2102)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -337,6 +337,30 @@ public class CascadesPlanner implements QueryPlanner {
     }
 
     @Nonnull
+    @Deprecated(forRemoval = true)
+    public RecordQueryPlan planGraph(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier,
+                                     @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
+                                     @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
+                                     final boolean isSortReverse,
+                                     @Nonnull ParameterRelationshipGraph ignored) {
+        try {
+            planPartial(expressionRefSupplier,
+                    rootReference ->
+                            MetaDataPlanContext.forRootReference(configuration,
+                                    metaData,
+                                    recordStoreState,
+                                    rootReference,
+                                    allowedIndexesOptional,
+                                    indexQueryabilityFilter,
+                                    isSortReverse),
+                    EvaluationContext.empty());
+            return resultOrFail();
+        } finally {
+            Debugger.withDebugger(Debugger::onDone);
+        }
+    }
+
+    @Nonnull
     public QueryPlanResult planGraph(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier,
                                      @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
                                      @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,


### PR DESCRIPTION
in `3.3.368.0` a method in `CascadesPlanner` has been changed from:

```java
public RecordQueryPlan planGraph(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier,
                                 @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
                                 @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
                                 final boolean isSortReverse,
                                 @Nonnull ParameterRelationshipGraph parameterRelationshipGraph)
```
to:

```java
public QueryPlanResult planGraph(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier,
                                 @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
                                 @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
                                 final boolean isSortReverse,
                                 @Nonnull final EvaluationContext evaluationContext)
```

this could break customers still relying on the old signature of the method. Instead we should restore and mark it for deprecation giving grace period before its removal.

This fixes #2102.