### PR TITLE
Fixes for filtered indexes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Captured constraints of filtered indexes are too restrictive [(Issue #2104)](https://github.com/FoundationDB/fdb-record-layer/issues/2104)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -671,6 +671,9 @@ public class Comparisons {
         @Nonnull
         Type getType();
 
+        @Nonnull
+        Comparison withType(@Nonnull final Type newType);
+
         /**
          * Get the comparison value without any bindings.
          * @return the value to be compared
@@ -823,6 +826,15 @@ public class Comparisons {
             return type;
         }
 
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new SimpleComparison(newType, comparand);
+        }
+
         @Nullable
         @Override
         public Boolean eval(@Nonnull FDBRecordStoreBase<?> store, @Nonnull EvaluationContext context, @Nullable Object value) {
@@ -971,6 +983,15 @@ public class Comparisons {
         @Override
         public Type getType() {
             return type;
+        }
+
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new ParameterComparison(newType, parameter, internal, parameterRelationshipGraph);
         }
 
         public boolean isCorrelation() {
@@ -1206,6 +1227,15 @@ public class Comparisons {
         }
 
         @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new ValueComparison(newType, comparandValue, parameterRelationshipGraph);
+        }
+
+        @Nonnull
         public Value getComparandValue() {
             return comparandValue;
         }
@@ -1426,6 +1456,15 @@ public class Comparisons {
             return type;
         }
 
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new ListComparison(newType, comparand);
+        }
+
         @Nullable
         @Override
         public Boolean eval(@Nonnull FDBRecordStoreBase<?> store, @Nonnull EvaluationContext context, @Nullable Object value) {
@@ -1526,6 +1565,15 @@ public class Comparisons {
             return type;
         }
 
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new NullComparison(newType);
+        }
+
         @Nullable
         @Override
         public Object getComparand(@Nullable FDBRecordStoreBase<?> store, @Nullable EvaluationContext context) {
@@ -1605,6 +1653,12 @@ public class Comparisons {
         @Override
         public Type getType() {
             return Type.EQUALS;
+        }
+
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            return this;
         }
 
         @Nullable
@@ -1764,6 +1818,19 @@ public class Comparisons {
         @Override
         public Type getType() {
             return type;
+        }
+
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            if (tokenList == null) {
+                return new TextComparison(newType, Objects.requireNonNull(tokenStr), tokenizerName, fallbackTokenizerName);
+            } else {
+                return new TextComparison(newType, tokenList, tokenizerName, fallbackTokenizerName);
+            }
         }
 
         @Nullable
@@ -2083,6 +2150,16 @@ public class Comparisons {
 
         @Nonnull
         @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            final var newInner = inner.withType(newType);
+            if (newInner == inner) {
+                return this;
+            }
+            return new MultiColumnComparison(newInner);
+        }
+
+        @Nonnull
+        @Override
         @SuppressWarnings("PMD.CompareObjectsWithEquals")
         public Comparison translateCorrelations(@Nonnull final TranslationMap translationMap) {
             final var translatedInner = inner.translateCorrelations(translationMap);
@@ -2245,6 +2322,11 @@ public class Comparisons {
         @Override
         public Type getType() {
             return type;
+        }
+
+        @Nonnull
+        public Comparison withType(@Nonnull final Type newType) {
+            return from(function, originalComparison.withType(newType));
         }
 
         @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -672,7 +672,7 @@ public class Comparisons {
         Type getType();
 
         @Nonnull
-        Comparison withType(@Nonnull final Type newType);
+        Comparison withType(@Nonnull Type newType);
 
         /**
          * Get the comparison value without any bindings.
@@ -2150,6 +2150,7 @@ public class Comparisons {
 
         @Nonnull
         @Override
+        @SuppressWarnings("PMD.CompareObjectsWithEquals")
         public Comparison withType(@Nonnull final Type newType) {
             final var newInner = inner.withType(newType);
             if (newInner == inner) {
@@ -2325,6 +2326,7 @@ public class Comparisons {
         }
 
         @Nonnull
+        @Override
         public Comparison withType(@Nonnull final Type newType) {
             return from(function, originalComparison.withType(newType));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
@@ -183,7 +184,12 @@ public class RecordTypeKeyComparison implements ComponentWithComparison {
         @Nonnull
         @Override
         public Comparisons.Comparison withType(@Nonnull final Comparisons.Type newType) {
-            return this;
+            if (newType == Comparisons.Type.EQUALS) {
+                return this;
+            }
+            throw new RecordCoreException(String.format("'%s' expects '%s' comparison only",
+                    RecordTypeKeyComparison.class.getSimpleName(),
+                    Comparisons.Type.EQUALS.name()));
         }
 
         @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
@@ -180,6 +180,12 @@ public class RecordTypeKeyComparison implements ComponentWithComparison {
             return Comparisons.Type.EQUALS;
         }
 
+        @Nonnull
+        @Override
+        public Comparisons.Comparison withType(@Nonnull final Comparisons.Type newType) {
+            return this;
+        }
+
         @Nullable
         @Override
         public Object getComparand(@Nullable FDBRecordStoreBase<?> store, @Nullable EvaluationContext context) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
@@ -77,6 +77,11 @@ public class QueryPlanConstraint {
         return Objects.hash(predicate);
     }
 
+    @Override
+    public String toString() {
+        return predicate.toString();
+    }
+
     @Nonnull
     public static QueryPlanConstraint compose(@Nonnull final Collection<QueryPlanConstraint> constraints) {
         return new QueryPlanConstraint(AndPredicate.and(constraints.stream().map(QueryPlanConstraint::getPredicate).collect(Collectors.toList())));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexPredicateExpansion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexPredicateExpansion.java
@@ -54,9 +54,6 @@ public class IndexPredicateExpansion {
 
         // simple case: x > 3 is DNF
         if (!(predicate instanceof OrPredicate)) {
-            if (!(predicate instanceof ValuePredicate)) {
-                return Optional.empty();
-            }
             if (!conjunctionToRange(predicate, result, predicate)) {
                 return Optional.empty();
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
@@ -376,13 +376,15 @@ public class PredicateWithValueAndRanges implements PredicateWithValue {
      * Candidate Predicate: (Value1, ((LTE,1000) AND (LTE,2000)))
      * <br>
      * The resulting constraint: ((#COV1, ((LTE,1000) AND (LTE,2000))) AND (#COV4, ((LTE,1000) AND (LTE,2000))) OR (#COV5,((LTE,1000) AND (LTE,2000)))
+     * <br>
+     * Any candidate range that is exclusive is turned into inclusive, this is necessary, so we can match, for example, query
+     * predicates with exactly the same range boundaries.
      *
      * @param candidatePredicate The candidate predicate to capture as a {@link QueryPlanConstraint}.
      * @return The resulting {@link QueryPlanConstraint}.
      */
     @Nonnull
     private QueryPlanConstraint captureConstraint(@Nonnull final PredicateWithValueAndRanges candidatePredicate) {
-        // todo: add another constraint for semantic equality of the plans maybe, although semantic hashcode should do this for us I think.
         final var candidateRanges = candidatePredicate.getRanges().stream().map(constraint -> {
             final var builder = RangeConstraints.newBuilder();
             constraint.getComparisons().stream().map(PredicateWithValueAndRanges::exclusiveToInclusive).forEach(builder::addComparisonMaybe);
@@ -411,7 +413,7 @@ public class PredicateWithValueAndRanges implements PredicateWithValue {
                 return comparison.withType(Comparisons.Type.GREATER_THAN_OR_EQUALS);
             case NOT_EQUALS: // fallthrough
             case LESS_THAN_OR_EQUALS: // fallthrough
-            case EQUALS: // fallthough
+            case EQUALS: // fallthrough
             case GREATER_THAN_OR_EQUALS: // fallthrough
             case STARTS_WITH: // fallthrough
             case NOT_NULL: // fallthrough

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
@@ -383,7 +383,11 @@ public class PredicateWithValueAndRanges implements PredicateWithValue {
     @Nonnull
     private QueryPlanConstraint captureConstraint(@Nonnull final PredicateWithValueAndRanges candidatePredicate) {
         // todo: add another constraint for semantic equality of the plans maybe, although semantic hashcode should do this for us I think.
-        final var candidateRanges = candidatePredicate.getRanges();
+        final var candidateRanges = candidatePredicate.getRanges().stream().map(constraint -> {
+            final var builder = RangeConstraints.newBuilder();
+            constraint.getComparisons().stream().map(PredicateWithValueAndRanges::exclusiveToInclusive).forEach(builder::addComparisonMaybe);
+            return builder.build();
+        }).flatMap(Optional::stream).collect(Collectors.toSet());
         final ImmutableList.Builder<QueryPredicate> conjunctions = ImmutableList.builder();
         for (final var queryRange : getRanges()) {
             conjunctions.add(AndPredicate.and(queryRange.getComparisons()
@@ -391,22 +395,39 @@ public class PredicateWithValueAndRanges implements PredicateWithValue {
                     .filter(comparison -> comparison instanceof Comparisons.ValueComparison)
                     .map(valueComparison -> ((Comparisons.ValueComparison)valueComparison).getComparandValue())
                     .filter(comparand -> comparand instanceof ConstantObjectValue)
-                    .map(constant -> PredicateWithValueAndRanges.ofRanges((ConstantObjectValue)constant, candidateRanges))
+                    .map(constant -> PredicateWithValueAndRanges.ofRanges(constant, candidateRanges))
                     .collect(Collectors.toList())));
-
-            // TODO
-            // conjunctions.add(AndPredicate.and(queryRange.getComparisons()
-            //         .stream()
-            //         .filter(comparison -> comparison instanceof Comparisons.ValueComparison)
-            //         .map(valueComparison -> ((Comparisons.ValueComparison)valueComparison).getComparandValue())
-            //         .filter(comparand -> comparand instanceof ConstantObjectValue)
-            //                         .map(constantObjectValue -> PromoteValue.of(ConstantObjectValue.of(constantObjectValue.getAlias(), constantObjectValue.getOrdinal(), Type.nullType()), constantObjectValue.getResultType())
-            //         //.map(c -> PromoteValue.inject(c, ((ConstantObjectValue)c).getResultType())) // check.
-            //         .map(constant -> PredicateWithValueAndRanges.constraint((ConstantObjectValue)constant, candidateRanges))
-            //         .collect(Collectors.toList())));
         }
         final var orPredicate = OrPredicate.or(conjunctions.build());
         return QueryPlanConstraint.ofPredicate(orPredicate);
+    }
+
+    @Nonnull
+    private static Comparisons.Comparison exclusiveToInclusive(@Nonnull final Comparisons.Comparison comparison) {
+        switch (comparison.getType()) {
+            case LESS_THAN:
+                return comparison.withType(Comparisons.Type.LESS_THAN_OR_EQUALS);
+            case GREATER_THAN:
+                return comparison.withType(Comparisons.Type.GREATER_THAN_OR_EQUALS);
+            case NOT_EQUALS: // fallthrough
+            case LESS_THAN_OR_EQUALS: // fallthrough
+            case EQUALS: // fallthough
+            case GREATER_THAN_OR_EQUALS: // fallthrough
+            case STARTS_WITH: // fallthrough
+            case NOT_NULL: // fallthrough
+            case IS_NULL: // fallthrough
+            case IN: // fallthrough
+            case TEXT_CONTAINS_ALL: // fallthrough
+            case TEXT_CONTAINS_ALL_WITHIN: // fallthrough
+            case TEXT_CONTAINS_ANY: // fallthrough
+            case TEXT_CONTAINS_PHRASE: // fallthrough
+            case TEXT_CONTAINS_PREFIX: // fallthrough
+            case TEXT_CONTAINS_ALL_PREFIXES: // fallthrough
+            case TEXT_CONTAINS_ANY_PREFIX: // fallthrough
+            case SORT: // fallthrough
+            default:
+                return comparison;
+        }
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/RangeConstraints.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/RangeConstraints.java
@@ -528,6 +528,11 @@ public class RangeConstraints implements PlanHashable, Correlated<RangeConstrain
             }
             return range;
         }
+
+        @Override
+        public String toString() {
+            return compilableComparisons.stream().map(Objects::toString).collect(Collectors.joining("∩"));
+        }
     }
 
     /**


### PR DESCRIPTION
This provides few fixes pertaining filtered indexes:

* Fix for an issue with a flat conjunction not being recognized as a DNF.
* Fix for another issue with the captured constraints of filtered indexes being very strict (solves #2104).
* Finally, it adds `toString` to some of constructs used during filtered index matching, making debugging somewhat easier.