### PR TITLE
Resolve #2106: OnlineIndexer: indexingThrottle: limit handling

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,6 +29,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** OnlineIndexer: IndexingThrottle: re-write limit handling  [(Issue #2106)](https://github.com/FoundationDB/fdb-record-layer/issues/2106)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -269,12 +269,18 @@ public enum LogMessageKeys {
 
     // record count limits for reading/indexing
     LIMIT,
+    OLD_LIMIT,
     RECORD_COUNT,
     RECORDS_SIZE_ESTIMATE,
     REBUILD_RECORD_COUNTS,
     SCANNED_SO_FAR,
     MAX_LIMIT,
     NEXT_CONTINUATION,
+    SUCCESSFUL_TRANSACTIONS_COUNT,
+    FAILED_TRANSACTIONS_COUNT,
+    FAILED_TRANSACTIONS_COUNT_IN_RUNNER,
+    TOTAL_RECORDS_SCANNED,
+    TOTAL_RECORDS_SCANNED_DURING_FAILURES,
 
     // time limits milliseconds
     TIME_LIMIT_MILLIS("time_limit_milliseconds"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -52,7 +52,6 @@ import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -598,9 +597,7 @@ public abstract class IndexingBase {
 
     // Helpers for implementing modules. Some of them are public to support unit-testing.
     protected CompletableFuture<Boolean> throttleDelayAndMaybeLogProgress(SubspaceProvider subspaceProvider, List<Object> additionalLogMessageKeyValues) {
-        int limit = getLimit();
-        int recordsPerSecond = common.config.getRecordsPerSecond();
-        int toWait = (recordsPerSecond == IndexingCommon.UNLIMITED) ? 0 : 1000 * limit / recordsPerSecond;
+        long toWait = throttle.waitTimeMilliseconds();
 
         if (LOGGER.isInfoEnabled() && shouldLogBuildProgress()) {
             FDBStoreTimer timer = getRunner().getTimer();
@@ -611,12 +608,11 @@ public abstract class IndexingBase {
             }
             LOGGER.info(KeyValueLogMessage.build("Indexer: Built Range",
                     subspaceProvider.logKey(), subspaceProvider,
-                    LogMessageKeys.LIMIT, limit,
-                    LogMessageKeys.DELAY, toWait,
-                    LogMessageKeys.RECORDS_PER_SECOND, recordsPerSecond)
+                    LogMessageKeys.DELAY, toWait)
                     .addKeysAndValues(additionalLogMessageKeyValues != null ? additionalLogMessageKeyValues : Collections.emptyList())
                     .addKeysAndValues(indexingLogMessageKeyValues())
                     .addKeysAndValues(common.indexLogMessageKeyValues())
+                    .addKeysAndValues(throttle.logMessageKeyValues())
                     .addKeysAndValues(metricsDiff == null ? Collections.emptyMap() : metricsDiff.getKeysAndValues())
                     .toString());
         }
@@ -630,7 +626,7 @@ public abstract class IndexingBase {
         return delay;
     }
 
-    private void validateTimeLimit(int toWait) {
+    private void validateTimeLimit(long toWait) {
         final long timeLimitMilliseconds = common.config.getTimeLimitMilliseconds();
         if (timeLimitMilliseconds == OnlineIndexer.Config.UNLIMITED_TIME) {
             return;
@@ -663,7 +659,12 @@ public abstract class IndexingBase {
 
     public <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
                                                           @Nullable List<Object> additionalLogMessageKeyValues) {
-        return throttle.buildCommitRetryAsync(buildFunction, null, additionalLogMessageKeyValues);
+        return buildCommitRetryAsync(buildFunction, additionalLogMessageKeyValues, false);
+    }
+
+    public <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
+                                                          @Nullable List<Object> additionalLogMessageKeyValues, final boolean duringRangesIteration) {
+        return throttle.buildCommitRetryAsync(buildFunction, null, additionalLogMessageKeyValues, duringRangesIteration);
     }
 
     protected void timerIncrement(FDBStoreTimer.Counts event) {
@@ -913,9 +914,7 @@ public abstract class IndexingBase {
                                                        @Nullable Function<FDBException, Optional<Boolean>> shouldReturnQuietly) {
 
         return AsyncUtil.whileTrue(() ->
-                    throttle.buildCommitRetryAsync(iterateRange,
-                            shouldReturnQuietly,
-                            additionalLogMessageKeyValues)
+                    throttle.buildCommitRetryAsync(iterateRange, shouldReturnQuietly, additionalLogMessageKeyValues, true)
                             .handle((hasMore, ex) -> {
                                 if (ex == null) {
                                     if (Boolean.FALSE.equals(hasMore)) {
@@ -970,14 +969,6 @@ public abstract class IndexingBase {
     }
 
     abstract CompletableFuture<Void> rebuildIndexInternalAsync(FDBRecordStore store);
-
-    // These throttle methods are externalized for testing usage only
-    @Nonnull
-    <R> CompletableFuture<R> throttledRunAsync(@Nonnull final Function<FDBRecordStore, CompletableFuture<R>> function,
-                                               @Nonnull final BiFunction<R, Throwable, Pair<R, Throwable>> handlePostTransaction,
-                                               @Nullable final List<Object> additionalLogMessageKeyValues) {
-        return throttle.throttledRunAsync(function, handlePostTransaction, null, additionalLogMessageKeyValues);
-    }
 
     protected void validateOrThrowEx(boolean isValid, @Nonnull String msg) {
         if (!isValid) {
@@ -1184,7 +1175,7 @@ public abstract class IndexingBase {
         return findException(ex, UnexpectedReadableException.class);
     }
 
-    private static <T> T findException(@Nullable Throwable ex, Class<T> classT) {
+    protected static <T> T findException(@Nullable Throwable ex, Class<T> classT) {
         Set<Throwable> seenSet = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Throwable current = ex;
                 current != null && !seenSet.contains(current);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -667,6 +667,10 @@ public abstract class IndexingBase {
         return throttle.buildCommitRetryAsync(buildFunction, null, additionalLogMessageKeyValues, duringRangesIteration);
     }
 
+    public long getTotalRecordsScannedScuccessfully() {
+        return throttle.getTotalRecordsScannedScuccessfully();
+    }
+
     protected void timerIncrement(FDBStoreTimer.Counts event) {
         // helper function to reduce complexity
         final FDBStoreTimer timer = getRunner().getTimer();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByRecords.java
@@ -460,7 +460,7 @@ public class IndexingByRecords extends IndexingBase {
                 LogMessageKeys.RANGE_END, end);
 
         return buildCommitRetryAsync((store, recordsScanned) -> buildUnbuiltRange(store, start, end, recordsScanned),
-                additionalLogMessageKeyValues);
+                additionalLogMessageKeyValues, true);
     }
 
     @VisibleForTesting
@@ -470,7 +470,7 @@ public class IndexingByRecords extends IndexingBase {
                 LogMessageKeys.RANGE_START, start,
                 LogMessageKeys.RANGE_END, end);
         return buildCommitRetryAsync((store, recordsScanned) -> buildUnbuiltRange(store, start, end, recordsScanned),
-                additionalLogMessageKeyValues);
+                additionalLogMessageKeyValues, true);
     }
 
     // Builds the index for all of the keys within a given range. This does not update the range set

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -40,7 +40,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -57,7 +56,6 @@ public class IndexingCommon {
     @Nullable private SynchronizedSessionRunner synchronizedSessionRunner = null;
 
     @Nonnull private final FDBRecordStore.Builder recordStoreBuilder;
-    @Nonnull private final AtomicLong totalRecordsScanned;
 
     private final boolean useSynchronizedSession;
     private final boolean trackProgress;
@@ -109,7 +107,6 @@ public class IndexingCommon {
         this.recordStoreBuilder = recordStoreBuilder;
         this.leaseLengthMillis = leaseLengthMillis;
 
-        this.totalRecordsScanned = new AtomicLong(0);
         this.targetIndexContexts = new ArrayList<>(targetIndexes.size());
         this.allRecordTypes = new HashSet<>();
 
@@ -170,7 +167,6 @@ public class IndexingCommon {
 
         logIf(true, keyValues,
                 LogMessageKeys.TARGET_INDEX_NAME, getTargetIndexesNames(),
-                LogMessageKeys.RECORDS_SCANNED, totalRecordsScanned.get(),
                 LogMessageKeys.INDEXER_ID, uuid);
 
         if (moreKeyValues != null && !moreKeyValues.isEmpty()) {
@@ -268,11 +264,6 @@ public class IndexingCommon {
 
     public void setSynchronizedSessionRunner(@Nullable final SynchronizedSessionRunner synchronizedSessionRunner) {
         this.synchronizedSessionRunner = synchronizedSessionRunner;
-    }
-
-    @Nonnull
-    public AtomicLong getTotalRecordsScanned() {
-        return totalRecordsScanned;
     }
 
     public int getConfigLoaderInvocationCount() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -95,7 +96,7 @@ public class IndexingCommon {
                    @Nonnull FDBRecordStore.Builder recordStoreBuilder,
                    @Nonnull List<Index> targetIndexes,
                    @Nullable Collection<RecordType> allRecordTypes,
-                   @Nullable Function<OnlineIndexer.Config, OnlineIndexer.Config> configLoader,
+                   @Nullable UnaryOperator<OnlineIndexer.Config> configLoader,
                    @Nonnull OnlineIndexer.Config config,
                    boolean trackProgress,
                    boolean useSynchronizedSession,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -56,7 +57,7 @@ public class IndexingCommon {
     @Nullable private SynchronizedSessionRunner synchronizedSessionRunner = null;
 
     @Nonnull private final FDBRecordStore.Builder recordStoreBuilder;
-
+    @Nonnull private final AtomicLong totalRecordsScanned;
     private final boolean useSynchronizedSession;
     private final boolean trackProgress;
     private final long leaseLengthMillis;
@@ -107,6 +108,7 @@ public class IndexingCommon {
         this.recordStoreBuilder = recordStoreBuilder;
         this.leaseLengthMillis = leaseLengthMillis;
 
+        this.totalRecordsScanned = new AtomicLong(0);
         this.targetIndexContexts = new ArrayList<>(targetIndexes.size());
         this.allRecordTypes = new HashSet<>();
 
@@ -167,6 +169,7 @@ public class IndexingCommon {
 
         logIf(true, keyValues,
                 LogMessageKeys.TARGET_INDEX_NAME, getTargetIndexesNames(),
+                LogMessageKeys.RECORDS_SCANNED, totalRecordsScanned.get(),
                 LogMessageKeys.INDEXER_ID, uuid);
 
         if (moreKeyValues != null && !moreKeyValues.isEmpty()) {
@@ -264,6 +267,11 @@ public class IndexingCommon {
 
     public void setSynchronizedSessionRunner(@Nullable final SynchronizedSessionRunner synchronizedSessionRunner) {
         this.synchronizedSessionRunner = synchronizedSessionRunner;
+    }
+
+    @Nonnull
+    public AtomicLong getTotalRecordsScanned() {
+        return totalRecordsScanned;
     }
 
     public int getConfigLoaderInvocationCount() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -305,6 +305,7 @@ public class IndexingThrottle {
             }, onlineIndexerLogMessageKeyValues).handle((value, e) -> {
                 if (e == null) {
                     // Here: success path - also the common path (or so we hope)
+                    common.getTotalRecordsScanned().addAndGet(recordsScanned.get());
                     ret.complete(value);
                     return AsyncUtil.READY_FALSE;
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * Scan indexes for problems and optionally report or repair.
@@ -67,7 +67,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
                         @Nonnull FDBRecordStore.Builder recordStoreBuilder,
                         @Nonnull Index index,
                         @Nonnull Collection<RecordType> recordTypes,
-                        @Nonnull Function<OnlineIndexer.Config, OnlineIndexer.Config> configLoader,
+                        @Nonnull UnaryOperator<OnlineIndexer.Config> configLoader,
                         @Nonnull OnlineIndexer.Config config,
                         long leaseLengthMillis,
                         boolean trackProgress,
@@ -285,7 +285,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
         @Nullable
         protected Collection<RecordType> recordTypes;
         @Nonnull
-        protected Function<OnlineIndexer.Config, OnlineIndexer.Config> configLoader = old -> old;
+        protected UnaryOperator<OnlineIndexer.Config> configLoader = old -> old;
 
         ScrubbingPolicy scrubbingPolicy = null;
         ScrubbingPolicy.Builder scrubbingPolicyBuilder = null;
@@ -408,7 +408,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
          * @return this builder
          */
         @Nonnull
-        public Builder setConfigLoader(@Nonnull Function<OnlineIndexer.Config, OnlineIndexer.Config> configLoader) {
+        public Builder setConfigLoader(@Nonnull UnaryOperator<OnlineIndexer.Config> configLoader) {
             this.configLoader = configLoader;
             return this;
         }
@@ -417,7 +417,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
          * Set the maximum number of records to process in one transaction.
          *
          * The default limit is {@link OnlineIndexer#DEFAULT_LIMIT} = {@value OnlineIndexer#DEFAULT_LIMIT}.
-         * Note {@link #setConfigLoader(Function)} is the recommended way of loading online index builder's parameters
+         * Note {@link #setConfigLoader(UnaryOperator)} is the recommended way of loading online index builder's parameters
          * and the values set by this method will be overwritten if the supplier is set.
          * @param limit the maximum number of records to process in one transaction
          * @return this builder
@@ -448,7 +448,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
          * codes, such as {@code transaction_too_large}.
          *
          * The default number of retries is {@link OnlineIndexer#DEFAULT_MAX_RETRIES} = {@value OnlineIndexer#DEFAULT_MAX_RETRIES}.
-         * Note {@link #setConfigLoader(Function)} is the recommended way of loading online index builder's parameters
+         * Note {@link #setConfigLoader(UnaryOperator)} is the recommended way of loading online index builder's parameters
          * and the values set by this method will be overwritten if the supplier is set.
          * @param maxRetries the maximum number of times to retry a single range rebuild
          * @return this builder
@@ -463,7 +463,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
          * Set the maximum number of records to process in a single second.
          *
          * The default number of retries is {@link OnlineIndexer#DEFAULT_RECORDS_PER_SECOND} = {@value OnlineIndexer#DEFAULT_RECORDS_PER_SECOND}.
-         * Note {@link #setConfigLoader(Function)} is the recommended way of loading online index builder's parameters
+         * Note {@link #setConfigLoader(UnaryOperator)} is the recommended way of loading online index builder's parameters
          * and the values set by this method will be overwritten if the supplier is set.
          * @param recordsPerSecond the maximum number of records to process in a single second.
          * @return this builder
@@ -636,7 +636,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
          * transaction. The number of records to process in a single transaction will never go above {@link #limit}.
          * By default this is -1}, which means it will not re-increase after successes.
          * <p>
-         * Note {@link #setConfigLoader(Function)} is the recommended way of loading online index builder's parameters
+         * Note {@link #setConfigLoader(UnaryOperator)} is the recommended way of loading online index builder's parameters
          * and the values set by this method will be overwritten if the supplier is set.
          * </p>
          * @param increaseLimitAfter the number of successful range scrubbed before increasing the number of records
@@ -744,7 +744,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
          * </ul>
          *
          * <p>
-         * Note {@link #setConfigLoader(Function)} is the recommended way of loading online index builder's parameters
+         * Note {@link #setConfigLoader(UnaryOperator)} is the recommended way of loading online index builder's parameters
          * and the values set by this method will be overwritten if the supplier is set.
          * </p>
          *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -836,8 +836,7 @@ public class OnlineIndexer implements AutoCloseable {
     @VisibleForTesting
     // Public could use IndexBuildState.getTotalRecordsScanned instead.
     long getTotalRecordsScanned() {
-        // TODO: use Throttle.Booker's internal count instead
-        return common.getTotalRecordsScanned().get();
+        return indexer == null ? 0 : indexer.getTotalRecordsScannedScuccessfully();
     }
 
     private FDBDatabaseRunner getRunner() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -836,7 +836,7 @@ public class OnlineIndexer implements AutoCloseable {
     @VisibleForTesting
     // Public could use IndexBuildState.getTotalRecordsScanned instead.
     long getTotalRecordsScanned() {
-        return indexer == null ? 0 : indexer.getTotalRecordsScannedScuccessfully();
+        return common.getTotalRecordsScanned().get();
     }
 
     private FDBDatabaseRunner getRunner() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -938,7 +938,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         AtomicLong scanned = new AtomicLong(recordScanned);
         final Throwable dummyThrowable = failed ? new Throwable() : null;
         for (int i = 0; i < repeats; i++) {
-            booker.handleLimitsPostRunnerTransaction(dummyThrowable, scanned, true);
+            booker.handleLimitsPostRunnerTransaction(dummyThrowable, scanned, true, null);
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -1090,7 +1090,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                     }
                     readVersionA.set(readVersion);
                     return null;
-                }, null).handle((val, e) -> null);
+                }, null).handle((val, e) -> null).join();
                 indexBuilder.buildCommitRetryAsync((recordStore, recordsScanned) -> {
                     assertSame(weakReadSemantics, recordStore.getContext().getWeakReadSemantics());
                     assertTrue(recordStore.getContext().hasReadVersion());
@@ -1102,7 +1102,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                     }
                     readVersionB.set(readVersion);
                     return null;
-                }, null).handle((val, e) -> null);
+                }, null).handle((val, e) -> null).join();
                 assertEquals(readVersionA.get(), readVersionB.get(), "weak read semantics did not preserve read version");
             }
         } finally {


### PR DESCRIPTION
Decreasing limit, let new value be  0.9 * the number of records scanned during the failure.