### PR TITLE
Revert "Ignore deprecated fields when constructing a Type from ProtoB…

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
@@ -1495,9 +1495,6 @@ public interface Type extends Narrowable<Type> {
             final var fieldsBuilder = ImmutableList.<Field>builder();
             for (final var entry : Objects.requireNonNull(fieldDescriptorMap).entrySet()) {
                 final var fieldDescriptor = entry.getValue();
-                if (fieldDescriptor.getOptions().getDeprecated()) {
-                    continue;
-                }
                 fieldsBuilder.add(
                         new Field(fromProtoType(getTypeSpecificDescriptor(fieldDescriptor),
                                 fieldDescriptor.getType(),


### PR DESCRIPTION
…uf."

This reverts commit 234bef7e835a006632b33c29aa3253d40659f6a3.

`FieldValue.eval` is relying on the field ordinal to retrieve the value from the PB message object, this assumes 1-1 mapping between PB descriptor fields and ordinals, which becomes invalid if we ignore some fields.

We should approach the problem differently, by e.g. continue to add a deprecated field and mark it as deprecated instead of skipping it entirely.