### PR TITLE
Lucene skip data integrity static

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Lucene: add context property to skip data integrity check [(Issue #2198)](https://github.com/FoundationDB/fdb-record-layer/issues/2198)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -70,9 +70,4 @@ public final class LuceneRecordContextProperties {
      * This controls the page size to scan the basic Lucene index.
      */
     public static final RecordLayerPropertyKey<Integer> LUCENE_INDEX_CURSOR_PAGE_SIZE = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.cursor.pageSize", 201);
-
-    /**
-     * If enabled, allow checkIntegrity during indexing.
-     */
-    public static final RecordLayerPropertyKey<Boolean> LUCENE_INDEX_CHECK_INTEGRITY_ENABLED = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.checkIntegrity", true);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCodec.java
@@ -85,15 +85,7 @@ public class LuceneOptimizedCodec extends Codec {
      * Instantiates a new codec.
      */
     public LuceneOptimizedCodec() {
-        this(true);
-    }
-
-    /**
-     * Instantiates a new codec.
-     * @param allowIntegrityCheck if false, skip data integrity verification
-     */
-    public LuceneOptimizedCodec(boolean allowIntegrityCheck) {
-        this(Lucene87Codec.Mode.BEST_SPEED, allowIntegrityCheck);
+        this(Lucene87Codec.Mode.BEST_SPEED);
     }
 
     /**
@@ -102,15 +94,14 @@ public class LuceneOptimizedCodec extends Codec {
      * The constant "RL" is an arbitrary name for the codec that will be written into the index segment.
      * @param mode stored fields compression mode to use for newly
      *             flushed/merged segments.
-     * @param allowIntegrityCheck if false, skip data integrity verification
      */
-    public LuceneOptimizedCodec(Lucene87Codec.Mode mode, boolean allowIntegrityCheck) {
+    public LuceneOptimizedCodec(Lucene87Codec.Mode mode) {
         super("RL");
         baseCodec = new Lucene87Codec(mode);
         compoundFormat = new LuceneOptimizedCompoundFormat();
         segmentInfoFormat = new LuceneOptimizedSegmentInfoFormat();
         pointsFormat = new LuceneOptimizedPointsFormat(baseCodec.pointsFormat());
-        defaultPostingsFormat = new LuceneOptimizedPostingsFormat(new Lucene84PostingsFormat(), allowIntegrityCheck);
+        defaultPostingsFormat = new LuceneOptimizedPostingsFormat(new Lucene84PostingsFormat());
         defaultDocValuesFormat = new LuceneOptimizedDocValuesFormat(new Lucene80DocValuesFormat());
         storedFieldsFormat = new LuceneOptimizedStoredFieldsFormat(baseCodec.storedFieldsFormat());
         liveDocsFormat = new LuceneOptimizedLiveDocsFormat(baseCodec.liveDocsFormat());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
@@ -44,6 +44,7 @@ import java.util.Iterator;
 @AutoService(PostingsFormat.class)
 public class LuceneOptimizedPostingsFormat extends PostingsFormat {
     PostingsFormat postingsFormat;
+    private static boolean allowCheckDataIntegrity = true;
 
     public LuceneOptimizedPostingsFormat() {
         this(new Lucene84PostingsFormat());
@@ -52,6 +53,10 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
     public LuceneOptimizedPostingsFormat(PostingsFormat postingsFormat) {
         super("RL" + postingsFormat.getName());
         this.postingsFormat = postingsFormat;
+    }
+
+    public static void setAllowCheckDataIntegrity(boolean allow) {
+        allowCheckDataIntegrity = allow;
     }
 
     @Override
@@ -93,7 +98,9 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
 
         @Override
         public void checkIntegrity() throws IOException {
-            fieldsProducer.get().checkIntegrity();
+            if (allowCheckDataIntegrity) {
+                fieldsProducer.get().checkIntegrity();
+            }
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
@@ -44,16 +44,14 @@ import java.util.Iterator;
 @AutoService(PostingsFormat.class)
 public class LuceneOptimizedPostingsFormat extends PostingsFormat {
     PostingsFormat postingsFormat;
-    boolean allowIntegrityCheck = true;
 
     public LuceneOptimizedPostingsFormat() {
-        this(new Lucene84PostingsFormat(), true);
+        this(new Lucene84PostingsFormat());
     }
 
-    public LuceneOptimizedPostingsFormat(PostingsFormat postingsFormat, boolean allowIntegrityCheck) {
+    public LuceneOptimizedPostingsFormat(PostingsFormat postingsFormat) {
         super("RL" + postingsFormat.getName());
         this.postingsFormat = postingsFormat;
-        this.allowIntegrityCheck = allowIntegrityCheck;
     }
 
     @Override
@@ -64,7 +62,7 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
     @Override
     @SuppressWarnings("PMD.CloseResource")
     public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
-        return new LazyFieldsProducer(state, allowIntegrityCheck);
+        return new LazyFieldsProducer(state);
     }
 
     private static class LazyFieldsProducer extends FieldsProducer {
@@ -72,10 +70,8 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
         private Supplier<FieldsProducer> fieldsProducer;
 
         private boolean initialized;
-        private boolean allowIntegrityCheck;
 
-        private LazyFieldsProducer(final SegmentReadState state, boolean allowIntegrityCheck) {
-            this.allowIntegrityCheck = allowIntegrityCheck;
+        private LazyFieldsProducer(final SegmentReadState state) {
             fieldsProducer = Suppliers.memoize(() -> {
                 try {
                     PostingsReaderBase postingsReader = new LuceneOptimizedPostingsReader(state);
@@ -97,9 +93,7 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
 
         @Override
         public void checkIntegrity() throws IOException {
-            if (allowIntegrityCheck) {
-                fieldsProducer.get().checkIntegrity();
-            }
+            fieldsProducer.get().checkIntegrity();
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -135,7 +134,6 @@ class FDBDirectoryWrapper implements AutoCloseable {
     @SuppressWarnings("PMD.CloseResource")
     public IndexWriter getWriter(LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
         if (writer == null || !writerAnalyzerId.equals(analyzerWrapper.getUniqueIdentifier())) {
-            boolean allowIntegrityCheck = Objects.requireNonNullElse(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_CHECK_INTEGRITY_ENABLED), false);
             synchronized (this) {
                 if (writer == null || !writerAnalyzerId.equals(analyzerWrapper.getUniqueIdentifier())) {
                     TieredMergePolicy tieredMergePolicy = new TieredMergePolicy()
@@ -145,7 +143,7 @@ class FDBDirectoryWrapper implements AutoCloseable {
                             .setUseCompoundFile(true)
                             .setMergePolicy(tieredMergePolicy)
                             .setMergeScheduler(new FDBDirectoryMergeScheduler(state, mergeDirectoryCount))
-                            .setCodec(new LuceneOptimizedCodec(allowIntegrityCheck))
+                            .setCodec(new LuceneOptimizedCodec())
                             .setInfoStream(new LuceneLoggerInfoStream(LOGGER));
 
                     IndexWriter oldWriter = writer;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecordsTextProto;
 import com.apple.foundationdb.record.TestRecordsTextProto.ComplexDocument;
+import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedPostingsFormat;
 import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
 import com.apple.foundationdb.record.lucene.directory.FDBLuceneFileReference;
 import com.apple.foundationdb.record.lucene.ngram.NgramAnalyzer;
@@ -914,6 +915,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
 
     @Test
     void simpleInsertAndSearchSingleTransaction() {
+        LuceneOptimizedPostingsFormat.setAllowCheckDataIntegrity(false);
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             // Save one record and try and search for it

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
+import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedPostingsFormat;
 import com.apple.test.Tags;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -68,6 +69,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
 
     @Test
     public void givenTermQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        LuceneOptimizedPostingsFormat.setAllowCheckDataIntegrity(false);
         luceneIndex.indexDocument("activity", "running in track");
         luceneIndex.indexDocument("activity", "Cars are running on road");
         Term term = new Term("body", "running");
@@ -89,6 +91,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
     @Test
     public void givenBooleanQueryWhenFetchedDocumentThenCorrect() throws Exception {
         luceneIndex.indexDocument("Destination", "Las Vegas singapore car");
+        LuceneOptimizedPostingsFormat.setAllowCheckDataIntegrity(false);
         luceneIndex.indexDocument("Commutes in singapore", "Bus Car Bikes");
         Term term1 = new Term("body", "singapore");
         Term term2 = new Term("body", "car");
@@ -110,6 +113,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
 
     @Test
     public void givenFuzzyQueryWhenFetchedDocumentThenCorrect() throws Exception {
+        LuceneOptimizedPostingsFormat.setAllowCheckDataIntegrity(false);
         luceneIndex.indexDocument("article", "Halloween Festival");
         luceneIndex.indexDocument("decoration", "Decorations for Halloween");
         Term term = new Term("body", "hallowen");
@@ -132,6 +136,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
     public void givenSortFieldWhenSortedThenCorrect() throws Exception {
         luceneIndex.indexDocument("Ganges", "River in India");
         luceneIndex.indexDocument("Mekong", "This river flows in south Asia");
+        LuceneOptimizedPostingsFormat.setAllowCheckDataIntegrity(false);
         luceneIndex.indexDocument("Amazon", "Rain forest river");
         luceneIndex.indexDocument("Rhine", "Belongs to Europe");
         luceneIndex.indexDocument("Nile", "Longest River");
@@ -149,6 +154,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
 
     @Test
     public void whenDocumentDeletedThenCorrect() throws IOException {
+        LuceneOptimizedPostingsFormat.setAllowCheckDataIntegrity(false);
         luceneIndex.indexDocument("Ganges", "River in India");
         luceneIndex.indexDocument("Mekong", "This river flows in south Asia");
         Term term = new Term("title", "ganges");

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
@@ -68,7 +68,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
 
     @Test
     public void givenTermQueryWhenFetchedDocumentThenCorrect() throws Exception {
-        luceneIndex.indexDocument("activity", "running in track", false);
+        luceneIndex.indexDocument("activity", "running in track");
         luceneIndex.indexDocument("activity", "Cars are running on road");
         Term term = new Term("body", "running");
         Query query = new TermQuery(term);
@@ -89,7 +89,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
     @Test
     public void givenBooleanQueryWhenFetchedDocumentThenCorrect() throws Exception {
         luceneIndex.indexDocument("Destination", "Las Vegas singapore car");
-        luceneIndex.indexDocument("Commutes in singapore", "Bus Car Bikes", false);
+        luceneIndex.indexDocument("Commutes in singapore", "Bus Car Bikes");
         Term term1 = new Term("body", "singapore");
         Term term2 = new Term("body", "car");
         TermQuery query1 = new TermQuery(term1);
@@ -110,7 +110,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
 
     @Test
     public void givenFuzzyQueryWhenFetchedDocumentThenCorrect() throws Exception {
-        luceneIndex.indexDocument("article", "Halloween Festival", false);
+        luceneIndex.indexDocument("article", "Halloween Festival");
         luceneIndex.indexDocument("decoration", "Decorations for Halloween");
         Term term = new Term("body", "hallowen");
         Query query = new FuzzyQuery(term);
@@ -132,7 +132,7 @@ public class FDBLuceneFunctionalityTest extends FDBDirectoryBaseTest {
     public void givenSortFieldWhenSortedThenCorrect() throws Exception {
         luceneIndex.indexDocument("Ganges", "River in India");
         luceneIndex.indexDocument("Mekong", "This river flows in south Asia");
-        luceneIndex.indexDocument("Amazon", "Rain forest river", false);
+        luceneIndex.indexDocument("Amazon", "Rain forest river");
         luceneIndex.indexDocument("Rhine", "Belongs to Europe");
         luceneIndex.indexDocument("Nile", "Longest River");
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneTestIndex.java
@@ -66,19 +66,8 @@ public class FDBLuceneTestIndex {
      * @param body body
      */
     public void indexDocument(String title, String body) throws IOException {
-        indexDocument(title, body, true);
-    }
-
-    /**
-     * Method to index a simple document.
-     *
-     * @param title title
-     * @param body body
-     * @param allowIntegrityCheck if false, skip data integrity verification
-     */
-    public void indexDocument(String title, String body, boolean allowIntegrityCheck) throws IOException {
         IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
-        indexWriterConfig.setCodec(new LuceneOptimizedCodec(allowIntegrityCheck));
+        indexWriterConfig.setCodec(new LuceneOptimizedCodec());
         try (IndexWriter writer = new IndexWriter(directory, indexWriterConfig)) {
             Document document = new Document();
             document.add(new TextField("title", title, Field.Store.YES));


### PR DESCRIPTION
This will: 
  1. Revert commit 3918fd5b184b222571c34317351a85132340476d (which doesn't work as expected - apparently because often a default constructor is called via the `@AutoService(PostingsFormat.class)`. 
  2. Add static var to control `checkIntergrity` +  allow callers to set it for all future transactions

   Note to reviewer: the use of a static var is ugly. Please consider that a quick n dirty way to test skipping the checksums test. If it does works we'll find a better way to do it. 