### PR TITLE
FieldInfosFormat requires each segment to fetch their schema definition #2182

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -40,6 +40,8 @@ public class LuceneEvents {
     public enum Events implements StoreTimer.Event {
         /** Time to read a block from Lucene's FDBDirectory. */
         LUCENE_READ_BLOCK("lucene block reads"),
+        /** Time to read a schema from Lucene's FDBDirectory. */
+        LUCENE_READ_SCHEMA("lucene schema read"),
         /** Time to read a lucene block from FBB loader. */
         LUCENE_FDB_READ_BLOCK("lucene read from fdb"),
         /** Time to list all files from Lucene's FDBDirectory. */

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimized60FieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimized60FieldInfosFormat.java
@@ -1,0 +1,334 @@
+/*
+ * LuceneOptimized60FieldInfosFormat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+
+/**
+ * Lucene 6.0 Field Infos format.
+ * <p>Field names are stored in the field info file, with suffix <b>.fnm</b>.
+ * <p>FieldInfos (.fnm) --&gt; Header,FieldsCount, &lt;FieldName,FieldNumber,
+ * FieldBits,DocValuesBits,DocValuesGen,Attributes,DimensionCount,DimensionNumBytes&gt; <sup>FieldsCount</sup>,Footer
+ * <p>Data types:
+ * <ul>
+ *   <li>Header --&gt; {@link CodecUtil#checkIndexHeader IndexHeader}</li>
+ *   <li>FieldsCount --&gt; {@link DataOutput#writeVInt VInt}</li>
+ *   <li>FieldName --&gt; {@link DataOutput#writeString String}</li>
+ *   <li>FieldBits, IndexOptions, DocValuesBits --&gt; {@link DataOutput#writeByte Byte}</li>
+ *   <li>FieldNumber, DimensionCount, DimensionNumBytes --&gt; {@link DataOutput#writeInt VInt}</li>
+ *   <li>Attributes --&gt; {@link DataOutput#writeMapOfStrings Map&lt;String,String&gt;}</li>
+ *   <li>DocValuesGen --&gt; {@link DataOutput#writeLong(long) Int64}</li>
+ *   <li>Footer --&gt; {@link CodecUtil#writeFooter CodecFooter}</li>
+ * </ul>
+ * Field Descriptions:
+ * <ul>
+ *   <li>FieldsCount: the number of fields in this file.</li>
+ *   <li>FieldName: name of the field as a UTF-8 String.</li>
+ *   <li>FieldNumber: the field's number. Note that unlike previous versions of
+ *       Lucene, the fields are not numbered implicitly by their order in the
+ *       file, instead explicitly.</li>
+ *   <li>FieldBits: a byte containing field options.
+ *     <ul>
+ *       <li>The low order bit (0x1) is one for fields that have term vectors
+ *           stored, and zero for fields without term vectors.</li>
+ *       <li>If the second lowest order-bit is set (0x2), norms are omitted for the
+ *           indexed field.</li>
+ *       <li>If the third lowest-order bit is set (0x4), payloads are stored for the
+ *           indexed field.</li>
+ *     </ul>
+ *   </li>
+ *   <li>IndexOptions: a byte containing index options.
+ *     <ul>
+ *       <li>0: not indexed</li>
+ *       <li>1: indexed as DOCS_ONLY</li>
+ *       <li>2: indexed as DOCS_AND_FREQS</li>
+ *       <li>3: indexed as DOCS_AND_FREQS_AND_POSITIONS</li>
+ *       <li>4: indexed as DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS</li>
+ *     </ul>
+ *   </li>
+ *   <li>DocValuesBits: a byte containing per-document value types. The type
+ *       recorded as two four-bit integers, with the high-order bits representing
+ *       <code>norms</code> options, and the low-order bits representing
+ *       {@code DocValues} options. Each four-bit integer can be decoded as such:
+ *     <ul>
+ *       <li>0: no DocValues for this field.</li>
+ *       <li>1: NumericDocValues. ({@link DocValuesType#NUMERIC})</li>
+ *       <li>2: BinaryDocValues. ({@code DocValuesType#BINARY})</li>
+ *       <li>3: SortedDocValues. ({@code DocValuesType#SORTED})</li>
+ *      </ul>
+ *   </li>
+ *   <li>DocValuesGen is the generation count of the field's DocValues. If this is -1,
+ *       there are no DocValues updates to that field. Anything above zero means there
+ *       are updates stored by {@link DocValuesFormat}.</li>
+ *   <li>Attributes: a key-value map of codec-private attributes.</li>
+ *   <li>PointDimensionCount, PointNumBytes: these are non-zero only if the field is
+ *       indexed as points, e.g. using {@link org.apache.lucene.document.LongPoint}</li>
+ * </ul>
+ *
+ * This has been added because the existing header strategy wrote
+ * the file name.
+ *
+ */
+public final class LuceneOptimized60FieldInfosFormat extends FieldInfosFormat {
+    /** Extension of field infos. */
+    static final String EXTENSION = "fnm";
+
+    // Codec header
+    static final String CODEC_NAME = "Lucene60FieldInfos";
+    static final int FORMAT_START = 0;
+    static final int FORMAT_SOFT_DELETES = 1;
+    static final int FORMAT_SELECTIVE_INDEXING = 2;
+    static final int FORMAT_CURRENT = FORMAT_SELECTIVE_INDEXING;
+
+    // Field flags
+    static final byte STORE_TERMVECTOR = 0x1;
+    static final byte OMIT_NORMS = 0x2;
+    static final byte STORE_PAYLOADS = 0x4;
+    static final byte SOFT_DELETES_FIELD = 0x8;
+
+    /** Sole constructor. */
+    public LuceneOptimized60FieldInfosFormat() {
+        // Empty Constructor
+    }
+
+    @Override
+    public FieldInfos read(Directory directory, SegmentInfo segmentInfo, String segmentSuffix, IOContext context) throws IOException {
+        final String fileName = IndexFileNames.segmentFileName(segmentInfo.name, segmentSuffix, EXTENSION);
+        try (ChecksumIndexInput input = directory.openChecksumInput(fileName, context)) {
+            Throwable priorE = null;
+            FieldInfo[] infos = null;
+            try {
+                // CUSTOMIZED FROM CodecUtil.checkIndexHeader()
+                int version = CodecUtil.checkHeader(input,
+                        CODEC_NAME,
+                        FORMAT_START,
+                        FORMAT_CURRENT);
+
+                final int size = input.readVInt(); //read in the size
+                infos = new FieldInfo[size];
+
+                // previous field's attribute map, we share when possible:
+                Map<String, String> lastAttributes = Collections.emptyMap();
+
+                for (int i = 0; i < size; i++) {
+                    String name = input.readString();
+                    final int fieldNumber = input.readVInt();
+                    if (fieldNumber < 0) {
+                        throw new CorruptIndexException("invalid field number for field: " + name + ", fieldNumber=" + fieldNumber, input);
+                    }
+                    byte bits = input.readByte();
+                    boolean storeTermVector = (bits & STORE_TERMVECTOR) != 0;
+                    boolean omitNorms = (bits & OMIT_NORMS) != 0;
+                    boolean storePayloads = (bits & STORE_PAYLOADS) != 0;
+                    boolean isSoftDeletesField = (bits & SOFT_DELETES_FIELD) != 0;
+
+                    final IndexOptions indexOptions = getIndexOptions(input, input.readByte());
+
+                    // DV Types are packed in one byte
+                    final DocValuesType docValuesType = getDocValuesType(input, input.readByte());
+                    final long dvGen = input.readLong();
+                    Map<String, String> attributes = input.readMapOfStrings();
+                    // just use the last field's map if its the same
+                    if (attributes.equals(lastAttributes)) {
+                        attributes = lastAttributes;
+                    }
+                    lastAttributes = attributes;
+                    int pointDataDimensionCount = input.readVInt();
+                    int pointNumBytes;
+                    int pointIndexDimensionCount = pointDataDimensionCount;
+                    if (pointDataDimensionCount != 0) {
+                        if (version >= FORMAT_SELECTIVE_INDEXING) {
+                            pointIndexDimensionCount = input.readVInt();
+                        }
+                        pointNumBytes = input.readVInt();
+                    } else {
+                        pointNumBytes = 0;
+                    }
+
+                    try {
+                        infos[i] = new FieldInfo(name, fieldNumber, storeTermVector, omitNorms, storePayloads,
+                                indexOptions, docValuesType, dvGen, attributes,
+                                pointDataDimensionCount, pointIndexDimensionCount, pointNumBytes, isSoftDeletesField);
+                    } catch (IllegalStateException e) {
+                        throw new CorruptIndexException("invalid fieldinfo for field: " + name + ", fieldNumber=" + fieldNumber, input, e);
+                    }
+                }
+            } catch (RuntimeException exception) {
+                priorE = exception;
+            } finally {
+                CodecUtil.checkFooter(input, priorE);
+            }
+            return new FieldInfos(infos);
+        }
+    }
+
+    static {
+        // We "mirror" DocValues enum values with the constants below; let's try to ensure if we add a new DocValuesType while this format is
+        // still used for writing, we remember to fix this encoding:
+        assert DocValuesType.values().length == 6;
+    }
+
+    private static byte docValuesByte(DocValuesType type) {
+        switch (type) {
+            case NONE:
+                return 0;
+            case NUMERIC:
+                return 1;
+            case BINARY:
+                return 2;
+            case SORTED:
+                return 3;
+            case SORTED_SET:
+                return 4;
+            case SORTED_NUMERIC:
+                return 5;
+            default:
+                // BUG
+                throw new AssertionError("unhandled DocValuesType: " + type);
+        }
+    }
+
+    private static DocValuesType getDocValuesType(IndexInput input, byte b) throws IOException {
+        switch (b) {
+            case 0:
+                return DocValuesType.NONE;
+            case 1:
+                return DocValuesType.NUMERIC;
+            case 2:
+                return DocValuesType.BINARY;
+            case 3:
+                return DocValuesType.SORTED;
+            case 4:
+                return DocValuesType.SORTED_SET;
+            case 5:
+                return DocValuesType.SORTED_NUMERIC;
+            default:
+                throw new CorruptIndexException("invalid docvalues byte: " + b, input);
+        }
+    }
+
+    static {
+        // We "mirror" IndexOptions enum values with the constants below; let's try to ensure if we add a new IndexOption while this format is
+        // still used for writing, we remember to fix this encoding:
+        assert IndexOptions.values().length == 5;
+    }
+
+    private static byte indexOptionsByte(IndexOptions indexOptions) {
+        switch (indexOptions) {
+            case NONE:
+                return 0;
+            case DOCS:
+                return 1;
+            case DOCS_AND_FREQS:
+                return 2;
+            case DOCS_AND_FREQS_AND_POSITIONS:
+                return 3;
+            case DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS:
+                return 4;
+            default:
+                // BUG:
+                throw new AssertionError("unhandled IndexOptions: " + indexOptions);
+        }
+    }
+
+    private static IndexOptions getIndexOptions(IndexInput input, byte b) throws IOException {
+        switch (b) {
+            case 0:
+                return IndexOptions.NONE;
+            case 1:
+                return IndexOptions.DOCS;
+            case 2:
+                return IndexOptions.DOCS_AND_FREQS;
+            case 3:
+                return IndexOptions.DOCS_AND_FREQS_AND_POSITIONS;
+            case 4:
+                return IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS;
+            default:
+                // BUG
+                throw new CorruptIndexException("invalid IndexOptions byte: " + b, input);
+        }
+    }
+
+    @Override
+    public void write(Directory directory, SegmentInfo segmentInfo, String segmentSuffix, FieldInfos infos, IOContext context) throws IOException {
+        final String fileName = IndexFileNames.segmentFileName(segmentInfo.name, segmentSuffix, EXTENSION);
+        try (IndexOutput output = directory.createOutput(fileName, context)) {
+            // CUSTOMIZED FROM CodecUtil.writeIndexHeader()
+            CodecUtil.writeHeader(output, CODEC_NAME, FORMAT_CURRENT);
+            output.writeVInt(infos.size());
+            for (FieldInfo fi : infos) {
+                fi.checkConsistency();
+
+                output.writeString(fi.name);
+                output.writeVInt(fi.number);
+
+                byte bits = 0x0;
+                if (fi.hasVectors()) {
+                    bits |= STORE_TERMVECTOR;
+                }
+                if (fi.omitsNorms()) {
+                    bits |= OMIT_NORMS;
+                }
+                if (fi.hasPayloads()) {
+                    bits |= STORE_PAYLOADS;
+                }
+                if (fi.isSoftDeletesField()) {
+                    bits |= SOFT_DELETES_FIELD;
+                }
+                output.writeByte(bits);
+
+                output.writeByte(indexOptionsByte(fi.getIndexOptions()));
+
+                // pack the DV type and hasNorms in one byte
+                output.writeByte(docValuesByte(fi.getDocValuesType()));
+                output.writeLong(fi.getDocValuesGen());
+                output.writeMapOfStrings(fi.attributes());
+                output.writeVInt(fi.getPointDimensionCount());
+                if (fi.getPointDimensionCount() != 0) {
+                    output.writeVInt(fi.getPointIndexDimensionCount());
+                    output.writeVInt(fi.getPointNumBytes());
+                }
+            }
+            CodecUtil.writeFooter(output);
+        }
+    }
+
+}
+

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
@@ -66,6 +66,7 @@ public class LuceneOptimizedCodec extends Codec {
     private final PostingsFormat defaultPostingsFormat;
     private final DocValuesFormat defaultDocValuesFormat;
     private final LiveDocsFormat liveDocsFormat;
+    private final FieldInfosFormat fieldInfosFormat;
 
     private final PostingsFormat postingsFormat = new PerFieldPostingsFormat() {
         @Override
@@ -105,6 +106,7 @@ public class LuceneOptimizedCodec extends Codec {
         defaultDocValuesFormat = new LuceneOptimizedDocValuesFormat(new Lucene80DocValuesFormat());
         storedFieldsFormat = new LuceneOptimizedStoredFieldsFormat(baseCodec.storedFieldsFormat());
         liveDocsFormat = new LuceneOptimizedLiveDocsFormat(baseCodec.liveDocsFormat());
+        fieldInfosFormat = new LuceneOptimizedFieldInfosFormat(new LuceneOptimized60FieldInfosFormat());
     }
 
 
@@ -130,7 +132,7 @@ public class LuceneOptimizedCodec extends Codec {
 
     @Override
     public FieldInfosFormat fieldInfosFormat() {
-        return baseCodec.fieldInfosFormat();
+        return fieldInfosFormat;
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
@@ -44,6 +44,7 @@ public class LuceneOptimizedCompoundFormat extends CompoundFormat {
     /** Extension of compound file entries. */
     public static final String ENTRIES_EXTENSION = "cfe";
 
+    public static final String FIELD_INFO_EXTENSION = "fnm";
     public static final String DATA_CODEC = "Lucene50CompoundData";
     public static final String ENTRY_CODEC = "Lucene50CompoundEntries";
     public static final int VERSION_START = 0;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
@@ -165,4 +165,9 @@ final class LuceneOptimizedCompoundReader extends CompoundDirectory {
     public void checkIntegrity() throws IOException {
         CodecUtil.checksumEntireFile(handle);
     }
+
+    public Directory getDirectory() {
+        return directory;
+    }
+
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
@@ -1,0 +1,55 @@
+/*
+ * LuceneOptimizedFieldInfosFormat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+
+import java.io.IOException;
+
+/**
+ * This class attempts to reduce the number of .fnm entries when numerous segments are present in FDB.
+ *
+ */
+public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
+
+    private final FieldInfosFormat fieldInfosFormat;
+
+    public LuceneOptimizedFieldInfosFormat(FieldInfosFormat fieldInfosFormat) {
+        this.fieldInfosFormat = fieldInfosFormat;
+    }
+
+    @Override
+    public FieldInfos read(final Directory directory, final SegmentInfo segmentInfo, final String segmentSuffix, final IOContext iocontext) throws IOException {
+        return fieldInfosFormat.read(
+                ((LuceneOptimizedCompoundReader) directory).getDirectory(),
+                segmentInfo, segmentSuffix, iocontext);
+    }
+
+    @Override
+    public void write(final Directory directory, final SegmentInfo segmentInfo, final String segmentSuffix, final FieldInfos infos, final IOContext context) throws IOException {
+        fieldInfosFormat.write(new LuceneOptimizedWrappedDirectory(directory, infos), segmentInfo, segmentSuffix, infos, context);
+    }
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
@@ -22,6 +22,9 @@ package com.apple.foundationdb.record.lucene.codec;
 
 import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
 import com.apple.foundationdb.record.lucene.directory.FDBLuceneFileReference;
+import com.google.common.primitives.Longs;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
@@ -29,12 +32,17 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.Lock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCompoundFormat.DATA_EXTENSION;
 
@@ -45,12 +53,19 @@ import static com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCompound
  *
  */
 class LuceneOptimizedWrappedDirectory extends Directory {
+    private static final Logger LOG = LoggerFactory.getLogger(LuceneOptimizedWrappedDirectory.class);
     private final FDBDirectory fdbDirectory;
     private final Directory wrappedDirectory;
+    private FieldInfos fieldInfos;
 
     LuceneOptimizedWrappedDirectory(Directory directory) {
         this.wrappedDirectory = directory;
         this.fdbDirectory = (FDBDirectory)FilterDirectory.unwrap(directory);
+    }
+
+    LuceneOptimizedWrappedDirectory(Directory directory, FieldInfos fieldInfos) {
+        this(directory);
+        this.fieldInfos = fieldInfos;
     }
 
     @Override
@@ -89,6 +104,27 @@ class LuceneOptimizedWrappedDirectory extends Directory {
                 }
             };
 
+        } else if (FDBDirectory.isFieldInfoFile(name)) {
+            return new LuceneOptimizedWrappedIndexOutput(name) {
+                @Override
+                public void close() throws IOException {
+                    try {
+                        FDBLuceneFileReference reference = new FDBLuceneFileReference(-1, -1, -1, -1);
+                        List<Long> words = getBitSetWords(fieldInfos);
+                        reference.setBitSetWords(words);
+                        byte[] schema = fdbDirectory.readSchema(words).get();
+                        if (schema == null) {
+                            fdbDirectory.writeSchema(words, outputStream.toByteArray()).get();
+                        }
+                        ((FDBDirectory)FilterDirectory.unwrap(fdbDirectory)).writeFDBLuceneFileReference(name, reference);
+                    } catch (InterruptedException ie) {
+                        LOG.error("interrupted exception during close", ie);
+                        Thread.currentThread().interrupt();
+                    } catch (ExecutionException e) {
+                        throw new IOException(e);
+                    }
+                }
+            };
         } else {
             return wrappedDirectory.createOutput(name, context);
         }
@@ -122,6 +158,20 @@ class LuceneOptimizedWrappedDirectory extends Directory {
         } else if (FDBDirectory.isEntriesFile(name)) {
             return new LuceneOptimizedWrappedIndexInput(name,
                     () -> fdbDirectory.getFDBLuceneFileReference(convertToDataFile(name)).getEntries());
+        } else if (FDBDirectory.isFieldInfoFile(name)) {
+            return new LuceneOptimizedWrappedIndexInput(name,
+                    () -> {
+                        try {
+                            return fdbDirectory.readSchema(fdbDirectory.getFDBLuceneFileReference(
+                                    convertToDataFile(name)).getBitSetWords()).get();
+                        } catch (InterruptedException ie) {
+                            LOG.error("Interrupted Exception During Open Input", ie);
+                            Thread.currentThread().interrupt();
+                        } catch (ExecutionException e) {
+                            LOG.error("Execution Exception", e);
+                        }
+                        return null;
+                    });
         } else {
             return wrappedDirectory.openInput(name, context);
         }
@@ -173,11 +223,19 @@ class LuceneOptimizedWrappedDirectory extends Directory {
     public static String convertToDataFile(String name) {
         if (FDBDirectory.isSegmentInfo(name)) {
             return name.substring(0, name.length() - 2) + DATA_EXTENSION;
-        } else if (FDBDirectory.isEntriesFile(name)) {
+        } else if (FDBDirectory.isEntriesFile(name) || FDBDirectory.isFieldInfoFile(name)) {
             return name.substring(0, name.length() - 3) + DATA_EXTENSION;
         } else {
             return name;
         }
 
+    }
+
+    public static List<Long> getBitSetWords(final FieldInfos infos) {
+        BitSet bitSet = new BitSet(infos.size());
+        for (FieldInfo fi : infos) {
+            bitSet.set(fi.number);
+        }
+        return Longs.asList(bitSet.toLongArray());
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
@@ -29,6 +29,7 @@ import com.google.protobuf.ZeroCopyByteString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * A File Reference record laying out the id, size, and block size.
@@ -42,24 +43,28 @@ public class FDBLuceneFileReference {
     private final long blockSize;
     private byte[] segmentInfo;
     private byte[] entries;
+    private List<Long> bitSetWords;
 
     private FDBLuceneFileReference(@Nonnull LuceneFileSystemProto.LuceneFileReference protoMessage) {
         this(protoMessage.getId(), protoMessage.getSize(), protoMessage.getActualSize(), protoMessage.getBlockSize(),
                 protoMessage.hasSegmentInfo() ? protoMessage.getSegmentInfo().toByteArray() : null,
-                protoMessage.hasEntries() ? protoMessage.getEntries().toByteArray() : null);
+                protoMessage.hasEntries() ? protoMessage.getEntries().toByteArray() : null,
+                protoMessage.getColumnBitSetWordsList());
     }
 
     public FDBLuceneFileReference(long id, long size, long actualSize, long blockSize) {
-        this(id, size, actualSize, blockSize, null, null);
+        this(id, size, actualSize, blockSize, null, null, null);
     }
 
-    private FDBLuceneFileReference(long id, long size, long actualSize, long blockSize, byte[] segmentInfo, byte[] entries) {
+    private FDBLuceneFileReference(long id, long size, long actualSize, long blockSize, byte[] segmentInfo,
+                                   byte[] entries, List<Long> bitSetWords) {
         this.id = id;
         this.size = size;
         this.actualSize = actualSize;
         this.blockSize = blockSize;
         this.segmentInfo = segmentInfo;
         this.entries = entries;
+        this.bitSetWords = bitSetWords;
     }
 
     public long getId() {
@@ -86,6 +91,10 @@ public class FDBLuceneFileReference {
         this.entries = entries;
     }
 
+    public void setBitSetWords(List<Long> bitSetWords) {
+        this.bitSetWords = bitSetWords;
+    }
+
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
     public byte[] getSegmentInfo() {
         return segmentInfo;
@@ -94,6 +103,11 @@ public class FDBLuceneFileReference {
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
     public byte[] getEntries() {
         return entries;
+    }
+
+    @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
+    public List<Long> getBitSetWords() {
+        return bitSetWords;
     }
 
     @Nonnull
@@ -109,12 +123,15 @@ public class FDBLuceneFileReference {
         if (this.entries != null) {
             builder.setEntries(ZeroCopyByteString.wrap(this.entries));
         }
+        if (this.bitSetWords != null) {
+            builder.addAllColumnBitSetWords(bitSetWords);
+        }
         return builder.build().toByteArray();
     }
 
     @Override
     public String toString() {
-        return "Reference [ id=" + id + ", size=" + size + ", actualSize=" + actualSize + ", blockSize=" + blockSize + ", segmentInfo=" + (getSegmentInfo() == null ? 0 : getSegmentInfo().length) + ", entries=" + (getEntries() == null ? 0 : getEntries().length) + "]";
+        return "Reference [ id=" + id + ", size=" + size + ", actualSize=" + actualSize + ", blockSize=" + blockSize + ", segmentInfo=" + (getSegmentInfo() == null ? 0 : getSegmentInfo().length) + ", entries=" + (getEntries() == null ? 0 : getEntries().length) + ", bitSetWords=" + (getBitSetWords() == null ? 0 : getBitSetWords().size()) + "]";
     }
 
     @Nullable

--- a/fdb-record-layer-lucene/src/main/proto/lucene_file_system.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_file_system.proto
@@ -30,4 +30,5 @@ message LuceneFileReference {
   optional bytes segment_info = 4;
   optional bytes entries = 5;
   optional int64 actualSize = 6;
+  repeated int64 columnBitSetWords = 7;
 }


### PR DESCRIPTION
FieldInfo information will be once per unique entry vs. one per segment in the directory.  As the implementation scales to 100's of segments, we do not want to have to read 100's of entries with the same information in it.  When the index writer is initialized, it has to look at the discrete field infos to make sure it provides correct field ordering.