### PR TITLE
Resolves #2203: Allow for setting the store state cacheability during checkVersion

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Stores can now be configured to update their state cacheability during store opening or creation [(Issue #2203)](https://github.com/FoundationDB/fdb-record-layer/issues/2203)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -2313,6 +2313,29 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
         BaseBuilder<M, R> setStoreStateCache(@Nonnull FDBRecordStoreStateCache storeStateCache);
 
         /**
+         * Get how the store state cacheability should be modified during store opening.
+         *
+         * @return how the store state cacheability should be modified when the store is created or opened
+         * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore.StateCacheabilityOnOpen
+         * @see FDBRecordStore#setStateCacheabilityAsync(boolean)
+         */
+        @API(API.Status.EXPERIMENTAL)
+        @Nonnull
+        FDBRecordStore.StateCacheabilityOnOpen getStateCacheabilityOnOpen();
+
+        /**
+         * Sets the behavior for how the store state cacheability should be modified when the store is opened.
+         *
+         * @param stateCacheabilityOnOpen how the store state cacheability should be modified when the store is opened
+         * @return this builder
+         * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore.StateCacheabilityOnOpen
+         * @see FDBRecordStore#setStateCacheabilityAsync(boolean)
+         */
+        @API(API.Status.EXPERIMENTAL)
+        @Nonnull
+        BaseBuilder<M, R> setStateCacheabilityOnOpen(@Nonnull FDBRecordStore.StateCacheabilityOnOpen stateCacheabilityOnOpen);
+
+        /**
          * Make a copy of this builder.
          * This can be used to share enough of the state to connect to the same record store several times in different transactions.
          * <pre>

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -320,7 +320,7 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
     public static class Builder<M extends Message> implements BaseBuilder<M, FDBTypedRecordStore<M>> {
 
         @Nonnull
-        private FDBRecordStore.Builder untypedStoreBuilder;
+        private final FDBRecordStore.Builder untypedStoreBuilder;
         @Nullable
         private RecordSerializer<M> typedSerializer;
 
@@ -511,6 +511,19 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
         @Override
         public Builder<M> setStoreStateCache(@Nonnull FDBRecordStoreStateCache storeStateCache) {
             untypedStoreBuilder.setStoreStateCache(storeStateCache);
+            return this;
+        }
+
+        @Nonnull
+        @Override
+        public FDBRecordStore.StateCacheabilityOnOpen getStateCacheabilityOnOpen() {
+            return untypedStoreBuilder.getStateCacheabilityOnOpen();
+        }
+
+        @Override
+        @Nonnull
+        public BaseBuilder<M, FDBTypedRecordStore<M>> setStateCacheabilityOnOpen(@Nonnull final FDBRecordStore.StateCacheabilityOnOpen stateCacheabilityOnOpen) {
+            untypedStoreBuilder.setStateCacheabilityOnOpen(stateCacheabilityOnOpen);
             return this;
         }
 


### PR DESCRIPTION
A new record store configuration parameter is added. It can be configured to instruct `checkVersion` to update the `cacheability` flag. If the store header is alreadyin the desired state, then no update is performed. In addition, this allows the user to skip updating the flag if the store is pre-existing, which was the old behavior, and which is still important during roll outs. In particular, if the same set of instances are configured to operate on the same store, and some of them are configured to set cacheability to `true` while others to set it to `false`, then operations from the one set will always step on operations from the other set. To avoid that, one can first set the parameter to ignore existing stores and then make a second change to start updating existing stores again.

This resolve #2203.