### PR TITLE
Allow placeholders in aggregate index match candidate's underlying SelectExpression

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Allow placeholders in aggregate index match candidate's underlying `SelectExpression` [(Issue #2135)](https://github.com/FoundationDB/fdb-record-layer/issues/2135)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -166,7 +166,6 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
     @Override
     public List<MatchedOrderingPart> computeMatchedOrderingParts(@Nonnull final MatchInfo matchInfo, @Nonnull final List<CorrelationIdentifier> sortParameterIds, final boolean isReverse) {
         final var parameterBindingMap = matchInfo.getParameterBindingMap();
-        final var parameterBindingPredicateMap = matchInfo.getParameterPredicateMap();
 
         final var normalizedKeys =
                 getFullKeyExpression().normalizeKeyForPositions();
@@ -182,9 +181,6 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
             Objects.requireNonNull(parameterId);
             Objects.requireNonNull(normalizedKeyExpression);
             @Nullable final var comparisonRange = parameterBindingMap.get(parameterId);
-            @Nullable final var queryPredicate = parameterBindingPredicateMap.get(parameterId);
-
-            Verify.verify(comparisonRange == null || comparisonRange.getRangeType() == ComparisonRange.Type.EMPTY || queryPredicate != null);
 
             if (normalizedKeyExpression.createsDuplicates()) {
                 if (comparisonRange != null) {
@@ -208,7 +204,6 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
             builder.add(
                     MatchedOrderingPart.of(value,
                             comparisonRange == null ? ComparisonRange.Type.EMPTY : comparisonRange.getRangeType(),
-                            queryPredicate,
                             isReverse));
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
@@ -416,7 +416,7 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
 
         ComparisonRange resultRange = this;
         for (final Comparisons.Comparison comparison : comparisons) {
-            MergeResult mergeResult = comparisonRange.merge(comparison);
+            MergeResult mergeResult = resultRange.merge(comparison);
             resultRange = mergeResult.getComparisonRange();
             residualPredicatesBuilder.addAll(mergeResult.getResidualComparisons());
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchedOrderingPart.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchedOrderingPart.java
@@ -76,12 +76,13 @@ public class MatchedOrderingPart {
             return false;
         }
         final MatchedOrderingPart that = (MatchedOrderingPart)o;
-        return getOrderingPart().equals(that.getOrderingPart());
+        return getOrderingPart().equals(that.getOrderingPart()) &&
+               comparisonRangeType.equals(that.comparisonRangeType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getOrderingPart().hashCode());
+        return Objects.hash(getOrderingPart(), comparisonRangeType);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchedOrderingPart.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchedOrderingPart.java
@@ -20,12 +20,9 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
-import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
-import com.google.common.base.Preconditions;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -38,25 +35,17 @@ public class MatchedOrderingPart {
     @Nonnull
     private final ComparisonRange.Type comparisonRangeType;
 
-    @Nullable
-    private final QueryPredicate queryPredicate;
-
     /**
      * Constructor.
      * @param orderByValue value that defines what to order by
      * @param comparisonRangeType type of comparison
-     * @param queryPredicate reference to {@link QueryPredicate} on query side
      */
     private MatchedOrderingPart(@Nonnull final Value orderByValue,
                                 @Nonnull final ComparisonRange.Type comparisonRangeType,
-                                @Nullable final QueryPredicate queryPredicate,
                                 final boolean isReverse) {
-        Preconditions.checkArgument((queryPredicate == null && comparisonRangeType == ComparisonRange.Type.EMPTY) ||
-                                    (queryPredicate != null && comparisonRangeType != ComparisonRange.Type.EMPTY));
 
         this.orderingPart = OrderingPart.of(orderByValue, isReverse);
         this.comparisonRangeType = comparisonRangeType;
-        this.queryPredicate = queryPredicate;
     }
 
     @Nonnull
@@ -73,11 +62,6 @@ public class MatchedOrderingPart {
         return orderingPart.isReverse();
     }
 
-    @Nullable
-    public QueryPredicate getQueryPredicate() {
-        return queryPredicate;
-    }
-
     @Nonnull
     public ComparisonRange.Type getComparisonRangeType() {
         return comparisonRangeType;
@@ -92,20 +76,18 @@ public class MatchedOrderingPart {
             return false;
         }
         final MatchedOrderingPart that = (MatchedOrderingPart)o;
-        return getOrderingPart().equals(that.getOrderingPart()) &&
-               Objects.equals(getQueryPredicate(), that.getQueryPredicate());
+        return getOrderingPart().equals(that.getOrderingPart());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getOrderingPart().hashCode(), getQueryPredicate());
+        return Objects.hash(getOrderingPart().hashCode());
     }
 
     @Nonnull
     public static MatchedOrderingPart of(@Nonnull final Value orderByValue,
                                          @Nonnull final ComparisonRange.Type comparisonRangeType,
-                                         @Nullable final QueryPredicate queryPredicate,
                                          final boolean isReverse) {
-        return new MatchedOrderingPart(orderByValue, comparisonRangeType, queryPredicate, isReverse);
+        return new MatchedOrderingPart(orderByValue, comparisonRangeType, isReverse);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexLikeMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexLikeMatchCandidate.java
@@ -58,7 +58,6 @@ public interface ValueIndexLikeMatchCandidate extends MatchCandidate, WithBaseQu
                                                                   @Nonnull List<CorrelationIdentifier> sortParameterIds,
                                                                   boolean isReverse) {
         final var parameterBindingMap = matchInfo.getParameterBindingMap();
-        final var parameterBindingPredicateMap = matchInfo.getParameterPredicateMap();
 
         final var normalizedKeys =
                 getFullKeyExpression().normalizeKeyForPositions();
@@ -74,9 +73,6 @@ public interface ValueIndexLikeMatchCandidate extends MatchCandidate, WithBaseQu
             Objects.requireNonNull(parameterId);
             Objects.requireNonNull(normalizedKeyExpression);
             @Nullable final var comparisonRange = parameterBindingMap.get(parameterId);
-            @Nullable final var queryPredicate = parameterBindingPredicateMap.get(parameterId);
-
-            Verify.verify(comparisonRange == null || comparisonRange.getRangeType() == ComparisonRange.Type.EMPTY || queryPredicate != null);
 
             if (normalizedKeyExpression.createsDuplicates()) {
                 if (comparisonRange != null) {
@@ -100,7 +96,6 @@ public interface ValueIndexLikeMatchCandidate extends MatchCandidate, WithBaseQu
             builder.add(
                     MatchedOrderingPart.of(value,
                             comparisonRange == null ? ComparisonRange.Type.EMPTY : comparisonRange.getRangeType(),
-                            queryPredicate,
                             isReverse));
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
@@ -230,7 +230,6 @@ public class WindowedIndexScanMatchCandidate implements ScanWithFetchMatchCandid
                                                                  @Nonnull List<CorrelationIdentifier> sortParameterIds,
                                                                  boolean isReverse) {
         final var parameterBindingMap = matchInfo.getParameterBindingMap();
-        final var parameterBindingPredicateMap = matchInfo.getParameterPredicateMap();
 
         final var normalizedKeys =
                 getFullKeyExpression().normalizeKeyForPositions();
@@ -245,9 +244,6 @@ public class WindowedIndexScanMatchCandidate implements ScanWithFetchMatchCandid
             Objects.requireNonNull(normalizedKeyExpression);
             Objects.requireNonNull(parameterId);
             @Nullable final var comparisonRange = parameterBindingMap.get(parameterId);
-            @Nullable final var queryPredicate = parameterBindingPredicateMap.get(parameterId);
-
-            Verify.verify(comparisonRange == null || comparisonRange.getRangeType() == ComparisonRange.Type.EMPTY || queryPredicate != null);
 
             if (normalizedKeyExpression.createsDuplicates()) {
                 if (comparisonRange != null) {
@@ -273,18 +269,15 @@ public class WindowedIndexScanMatchCandidate implements ScanWithFetchMatchCandid
                 // We need to record that.
                 //
                 @Nullable final var rankComparisonRange = parameterBindingMap.get(rankAlias);
-                @Nullable final var rankQueryPredicate = parameterBindingPredicateMap.get(rankAlias);
 
                 builder.add(
                         MatchedOrderingPart.of(normalizedValue,
                                 rankComparisonRange == null ? ComparisonRange.Type.EMPTY : rankComparisonRange.getRangeType(),
-                                rankQueryPredicate,
                                 isReverse));
             } else {
                 builder.add(
                         MatchedOrderingPart.of(normalizedValue,
                                 comparisonRange == null ? ComparisonRange.Type.EMPTY : comparisonRange.getRangeType(),
-                                queryPredicate,
                                 isReverse));
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
@@ -346,7 +346,7 @@ public class PredicateWithValueAndRanges implements PredicateWithValue {
 
     @Override
     public String toString() {
-        return "(" + getValue() + ranges.stream().map(RangeConstraints::toString).collect(Collectors.joining("||")) + ")";
+        return "(" + getValue() + " " + ranges.stream().map(RangeConstraints::toString).collect(Collectors.joining("||")) + ")";
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
 import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
@@ -63,7 +64,7 @@ import java.util.stream.StreamSupport;
  * A query plan that reconstructs records from the entries in an aggregate index.
  */
 @API(API.Status.INTERNAL)
-public class RecordQueryAggregateIndexPlan implements RecordQueryPlanWithNoChildren, RecordQueryPlanWithMatchCandidate, RecordQueryPlanWithConstraint {
+public class RecordQueryAggregateIndexPlan implements RecordQueryPlanWithNoChildren, RecordQueryPlanWithMatchCandidate, RecordQueryPlanWithConstraint, RecordQueryPlanWithComparisons {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Record-Query-Aggregate-Index-Plan");
 
     @Nonnull
@@ -323,5 +324,11 @@ public class RecordQueryAggregateIndexPlan implements RecordQueryPlanWithNoChild
     @Override
     public QueryPlanConstraint getConstraint() {
         return constraint;
+    }
+
+    @Nonnull
+    @Override
+    public ScanComparisons getScanComparisons() {
+        return indexPlan.getScanComparisons();
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
@@ -83,7 +83,7 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
         setupHookAndAddData(true, false);
         final var cascadesPlanner = (CascadesPlanner)planner;
         final var plan = cascadesPlanner.planGraph(
-                () -> constructGroupByPlan(false),
+                () -> constructGroupByPlan(false, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
                 false,
@@ -104,7 +104,7 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
         setupHookAndAddData(false, false);
         final var cascadesPlanner = (CascadesPlanner)planner;
         Assertions.assertThrows(RecordCoreException.class, () -> cascadesPlanner.planGraph(
-                () -> constructGroupByPlan(false),
+                () -> constructGroupByPlan(false, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
                 false,
@@ -116,7 +116,7 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
         setupHookAndAddData(false, true);
         final var cascadesPlanner = (CascadesPlanner)planner;
         final var plan = cascadesPlanner.planGraph(
-                () -> constructGroupByPlan(false),
+                () -> constructGroupByPlan(false, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
                 false,
@@ -126,11 +126,11 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
     }
 
     @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
-    public void testIndexPlanningWithPredicate() throws Exception {
-        setupHookAndAddData(true, true);
+    public void testIndexPlanningWithPredicateInSelectWhere() throws Exception {
+        setupHookAndAddData(true, false);
         final var cascadesPlanner = (CascadesPlanner)planner;
         final var plan = cascadesPlanner.planGraph(
-                () -> constructGroupByPlan(true),
+                () -> constructGroupByPlan(true, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
                 false,
@@ -147,20 +147,36 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
     }
 
     @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
-    public void testIndexPlanningWithPredicateNoValueIndex() throws Exception {
-        setupHookAndAddData(false, true);
+    public void testIndexPlanningWithPredicateInSelectWhereMatchesAggregateIndex() throws Exception {
+        setupHookAndAddData(true, true);
         final var cascadesPlanner = (CascadesPlanner)planner;
-
-        Assertions.assertThrows(RecordCoreException.class, () -> cascadesPlanner.planGraph(
-                () -> constructGroupByPlan(true),
+        final var plan = cascadesPlanner.planGraph(
+                () -> constructGroupByPlan(true, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
                 false,
-                EvaluationContext.empty()), "Cascades planner could not plan query");
+                EvaluationContext.empty()).getPlan();
+
+        assertMatchesExactly(plan, mapPlan(aggregateIndexPlan().where(scanComparisons(range("[[42],>")))));
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    public void testIndexPlanningWithPredicateInSelectWhereAndSelectHavingMatchesAggregateIndex() throws Exception {
+        setupHookAndAddData(true, true);
+        final var cascadesPlanner = (CascadesPlanner)planner;
+        final var plan = cascadesPlanner.planGraph(
+                () -> constructGroupByPlan(true, true),
+                Optional.empty(),
+                IndexQueryabilityFilter.TRUE,
+                false,
+                EvaluationContext.empty()).getPlan();
+
+        assertMatchesExactly(plan, mapPlan(aggregateIndexPlan().where(scanComparisons(range("[[42],[44]]")))));
     }
 
     @Nonnull
-    private GroupExpressionRef<RelationalExpression> constructGroupByPlan(final boolean withPredicate) {
+    private GroupExpressionRef<RelationalExpression> constructGroupByPlan(final boolean withPredicateInSelectWhere,
+                                                                          final boolean withPredicateInSelectHaving) {
         final var cascadesPlanner = (CascadesPlanner)planner;
         final var allRecordTypes = ImmutableSet.of("MySimpleRecord", "MyOtherRecord");
         var qun =
@@ -194,14 +210,12 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
 
             selectBuilder.addQuantifier(qun).addAllResultColumns(List.of(col1, col2));
 
-            if (withPredicate) {
+            if (withPredicateInSelectWhere) {
                 selectBuilder.addPredicate(new ValuePredicate(num2Value, new Comparisons.SimpleComparison(Comparisons.Type.GREATER_THAN_OR_EQUALS, 42)));
             }
 
             qun = Quantifier.forEach(GroupExpressionRef.of(selectBuilder.build().buildSelect()));
         }
-
-        CorrelationIdentifier groupingExprAlias;
 
         // 2. build the group by expression, for that we need the aggregation expression and the grouping expression.
         {
@@ -221,11 +235,17 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
         // 3. construct the select expression on top containing the final result set
         {
             // construct a result set that makes sense.
-            final var numValue2Reference = Column.of(Type.Record.Field.of(num2Value.getResultType(), Optional.of("num_value_2")),
-                    FieldValue.ofFieldNameAndFuseIfPossible(FieldValue.ofOrdinalNumber(QuantifiedObjectValue.of(qun.getAlias(), qun.getFlowedObjectType()), 0), "num_value_2"));
+            final var numValue2FieldValue = FieldValue.ofFieldNameAndFuseIfPossible(FieldValue.ofOrdinalNumber(QuantifiedObjectValue.of(qun.getAlias(), qun.getFlowedObjectType()), 0), "num_value_2");
+            final var numValue2Reference = Column.of(Type.Record.Field.of(num2Value.getResultType(), Optional.of("num_value_2")), numValue2FieldValue);
             final var aggregateReference = Column.unnamedOf(FieldValue.ofOrdinalNumber(FieldValue.ofOrdinalNumber(ObjectValue.of(qun.getAlias(), qun.getFlowedObjectType()), 0), 0));
 
-            final var result = GraphExpansion.builder().addQuantifier(qun).addAllResultColumns(ImmutableList.of(numValue2Reference,  aggregateReference)).build().buildSelect();
+            final var graphBuilder = GraphExpansion.builder().addQuantifier(qun).addAllResultColumns(ImmutableList.of(numValue2Reference,  aggregateReference));
+
+            if (withPredicateInSelectHaving) {
+                graphBuilder.addPredicate(new ValuePredicate(numValue2FieldValue, new Comparisons.SimpleComparison(Comparisons.Type.LESS_THAN_OR_EQUALS, 44)));
+            }
+
+            final var result = graphBuilder.build().buildSelect();
             qun = Quantifier.forEach(GroupExpressionRef.of(result));
             return GroupExpressionRef.of(new LogicalSortExpression(ImmutableList.of(), false, qun));
         }


### PR DESCRIPTION
Currently we expose placeholders only in the upper `SelectExpression` of the aggregate index match candidate. This matches well with group-by queries that have a predicate on the grouping column(s) in its upper `SelectExpression`. However this fails to match when the group-by query has a predicate in its underlying select because we do not expose any placeholders in the corresponding `SelectExpression` of the aggregate index plan.

This PR addresses this issues by exposing the _same_ set of placeholders in both `SelectExpressions` of the aggregate index plan. I had to do some adaptations to make this work:
* In `MatchInfo`, when trying to merge the parameter binding map, it is now cognizant to the fact that a binding could be associated with multiple `ComparisonRange`s and it attempts to merge them. There was a small bug in `ComparisonRange` merge logic that is fixed as a byproduct of this.
* In `computeMatchedOrderingParts` we used to create a parameter binding predicate _map_ and stash the `QueryPredicate` of each parameter binding in the resulting `MatchedOrderedPart`. This code broke because now it is possible to associate a parameter binding with multiple predicates instead of one. When attempting to refactor this logic, it turned out that stashing the `QueryPredicate` inside hat `MatchedOrderedPart` is not really necessary and is a remnant of previous work on ordering logic, so it is removed, and it caused a bunch of dead code to be cleaned up as a side-effect.
* Refactored the `GroupByTest` to reflect the fact that we can now plan aggregate indexes for more complex groups by plans correctly.

This fixes #2135.