### PR TITLE
Fixes #2136: Lucene query plan toString results in StackOverflow

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Removed infinite recursion from `LuceneIndexQueryPlan`'s `toString` implementation [(Issue #2136)](https://github.com/FoundationDB/fdb-record-layer/issues/2136)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
 import com.apple.foundationdb.record.query.plan.PlanOrderingKey;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.PlanWithOrderingKey;
 import com.apple.foundationdb.record.query.plan.PlanWithStoredFields;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords;
@@ -208,5 +209,23 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
             return new LuceneIndexSpellCheckQueryPlan(indexName, scanParameters, fetchIndexRecords, reverse, planOrderingKey, storedFields);
         }
         throw new RecordCoreException("unknown lucene scan warranted by caller");
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        // To avoid infinite recursion, this calls an explicit method within the plan string representation
+        // visitor. Otherwise, calling visit() would wind up calling visitDefault() in the visitor (as the jump map
+        // used by the visitor does its matching by exact class and doesn't account for inheritance) which in turn
+        // calls toString(). If a method is added to register new RecordQueryPlan implementations with the visitor,
+        // we should switch to using that.
+        //
+        // Note that if this plan is a sub-plan within a larger plan tree, then this will end up creating a
+        // new PlanStringRepresentation object with a new string builder. However, as index plans are always leaf plans,
+        // the amount of waste here is limited to a constant overhead per Lucene leaf node (whereas this could
+        // be much costlier on, say, a union or intersection plan).
+        return new PlanStringRepresentation(Integer.MAX_VALUE)
+                .visitIndexPlan(this)
+                .toString();
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
@@ -76,6 +76,7 @@ import static com.apple.foundationdb.record.query.plan.match.PlanMatchers.unorde
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 
@@ -283,6 +284,11 @@ public class LucenePlannerTest extends FDBRecordStoreTestBase {
                     indexScanType(LuceneScanTypes.BY_LUCENE),
                     scanParams(query(hasToString("text:\"first\" AND text2:\"second\"")))));
             assertThat(plan, matcher);
+
+            assertThat(plan.toString(), allOf(
+                    containsString(COMPLEX_BOTH_INDEX.getName()),
+                    containsString(LuceneScanTypes.BY_LUCENE.toString()),
+                    containsString("text:\"first\" AND text2:\"second\"")));
         }
     }
 
@@ -340,6 +346,13 @@ public class LucenePlannerTest extends FDBRecordStoreTestBase {
                             indexScanType(LuceneScanTypes.BY_LUCENE),
                             scanParams(query(hasToString("text2:\"second\""))))));
             assertThat(plan, matcher);
+            assertThat(plan.toString(), allOf(
+                    containsString(COMPLEX_TEXT1_INDEX.getName()),
+                    containsString(COMPLEX_TEXT2_INDEX.getName()),
+                    containsString("text:\"first\""),
+                    containsString("text2:\"second\""),
+                    containsString(LuceneScanTypes.BY_LUCENE.toString())
+            ));
         }
     }
 


### PR DESCRIPTION
This adds an explicit implementation of `toString` to the Lucene query plan that calls the right method of a the plan string representation class in order to simulate the old behavior (which was to inherit its `toString` from `RecordQueryIndexPlan`). The other thing that occurred to me was to update `visitDefault` so that it would do something else if we were in `visitDefault` but had a `RecordQueryIndexPlan`. This could either be specific to a `RecordQueryIndexPlan`, or it could walk up the class hierarchy until it found a plan with a known `visit` implementation. I went with the approach I did because it seemed like this approach gives classes outside of `fdb-record-layer-core` the best ability to chose their own `toString` implementations, but there is some waste. In particular, each `LuceneIndexQueryPlan` in the plan tree will create its own `PlanStringRepresentation` class (and underlying `StringBuilder`), but note that these plans don't have any children, so the relative amount that this should cause waste should be relatively contained.

This fixes #2136.