### PR TITLE
Avoid choosing filtered index for unfiltered scan

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Filtered match candidate is incorrectly considered for unfiltered scan [(Issue #2118)](https://github.com/FoundationDB/fdb-record-layer/issues/2118)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/SelectExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/SelectExpression.java
@@ -406,7 +406,7 @@ public class SelectExpression implements RelationalExpressionWithChildren.Childr
         if (getPredicates().isEmpty()) {
             final var allNonFiltering = candidateSelectExpression.getPredicates()
                     .stream()
-                    .allMatch(queryPredicate -> queryPredicate instanceof PredicateWithValueAndRanges || queryPredicate.isTautology());
+                    .allMatch(QueryPredicate::isTautology);
             if (allNonFiltering) {
                 return MatchInfo.tryMerge(partialMatchMap, mergedParameterBindingMap, PredicateMap.empty(), remainingValueComputationOptional)
                         .map(ImmutableList::of)
@@ -500,9 +500,7 @@ public class SelectExpression implements RelationalExpressionWithChildren.Childr
                     // unmapped, we can (and should) remove it from the unmapped other set now. The reasoning is that this predicate is
                     // not filtering, so it does not cause records to be filtered that are not filtered on the query side.
                     //
-                    remainingUnmappedCandidatePredicates
-                            .removeIf(queryPredicate -> (queryPredicate instanceof Placeholder && !((Placeholder)queryPredicate).isConstraining()) ||
-                                                        queryPredicate.isTautology());
+                    remainingUnmappedCandidatePredicates.removeIf(QueryPredicate::isTautology);
 
                     if (!remainingUnmappedCandidatePredicates.isEmpty()) {
                         return ImmutableList.of();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
@@ -142,7 +142,9 @@ public class ExistsPredicate implements LeafQueryPredicate {
     @Nonnull
     @Override
     public Optional<PredicateMapping> impliesCandidatePredicate(@NonNull final AliasMap aliasMap, @Nonnull final QueryPredicate candidatePredicate, final @Nonnull EvaluationContext evaluationContext) {
-        if (candidatePredicate instanceof ExistsPredicate) {
+        if (candidatePredicate instanceof Placeholder) {
+            return Optional.empty();
+        } else if (candidatePredicate instanceof ExistsPredicate) {
             final ExistsPredicate candidateExistsPredicate = (ExistsPredicate)candidatePredicate;
             if (!existentialAlias.equals(aliasMap.getTarget(candidateExistsPredicate.getExistentialAlias()))) {
                 return Optional.empty();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
@@ -64,13 +64,18 @@ public class Placeholder extends PredicateWithValueAndRanges implements WithAlia
         return false;
     }
 
+    @Override
+    public boolean isTautology() {
+        return !isConstraining();
+    }
+
     @Nonnull
     public static Placeholder newInstance(@Nonnull Value value, @Nonnull CorrelationIdentifier parameterAlias) {
         return new Placeholder(value, ImmutableSet.of(), parameterAlias);
     }
 
     public boolean isConstraining() {
-        return !getRanges().isEmpty();
+        return getRanges().stream().anyMatch(RangeConstraints::isConstraining);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
@@ -236,10 +236,6 @@ public class PredicateWithValueAndRanges implements PredicateWithValue {
             return Optional.empty();
         }
 
-        if (candidatePredicate.isTautology()) {
-            return Optional.of(new PredicateMapping(this, candidatePredicate, (ignore, alsoIgnore) -> injectCompensationFunctionMaybe()));
-        }
-
         if (candidatePredicate instanceof PredicateWithValueAndRanges) {
             final var candidate = (PredicateWithValueAndRanges)candidatePredicate;
 
@@ -287,6 +283,10 @@ public class PredicateWithValueAndRanges implements PredicateWithValue {
                     }, Optional.empty(), Optional.of(captureConstraint(candidate))));
                 }
             }
+        }
+
+        if (candidatePredicate.isTautology()) {
+            return Optional.of(new PredicateMapping(this, candidatePredicate, (ignore, alsoIgnore) -> injectCompensationFunctionMaybe()));
         }
 
         //

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/QueryPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/QueryPredicate.java
@@ -164,6 +164,10 @@ public interface QueryPredicate extends Correlated<QueryPredicate>, TreeLike<Que
     default Optional<PredicateMapping> impliesCandidatePredicate(@NonNull AliasMap aliasMap,
                                                                  @Nonnull final QueryPredicate candidatePredicate,
                                                                  @Nonnull final EvaluationContext evaluationContext) {
+        if (candidatePredicate instanceof Placeholder) {
+            return Optional.empty();
+        }
+
         if (candidatePredicate.isTautology()) {
             return Optional.of(new PredicateMapping(this,
                     candidatePredicate,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/RangeConstraints.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/RangeConstraints.java
@@ -111,6 +111,10 @@ public class RangeConstraints implements PlanHashable, Correlated<RangeConstrain
         return result.build();
     }
 
+    public boolean isConstraining() {
+        return evaluableRange != null || !deferredRanges.isEmpty();
+    }
+
     /**
      * Computes a list of {@link Comparisons.Comparison} from this {@link RangeConstraints}.
      *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/SparseIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/SparseIndexTest.java
@@ -42,11 +42,11 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSort
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers;
-import com.apple.foundationdb.record.query.plan.cascades.predicates.RangeConstraints;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.OrPredicate;
-import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
-import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.PredicateWithValueAndRanges;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.RangeConstraints;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
@@ -58,8 +58,10 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Tag;
 
 import javax.annotation.Nonnull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
@@ -123,6 +125,19 @@ public class SparseIndexTest extends FDBRecordStoreQueryTestBase {
         assertMatchesExactly(plan, mapPlan(descendantPlans(scanPlan())));
     }
 
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    public void sparseIndexIsNotPickedWhenDoingFullScan() throws Exception {
+        final var compileTimeRange = RangeConstraints.newBuilder();
+        compileTimeRange.addComparisonMaybe(new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN, 100));
+        final var recordType = Type.Record.fromDescriptor(TestRecords1Proto.MySimpleRecord.getDescriptor());
+        complexQuerySetup(metaData -> setupIndex(metaData, PredicateWithValueAndRanges.sargable(FieldValue.ofFieldName(QuantifiedObjectValue.of(Quantifier.current(), recordType), "num_value_2"),
+                compileTimeRange.build().orElseThrow()).toResidualPredicate()));
+        final var cascadesPlanner = (CascadesPlanner)planner;
+        final var plan = planQueryWithAllowedIndexes(cascadesPlanner, Optional.of(Set.of("SparseIndex")), false);
+        assertMatchesExactly(plan, mapPlan(descendantPlans(scanPlan())));
+    }
+
+
     /**
      * Appends a filtered (sparse) {@link Index} to the {@link RecordMetaData} object with a specific {@link QueryPredicate}.
      *
@@ -145,10 +160,12 @@ public class SparseIndexTest extends FDBRecordStoreQueryTestBase {
     /**
      * Constructs query {@code SELECT num_value_2 FROM MySimpleRecord WHERE num_value_2 > 50} using the provided metadata.
      * @param metadata The record metadata.
+     * @param addPredicate if {@code true} attaches a predicate to the query, otherwise it does not.
      * @return A graph expansion representing the query.
      */
     @Nonnull
-    private static GroupExpressionRef<RelationalExpression> constructQueryWithPredicate(@Nonnull final RecordMetaData metadata) {
+    private static GroupExpressionRef<RelationalExpression> constructQueryWithPredicate(@Nonnull final RecordMetaData metadata,
+                                                                                        boolean addPredicate) {
         final var allRecordTypes = ImmutableSet.of("MySimpleRecord", "MyOtherRecord");
         var qun =
                 Quantifier.forEach(GroupExpressionRef.of(
@@ -163,7 +180,9 @@ public class SparseIndexTest extends FDBRecordStoreQueryTestBase {
 
         final var num2Value = FieldValue.ofFieldName(qun.getFlowedObjectValue(), "num_value_2");
         final var queryBuilder = GraphExpansion.builder();
-        queryBuilder.addPredicate(new ValuePredicate(num2Value, new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN, 50)));
+        if (addPredicate) {
+            queryBuilder.addPredicate(new ValuePredicate(num2Value, new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN, 50)));
+        }
         queryBuilder.addQuantifier(qun);
         queryBuilder.addResultColumn(Column.unnamedOf(num2Value));
         final var query = queryBuilder.build().buildSelect();
@@ -181,9 +200,26 @@ public class SparseIndexTest extends FDBRecordStoreQueryTestBase {
      */
     @Nonnull
     private static RecordQueryPlan planQuery(@Nonnull final CascadesPlanner planner) {
+        return planQueryWithAllowedIndexes(planner, Optional.empty(), true);
+    }
+
+    /**
+     * Generates query {@code SELECT num_value_2 FROM MySimpleRecord WHERE num_value_2 > 50} using {@link CascadesPlanner}
+     * with a list of allowed indexes and returns an optimized physical plan.
+     *
+     * @param planner The planner.
+     * @param allowedIndexes A list of allowed indexes.
+     * @param addQueryPredicate if {@code true} attaches a predicate to the query, otherwise it does not.
+     * @return optimized query of {@code SELECT num_value_2 FROM MySimpleRecord WHERE num_value_2 > 50}
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @Nonnull
+    private static RecordQueryPlan planQueryWithAllowedIndexes(@Nonnull final CascadesPlanner planner,
+                                                               @Nonnull final Optional<Collection<String>> allowedIndexes,
+                                                               boolean addQueryPredicate) {
         return planner.planGraph(
-                () -> constructQueryWithPredicate(planner.getRecordMetaData()),
-                Optional.empty(),
+                () -> constructQueryWithPredicate(planner.getRecordMetaData(), addQueryPredicate),
+                allowedIndexes,
                 IndexQueryabilityFilter.TRUE,
                 false,
                 EvaluationContext.empty()).getPlan();


### PR DESCRIPTION
If we have a filtered index with a non-tautological filter, this index will be incorrectly considered by Cascades when subsuming a non-filtering select. This provides a fix for this bug and adds a test.

Fixes #2118 