### PR TITLE
LuceneOptimizedCompoundReader always reads block 0, even when not needed... #2169

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
@@ -71,7 +71,10 @@ final class LuceneOptimizedCompoundReader extends CompoundDirectory {
         this.segmentName = si.name;
         String dataFileName = IndexFileNames.segmentFileName(segmentName, "", LuceneOptimizedCompoundFormat.DATA_EXTENSION);
         String entriesFileName = IndexFileNames.segmentFileName(segmentName, "", LuceneOptimizedCompoundFormat.ENTRIES_EXTENSION);
-        handle = directory.openInput(dataFileName, context); // async
+        if ( !(directory instanceof LuceneOptimizedWrappedDirectory) ) {
+            throw new IOException("Directory Must Be Wrapped");
+        }
+        handle = ((LuceneOptimizedWrappedDirectory) directory).openLazyInput(dataFileName, context, 0, 0L); // attempting not to read
         this.entries = readEntries(si.getId(), directory, entriesFileName); // synchronous
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
@@ -29,6 +29,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.Lock;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -103,6 +104,20 @@ class LuceneOptimizedWrappedDirectory extends Directory {
         } else {
             return wrappedDirectory.openInput(name, context);
         }
+    }
+
+    /**
+     * Opens a lazy input with performing a seek.
+     *
+     * @param name name
+     * @param ioContext ioContext
+     * @param initialOffset offset
+     * @param position current position
+     * @return IndexInput
+     * @throws IOException exception
+     */
+    public IndexInput openLazyInput(@Nonnull final String name, @Nonnull final IOContext ioContext, long initialOffset, long position) throws IOException {
+        return fdbDirectory.openLazyInput(name, ioContext, initialOffset, position);
     }
 
     @Override


### PR DESCRIPTION
This removes a read to block 0 for compound files when we do a single row insert.