### PR TITLE
Resolve #2069: Use Index.predicate as an index maintenance filter whe…

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexPredicate.java
@@ -64,6 +64,7 @@ public abstract class IndexPredicate {
      * Check if a given record should be indexed.
      * @param store record store
      * @param savedRecord the updated record
+     * @param <M> type of {@link Message} that underlying records will use
      * @return true if this index should generate index entries for this record
      *
      * Note that for now, IndexPredicate does not support filtering of certain index entries.


### PR DESCRIPTION
…n appropriate - javadoc fix