### PR TITLE
LiveDocsFormat will perform a read of the bit vector in the case where we are doing a simple insert. #2178

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
@@ -65,6 +65,7 @@ public class LuceneOptimizedCodec extends Codec {
     private final StoredFieldsFormat storedFieldsFormat;
     private final PostingsFormat defaultPostingsFormat;
     private final DocValuesFormat defaultDocValuesFormat;
+    private final LiveDocsFormat liveDocsFormat;
 
     private final PostingsFormat postingsFormat = new PerFieldPostingsFormat() {
         @Override
@@ -103,6 +104,7 @@ public class LuceneOptimizedCodec extends Codec {
         defaultPostingsFormat = new LuceneOptimizedPostingsFormat(new Lucene84PostingsFormat());
         defaultDocValuesFormat = new LuceneOptimizedDocValuesFormat(new Lucene80DocValuesFormat());
         storedFieldsFormat = new LuceneOptimizedStoredFieldsFormat(baseCodec.storedFieldsFormat());
+        liveDocsFormat = new LuceneOptimizedLiveDocsFormat(baseCodec.liveDocsFormat());
     }
 
 
@@ -143,7 +145,7 @@ public class LuceneOptimizedCodec extends Codec {
 
     @Override
     public LiveDocsFormat liveDocsFormat() {
-        return baseCodec.liveDocsFormat();
+        return liveDocsFormat;
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedLiveDocsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedLiveDocsFormat.java
@@ -1,0 +1,88 @@
+/*
+ * LuceneLiveDocsFormat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.apache.lucene.codecs.LiveDocsFormat;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.Bits;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+
+/**
+ *  Lazy Reads the LiveDocsFormat to limit the amount of bytes returned
+ *  from FDB.
+ *
+ */
+public class LuceneOptimizedLiveDocsFormat extends LiveDocsFormat {
+
+    private LiveDocsFormat liveDocsFormat;
+
+    public LuceneOptimizedLiveDocsFormat(LiveDocsFormat liveDocsFormat) {
+        this.liveDocsFormat = liveDocsFormat;
+    }
+
+    @Override
+    public Bits readLiveDocs(final Directory dir, final SegmentCommitInfo info, final IOContext context) throws IOException {
+        return new LazyBits(dir, info, context);
+    }
+
+    @Override
+    public void writeLiveDocs(final Bits bits, final Directory dir, final SegmentCommitInfo info, final int newDelCount, final IOContext context) throws IOException {
+        liveDocsFormat.writeLiveDocs(bits, dir, info, newDelCount, context);
+    }
+
+    @Override
+    public void files(final SegmentCommitInfo info, final Collection<String> files) throws IOException {
+        liveDocsFormat.files(info, files);
+    }
+
+    private class LazyBits implements Bits {
+
+        private final Supplier<Bits> bits;
+
+        public LazyBits(final Directory dir, final SegmentCommitInfo info, final IOContext context) {
+            bits = Suppliers.memoize(() -> {
+                try {
+                    return liveDocsFormat.readLiveDocs(dir, info, context);
+                } catch (IOException ioe) {
+                    throw new UncheckedIOException(ioe);
+                }
+            });
+        }
+
+        @Override
+        public boolean get(final int index) {
+            return bits.get().get(index);
+        }
+
+        @Override
+        public int length() {
+            return bits.get().length();
+        }
+    }
+
+}


### PR DESCRIPTION
More lazy reading for the single insert use case.