### PR TITLE
Shrink Lucene Block Size to save in read overhead... #2155

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -95,7 +95,7 @@ import static org.apache.lucene.codecs.lucene86.Lucene86SegmentInfoFormat.SI_EXT
 @NotThreadSafe
 public class FDBDirectory extends Directory {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDirectory.class);
-    public static final int DEFAULT_BLOCK_SIZE = 16_384;
+    public static final int DEFAULT_BLOCK_SIZE = 1_024;
     public static final int DEFAULT_MAXIMUM_SIZE = 1024;
     public static final int DEFAULT_CONCURRENCY_LEVEL = 16;
     public static final int DEFAULT_INITIAL_CAPACITY = 128;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
@@ -45,7 +45,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
     private static final String FILE_NAME = "y";
     private static final String FILE_NAME_TWO = "z";
     private static final Random RANDOM = new Random();
-    private static final byte[] BLOCK_ARRAY_100 = new byte[100 * 16 * 1024];
+    private static final byte[] BLOCK_ARRAY_100 = new byte[100 * FDBDirectory.DEFAULT_BLOCK_SIZE];
 
     static {
         RANDOM.nextBytes(BLOCK_ARRAY_100);
@@ -90,7 +90,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
-        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 2 * 16 * 1024);
+        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 2 * FDBDirectory.DEFAULT_BLOCK_SIZE);
         assertEquals("[(1,0), (1,1)]", directoryCacheToString());
     }
 
@@ -106,10 +106,10 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
-        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * 16 * 1024);
+        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * FDBDirectory.DEFAULT_BLOCK_SIZE);
         assertEquals("[(1,0), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (1,8), (1,9)]",
                 directoryCacheToString());
-        byte[] fooey = new byte[16 * 1024];
+        byte[] fooey = new byte[FDBDirectory.DEFAULT_BLOCK_SIZE];
         blocks.readBytes(fooey, 0, fooey.length); // 1 block (refresh)
         assertEquals("[(1,0), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (1,8), (1,9), (1,10)]",
                 directoryCacheToString());
@@ -118,7 +118,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         assertEquals("[(1,0), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (1,8), (1,9), (1,10), (1,11), " +
                      "(1,12)]",
                 directoryCacheToString());
-        fooey = new byte[10 * 16 * 1024];
+        fooey = new byte[10 * FDBDirectory.DEFAULT_BLOCK_SIZE];
         blocks.readBytes(fooey, 0, fooey.length); // another block, no fetch
         assertEquals("[(1,0), (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (1,7), (1,8), (1,9), (1,10), (1,11), " +
                      "(1,12), (1,13), (1,14), (1,15), (1,16), (1,17), (1,18), (1,19), (1,20), (1,21), (1,22)]",
@@ -133,9 +133,9 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
-        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * 16 * 1024);
+        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * FDBDirectory.DEFAULT_BLOCK_SIZE);
         assertEquals(10, directory.getBlockCache().asMap().size());
-        blocks.seek(16L * 1024L);
+        blocks.seek(FDBDirectory.DEFAULT_BLOCK_SIZE);
         assertEquals(11, directory.getBlockCache().asMap().size());
     }
 
@@ -147,9 +147,9 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
-        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * 16 * 1024);
+        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * FDBDirectory.DEFAULT_BLOCK_SIZE);
         assertEquals(10, directory.getBlockCache().asMap().size());
-        blocks.seek(16L * 1024L);
+        blocks.seek(FDBDirectory.DEFAULT_BLOCK_SIZE);
         assertEquals(11, directory.getBlockCache().asMap().size());
     }
 
@@ -175,8 +175,8 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
-        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, (100L * 16L * 1024L));
-        byte[] fooey = new byte[16 * 1024];
+        output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, (100L * FDBDirectory.DEFAULT_BLOCK_SIZE));
+        byte[] fooey = new byte[FDBDirectory.DEFAULT_BLOCK_SIZE];
         List<Pair<Integer, Integer>> state = new ArrayList<>();
         state.add(Pair.of(-1, directory.getBlockCache().asMap().size()));
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Moving from 16K to 1k.

Simple write reads 99K of data vs. 570K when block size is reduced.  This is for 10K emails. 

This will require indexes to be rebuilt that were built before to take advantage of the optimization.

Write Execution 16K
`2023-06-07 15:07:56,074 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_deleted_count="1814" bytes_fetched_count="570024" bytes_read_count="569910" bytes_written_count="11679" check_version_count="1" check_version_micros="19010" close_context_count="1" commit_count="1" commit_micros="38807" commits_count="1" commits_micros="9549" compress_serialized_record_count="1" compress_serialized_record_micros="354" decompress_serialized_record_count="1" decompress_serialized_record_micros="45" deletes_count="35" deserialize_protobuf_record_count="1" deserialize_protobuf_record_micros="276" empty_scans_count="1" fetches_count="4" fetches_micros="39414" get_read_version_count="1" get_read_version_micros="680" get_record_range_raw_first_chunk_count="1" get_record_range_raw_first_chunk_micros="845" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="18925" jni_calls_count="190" load_record_count="1" load_record_key_bytes_count="12" load_record_key_count="1" load_record_micros="1203" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="18923" load_record_store_info_count="1" load_record_store_info_micros="18975" load_record_store_state_count="1" load_record_store_state_micros="18971" load_record_value_bytes_count="1814" lucene_fdb_read_block_count="72" lucene_fdb_read_block_micros="37320" lucene_get_file_length_count="36" lucene_get_file_length_micros="13" lucene_get_increment_calls_count="19" lucene_list_all_count="3" lucene_list_all_micros="983" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="956" lucene_read_block_count="279" lucene_read_block_micros="46293" lucene_write_call_count="19" lucene_write_file_reference_call_count="21" lucene_write_file_reference_size_count="1036" lucene_write_size_count="7481" mutations_count="19" open_context_count="1" range_deletes_count="17" range_fetches_count="4" range_keyvalues_fetched_count="13" range_query_direct_buffer_miss_count="4" range_reads_count="4" reads_count="78" record_bytes_after_compression_count="1813" record_bytes_before_compression_count="4317" replace_record_value_bytes_count="1814" save_record_count="1" save_record_key_bytes_count="12" save_record_key_count="1" save_record_micros="9346" save_record_value_bytes_count="1814" serialize_protobuf_record_count="1" serialize_protobuf_record_micros="32" transaction_time_count="1" transaction_time_micros="82069" wait_check_version_count="1" wait_check_version_micros="19024" wait_commit_count="1" wait_commit_micros="9578" wait_lucene_get_data_block_count="46" wait_lucene_get_data_block_micros="21270" wait_lucene_get_increment_count="1" wait_lucene_get_increment_micros="308" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="931" wait_save_record_count="1" wait_save_record_micros="9356" writes_count="42"
`
Write Execution 1K
`2023-06-07 15:11:40,106 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_deleted_count="1816" bytes_fetched_count="99713" bytes_read_count="99599" bytes_written_count="12424" check_version_count="1" check_version_micros="6426" close_context_count="1" commit_count="1" commit_micros="47236" commits_count="1" commits_micros="6990" compress_serialized_record_count="1" compress_serialized_record_micros="136" decompress_serialized_record_count="1" decompress_serialized_record_micros="39" deletes_count="35" deserialize_protobuf_record_count="1" deserialize_protobuf_record_micros="197" empty_scans_count="1" fetches_count="4" fetches_micros="13673" get_read_version_count="1" get_read_version_micros="2406" get_record_range_raw_first_chunk_count="1" get_record_range_raw_first_chunk_micros="426" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="6329" jni_calls_count="290" load_record_count="1" load_record_key_bytes_count="12" load_record_key_count="1" load_record_micros="672" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="6323" load_record_store_info_count="1" load_record_store_info_micros="6403" load_record_store_state_count="1" load_record_store_state_micros="6404" load_record_value_bytes_count="1816" lucene_fdb_read_block_count="165" lucene_fdb_read_block_micros="50411" lucene_get_file_length_count="36" lucene_get_file_length_micros="14" lucene_get_increment_calls_count="19" lucene_list_all_count="3" lucene_list_all_micros="807" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="769" lucene_read_block_count="434" lucene_read_block_micros="62405" lucene_write_call_count="26" lucene_write_file_reference_call_count="21" lucene_write_file_reference_size_count="1018" lucene_write_size_count="8047" mutations_count="19" open_context_count="1" range_deletes_count="17" range_fetches_count="4" range_keyvalues_fetched_count="13" range_query_direct_buffer_miss_count="4" range_reads_count="4" reads_count="171" record_bytes_after_compression_count="1815" record_bytes_before_compression_count="4317" replace_record_value_bytes_count="1816" save_record_count="1" save_record_key_bytes_count="12" save_record_key_count="1" save_record_micros="8634" save_record_value_bytes_count="1816" serialize_protobuf_record_count="1" serialize_protobuf_record_micros="33" transaction_time_count="1" transaction_time_micros="77182" wait_check_version_count="1" wait_check_version_micros="6437" wait_commit_count="1" wait_commit_micros="7013" wait_lucene_get_data_block_count="107" wait_lucene_get_data_block_micros="32319" wait_lucene_get_increment_count="1" wait_lucene_get_increment_micros="360" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="761" wait_save_record_count="1" wait_save_record_micros="8641" writes_count="49"`

Update Execution 16K
`2023-06-07 15:07:40,889 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_deleted_count="827" bytes_fetched_count="569174" bytes_read_count="569060" bytes_written_count="11659" check_version_count="1" check_version_micros="2387" close_context_count="1" commit_count="1" commit_micros="63916" commits_count="1" commits_micros="9550" compress_serialized_record_count="1" compress_serialized_record_micros="227" decompress_serialized_record_count="1" decompress_serialized_record_micros="43" deletes_count="35" deserialize_protobuf_record_count="1" deserialize_protobuf_record_micros="3322" empty_scans_count="1" fetches_count="4" fetches_micros="5936" get_read_version_count="1" get_read_version_micros="700" get_record_range_raw_first_chunk_count="1" get_record_range_raw_first_chunk_micros="543" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="2287" jni_calls_count="190" load_record_count="1" load_record_key_bytes_count="11" load_record_key_count="1" load_record_micros="4140" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="2288" load_record_store_info_count="1" load_record_store_info_micros="2355" load_record_store_state_count="1" load_record_store_state_micros="2366" load_record_value_bytes_count="827" lucene_fdb_read_block_count="72" lucene_fdb_read_block_micros="29899" lucene_get_file_length_count="36" lucene_get_file_length_micros="16" lucene_get_increment_calls_count="19" lucene_list_all_count="3" lucene_list_all_micros="1171" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="1132" lucene_read_block_count="279" lucene_read_block_micros="36218" lucene_write_call_count="19" lucene_write_file_reference_call_count="21" lucene_write_file_reference_size_count="1035" lucene_write_size_count="7468" mutations_count="19" open_context_count="1" range_deletes_count="17" range_fetches_count="4" range_keyvalues_fetched_count="13" range_query_direct_buffer_miss_count="4" range_reads_count="4" reads_count="78" record_bytes_after_compression_count="1808" record_bytes_before_compression_count="4315" replace_record_value_bytes_count="827" save_record_count="1" save_record_key_bytes_count="11" save_record_key_count="1" save_record_micros="13129" save_record_value_bytes_count="1809" serialize_protobuf_record_count="1" serialize_protobuf_record_micros="47" transaction_time_count="1" transaction_time_micros="94016" wait_check_version_count="1" wait_check_version_micros="2397" wait_commit_count="1" wait_commit_micros="9581" wait_lucene_get_data_block_count="46" wait_lucene_get_data_block_micros="19905" wait_lucene_get_increment_count="1" wait_lucene_get_increment_micros="402" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="1113" wait_save_record_count="1" wait_save_record_micros="13143" writes_count="42"`

Update Execution 1K
`2023-06-07 15:11:23,957 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_deleted_count="829" bytes_fetched_count="99699" bytes_read_count="99585" bytes_written_count="12400" check_version_count="1" check_version_micros="7960" close_context_count="1" commit_count="1" commit_micros="77444" commits_count="1" commits_micros="8537" compress_serialized_record_count="1" compress_serialized_record_micros="400" decompress_serialized_record_count="1" decompress_serialized_record_micros="48" deletes_count="35" deserialize_protobuf_record_count="1" deserialize_protobuf_record_micros="3851" empty_scans_count="1" fetches_count="4" fetches_micros="16922" get_read_version_count="1" get_read_version_micros="1071" get_record_range_raw_first_chunk_count="1" get_record_range_raw_first_chunk_micros="500" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="7863" jni_calls_count="292" load_record_count="1" load_record_key_bytes_count="11" load_record_key_count="1" load_record_micros="4645" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="7862" load_record_store_info_count="1" load_record_store_info_micros="7928" load_record_store_state_count="1" load_record_store_state_micros="7933" load_record_value_bytes_count="829" lucene_fdb_read_block_count="167" lucene_fdb_read_block_micros="69020" lucene_get_file_length_count="36" lucene_get_file_length_micros="21" lucene_get_increment_calls_count="19" lucene_list_all_count="3" lucene_list_all_micros="997" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="968" lucene_read_block_count="438" lucene_read_block_micros="85407" lucene_write_call_count="26" lucene_write_file_reference_call_count="21" lucene_write_file_reference_size_count="1015" lucene_write_size_count="8032" mutations_count="19" open_context_count="1" range_deletes_count="17" range_fetches_count="4" range_keyvalues_fetched_count="13" range_query_direct_buffer_miss_count="4" range_reads_count="4" reads_count="173" record_bytes_after_compression_count="1810" record_bytes_before_compression_count="4315" replace_record_value_bytes_count="829" save_record_count="1" save_record_key_bytes_count="11" save_record_key_count="1" save_record_micros="14613" save_record_value_bytes_count="1811" serialize_protobuf_record_count="1" serialize_protobuf_record_micros="48" transaction_time_count="1" transaction_time_micros="115040" wait_check_version_count="1" wait_check_version_micros="7970" wait_commit_count="1" wait_commit_micros="8590" wait_lucene_get_data_block_count="107" wait_lucene_get_data_block_micros="44555" wait_lucene_get_increment_count="1" wait_lucene_get_increment_micros="353" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="948" wait_save_record_count="1" wait_save_record_micros="14624" writes_count="49"`

Query Execution 16K
`2023-06-07 15:07:25,534 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_fetched_count="940808" bytes_read_count="940712" check_version_count="1" check_version_micros="5227" close_context_count="1" commit_read_only_count="1" commit_read_only_micros="496" commits_count="1" commits_micros="147" empty_scans_count="1" fetches_count="3" fetches_micros="12628" get_read_version_count="1" get_read_version_micros="708" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="5117" jni_calls_count="104" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="5110" load_record_store_info_count="1" load_record_store_info_micros="5213" load_record_store_state_count="1" load_record_store_state_micros="5205" load_scan_entry_count="40" lucene_fdb_read_block_count="86" lucene_fdb_read_block_micros="105581" lucene_index_scan_count="1" lucene_index_scan_micros="73051" lucene_list_all_count="2" lucene_list_all_micros="2787" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="2754" lucene_read_block_count="291" lucene_read_block_micros="113583" lucene_scan_matched_documents_count="40" open_context_count="1" range_fetches_count="3" range_keyvalues_fetched_count="12" range_query_direct_buffer_miss_count="3" range_reads_count="3" reads_count="90" scan_index_keys_count="41" scan_index_keys_micros="89721" transaction_time_count="1" transaction_time_micros="151932" wait_check_version_count="1" wait_check_version_micros="5241" wait_commit_count="1" wait_commit_micros="188" wait_lucene_get_data_block_count="74" wait_lucene_get_data_block_micros="90738" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="2723"`


Query Execution 1K
`2023-06-07 15:11:07,370 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_fetched_count="151898" bytes_read_count="151802" check_version_count="1" check_version_micros="5997" close_context_count="1" commit_read_only_count="1" commit_read_only_micros="1088" commits_count="1" commits_micros="173" empty_scans_count="1" fetches_count="3" fetches_micros="13634" get_read_version_count="1" get_read_version_micros="1690" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="5888" jni_calls_count="250" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="5877" load_record_store_info_count="1" load_record_store_info_micros="5992" load_record_store_state_count="1" load_record_store_state_micros="5977" load_scan_entry_count="40" lucene_fdb_read_block_count="232" lucene_fdb_read_block_micros="267545" lucene_index_scan_count="1" lucene_index_scan_micros="106321" lucene_list_all_count="2" lucene_list_all_micros="2284" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="2249" lucene_read_block_count="551" lucene_read_block_micros="303054" lucene_scan_matched_documents_count="40" open_context_count="1" range_fetches_count="3" range_keyvalues_fetched_count="12" range_query_direct_buffer_miss_count="3" range_reads_count="3" reads_count="236" scan_index_keys_count="41" scan_index_keys_micros="129861" transaction_time_count="1" transaction_time_micros="195228" wait_check_version_count="1" wait_check_version_micros="6007" wait_commit_count="1" wait_commit_micros="215" wait_lucene_get_data_block_count="224" wait_lucene_get_data_block_micros="247825" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="2219"`

