### PR TITLE
Fix parameterized dual-planner test display name

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Parameterized dual-planner test results do not show test name [(Issue #2201)](https://github.com/FoundationDB/fdb-record-layer/issues/2201)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/DualPlannerExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/DualPlannerExtension.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.platform.commons.util.AnnotationUtils;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -64,7 +65,7 @@ public class DualPlannerExtension implements TestTemplateInvocationContextProvid
                 throw new RecordCoreException(e.getClass() + " " + e.getMessage());
             }
             return nestedProvider.provideTestTemplateInvocationContexts(context).map(existingContext ->
-                            new DualPlannerTestInvocationContext(displayName, true, existingContext.getAdditionalExtensions())); // new planner
+                            new DualPlannerTestInvocationDisplayNameDecorator(existingContext, true)); // new planner
         } else {
             final Optional<DualPlannerTest> annotationOptional =
                     AnnotationUtils.findAnnotation(context.getTestMethod(), DualPlannerTest.class);
@@ -114,6 +115,29 @@ public class DualPlannerExtension implements TestTemplateInvocationContextProvid
         @Override
         public List<Extension> getAdditionalExtensions() {
             return extensions;
+        }
+    }
+
+    private static class DualPlannerTestInvocationDisplayNameDecorator implements TestTemplateInvocationContext {
+
+        @Nonnull
+        private final TestTemplateInvocationContext underlying;
+
+        private final boolean useCascades;
+
+        public DualPlannerTestInvocationDisplayNameDecorator(@Nonnull final TestTemplateInvocationContext underlying, boolean useCascades) {
+            this.underlying = underlying;
+            this.useCascades = useCascades;
+        }
+
+        @Override
+        public String getDisplayName(final int invocationIndex) {
+            return underlying.getDisplayName(invocationIndex) + (useCascades ? "[cascades]" : "[heuristics]");
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return underlying.getAdditionalExtensions();
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/DualPlannerExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/DualPlannerExtension.java
@@ -125,7 +125,7 @@ public class DualPlannerExtension implements TestTemplateInvocationContextProvid
 
         private final boolean useCascades;
 
-        public DualPlannerTestInvocationDisplayNameDecorator(@Nonnull final TestTemplateInvocationContext underlying, boolean useCascades) {
+        public DualPlannerTestInvocationDisplayNameDecorator(@Nonnull final TestTemplateInvocationContext underlying, final boolean useCascades) {
             this.underlying = underlying;
             this.useCascades = useCascades;
         }


### PR DESCRIPTION
When running a parameterised test suite such as `FDBOrQueryToUnionTest`, IntelliJ does not render the name of the parameterised dual-planner test correctly when Cascades is used. Here an example of running `testOrQuery5`:

<img width="409" alt="Screenshot 2023-06-29 at 12 31 03" src="https://github.com/FoundationDB/fdb-record-layer/assets/52752081/8abaa53c-0d43-4a46-bde3-42266dacb279">

This makes it difficult to figure out e.g. under which configuration(s) did a test fail.

This provides a fix for that by adding a display name decorator of `TestTemplateInvocationContext` (called `DualPlannerTestInvocationDisplayNameDecorator`) which delegates to the underlying `ParameterizedTestInvocationContext` context by adding either `[cascades]` or `[heuristics]` to test name instead of creating a vanilla `TestInvocationContext` that ignores the (parameterised) test display name completely and displays only `[cascades]` instead.

Here is how IntelliJ now outputs the parameterised tests of `testOrQuery5`:

<img width="459" alt="Screenshot 2023-06-29 at 12 31 58" src="https://github.com/FoundationDB/fdb-record-layer/assets/52752081/be8a4197-0f2a-4bf9-be2c-9f127fe496e5">

This fixes #2201.
