### PR TITLE
Resolves #2112: Add a length-limited query plan printer

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The `PlanStringRepresentation` class separates out plan explain printing from `RecordQueryPlan::toString` including adding logic to create length-limited strings [(Issue #2112)](https://github.com/FoundationDB/fdb-record-layer/issues/2112)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
@@ -1,0 +1,582 @@
+/*
+ * PlanStringRepresentation.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
+import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.InSource;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFirstOrDefaultPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFlatMapPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInComparandJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInParameterJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInUnionOnKeyExpressionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInUnionOnValuesPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInUnionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInValuesJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInsertPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnKeyExpressionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionOnValuesPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryLoadByKeysPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryMapPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanVisitor;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryRangePlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionOnKeyExpressionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionOnValuesPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlanBase;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+/**
+ * Visitor that produces a string representation of a {@link RecordQueryPlan}. This can be used as a
+ * (somewhat) compact way of explaining what is going on in the query. For example, index scans are
+ * represented as:
+ *
+ * <pre>
+ * Index(&lt;index_name&gt; &lt;scan_range&gt;)
+ * </pre>
+ *
+ * <p>
+ * Substituting in the index's name and the index scan range. Likewise, filter plans are represented by:
+ * </p>
+ *
+ * <pre>
+ * &lt;child_plan&gt; | &lt;filter&gt;
+ * </pre>
+ *
+ * <p>
+ * Here, the {@code child_plan} is calculated by recursively generating the string representation of
+ * the filter plan's child plan via the same class. Note that for more complicated queries like unions or
+ * intersections, there can be a lot of child plans which will be appended to the string. For very complex
+ * query plans, this can result in very large query strings. For that reason, this visitor can be
+ * given a {@linkplain #getMaxSize() maximum size}, after which it will stop appending new data. It
+ * is recommended when logging query plans to set some maximum value to avoid logging excessively long
+ * plan strings.
+ * </p>
+ *
+ * <p>
+ * Note that this class accumulates the plan string representation when it gets called. It is not safe to
+ * use in multiple threads, and a new object should be created each time a new string is needed.
+ * </p>
+ */
+@API(API.Status.EXPERIMENTAL)
+@SuppressWarnings("PMD.AvoidStringBufferField") // Class should be short-lived
+public class PlanStringRepresentation implements RecordQueryPlanVisitor<PlanStringRepresentation> {
+    private final int maxSize;
+    @Nonnull
+    private final StringBuilder stringBuilder;
+    private boolean done;
+
+    public PlanStringRepresentation(int maxSize) {
+        this.maxSize = maxSize;
+        this.stringBuilder = new StringBuilder();
+    }
+
+    /**
+     * Returns the maximum length of the plan string, not counting a potential trailing ellipsis.
+     * If the plan string representation would exceed this amount, a trailing ellipsis is added
+     * to indicate that data have been truncated. This returns {@link Integer#MAX_VALUE} if there
+     * is no maximum size.
+     *
+     * @return the maximum size of the string representation
+     */
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    /**
+     * Return whether the max-size of the string has already been hit. If this returns
+     * {@code true}, then visiting any additional plans or appending additional data will
+     * not change the returned string representation.
+     *
+     * @return whether the plan string representation is done appending new data
+     */
+    public boolean isDone() {
+        return done;
+    }
+
+    /**
+     * Add an arbitrary object to the string representation of a given plan. This can be useful if
+     * one wants to construct a (potentially length-limited) string that combines a {@link RecordQueryPlan}
+     * with other data. If this plan string representation {@linkplain #isDone() has hit its maximum size},
+     * this will be a no-op and, in particular, will not call {@link Object#toString()} to construct
+     * the given object's string representation. In this way, this method can be more efficient than
+     * calling {@code append(toAppend.toString())}.
+     *
+     * @param toAppend object to append to the end of the plan string representation
+     * @return this object
+     * @see #append(String)
+     * @see #getMaxSize()
+     * @see #isDone()
+     */
+    @Nonnull
+    public PlanStringRepresentation append(@Nullable Object toAppend) {
+        if (done) {
+            return this;
+        }
+        return append(toAppend == null ? "null" : toAppend.toString());
+    }
+
+    /**
+     * Append an arbitrary string to the end of this plan representation. This can be used to
+     * combine a string with plan data to form a larger (potentially length-limited) string
+     * that combines a {@link RecordQueryPlan} with other data. If this plan string representation
+     * {@linkplain #isDone() has hit its maximum size}, this will be a no-op.
+     *
+     * @param toAppend string to append to the end of the plan string representation
+     * @return this object
+     * @see #append(Object)
+     * @see #getMaxSize()
+     * @see #isDone()
+     */
+    @Nonnull
+    public PlanStringRepresentation append(@Nonnull String toAppend) {
+        if (done) {
+            return this;
+        }
+        if (stringBuilder.length() + toAppend.length() > maxSize) {
+            stringBuilder.append(toAppend, 0, maxSize - stringBuilder.length())
+                    .append("...");
+            done = true;
+            return this;
+        }
+        stringBuilder.append(toAppend);
+        return this;
+    }
+
+    /**
+     * Append a collection of items to this plan string representation. The string representation of
+     * each item will be added to the underlying string representation, with the given delimiter being
+     * used to separate each one. Note that if the {@link #isDone() maximum size has been hit}, the list
+     * may be truncated or may not actually be appended at all.
+     * 
+     * @param items the collection of items to add to the plan string representation
+     * @param delimiter the delimiter to use between each item
+     * @return this object
+     * @see #isDone() 
+     * @see #getMaxSize() 
+     * @see #append(String) 
+     */
+    @Nonnull
+    public PlanStringRepresentation appendItems(@Nonnull Collection<?> items, @Nonnull String delimiter) {
+        if (done) {
+            return this;
+        }
+        boolean first = true;
+        for (Object o : items) {
+            if (first) {
+                first = false;
+            } else {
+                append(delimiter);
+            }
+            if (o instanceof RecordQueryPlan) {
+                visit((RecordQueryPlan) o);
+            } else {
+                append(o);
+            }
+            if (done) {
+                return this;
+            }
+        }
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitComposedBitmapIndexQueryPlan(@Nonnull ComposedBitmapIndexQueryPlan element) {
+        return visitDefault(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitAggregateIndexPlan(@Nonnull RecordQueryAggregateIndexPlan element) {
+        return append("AggregateIndexScan(")
+                .visit(element.getIndexPlan())
+                .append(" -> ")
+                .append(element.getToRecord())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitComparatorPlan(@Nonnull RecordQueryComparatorPlan element) {
+        return append("COMPARATOR OF ")
+                .appendItems(element.getChildren(), " ");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitCoveringIndexPlan(@Nonnull RecordQueryCoveringIndexPlan element) {
+        return append("Covering(")
+                .visit(element.getIndexPlan())
+                .append(" -> ")
+                .append(element.getToRecord())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitDeletePlan(@Nonnull RecordQueryDeletePlan element) {
+        // TODO provide proper explain
+        return visit(element.getChild())
+                .append(" | UPDATE ")
+                .append(element.getTargetRecordType());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitExplodePlan(@Nonnull RecordQueryExplodePlan element) {
+        return append("explode([")
+                .append(element.getCollectionValue())
+                .append("])");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitFetchFromPartialRecordPlan(@Nonnull RecordQueryFetchFromPartialRecordPlan element) {
+        return append("Fetch(")
+                .visit(element.getChild())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitFilterPlan(@Nonnull RecordQueryFilterPlan element) {
+        return visit(element.getChild())
+                .append(" | ")
+                .append(element.getConjunctedFilter());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitFirstOrDefaultPlan(@Nonnull RecordQueryFirstOrDefaultPlan element) {
+        return append("firstOrDefault(")
+                .visit(element.getChild())
+                .append(" || ")
+                .append(element.getOnEmptyResultValue())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitFlatMapPlan(@Nonnull RecordQueryFlatMapPlan element) {
+        return append("flatMap(")
+                .visit(element.getOuterQuantifier().getRangesOverPlan())
+                .append(", ")
+                .visit(element.getInnerQuantifier().getRangesOverPlan())
+                .append(")");
+    }
+
+    @Nonnull
+    private PlanStringRepresentation visitInJoinPlan(@Nonnull RecordQueryInJoinPlan element) {
+        final InSource inSource = element.getInSource();
+        visit(element.getInnerPlan())
+                .append(" WHERE ")
+                .append(inSource.getBindingName())
+                .append(" IN ")
+                .append(inSource.valuesString());
+        if (inSource.isSorted()) {
+            append(" SORTED");
+            if (inSource.isReverse()) {
+                append(" DESC");
+            }
+        }
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitInComparandJoinPlan(@Nonnull RecordQueryInComparandJoinPlan element) {
+        return visitInJoinPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitInParameterJoinPlan(@Nonnull RecordQueryInParameterJoinPlan element) {
+        return visitInJoinPlan(element);
+    }
+
+    @Nonnull
+    private PlanStringRepresentation visitInUnionPlan(@Nonnull RecordQueryInUnionPlan element) {
+        return append("∪(")
+                .appendItems(element.getInSources(), ", ")
+                .append(") ")
+                .visit(element.getChild());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitInUnionOnKeyExpressionPlan(@Nonnull RecordQueryInUnionOnKeyExpressionPlan element) {
+        return visitInUnionPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitInUnionOnValuesPlan(@Nonnull RecordQueryInUnionOnValuesPlan element) {
+        return visitInUnionPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitInValuesJoinPlan(@Nonnull RecordQueryInValuesJoinPlan element) {
+        return visitInJoinPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitIndexPlan(@Nonnull RecordQueryIndexPlan element) {
+        final IndexScanParameters scanParameters = element.getScanParameters();
+        append("Index(")
+                .append(element.getIndexName())
+                .append(" ")
+                .append(element.getScanParameters().getScanDetails());
+        if (!IndexScanType.BY_VALUE.equals(scanParameters.getScanType())) {
+            append(" ").append(scanParameters.getScanType());
+        }
+        if (element.isReverse()) {
+            append(" REVERSE");
+        }
+        return append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitInsertPlan(@Nonnull RecordQueryInsertPlan element) {
+        return visit(element.getChild())
+                .append(" | INSERT INTO ")
+                .append(element.getTargetRecordType());
+    }
+
+    @Nonnull
+    private PlanStringRepresentation visitIntersectionPlan(@Nonnull RecordQueryIntersectionPlan element) {
+        return appendItems(element.getChildren(), " ∩ ");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitIntersectionOnKeyExpressionPlan(@Nonnull RecordQueryIntersectionOnKeyExpressionPlan element) {
+        return visitIntersectionPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitIntersectionOnValuesPlan(@Nonnull RecordQueryIntersectionOnValuesPlan element) {
+        return visitIntersectionPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitLoadByKeysPlan(@Nonnull RecordQueryLoadByKeysPlan element) {
+        return append("ByKeys(")
+                .append(element.getKeysSource())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitMapPlan(@Nonnull RecordQueryMapPlan element) {
+        return visit(element.getChild())
+                .append("[")
+                .append(element.getResultValue())
+                .append("]");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitPredicatesFilterPlan(@Nonnull RecordQueryPredicatesFilterPlan element) {
+        return visit(element.getChild())
+                .append(" | ")
+                .append(element.getConjunctedPredicate());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitRangePlan(@Nonnull RecordQueryRangePlan element) {
+        return append("Range(")
+                .append(element.getExclusiveLimitValue())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitScanPlan(@Nonnull RecordQueryScanPlan element) {
+        final TupleRange tupleRange = element.getScanComparisons().toTupleRangeWithoutContext();
+        return append("Scan(")
+                .append(tupleRange == null ? element.getScanComparisons() : tupleRange)
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitScoreForRankPlan(@Nonnull RecordQueryScoreForRankPlan element) {
+        return visit(element.getChild())
+                .append(" WHERE ")
+                .appendItems(element.getRanks(), ", ");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitSelectorPlan(@Nonnull RecordQuerySelectorPlan element) {
+        return append("SELECT OR ")
+                .appendItems(element.getChildren(), " ");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitStreamingAggregationPlan(@Nonnull RecordQueryStreamingAggregationPlan element) {
+        return visit(element.getChild())
+                .append(" | AGGREGATE BY ")
+                .append(element.getAggregateValue())
+                .append(", GROUP BY ")
+                .append(element.getGroupingValue());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitTextIndexPlan(@Nonnull RecordQueryTextIndexPlan element) {
+        final TextScan textScan = element.getTextScan();
+        return append("TextIndex(")
+                .append(textScan.getIndex().getName())
+                .append(" ")
+                .append(textScan.getGroupingComparisons())
+                .append(", ")
+                .append(textScan.getTextComparison())
+                .append(", ")
+                .append(textScan.getSuffixComparisons())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitTypeFilterPlan(@Nonnull RecordQueryTypeFilterPlan element) {
+        return visit(element.getChild())
+                .append(" | ")
+                .append(element.getRecordTypes());
+    }
+
+    @Nonnull
+    private PlanStringRepresentation visitUnionPlan(@Nonnull RecordQueryUnionPlanBase element) {
+        return appendItems(element.getChildren(), element.getDelimiter());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitUnionOnKeyExpressionPlan(@Nonnull RecordQueryUnionOnKeyExpressionPlan element) {
+        return visitUnionPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitUnionOnValuesPlan(@Nonnull RecordQueryUnionOnValuesPlan element) {
+        return visitUnionPlan(element);
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitUnorderedDistinctPlan(@Nonnull RecordQueryUnorderedDistinctPlan element) {
+        return visit(element.getChild())
+                .append(" | UnorderedDistinct(")
+                .append(element.getComparisonKey())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitUnorderedPrimaryKeyDistinctPlan(@Nonnull RecordQueryUnorderedPrimaryKeyDistinctPlan element) {
+        return visit(element.getChild())
+                .append(" | UnorderedPrimaryKeyDistinct()");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitUnorderedUnionPlan(@Nonnull RecordQueryUnorderedUnionPlan element) {
+        return append("Unordered(")
+                .visitUnionPlan(element)
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitUpdatePlan(@Nonnull RecordQueryUpdatePlan element) {
+        // TODO provide proper explain
+        return visit(element.getInnerPlan())
+                .append(" | UPDATE ")
+                .append(element.getTargetRecordType());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitSortPlan(@Nonnull RecordQuerySortPlan element) {
+        return visit(element.getChild())
+                .append(" ORDER BY ")
+                .append(element.getKey());
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitDefault(@Nonnull RecordQueryPlan element) {
+        return append(element.toString());
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return stringBuilder.toString();
+    }
+
+    @Nonnull
+    public static String toString(@Nonnull RecordQueryPlan plan, int maxSize) {
+        PlanStringRepresentation visitor = new PlanStringRepresentation(maxSize);
+        return visitor.visit(plan).toString();
+    }
+
+    @Nonnull
+    public static String toString(@Nonnull RecordQueryPlan plan) {
+        return toString(plan, Integer.MAX_VALUE);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
@@ -462,7 +462,7 @@ public class PlanStringRepresentation implements RecordQueryPlanVisitor<PlanStri
     @Nonnull
     @Override
     public PlanStringRepresentation visitSelectorPlan(@Nonnull RecordQuerySelectorPlan element) {
-        return append("SELECT OR ")
+        return append("SELECTOR OF ")
                 .appendItems(element.getChildren(), " ");
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InComparandSource.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InComparandSource.java
@@ -68,6 +68,12 @@ public class InComparandSource extends InSource {
         return false;
     }
 
+    @Nonnull
+    @Override
+    public String valuesString() {
+        return comparison.typelessString();
+    }
+
     @Override
     protected int size(@Nonnull final EvaluationContext context) {
         return getValues(context).size();
@@ -94,7 +100,7 @@ public class InComparandSource extends InSource {
     @Nonnull
     @Override
     public String toString() {
-        return getBindingName() + comparison;
+        return getBindingName() + " " + comparison;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InParameterSource.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InParameterSource.java
@@ -68,6 +68,12 @@ public class InParameterSource extends InSource {
         return false;
     }
 
+    @Nonnull
+    @Override
+    public String valuesString() {
+        return "$" + parameterName;
+    }
+
     @Override
     public int planHash(@Nonnull final PlanHashKind hashKind) {
         return PlanHashable.objectsPlanHash(hashKind, baseHash(hashKind, OBJECT_PLAN_HASH_IN_PARAMETER_SOURCE), parameterName);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InSource.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InSource.java
@@ -59,6 +59,9 @@ public abstract class InSource implements PlanHashable {
 
     public abstract boolean isReverse();
 
+    @Nonnull
+    public abstract String valuesString();
+
     protected abstract int size(@Nonnull EvaluationContext context);
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InValuesSource.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/InValuesSource.java
@@ -72,6 +72,12 @@ public class InValuesSource extends InSource {
         return false;
     }
 
+    @Nonnull
+    @Override
+    public String valuesString() {
+        return values.toString();
+    }
+
     @Override
     public int planHash(@Nonnull final PlanHashKind hashKind) {
         if (hashKind == PlanHashKind.STRUCTURAL_WITHOUT_LITERALS) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -218,6 +219,11 @@ public class RecordQueryAggregateIndexPlan implements RecordQueryPlanWithNoChild
         return AvailableFields.NO_FIELDS;
     }
 
+    @Nonnull
+    public IndexKeyValueToPartialRecord getToRecord() {
+        return toRecord;
+    }
+
     @Override
     public boolean hasLoadBykeys() {
         return false;
@@ -232,7 +238,7 @@ public class RecordQueryAggregateIndexPlan implements RecordQueryPlanWithNoChild
     @Nonnull
     @Override
     public String toString() {
-        return "AggregateIndexScan(" + indexPlan + " -> " + toRecord + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryComparatorPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryComparatorPlan.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.cursors.ComparatorCursor;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -179,7 +180,7 @@ public class RecordQueryComparatorPlan extends RecordQueryChooserPlanBase {
     @Nonnull
     @Override
     public String toString() {
-        return "COMPARATOR OF " + getChildStream().map(RecordQueryPlan::toString).collect(Collectors.joining(" "));
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
@@ -173,6 +174,11 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
         return availableFields;
     }
 
+    @Nonnull
+    public IndexKeyValueToPartialRecord getToRecord() {
+        return toRecord;
+    }
+
     @Override
     public boolean hasLoadBykeys() {
         return false;
@@ -191,7 +197,7 @@ public class RecordQueryCoveringIndexPlan implements RecordQueryPlanWithNoChildr
     @Nonnull
     @Override
     public String toString() {
-        return "Covering(" + indexPlan + " -> " + toRecord + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -192,8 +193,7 @@ public class RecordQueryDeletePlan implements RecordQueryPlanWithChild, PlannerG
     @Nonnull
     @Override
     public String toString() {
-        // TODO provide proper explain
-        return getInnerPlan() + " | " + "UPDATE " + getTargetRecordType();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryExplodePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryExplodePlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -166,7 +167,7 @@ public class RecordQueryExplodePlan implements RecordQueryPlanWithNoChildren {
     @Nonnull
     @Override
     public String toString() {
-        return "explode(" + collectionValue + "])";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexOrphanBehavior;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -233,7 +234,7 @@ public class RecordQueryFetchFromPartialRecordPlan implements RecordQueryPlanWit
 
     @Override
     public String toString() {
-        return "Fetch(" + getChild().toString() + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -110,7 +111,7 @@ public class RecordQueryFilterPlan extends RecordQueryFilterPlanBase {
     @Nonnull
     @Override
     public String toString() {
-        return getInnerPlan() + " | " + getConjunctedFilter();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFirstOrDefaultPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFirstOrDefaultPlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.cursors.FutureCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -144,7 +145,7 @@ public class RecordQueryFirstOrDefaultPlan implements RecordQueryPlanWithChild, 
     @Nonnull
     @Override
     public String toString() {
-        return "firstOrDefault(" + getChild() + " || " + onEmptyResultValue + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFlatMapPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFlatMapPlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -194,7 +195,7 @@ public class RecordQueryFlatMapPlan implements RecordQueryPlanWithChildren, Rela
     @Nonnull
     @Override
     public String toString() {
-        return "flatMap(" + outerQuantifier.getRangesOverPlan() + ", " + innerQuantifier.getRangesOverPlan() + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInComparandJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInComparandJoinPlan.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -110,17 +111,7 @@ public class RecordQueryInComparandJoinPlan extends RecordQueryInJoinPlan {
 
     @Override
     public String toString() {
-        StringBuilder str = new StringBuilder(getInnerPlan().toString());
-        str.append(" WHERE ").append(inSource.getBindingName())
-                .append(" IN ")
-                .append(inComparandSource().getComparison().typelessString());
-        if (inSource.isSorted()) {
-            str.append(" SORTED");
-            if (inSource.isReverse()) {
-                str.append(" DESC");
-            }
-        }
-        return str.toString();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInParameterJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInParameterJoinPlan.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.Bindings;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -93,16 +94,7 @@ public class RecordQueryInParameterJoinPlan extends RecordQueryInJoinPlan {
 
     @Override
     public String toString() {
-        StringBuilder str = new StringBuilder(getInnerPlan().toString());
-        str.append(" WHERE ").append(inSource.getBindingName())
-                .append(" IN $").append(inParameterSource().getParameterName());
-        if (inSource.isSorted()) {
-            str.append(" SORTED");
-            if (inSource.isReverse()) {
-                str.append(" DESC");
-            }
-        }
-        return str.toString();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.cursors.UnionCursor;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
@@ -285,8 +286,7 @@ public abstract class RecordQueryInUnionPlan implements RecordQueryPlanWithChild
     @Nonnull
     @Override
     public String toString() {
-        return inSources.stream().map(Object::toString).collect(Collectors.joining(", ", "∪(", ") ")) +
-               getChild();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInValuesJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInValuesJoinPlan.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
@@ -101,10 +102,7 @@ public class RecordQueryInValuesJoinPlan extends RecordQueryInJoinPlan {
 
     @Override
     public String toString() {
-        StringBuilder str = new StringBuilder(getInnerPlan().toString());
-        str.append(" WHERE ").append(inSource.getBindingName())
-                .append(" IN ").append(getInListValues());
-        return str.toString();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -55,6 +55,7 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanRange;
 import com.apple.foundationdb.record.provider.foundationdb.UnsupportedRemoteFetchIndexException;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
@@ -536,25 +537,12 @@ public class RecordQueryIndexPlan implements RecordQueryPlanWithNoChildren,
     @Nonnull
     @Override
     public String toString() {
-        StringBuilder str = new StringBuilder("Index(");
-        appendScanDetails(str);
-        str.append(")");
-        return str.toString();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override
     public void logPlanStructure(StoreTimer timer) {
         timer.increment(FDBStoreTimer.Counts.PLAN_INDEX);
-    }
-
-    protected void appendScanDetails(StringBuilder str) {
-        str.append(indexName).append(" ").append(scanParameters.getScanDetails());
-        if (!scanParameters.getScanType().equals(IndexScanType.BY_VALUE)) {
-            str.append(" ").append(scanParameters.getScanType());
-        }
-        if (reverse) {
-            str.append(" REVERSE");
-        }
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInsertPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInsertPlan.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.PromoteValue;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -111,7 +112,7 @@ public class RecordQueryInsertPlan extends RecordQueryAbstractDataModificationPl
     @Nonnull
     @Override
     public String toString() {
-        return getInnerPlan() + " | " + "INSERT INTO " + getTargetRecordType();
+        return PlanStringRepresentation.toString(this);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIntersectionPlan.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.cursors.IntersectionCursor;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
@@ -71,7 +72,6 @@ public abstract class RecordQueryIntersectionPlan implements RecordQueryPlanWith
 
     public static final Logger LOGGER = LoggerFactory.getLogger(RecordQueryIntersectionPlan.class);
 
-    private static final String INTERSECT = "∩"; // U+2229
     /* The current implementations of equals() and hashCode() treat RecordQueryIntersectionPlan as if it were isomorphic under
      * a reordering of its children. In particular, all of the tests assume that a RecordQueryIntersectionPlan with its children
      * reordered is identical. This is accurate in the current implementation (except that the continuation might no longer
@@ -149,7 +149,7 @@ public abstract class RecordQueryIntersectionPlan implements RecordQueryPlanWith
     @Nonnull
     @Override
     public String toString() {
-        return getChildStream().map(RecordQueryPlan::toString).collect(Collectors.joining(" " + INTERSECT + " "));
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -150,7 +151,7 @@ public class RecordQueryLoadByKeysPlan implements RecordQueryPlanWithNoChildren 
     @Nonnull
     @Override
     public String toString() {
-        return "ByKeys(" + getKeysSource() + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryMapPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryMapPlan.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -147,7 +148,7 @@ public class RecordQueryMapPlan implements RecordQueryPlanWithChild, RelationalE
     @Nonnull
     @Override
     public String toString() {
-        return "map(" + getChild() + "[" + resultValue + "])";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.expressions.AsyncBoolean;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -78,6 +79,11 @@ public class RecordQueryPredicatesFilterPlan extends RecordQueryFilterPlanBase i
     @Override
     public List<? extends QueryPredicate> getPredicates() {
         return predicates;
+    }
+
+    @Nonnull
+    public QueryPredicate getConjunctedPredicate() {
+        return conjunctedPredicate;
     }
 
     @Override
@@ -178,7 +184,7 @@ public class RecordQueryPredicatesFilterPlan extends RecordQueryFilterPlanBase i
     @Nonnull
     @Override
     public String toString() {
-        return getInnerPlan() + " | " + conjunctedPredicate;
+        return PlanStringRepresentation.toString(this);
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRangePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRangePlan.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.cursors.RangeCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -145,7 +146,7 @@ public class RecordQueryRangePlan implements RecordQueryPlanWithNoChildren {
     @Nonnull
     @Override
     public String toString() {
-        return "Range(" + exclusiveLimitValue.toString() + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -257,9 +258,7 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     @Nonnull
     @Override
     public String toString() {
-        @Nullable final TupleRange tupleRange = comparisons.toTupleRangeWithoutContext();
-        final String range = tupleRange == null ? comparisons.toString() : tupleRange.toString();
-        return "Scan(" + range + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScoreForRankPlan.java
@@ -37,6 +37,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.RankedSetIndexHelper;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -166,7 +167,7 @@ public class RecordQueryScoreForRankPlan implements RecordQueryPlanWithChild {
 
     @Override
     public String toString() {
-        return getChild() + " WHERE " + ranks.stream().map(Object::toString).collect(Collectors.joining(", "));
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySelectorPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySelectorPlan.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -60,7 +61,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.stream.Collectors;
 
 /**
  * A {@link RecordQueryChooserPlanBase} that selects one of its children to be executed.
@@ -158,7 +158,7 @@ public class RecordQuerySelectorPlan extends RecordQueryChooserPlanBase {
 
     @Override
     public String toString() {
-        return "SELECTOR OF " + getChildStream().map(RecordQueryPlan::toString).collect(Collectors.joining(" "));
+        return PlanStringRepresentation.toString(this);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryStreamingAggregationPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryStreamingAggregationPlan.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.cursors.aggregate.StreamGrouping;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -164,7 +165,7 @@ public class RecordQueryStreamingAggregationPlan implements RecordQueryPlanWithC
     @Nonnull
     @Override
     public String toString() {
-        return getInnerPlan() + " | AGGREGATE BY " + aggregateValue + ", GROUP BY " + groupingKeyValue;
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.TextScan;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -231,7 +232,7 @@ public class RecordQueryTextIndexPlan implements RecordQueryPlanWithIndex, Recor
     @Nonnull
     @Override
     public String toString() {
-        return "TextIndex(" + textScan.getIndex().getName() + " " + textScan.getGroupingComparisons() + ", " + textScan.getTextComparison() + ", " + textScan.getSuffixComparisons() + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTypeFilterPlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -119,7 +120,7 @@ public class RecordQueryTypeFilterPlan implements RecordQueryPlanWithChild, Type
     @Nonnull
     @Override
     public String toString() {
-        return getInnerPlan() + " | " + recordTypes;
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlan.java
@@ -139,7 +139,7 @@ public abstract class RecordQueryUnionPlan extends RecordQueryUnionPlanBase {
 
     @Nonnull
     @Override
-    String getDelimiter() {
+    public String getDelimiter() {
         return " " + UNION + (showComparisonKey ? comparisonKeyFunction.toString() : "") + " ";
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnionPlanBase.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -191,13 +192,14 @@ public abstract class RecordQueryUnionPlanBase implements RecordQueryPlanWithChi
         }
     }
 
+    @API(API.Status.INTERNAL)
     @Nonnull
-    abstract String getDelimiter();
+    public abstract String getDelimiter();
 
     @Nonnull
     @Override
     public String toString() {
-        return getChildStream().map(RecordQueryPlan::toString).collect(Collectors.joining(getDelimiter()));
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -119,7 +120,7 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
     }
 
     @Nonnull
-    private KeyExpression getComparisonKey() {
+    public KeyExpression getComparisonKey() {
         return comparisonKey;
     }
 
@@ -131,7 +132,7 @@ public class RecordQueryUnorderedDistinctPlan implements RecordQueryPlanWithChil
 
     @Override
     public String toString() {
-        return getInner() + " | UnorderedDistinct(" + getComparisonKey() + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -118,7 +119,7 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan implements RecordQueryPl
 
     @Override
     public String toString() {
-        return getInner() + " | UnorderedPrimaryKeyDistinct()";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedUnionPlan.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.cursors.UnorderedUnionCursor;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -74,14 +75,14 @@ public class RecordQueryUnorderedUnionPlan extends RecordQueryUnionPlanBase {
 
     @Nonnull
     @Override
-    String getDelimiter() {
+    public String getDelimiter() {
         return " " + UNION + " ";
     }
 
     @Nonnull
     @Override
     public String toString() {
-        return "Unordered(" + super.toString() + ")";
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUpdatePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUpdatePlan.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.PromoteValue;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -149,8 +150,7 @@ public class RecordQueryUpdatePlan extends RecordQueryAbstractDataModificationPl
     @Nonnull
     @Override
     public String toString() {
-        // TODO provide proper explain
-        return getInnerPlan() + " | " + "UPDATE " + getTargetRecordType();
+        return PlanStringRepresentation.toString(this);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
@@ -143,7 +144,7 @@ public class RecordQuerySortPlan implements RecordQueryPlanWithChild {
 
     @Override
     public String toString() {
-        return getChild() + " ORDER BY " + getKey();
+        return PlanStringRepresentation.toString(this);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentationTest.java
@@ -497,7 +497,17 @@ public class PlanStringRepresentationTest {
         Random r = ThreadLocalRandom.current();
         List<RecordQueryPlan> plans = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
-            plans.add(randomPlanAndString(r).getLeft());
+            RecordQueryPlan plan;
+            while (true) {
+                plan = randomPlanAndString(r).getLeft();
+                try {
+                    plan.isReverse();
+                    break;
+                } catch (RecordCoreException e) {
+                    // Not all plans have a defined reverse-ness. If this happens, generate a new plan
+                }
+            }
+            plans.add(plan);
         }
         final String withoutUnstringable = RecordQueryUnorderedUnionPlan.from(plans).toString();
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentationTest.java
@@ -421,7 +421,7 @@ public class PlanStringRepresentationTest {
     @Nonnull
     private static Pair<RecordQueryPlan, String> randomPlanAndString(@Nonnull Random r, double decay) {
         // Generate a random plan, but use the decay argument to avoid creating trees with too many
-        // levels (and potentially hitting the maximum stack depth). Every time we a plan with
+        // levels (and potentially hitting the maximum stack depth). Every time a plan with
         // child plans is chosen, the decay parameter is decreased, which eventually ensures that
         // a leaf plan is chosen.
         double leafChoice = r.nextDouble();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentationTest.java
@@ -1,0 +1,642 @@
+/*
+ * PlanStringRepresentationTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan;
+
+import com.apple.foundationdb.record.Bindings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanComparisons;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.expressions.RecordTypeKeyComparison;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
+import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.ConstantObjectValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInComparandJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInParameterJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryInValuesJoinPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIntersectionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryLoadByKeysPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
+import com.apple.foundationdb.record.query.plan.plans.TranslateValueFunction;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortKey;
+import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.primitives.ImmutableIntArray;
+import com.google.protobuf.Message;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests of the {@link PlanStringRepresentation} visitor. This test fixture has the ability to generate random plan
+ * trees, and then it attempts to compare the expected plan string representations built by those random plans with
+ * the plan strings that the visitor produces. The visitor also has logic to terminate early if it has reached
+ * a maximum size, which this also tests out on random plans.
+ */
+public class PlanStringRepresentationTest {
+    @Nonnull
+    private static String randomAlphabetic(@Nonnull Random r, int minCount, int maxCount) {
+        final int letterCount = minCount + r.nextInt(maxCount - minCount);
+        char[] letters = new char[letterCount];
+        for (int i = 0; i < letterCount; i++) {
+            int letter = r.nextInt(26);
+            letters[i] = (char)((r.nextBoolean() ? 'a' : 'A') + letter);
+        }
+        return new String(letters);
+    }
+
+    @Nonnull
+    private static String randomParameterName(@Nonnull Random r) {
+        return randomAlphabetic(r, 5, 8);
+    }
+
+    @Nonnull
+    private static String randomTypeName(@Nonnull Random r) {
+        return randomAlphabetic(r, 10, 15);
+    }
+
+    @Nonnull
+    private static String randomIndexName(@Nonnull Random r) {
+        return randomAlphabetic(r, 8, 10);
+    }
+
+    @Nonnull
+    private static String randomFieldName(@Nonnull Random r) {
+        return randomAlphabetic(r, 4, 9);
+    }
+
+    private static <T> T randomChoice(@Nonnull Random r, @Nonnull List<T> elements) {
+        int choice = r.nextInt(elements.size());
+        return elements.get(choice);
+    }
+
+    private static Comparisons.Comparison randomEqualityComparison(@Nonnull Random r) {
+        double choice = r.nextDouble();
+        if (choice < 0.25) {
+            return new Comparisons.NullComparison(Comparisons.Type.IS_NULL);
+        } else if (choice < 0.5) {
+            return new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, r.nextLong());
+        } else if (choice < 0.75) {
+            return new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, randomParameterName(r));
+        } else {
+            return new RecordTypeKeyComparison(randomTypeName(r)).getComparison();
+        }
+    }
+
+    private static Comparisons.Comparison randomInequalityComparison(@Nonnull Random r) {
+        Comparisons.Type type = randomChoice(r, List.of(Comparisons.Type.LESS_THAN, Comparisons.Type.LESS_THAN_OR_EQUALS, Comparisons.Type.GREATER_THAN, Comparisons.Type.GREATER_THAN_OR_EQUALS));
+        if (r.nextBoolean()) {
+            return new Comparisons.SimpleComparison(type, r.nextLong());
+        } else {
+            return new Comparisons.ParameterComparison(type, randomParameterName(r));
+        }
+    }
+
+    private static Pair<ScanComparisons, String> randomScanComparisons(Random r) {
+        final int equalityComparisonCount = r.nextInt(7);
+        final ScanComparisons.Builder builder = new ScanComparisons.Builder();
+        for (int i = 0; i < equalityComparisonCount; i++) {
+            builder.addEqualityComparison(randomEqualityComparison(r));
+        }
+        final int inequalityComparisonCount = r.nextInt(2);
+        for (int i = 0; i < inequalityComparisonCount; i++) {
+            builder.addInequalityComparison(randomInequalityComparison(r));
+        }
+        ScanComparisons comparisons = builder.build();
+        TupleRange tupleRange = comparisons.toTupleRangeWithoutContext();
+        return Pair.of(comparisons, tupleRange == null ? comparisons.toString() : tupleRange.toString());
+    }
+
+    private static Pair<RecordQueryPlan, String> randomScanPlan(Random r) {
+        Pair<ScanComparisons, String> comparisons = randomScanComparisons(r);
+        boolean reverse = r.nextBoolean();
+        return Pair.of(new RecordQueryScanPlan(comparisons.getLeft(), reverse), String.format("Scan(%s)", comparisons.getRight()));
+    }
+
+    private static Pair<RecordQueryPlan, String> randomIndexPlan(Random r) {
+        Pair<ScanComparisons, String> comparisons = randomScanComparisons(r);
+        IndexScanType scanType = randomChoice(r, List.of(IndexScanType.BY_VALUE, IndexScanType.BY_RANK, IndexScanType.BY_GROUP, IndexScanType.BY_VALUE_OVER_SCAN));
+        IndexScanParameters scanParameters = IndexScanComparisons.byValue(comparisons.getLeft(), scanType);
+        String indexName = randomIndexName(r);
+        boolean reverse = r.nextBoolean();
+        return Pair.of(new RecordQueryIndexPlan(indexName, scanParameters, reverse),
+                String.format("Index(%s %s%s%s)", indexName, comparisons.getRight(), scanType == IndexScanType.BY_VALUE ? "" : (" " + scanType), reverse ? " REVERSE" : ""));
+    }
+
+    private static Pair<RecordQueryPlan, String> randomTextIndexPlan(Random r) {
+        ScanComparisons.Builder groupComparisonsBuilder = new ScanComparisons.Builder();
+        int groupingComparisons = r.nextInt(3);
+        for (int i = 0; i < groupingComparisons; i++) {
+            groupComparisonsBuilder.addEqualityComparison(randomEqualityComparison(r));
+        }
+        ScanComparisons groupComparisons = groupComparisonsBuilder.build();
+        ScanComparisons suffixComparisons;
+        if (r.nextBoolean()) {
+            suffixComparisons = randomScanComparisons(r).getLeft();
+        } else {
+            suffixComparisons = null;
+        }
+
+        Comparisons.Type type = randomChoice(r, List.of(Comparisons.Type.TEXT_CONTAINS_ALL, Comparisons.Type.TEXT_CONTAINS_ANY, Comparisons.Type.TEXT_CONTAINS_ALL_PREFIXES, Comparisons.Type.TEXT_CONTAINS_ANY_PREFIX, Comparisons.Type.TEXT_CONTAINS_ALL_WITHIN, Comparisons.Type.TEXT_CONTAINS_PHRASE));
+        Comparisons.TextComparison textComparison;
+        List<String> tokens = Stream.generate(() -> randomAlphabetic(r, 5, 7)).limit(5).collect(Collectors.toList());
+        String phrase = String.join(" ", tokens);
+        boolean useTokens = r.nextBoolean();
+        String tokenizerName = r.nextBoolean() ? null : randomAlphabetic(r, 5, 8);
+        String defaultTokenizerName = randomAlphabetic(r, 5, 8);
+
+        if (type == Comparisons.Type.TEXT_CONTAINS_ALL_WITHIN) {
+            int distance = r.nextInt(20);
+            if (useTokens) {
+                textComparison = new Comparisons.TextWithMaxDistanceComparison(tokens, distance, tokenizerName, defaultTokenizerName);
+            } else {
+                textComparison = new Comparisons.TextWithMaxDistanceComparison(phrase, distance, tokenizerName, defaultTokenizerName);
+            }
+        } else if (type == Comparisons.Type.TEXT_CONTAINS_ALL_PREFIXES) {
+            boolean strict = r.nextBoolean();
+            if (useTokens) {
+                textComparison = new Comparisons.TextContainsAllPrefixesComparison(tokens, strict, tokenizerName, defaultTokenizerName);
+            } else {
+                textComparison = new Comparisons.TextContainsAllPrefixesComparison(phrase, strict, tokenizerName, defaultTokenizerName);
+            }
+        } else {
+            if (useTokens) {
+                textComparison = new Comparisons.TextComparison(type, tokens, tokenizerName, defaultTokenizerName);
+            } else {
+                textComparison = new Comparisons.TextComparison(type, phrase, tokenizerName, defaultTokenizerName);
+            }
+        }
+
+        String indexName = randomIndexName(r);
+        Index index = new Index(indexName, Key.Expressions.concatenateFields("text", "suffix").groupBy(Key.Expressions.field("group")), IndexTypes.TEXT);
+        TextScan textScan = new TextScan(index, groupComparisons, textComparison, suffixComparisons);
+        return Pair.of(new RecordQueryTextIndexPlan(indexName, textScan, r.nextBoolean()), String.format("TextIndex(%s %s, %s, %s)", indexName, groupComparisons, textComparison, suffixComparisons));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomCoveringIndexPlan(@Nonnull Random r) {
+        Pair<RecordQueryPlan, String> childPlan;
+        if (r.nextDouble() < 0.8) {
+            childPlan = randomIndexPlan(r);
+        } else {
+            childPlan = randomTextIndexPlan(r);
+        }
+
+        assertThat(childPlan.getLeft(), Matchers.instanceOf(RecordQueryPlanWithIndex.class));
+        RecordQueryPlanWithIndex planWithIndex = (RecordQueryPlanWithIndex) childPlan.getLeft();
+        IndexKeyValueToPartialRecord partialRecord = IndexKeyValueToPartialRecord.newBuilder(TestRecords1Proto.MySimpleRecord.getDescriptor())
+                .addField("str_value_indexed", r.nextBoolean() ? IndexKeyValueToPartialRecord.TupleSource.KEY : IndexKeyValueToPartialRecord.TupleSource.VALUE, tuple -> true, ImmutableIntArray.builder().add(r.nextInt(10)).build())
+                .build();
+        return Pair.of(new RecordQueryCoveringIndexPlan(planWithIndex, randomTypeName(r), planWithIndex.getAvailableFields(), partialRecord),
+                String.format("Covering(%s -> %s)", childPlan.getRight(), partialRecord));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomExplodePlan(@Nonnull Random r) {
+        Value collectionValue;
+        if (r.nextBoolean()) {
+            collectionValue = LiteralValue.ofList(List.of(1, 2, 3, 4, 5));
+        } else {
+            collectionValue = ConstantObjectValue.of(CorrelationIdentifier.uniqueID(), r.nextInt(10), new Type.Array(Type.primitiveType(Type.TypeCode.LONG, false)));
+        }
+        return Pair.of(new RecordQueryExplodePlan(collectionValue), String.format("explode([%s])", collectionValue));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomLoadByKeysPlan(@Nonnull Random r) {
+        if (r.nextBoolean()) {
+            String parameterName = randomParameterName(r);
+            return Pair.of(new RecordQueryLoadByKeysPlan(parameterName), String.format("ByKeys($%s)", parameterName));
+        } else {
+            List<Tuple> primaryKeys = new ArrayList<>();
+            int primaryKeyCount = r.nextInt(10);
+            for (int i = 0; i < primaryKeyCount; i++) {
+                primaryKeys.add(Tuple.from(r.nextBoolean(), r.nextLong()));
+            }
+            return Pair.of(new RecordQueryLoadByKeysPlan(primaryKeys), String.format("ByKeys(%s)", primaryKeys));
+        }
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomFilterPlan(@Nonnull Random r, double decay) {
+        Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+        List<QueryComponent> filters = new ArrayList<>();
+        int filterCount = 1 + r.nextInt(4);
+        for (int i = 0; i < filterCount; i++) {
+            filters.add(Query.field(randomFieldName(r)).equalsParameter(randomParameterName(r)));
+        }
+        return Pair.of(new RecordQueryFilterPlan(childPlan.getLeft(), filters),
+                String.format("%s | %s", childPlan.getRight(), filters.size() == 1 ? Iterables.getOnlyElement(filters) : Query.and(filters)));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomFetchFromPartialRecordPlan(@Nonnull Random r, double decay) {
+        Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+        return Pair.of(new RecordQueryFetchFromPartialRecordPlan(childPlan.getLeft(), TranslateValueFunction.unableToTranslate(), Type.primitiveType(Type.TypeCode.UNKNOWN), RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords.PRIMARY_KEY),
+                String.format("Fetch(%s)", childPlan.getRight()));
+    }
+
+    @Nonnull
+    public static Pair<RecordQueryPlan, String> randomInJoinPlan(@Nonnull Random r, double decay) {
+        Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+        double choice = r.nextDouble();
+        boolean sortValues = r.nextBoolean();
+        boolean sortReverse = r.nextBoolean();
+        String innerParam = Bindings.Internal.IN.bindingName(randomParameterName(r));
+
+        List<Long> values = new ArrayList<>();
+        int objCount = r.nextInt(7);
+        for (int i = 0; i < objCount; i++) {
+            values.add(r.nextLong());
+        }
+        if (sortValues) {
+            values.sort(sortReverse ? ((a, b) -> -1 * Long.compare(a, b)) : Long::compare);
+        }
+        String outerParamName = randomParameterName(r);
+
+        RecordQueryInJoinPlan inJoinPlan;
+        String valueString;
+        if (choice < 0.33) {
+            inJoinPlan = new RecordQueryInParameterJoinPlan(childPlan.getLeft(), innerParam, Bindings.Internal.IN, outerParamName, sortValues, sortReverse);
+            valueString = "$" + outerParamName;
+        } else if (choice < 0.67) {
+            inJoinPlan = new RecordQueryInValuesJoinPlan(childPlan.getLeft(), innerParam, Bindings.Internal.IN, ImmutableList.copyOf(values), sortValues, sortReverse);
+            valueString = values.toString();
+        } else {
+            Comparisons.Comparison comparison;
+            if (r.nextBoolean()) {
+                comparison = new Comparisons.ListComparison(Comparisons.Type.IN, values);
+                valueString = values.toString();
+            } else {
+                comparison = new Comparisons.ParameterComparison(Comparisons.Type.IN, outerParamName);
+                valueString = "$" + outerParamName;
+            }
+            inJoinPlan = new RecordQueryInComparandJoinPlan(childPlan.getLeft(), innerParam, Bindings.Internal.IN, comparison, sortValues, sortReverse);
+        }
+
+        return Pair.of(inJoinPlan, String.format("%s WHERE %s IN %s%s%s", childPlan.getRight(), innerParam, valueString, sortValues ? " SORTED" : "", sortValues && sortReverse ? " DESC" : ""));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomPrimaryKeyUnorderedDistinctPlan(@Nonnull Random r, double decay) {
+        Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+        return Pair.of(new RecordQueryUnorderedPrimaryKeyDistinctPlan(childPlan.getLeft()), String.format("%s | UnorderedPrimaryKeyDistinct()", childPlan.getRight()));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomUnorderedDistinctPlan(@Nonnull Random r, double decay) {
+        Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+        KeyExpression expression = Key.Expressions.field(randomAlphabetic(r, 5, 10));
+        return Pair.of(new RecordQueryUnorderedDistinctPlan(childPlan.getLeft(), expression), String.format("%s | UnorderedDistinct(%s)", childPlan.getRight(), expression));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomSortPlan(@Nonnull Random r, double decay) {
+        Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+        KeyExpression expression = Key.Expressions.field(randomAlphabetic(r, 5, 10));
+        boolean reverse = r.nextBoolean();
+        return Pair.of(new RecordQuerySortPlan(childPlan.getLeft(), new RecordQuerySortKey(expression, reverse)), String.format("%s ORDER BY %s%s", childPlan.getRight(), expression, reverse ? " DESC" : ""));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomTypeFilterPlan(@Nonnull Random r, double decay) {
+        Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+        int typeCount = r.nextInt(3) + 1;
+        Set<String> types = new HashSet<>();
+        for (int i = 0; i < typeCount; i++) {
+            types.add(randomTypeName(r));
+        }
+        return Pair.of(new RecordQueryTypeFilterPlan(childPlan.getLeft(), types), String.format("%s | %s", childPlan.getRight(), types));
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomUnionOrIntersectionPlan(@Nonnull Random r, double decay) {
+        List<RecordQueryPlan> plans = new ArrayList<>();
+        List<String> strings = new ArrayList<>();
+        int planCount = r.nextInt(5) + 2;
+        for (int i = 0; i < planCount; i++) {
+            while (true) {
+                Pair<RecordQueryPlan, String> childPlan = randomPlanAndString(r, decay);
+                try {
+                    childPlan.getLeft().isReverse();
+                    plans.add(childPlan.getLeft());
+                    strings.add(childPlan.getRight());
+                    break;
+                } catch (RecordCoreException e) {
+                    // Some plans do not have a defined reverseness. We don't want to include those here,
+                    // so generate a different plan.
+                }
+            }
+        }
+
+        double choice = r.nextDouble();
+        boolean allSameReverse = plans.stream().allMatch(plan -> plan.isReverse() == plans.get(0).isReverse());
+        if (!allSameReverse || choice < 0.2) {
+            return Pair.of(RecordQueryUnorderedUnionPlan.from(plans), "Unordered(" + String.join(" ∪ ", strings) + ")");
+        } else if (choice < 0.6) {
+            KeyExpression comparisonKey = Key.Expressions.field(randomFieldName(r));
+            return Pair.of(RecordQueryIntersectionPlan.from(plans, comparisonKey), String.join(" ∩ ", strings));
+        } else {
+            KeyExpression comparisonKey = Key.Expressions.field(randomFieldName(r));
+            boolean showComparisonKey = r.nextBoolean();
+            String delimiter = String.format(" ∪%s ", showComparisonKey ? comparisonKey : "");
+            return Pair.of(RecordQueryUnionPlan.from(plans, comparisonKey, showComparisonKey), String.join(delimiter, strings));
+        }
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomPlanAndString(@Nonnull Random r, double decay) {
+        // Generate a random plan, but use the decay argument to avoid creating trees with too many
+        // levels (and potentially hitting the maximum stack depth). Every time we a plan with
+        // child plans is chosen, the decay parameter is decreased, which eventually ensures that
+        // a leaf plan is chosen.
+        double leafChoice = r.nextDouble();
+        if (leafChoice * decay < 0.2) {
+            // Choose a leaf plan
+            double choice = r.nextDouble();
+            if (choice < 0.17) {
+                return randomScanPlan(r);
+            } else if (choice < 0.34) {
+                return randomIndexPlan(r);
+            } else if (choice < 0.5) {
+                return randomTextIndexPlan(r);
+            } else if (choice < 0.67) {
+                return randomCoveringIndexPlan(r);
+            } else if (choice < 0.84) {
+                return randomExplodePlan(r);
+            } else {
+                return randomLoadByKeysPlan(r);
+            }
+        } else {
+            // Choose a plan that has child plans
+            double newDecay = decay * 0.8;
+            double choice = r.nextDouble();
+            if (choice < 0.11) {
+                return randomIndexPlan(r);
+            } else if (choice < 0.22) {
+                return randomFetchFromPartialRecordPlan(r, newDecay);
+            } else if (choice < 0.33) {
+                return randomFilterPlan(r, newDecay);
+            } else if (choice < 0.44) {
+                return randomInJoinPlan(r, newDecay);
+            } else if (choice < 0.55) {
+                return randomPrimaryKeyUnorderedDistinctPlan(r, newDecay);
+            } else if (choice < 0.66) {
+                return randomSortPlan(r, newDecay);
+            } else if (choice < 0.77) {
+                return randomTypeFilterPlan(r, newDecay);
+            } else if (choice < 0.88) {
+                return randomUnorderedDistinctPlan(r, newDecay);
+            } else {
+                return randomUnionOrIntersectionPlan(r, newDecay);
+            }
+        }
+    }
+
+    @Nonnull
+    private static Pair<RecordQueryPlan, String> randomPlanAndString(@Nonnull Random r) {
+        return randomPlanAndString(r, 1.0);
+    }
+
+    @RepeatedTest(500)
+    void randomPlanRepresentation() {
+        Random r = ThreadLocalRandom.current();
+        Pair<RecordQueryPlan, String> planAndString = randomPlanAndString(r);
+        assertEquals(planAndString.getRight(), planAndString.getLeft().toString());
+        assertEquals(planAndString.getRight(), PlanStringRepresentation.toString(planAndString.getLeft()));
+    }
+
+    @RepeatedTest(100)
+    void shrinkPlansToFit() {
+        Random r = ThreadLocalRandom.current();
+        Pair<RecordQueryPlan, String> planAndString = randomPlanAndString(r);
+        RecordQueryPlan plan = planAndString.getLeft();
+        String planString = planAndString.getRight();
+        for (int i = 0; i < Math.min(planString.length() + 10, 1000); i++) {
+            String abbreviatedString = PlanStringRepresentation.toString(plan, i);
+            assertEquals(i < planString.length() ? (planString.substring(0, i) + "...") : planString, abbreviatedString);
+        }
+    }
+
+    @Test
+    void doNotEvaluateOutsideOfLimit() {
+        Random r = ThreadLocalRandom.current();
+        List<RecordQueryPlan> plans = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            plans.add(randomPlanAndString(r).getLeft());
+        }
+        final String withoutUnstringable = RecordQueryUnorderedUnionPlan.from(plans).toString();
+
+        plans.add(new UnstringableQueryPlan());
+        RecordQueryUnorderedUnionPlan unorderedUnionPlan = RecordQueryUnorderedUnionPlan.from(plans);
+
+        // Constructing the full plan string should throw an error
+        assertThrows(UnsupportedOperationException.class, unorderedUnionPlan::toString);
+        assertThrows(UnsupportedOperationException.class, () -> PlanStringRepresentation.toString(unorderedUnionPlan));
+
+        // If the unstringable query isn't needed for the string representation, it shouldn't be called, so the
+        // error shouldn't be thrown
+        String lengthLimitedString = PlanStringRepresentation.toString(unorderedUnionPlan, withoutUnstringable.length() - 2);
+        assertEquals(withoutUnstringable.substring(0, withoutUnstringable.length() - 2) + "...", lengthLimitedString);
+    }
+
+    /**
+     * Dummy plan that has a broken {@link #toString()} implementation. This class cannot be executed, but it
+     * can be used during testing to validate that the visitor does not attempt to create a string representation
+     * of a plan if the size limit has already been hit.
+     */
+    private static class UnstringableQueryPlan implements RecordQueryPlan {
+        private final boolean reverse;
+
+        public UnstringableQueryPlan() {
+            this(false);
+        }
+
+        public UnstringableQueryPlan(boolean reverse) {
+            this.reverse = reverse;
+        }
+
+        @Nonnull
+        @Override
+        public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final byte[] continuation, @Nonnull final ExecuteProperties executeProperties) {
+            throw new UnsupportedOperationException("cannot execute unstringable plan");
+        }
+
+        @Nonnull
+        public String toString() {
+            throw new UnsupportedOperationException("cannot call toString on unstringable plan");
+        }
+
+        @Override
+        public int planHash(@Nonnull final PlanHashKind hashKind) {
+            return hashCodeWithoutChildren();
+        }
+
+        @Nonnull
+        @Override
+        public Set<CorrelationIdentifier> getCorrelatedTo() {
+            return Collections.emptySet();
+        }
+
+        @Nonnull
+        @Override
+        public PlannerGraph rewritePlannerGraph(@Nonnull final List<? extends PlannerGraph> childGraphs) {
+            throw new UnsupportedOperationException("cannot run operation on unstringable plan");
+        }
+
+        @Nonnull
+        @Override
+        public Value getResultValue() {
+            return new NullValue(Type.primitiveType(Type.TypeCode.UNKNOWN, true));
+        }
+
+        @Nonnull
+        @Override
+        public List<? extends Quantifier> getQuantifiers() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean equalsWithoutChildren(@Nonnull final RelationalExpression other, @Nonnull final AliasMap equivalences) {
+            return other instanceof UnstringableQueryPlan && ((UnstringableQueryPlan)other).isReverse() == reverse;
+        }
+
+        @Override
+        public int hashCodeWithoutChildren() {
+            return reverse ? 1 : -1;
+        }
+
+        @Nonnull
+        @Override
+        public RelationalExpression translateCorrelations(@Nonnull final TranslationMap translationMap, @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
+            return this;
+        }
+
+        @Override
+        public boolean isReverse() {
+            return reverse;
+        }
+
+        @Override
+        public boolean hasRecordScan() {
+            return false;
+        }
+
+        @Override
+        public boolean hasFullRecordScan() {
+            return false;
+        }
+
+        @Override
+        public boolean hasIndexScan(@Nonnull final String indexName) {
+            return false;
+        }
+
+        @Nonnull
+        @Override
+        public Set<String> getUsedIndexes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean hasLoadBykeys() {
+            return false;
+        }
+
+        @Override
+        public void logPlanStructure(final StoreTimer timer) {
+
+        }
+
+        @Override
+        public int getComplexity() {
+            return 1;
+        }
+
+        @Nonnull
+        @Override
+        public List<RecordQueryPlan> getChildren() {
+            return Collections.emptyList();
+        }
+
+        @Nonnull
+        @Override
+        public AvailableFields getAvailableFields() {
+            return AvailableFields.NO_FIELDS;
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `RecordQueryPlanVisitor` called `PlanStringRepresentation`. It encapsulates the job of constructing the query plan string for a given query plan tree, and it has a parameter to allow for the maximum size of such a string to be capped. This allows for arbitrarily large and complex plans to be packed into a string of fixed size. This can then in turn be used to limit the amount data logged for those larger plans.

An effort was made to keep plan strings the same. Note that the `toString` implementations on the plan objects has been replaced with the new visitor to avoid having two implementations of plan-object-to-explain-string implementations. To test that strings were kept the same, the randomized tester that was added here was run with the old `toString` implementations. Then the implementations were switched over to use the new visitor without changing the test. The exceptions here are:

* Previously, explode plans had an unmatched `]` that appears to have been a typo. In particular, it would generate strings like `explode(@2])`. I've added in a new `[` to match it, so the strings now look like `explode([@2])`
* For `RecordQueryInValuesJoinPlan`, the explain string didn't include whether the values were sorted (ascending or descending). All of the other `InSource`s did, so the new string representation aligns that `InSource` with the other `RecordQueryInJoinPlan` string representations

This resolves #2112.