### PR TITLE
Make PointsFormat Codec Lazy to only read when needed for queries #2158

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
@@ -58,6 +58,7 @@ public class LuceneOptimizedCodec extends Codec {
     private final LuceneOptimizedCompoundFormat compoundFormat;
     private final LuceneOptimizedSegmentInfoFormat segmentInfoFormat;
     private final LuceneOptimizedPostingsFormat postingsFormat;
+    private final LuceneOptimizedPointsFormat pointsFormat;
 
     /**
      * Instantiates a new codec.
@@ -79,6 +80,7 @@ public class LuceneOptimizedCodec extends Codec {
         compoundFormat = new LuceneOptimizedCompoundFormat();
         segmentInfoFormat = new LuceneOptimizedSegmentInfoFormat();
         postingsFormat = new LuceneOptimizedPostingsFormat();
+        pointsFormat = new LuceneOptimizedPointsFormat(baseCodec.pointsFormat());
     }
 
 
@@ -129,6 +131,6 @@ public class LuceneOptimizedCodec extends Codec {
 
     @Override
     public PointsFormat pointsFormat() {
-        return baseCodec.pointsFormat();
+        return pointsFormat;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormat.java
@@ -1,0 +1,100 @@
+/*
+ * LuceneOptimizedPointsFormat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.codecs.PointsWriter;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * Lazy Reads the PointsFormat to limit the amount of bytes returned
+ * from FDB.
+ *
+ */
+public class LuceneOptimizedPointsFormat extends PointsFormat {
+
+    PointsFormat pointsFormat;
+
+    public LuceneOptimizedPointsFormat(PointsFormat pointsFormat) {
+        this.pointsFormat = pointsFormat;
+    }
+
+    @Override
+    public PointsWriter fieldsWriter(final SegmentWriteState state) throws IOException {
+        return pointsFormat.fieldsWriter(state);
+    }
+
+    @Override
+    public PointsReader fieldsReader(final SegmentReadState state) throws IOException {
+        return new LazyPointsReader(state);
+    }
+
+    private class LazyPointsReader extends PointsReader {
+
+        private Supplier<PointsReader> pointsReader;
+
+        private boolean initialized;
+
+        private LazyPointsReader(final SegmentReadState state) {
+            pointsReader = Suppliers.memoize(() -> {
+                try {
+                    return pointsFormat.fieldsReader(state);
+                } catch (IOException ioe) {
+                    throw new UncheckedIOException(ioe);
+                } finally {
+                    initialized = true;
+                }
+            });
+        }
+
+        @Override
+        public void checkIntegrity() throws IOException {
+            pointsReader.get().checkIntegrity();
+        }
+
+        @Override
+        public PointValues getValues(final String field) throws IOException {
+            return pointsReader.get().getValues(field);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (initialized) { // Needed to not fetch data...
+                pointsReader.get().close();
+            }
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return pointsReader.get().ramBytesUsed();
+        }
+    }
+
+
+}


### PR DESCRIPTION
Reading from 10K sample emails "session". 

Read Before:

2023-06-08 16:29:49,873 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_fetched_count="151822" bytes_read_count="151726" check_version_count="1" check_version_micros="3009" close_context_count="1" commit_read_only_count="1" commit_read_only_micros="462" commits_count="1" commits_micros="291" empty_scans_count="1" fetches_count="3" fetches_micros="32285" get_read_version_count="1" get_read_version_micros="2040" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="2888" jni_calls_count="250" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="2881" load_record_store_info_count="1" load_record_store_info_micros="3001" load_record_store_state_count="1" load_record_store_state_micros="2988" load_scan_entry_count="40" lucene_fdb_read_block_count="232" lucene_fdb_read_block_micros="231023" lucene_index_scan_count="1" lucene_index_scan_micros="152471" lucene_list_all_count="2" lucene_list_all_micros="27231" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="27195" lucene_read_block_count="540" lucene_read_block_micros="279913" lucene_scan_matched_documents_count="40" open_context_count="1" range_fetches_count="3" range_keyvalues_fetched_count="12" range_query_direct_buffer_miss_count="3" range_reads_count="3" reads_count="236" scan_index_keys_count="41" scan_index_keys_micros="177238" transaction_time_count="1" transaction_time_micros="232221" wait_check_version_count="1" wait_check_version_micros="3019" wait_commit_count="1" wait_commit_micros="324" wait_lucene_get_data_block_count="226" wait_lucene_get_data_block_micros="221064" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="27169"

Read After: (~ -4K)

2023-06-08 16:27:35,369 [INFO] c.a.f.r.p.f.FDBRecordStoreTestBase - committing transaction bytes_fetched_count="147752" bytes_read_count="147656" check_version_count="1" check_version_micros="9557" close_context_count="1" commit_read_only_count="1" commit_read_only_micros="308" commits_count="1" commits_micros="158" empty_scans_count="1" fetches_count="3" fetches_micros="22743" get_read_version_count="1" get_read_version_micros="1100" get_scan_range_raw_first_chunk_count="1" get_scan_range_raw_first_chunk_micros="9412" jni_calls_count="243" load_record_store_index_meta_data_count="1" load_record_store_index_meta_data_micros="9403" load_record_store_info_count="1" load_record_store_info_micros="9539" load_record_store_state_count="1" load_record_store_state_micros="9531" load_scan_entry_count="40" lucene_fdb_read_block_count="225" lucene_fdb_read_block_micros="255296" lucene_index_scan_count="1" lucene_index_scan_micros="111781" lucene_list_all_count="2" lucene_list_all_micros="4355" lucene_load_file_cache_count="1" lucene_load_file_cache_micros="4318" lucene_read_block_count="498" lucene_read_block_micros="305855" lucene_scan_matched_documents_count="40" open_context_count="1" range_fetches_count="3" range_keyvalues_fetched_count="12" range_query_direct_buffer_miss_count="3" range_reads_count="3" reads_count="229" scan_index_keys_count="41" scan_index_keys_micros="133815" transaction_time_count="1" transaction_time_micros="191404" wait_check_version_count="1" wait_check_version_micros="9569" wait_commit_count="1" wait_commit_micros="190" wait_lucene_get_data_block_count="213" wait_lucene_get_data_block_micros="222856" wait_lucene_load_file_cache_count="1" wait_lucene_load_file_cache_micros="4293"
