### PR TITLE
Fix grouping requested order if it is empty

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix grouping requested order if it is empty [(Issue #2150)](https://github.com/FoundationDB/fdb-record-layer/issues/2150)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
@@ -213,8 +213,13 @@ public class Ordering {
     public boolean satisfiesGroupingValues(@Nonnull final Set<Value> requestedGroupingValues) {
         final var normalizedRequestedOrderingValues =
                 requestedGroupingValues.stream()
-                        .filter(requestedOrderingValue -> !equalityBoundValueMap.containsKey(requestedOrderingValue))
+                        .filter(requestedGroupingValue -> !equalityBoundValueMap.containsKey(requestedGroupingValue))
                         .collect(ImmutableSet.toImmutableSet());
+
+        // no ordering is requested.
+        if (normalizedRequestedOrderingValues.isEmpty()) {
+            return true;
+        }
 
         final var filteredOrderingSet = orderingSet.filterIndependentElements(keyPart -> !equalityBoundValueMap.containsKey(keyPart.getValue()));
         final var permutations = TopologicalSort.topologicalOrderPermutations(filteredOrderingSet);


### PR DESCRIPTION
If the requested grouping order is effectively empty, e.g. in cases where we the grouping value appears in an equality predicate in select-where, we currently considering it unsatisfiable by any ordering. But on the contrary, it should be satisfiable by any order.

This fixes #2150.