### PR TITLE
Resolve #2194: Technical debt from binary point implementation

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -93,7 +93,7 @@ import java.util.stream.Collectors;
 @API(API.Status.EXPERIMENTAL)
 public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     private static final Logger LOG = LoggerFactory.getLogger(LuceneIndexMaintainer.class);
-    private static final long SERIALIZER_LOG_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
+    private static final long SERIALIZER_LOG_DELAY = TimeUnit.SECONDS.toMillis(3);
 
     private final FDBDirectoryManager directoryManager;
     private final LuceneAnalyzerCombinationProvider indexAnalyzerSelector;
@@ -448,10 +448,10 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
      * @param format the message format for the log
      * @param arguments teh message arguments
      */
-    private void logSerializationError(String format, Object ...arguments) {
+    private void logSerializationError(String format, Object ... arguments) {
         if (LOG.isWarnEnabled()) {
             long now = System.currentTimeMillis();
-            if ((now - lastSerializerLog) > SERIALIZER_LOG_TIMEOUT) {
+            if ((now - lastSerializerLog) > SERIALIZER_LOG_DELAY) {
                 LOG.warn(format, arguments);
                 // Not thread safe but OK as we may only log an extra message
                 lastSerializerLog = now;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -103,8 +103,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     protected static final String PRIMARY_KEY_BINARY_POINT_NAME = "_b";
     private final Executor executor;
     LuceneIndexKeySerializer keySerializer;
-    // The last time (in System.currentTimeMillis) this instance logged a serializer error
-    private long lastSerializerLog = 0;
+    // The last time this instance logged a serializer error
+    private volatile long lastSerializerLogTimeMillis = 0;
 
     public LuceneIndexMaintainer(@Nonnull final IndexMaintainerState state, @Nonnull Executor executor) {
         super(state);
@@ -451,10 +451,10 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     private void logSerializationError(String format, Object ... arguments) {
         if (LOG.isWarnEnabled()) {
             long now = System.currentTimeMillis();
-            if ((now - lastSerializerLog) > SERIALIZER_LOG_DELAY) {
+            if ((now - lastSerializerLogTimeMillis) > SERIALIZER_LOG_DELAY) {
                 LOG.warn(format, arguments);
                 // Not thread safe but OK as we may only log an extra message
-                lastSerializerLog = now;
+                lastSerializerLogTimeMillis = now;
             }
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -82,6 +82,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -92,6 +93,8 @@ import java.util.stream.Collectors;
 @API(API.Status.EXPERIMENTAL)
 public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     private static final Logger LOG = LoggerFactory.getLogger(LuceneIndexMaintainer.class);
+    private static final long SERIALIZER_LOG_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
+
     private final FDBDirectoryManager directoryManager;
     private final LuceneAnalyzerCombinationProvider indexAnalyzerSelector;
     private final LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector;
@@ -99,6 +102,9 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     protected static final String PRIMARY_KEY_SEARCH_NAME = "_s";
     protected static final String PRIMARY_KEY_BINARY_POINT_NAME = "_b";
     private final Executor executor;
+    LuceneIndexKeySerializer keySerializer;
+    // The last time (in System.currentTimeMillis) this instance logged a serializer error
+    private long lastSerializerLog = 0;
 
     public LuceneIndexMaintainer(@Nonnull final IndexMaintainerState state, @Nonnull Executor executor) {
         super(state);
@@ -107,6 +113,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(state.index, state.store.getRecordMetaData());
         this.indexAnalyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(state.index, LuceneAnalyzerType.FULL_TEXT, fieldInfos);
         this.autoCompleteAnalyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(state.index, LuceneAnalyzerType.AUTO_COMPLETE, fieldInfos);
+        String formatString = state.index.getOption(LuceneIndexOptions.PRIMARY_KEY_SERIALIZATION_FORMAT);
+        keySerializer = LuceneIndexKeySerializer.fromStringFormat(formatString);
     }
 
     public LuceneAnalyzerCombinationProvider getAutoCompleteAnalyzerSelector() {
@@ -220,23 +228,18 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         Document document = new Document();
         final IndexWriter newWriter = directoryManager.getIndexWriter(groupingKey, indexAnalyzerSelector.provideIndexAnalyzer(texts));
 
-        // null format string means don't use BinaryPoint for the index primary key
-        String formatString = state.index.getOption(LuceneIndexOptions.PRIMARY_KEY_SERIALIZATION_FORMAT);
-        LuceneIndexKeySerializer ser = LuceneIndexKeySerializer.fromStringFormat(formatString, primaryKey);
-        BytesRef ref = new BytesRef(ser.asPackedByteArray());
+        BytesRef ref = new BytesRef(keySerializer.asPackedByteArray(primaryKey));
         // use packed Tuple for the Stored and Sorted fields
         document.add(new StoredField(PRIMARY_KEY_FIELD_NAME, ref));
         document.add(new SortedDocValuesField(PRIMARY_KEY_SEARCH_NAME, ref));
-        if (formatString != null) {
+        if (keySerializer.hasFormat()) {
             try {
                 // Use BinaryPoint for fast lookup of ID when enabled
-                document.add(new BinaryPoint(PRIMARY_KEY_BINARY_POINT_NAME, ser.asFormattedBinaryPoint()));
+                document.add(new BinaryPoint(PRIMARY_KEY_BINARY_POINT_NAME, keySerializer.asFormattedBinaryPoint(primaryKey)));
             } catch (RecordCoreFormatException ex) {
                 // this can happen on format mismatch or encoding error
                 // just don't write the field, but allow the document to continue
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Failed to write using BinaryPoint encoded ID: {}", ex.getMessage());
-                }
+                logSerializationError("Failed to write using BinaryPoint encoded ID: {}", ex.getMessage());
             }
         }
 
@@ -265,24 +268,20 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     private void deleteDocument(Tuple groupingKey, Tuple primaryKey) throws IOException {
         final IndexWriter oldWriter = directoryManager.getIndexWriter(groupingKey, indexAnalyzerSelector.provideIndexAnalyzer(""));
         Query query;
-        String formatString = state.index.getOption(LuceneIndexOptions.PRIMARY_KEY_SERIALIZATION_FORMAT);
-        LuceneIndexKeySerializer ser = LuceneIndexKeySerializer.fromStringFormat(formatString, primaryKey);
-        // null format string means don't use BinaryPoint for the index primary key
-        if (formatString != null) {
+        // null format means don't use BinaryPoint for the index primary key
+        if (keySerializer.hasFormat()) {
             try {
-                byte[][] binaryPoint = ser.asFormattedBinaryPoint();
+                byte[][] binaryPoint = keySerializer.asFormattedBinaryPoint(primaryKey);
                 query = BinaryPoint.newRangeQuery(PRIMARY_KEY_BINARY_POINT_NAME, binaryPoint, binaryPoint);
             } catch (RecordCoreFormatException ex) {
                 // this can happen on format mismatch or encoding error
                 // fallback to the old way (less efficient)
-                query = SortedDocValuesField.newSlowExactQuery(PRIMARY_KEY_SEARCH_NAME, new BytesRef(ser.asPackedByteArray()));
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Failed to delete using BinaryPoint encoded ID: {}", ex.getMessage());
-                }
+                query = SortedDocValuesField.newSlowExactQuery(PRIMARY_KEY_SEARCH_NAME, new BytesRef(keySerializer.asPackedByteArray(primaryKey)));
+                logSerializationError("Failed to delete using BinaryPoint encoded ID: {}", ex.getMessage());
             }
         } else {
             // fallback to the old way (less efficient)
-            query = SortedDocValuesField.newSlowExactQuery(PRIMARY_KEY_SEARCH_NAME, new BytesRef(ser.asPackedByteArray()));
+            query = SortedDocValuesField.newSlowExactQuery(PRIMARY_KEY_SEARCH_NAME, new BytesRef(keySerializer.asPackedByteArray(primaryKey)));
         }
         oldWriter.deleteDocuments(query);
     }
@@ -439,5 +438,24 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         LOG.trace("performOperation operation={}", operation);
         return CompletableFuture.completedFuture(new IndexOperationResult() {
         });
+    }
+
+    /**
+     * Simple throttling mechanism for log messages.
+     * Since the index writer may see many of these errors in quick succession, limit the number of log messages by ensuring
+     * we only log every so often. This is a very simple mechanism that can be generalized if needed by holding the types of
+     * messages and the required timeouts.
+     * @param format the message format for the log
+     * @param arguments teh message arguments
+     */
+    private void logSerializationError(String format, Object ...arguments) {
+        if (LOG.isWarnEnabled()) {
+            long now = System.currentTimeMillis();
+            if ((now - lastSerializerLog) > SERIALIZER_LOG_TIMEOUT) {
+                LOG.warn(format, arguments);
+                // Not thread safe but OK as we may only log an extra message
+                lastSerializerLog = now;
+            }
+        }
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializerTest.java
@@ -31,174 +31,174 @@ public class LuceneIndexKeySerializerTest {
     @Test
     void singleElement() {
         Tuple key = Tuple.from(12345L);
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64]");
 
-        assertResult(new byte[] {22, 48, 57}, classUnderTest.asPackedByteArray());
-        assertResult(new byte[][] {{22, 48, 57, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
-        assertResult(new byte[][] {{22, 48, 57, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+        assertResult(new byte[] {22, 48, 57}, classUnderTest.asPackedByteArray(key));
+        assertResult(new byte[][] {{22, 48, 57, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
+        assertResult(new byte[][] {{22, 48, 57, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testMultipleElements() {
         Tuple key = Tuple.from(1234567890L, 56789);
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64, INT32]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64, INT32]");
 
-        assertResult(new byte[] {24, 73, -106, 2, -46, 22, -35, -43}, classUnderTest.asPackedByteArray());
-        assertResult(new byte[][] {{24, 73, -106, 2, -46, 22, -35, -43, 0}}, classUnderTest.asPackedBinaryPoint());
+        assertResult(new byte[] {24, 73, -106, 2, -46, 22, -35, -43}, classUnderTest.asPackedByteArray(key));
+        assertResult(new byte[][] {{24, 73, -106, 2, -46, 22, -35, -43, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{24, 73, -106, 2, -46, 0, 0, 0, 0},
-                                   {22, -35, -43, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {22, -35, -43, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testMultipleElementsOverflowAnotherDimension() {
         Tuple key = Tuple.from(1234567890L, 56789, 9876543210L);
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64, INT32, INT64]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64, INT32, INT64]");
 
-        assertResult(new byte[] {24, 73, -106, 2, -46, 22, -35, -43, 25, 2, 76, -80, 22, -22}, classUnderTest.asPackedByteArray());
+        assertResult(new byte[] {24, 73, -106, 2, -46, 22, -35, -43, 25, 2, 76, -80, 22, -22}, classUnderTest.asPackedByteArray(key));
         assertResult(new byte[][] {{24, 73, -106, 2, -46, 22, -35, -43, 25},
-                                   {2, 76, -80, 22, -22, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+                                   {2, 76, -80, 22, -22, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{24, 73, -106, 2, -46, 0, 0, 0, 0},
                                    {22, -35, -43, 0, 0, 0, 0, 0, 0},
-                                   {25, 2, 76, -80, 22, -22, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {25, 2, 76, -80, 22, -22, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testShortString() {
         Tuple key = Tuple.from("abc");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]");
 
-        assertResult(new byte[] {2, 97, 98, 99, 0}, classUnderTest.asPackedByteArray());
-        assertResult(new byte[][] {{2, 97, 98, 99, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+        assertResult(new byte[] {2, 97, 98, 99, 0}, classUnderTest.asPackedByteArray(key));
+        assertResult(new byte[][] {{2, 97, 98, 99, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{97, 98, 99, 0, 0, 0, 0, 0, 0},
                                    {0, 0, 0, 0, 0, 0, 0, 0, 0},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testLongString() {
         Tuple key = Tuple.from("abcdefghabcdefgh");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]");
 
-        assertResult(new byte[] {2, 97, 98, 99, 100, 101, 102, 103, 104, 97, 98, 99, 100, 101, 102, 103, 104, 0}, classUnderTest.asPackedByteArray());
+        assertResult(new byte[] {2, 97, 98, 99, 100, 101, 102, 103, 104, 97, 98, 99, 100, 101, 102, 103, 104, 0}, classUnderTest.asPackedByteArray(key));
         assertResult(new byte[][] {{2, 97, 98, 99, 100, 101, 102, 103, 104},
-                                   {97, 98, 99, 100, 101, 102, 103, 104, 0}}, classUnderTest.asPackedBinaryPoint());
+                                   {97, 98, 99, 100, 101, 102, 103, 104, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{97, 98, 99, 100, 101, 102, 103, 104, 97},
                                    {98, 99, 100, 101, 102, 103, 104, 0, 0},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testUuid() {
         Tuple key = Tuple.from("98e6c88d-d757-4d0f-a5f3-d3055e1163b0");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[UUID_AS_STRING]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[UUID_AS_STRING]");
 
-        assertResult(new byte[] {2, 57, 56, 101, 54, 99, 56, 56, 100, 45, 100, 55, 53, 55, 45, 52, 100, 48, 102, 45, 97, 53, 102, 51, 45, 100, 51, 48, 53, 53, 101, 49, 49, 54, 51, 98, 48, 0}, classUnderTest.asPackedByteArray());
+        assertResult(new byte[] {2, 57, 56, 101, 54, 99, 56, 56, 100, 45, 100, 55, 53, 55, 45, 52, 100, 48, 102, 45, 97, 53, 102, 51, 45, 100, 51, 48, 53, 53, 101, 49, 49, 54, 51, 98, 48, 0}, classUnderTest.asPackedByteArray(key));
         assertResult(new byte[][] {{2, 57, 56, 101, 54, 99, 56, 56, 100},
                                    {45, 100, 55, 53, 55, 45, 52, 100, 48},
                                    {102, 45, 97, 53, 102, 51, 45, 100, 51},
                                    {48, 53, 53, 101, 49, 49, 54, 51, 98},
-                                   {48, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+                                   {48, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{48, -104, -26, -56, -115, -41, 87, 77, 15},
-                                   {-91, -13, -45, 5, 94, 17, 99, -80, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {-91, -13, -45, 5, 94, 17, 99, -80, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testNested() {
         Tuple key = Tuple.from(123L, Tuple.from(456L, "abcdef"));
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64, [INT64, STRING_16]]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64, [INT64, STRING_16]]");
 
-        assertResult(new byte[] {21, 123, 5, 22, 1, -56, 2, 97, 98, 99, 100, 101, 102, 0, 0}, classUnderTest.asPackedByteArray());
+        assertResult(new byte[] {21, 123, 5, 22, 1, -56, 2, 97, 98, 99, 100, 101, 102, 0, 0}, classUnderTest.asPackedByteArray(key));
         assertResult(new byte[][] {{21, 123, 5, 22, 1, -56, 2, 97, 98},
-                                   {99, 100, 101, 102, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+                                   {99, 100, 101, 102, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{21, 123, 0, 0, 0, 0, 0, 0, 0},
                                    {22, 1, -56, 0, 0, 0, 0, 0, 0},
                                    {97, 98, 99, 100, 101, 102, 0, 0, 0},
                                    {0, 0, 0, 0, 0, 0, 0, 0, 0},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testNull() {
         Tuple key = Tuple.from(12L, 45L, 78L);
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[NULL, INT64, NULL]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[NULL, INT64, NULL]");
 
-        assertResult(new byte[] {21, 12, 21, 45, 21, 78}, classUnderTest.asPackedByteArray());
-        assertResult(new byte[][] {{21, 12, 21, 45, 21, 78, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+        assertResult(new byte[] {21, 12, 21, 45, 21, 78}, classUnderTest.asPackedByteArray(key));
+        assertResult(new byte[][] {{21, 12, 21, 45, 21, 78, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{0, 0, 0, 0, 0, 0, 0, 0, 0},
                                    {21, 45, 0, 0, 0, 0, 0, 0, 0},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testNullableInteger() {
         Tuple key = Tuple.from(null, 45L, null);
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64_OR_NULL, INT64, INT32_OR_NULL]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64_OR_NULL, INT64, INT32_OR_NULL]");
 
-        assertResult(new byte[] {0, 21, 45, 0}, classUnderTest.asPackedByteArray());
-        assertResult(new byte[][] {{0, 21, 45, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+        assertResult(new byte[] {0, 21, 45, 0}, classUnderTest.asPackedByteArray(key));
+        assertResult(new byte[][] {{0, 21, 45, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{0, 0, 0, 0, 0, 0, 0, 0, 0},
                                    {21, 45, 0, 0, 0, 0, 0, 0, 0},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testNone() {
         Tuple key = Tuple.from(12L, 45L, 78L);
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[NONE, INT64, NONE]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[NONE, INT64, NONE]");
 
-        assertResult(new byte[] {21, 12, 21, 45, 21, 78}, classUnderTest.asPackedByteArray());
-        assertResult(new byte[][] {{21, 12, 21, 45, 21, 78, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
-        assertResult(new byte[][] {{21, 45, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+        assertResult(new byte[] {21, 12, 21, 45, 21, 78}, classUnderTest.asPackedByteArray(key));
+        assertResult(new byte[][] {{21, 12, 21, 45, 21, 78, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
+        assertResult(new byte[][] {{21, 45, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testStringTooLong() {
         Tuple key = Tuple.from("abcdefghij abcdefghij");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]");
 
-        Assertions.assertThrows(RecordCoreFormatException.class, classUnderTest::asFormattedBinaryPoint);
+        Assertions.assertThrows(RecordCoreFormatException.class, () -> classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testStringEncodedTooLong() {
         Tuple key = Tuple.from("æčęÿæčęÿæčęÿæčęÿ");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]");
 
-        Assertions.assertThrows(RecordCoreSizeException.class, classUnderTest::asFormattedBinaryPoint);
+        Assertions.assertThrows(RecordCoreSizeException.class, () -> classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testInvalidUuid() {
         Tuple key = Tuple.from("abcdefghij");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[UUID_AS_STRING]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[UUID_AS_STRING]");
 
-        Assertions.assertThrows(RecordCoreFormatException.class, classUnderTest::asFormattedBinaryPoint);
+        Assertions.assertThrows(RecordCoreFormatException.class, () -> classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testStringNonAscii() {
         Tuple key = Tuple.from("æčęÿ");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]");
 
-        assertResult(new byte[] {2, -61, -90, -60, -115, -60, -103, -61, -65, 0}, classUnderTest.asPackedByteArray());
+        assertResult(new byte[] {2, -61, -90, -60, -115, -60, -103, -61, -65, 0}, classUnderTest.asPackedByteArray(key));
         assertResult(new byte[][] {{2, -61, -90, -60, -115, -60, -103, -61, -65},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{-61, -90, -60, -115, -60, -103, -61, -65, 0},
                                    {0, 0, 0, 0, 0, 0, 0, 0, 0},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     @Test
     void testStringCjk() {
         Tuple key = Tuple.from("苹果园区");
-        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]", key);
+        LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[STRING_16]");
 
-        assertResult(new byte[] {2, -24, -117, -71, -26, -98, -100, -27, -101, -83, -27, -116, -70, 0}, classUnderTest.asPackedByteArray());
+        assertResult(new byte[] {2, -24, -117, -71, -26, -98, -100, -27, -101, -83, -27, -116, -70, 0}, classUnderTest.asPackedByteArray(key));
         assertResult(new byte[][] {{2, -24, -117, -71, -26, -98, -100, -27, -101},
-                                   {-83, -27, -116, -70, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint());
+                                   {-83, -27, -116, -70, 0, 0, 0, 0, 0}}, classUnderTest.asPackedBinaryPoint(key));
         assertResult(new byte[][] {{-24, -117, -71, -26, -98, -100, -27, -101, -83},
                                    {-27, -116, -70, 0, 0, 0, 0, 0, 0},
-                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint());
+                                   {0, 0, 0, 0, 0, 0, 0, 0, 0}}, classUnderTest.asFormattedBinaryPoint(key));
     }
 
     private void assertResult(byte[] expected, byte[] actual) {


### PR DESCRIPTION
- Improve logging for serialization errors: Log as `WARN`, add throttling to reduce floods of log messages
- Reuse the serializer: Make the `key` a parameter to the serialization methods, construct serializer with only format at index maintainer constructor.

The attempt to look at the `oldWriter.deleteDocument` return value will not work since the return value is a `sequenceNumber` and not a count of the found documents. Will have to look for another way to validate the deletion.
