### PR TITLE
Actually use LUCENE_READ_SCHEMA metric #2188

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -449,7 +449,7 @@ public class FDBDirectory extends Directory {
     }
 
     public CompletableFuture<byte[]> readSchema(List<Long> bitSetWords) {
-        return context.instrument(LuceneEvents.Events.LUCENE_FDB_READ_BLOCK,
+        return context.instrument(LuceneEvents.Events.LUCENE_READ_SCHEMA,
                 context.ensureActive().get(schemaSubspace.pack(Tuple.from(bitSetWords))));
     }
 


### PR DESCRIPTION
The metric was created but an old metric was used for the call. :(