### PR TITLE
Resolve #2210: Add more metrics to Lucene.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Add more metrics to Lucene operations [(Issue #2210)](https://github.com/FoundationDB/fdb-record-layer/issues/2210)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -54,6 +54,8 @@ public class LuceneEvents {
         LUCENE_AUTO_COMPLETE_SUGGESTIONS_SCAN("lucene search returned auto complete suggestions"),
         /** Number of documents returned from a single Lucene spellcheck scan. */
         LUCENE_SPELLCHECK_SCAN("lucene search returned spellcheck suggestions"),
+        /** Number of merge calls to the FDBDirectory. */
+        LUCENE_MERGE("Lucene merge")
         ;
 
         private final String title;
@@ -132,6 +134,8 @@ public class LuceneEvents {
         WAIT_LUCENE_GET_DATA_BLOCK("lucene get data block"),
         /** Wait for lucene to load the file cache. */
         WAIT_LUCENE_LOAD_FILE_CACHE("lucene load file cache"),
+        /** Create a file from FDBDirectory. */
+        WAIT_LUCENE_CREATE_OUTPUT("lucene create output")
         ;
 
         private final String title;
@@ -188,6 +192,10 @@ public class LuceneEvents {
         LUCENE_SHARED_CACHE_MISSES("lucene shared cache misses", false),
         /** Plan contains highlight operator. **/
         PLAN_HIGHLIGHT_TERMS("lucene highlight plans", false),
+        /** Number of file delete operations on the FDBDirectory. */
+        LUCENE_DELETE_FILE("lucene delete file", false),
+        /** Number of file delete operations on the FDBDirectory. */
+        LUCENE_RENAME_FILE("lucene rename file", false),
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormat.java
@@ -58,7 +58,7 @@ public class LuceneOptimizedCompoundFormat extends CompoundFormat {
     @Override
     public CompoundDirectory getCompoundReader(Directory dir, final SegmentInfo si, final IOContext context) throws IOException {
         dir = (dir instanceof LuceneOptimizedWrappedDirectory) ? dir : new LuceneOptimizedWrappedDirectory(dir);
-        return new LuceneOptimizedCompoundReader(dir, si, context);
+        return new LuceneOptimizedCompoundReader(dir, si);
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
@@ -74,7 +74,7 @@ final class LuceneOptimizedCompoundReader extends CompoundDirectory {
         if ( !(directory instanceof LuceneOptimizedWrappedDirectory) ) {
             throw new IOException("Directory Must Be Wrapped");
         }
-        handle = ((LuceneOptimizedWrappedDirectory) directory).openLazyInput(dataFileName, context, 0, 0L); // attempting not to read
+        handle = ((LuceneOptimizedWrappedDirectory) directory).openLazyInput(dataFileName, 0, 0L); // attempting not to read
         this.entries = readEntries(si.getId(), directory, entriesFileName); // synchronous
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
@@ -66,7 +66,7 @@ final class LuceneOptimizedCompoundReader extends CompoundDirectory {
      */
     // TODO: we should just pre-strip "entries" and append segment name up-front like simpletext?
     // this need not be a "general purpose" directory anymore (it only writes index files)
-    public LuceneOptimizedCompoundReader(Directory directory, SegmentInfo si, IOContext context) throws IOException {
+    public LuceneOptimizedCompoundReader(Directory directory, SegmentInfo si) throws IOException {
         this.directory = directory;
         this.segmentName = si.name;
         String dataFileName = IndexFileNames.segmentFileName(segmentName, "", LuceneOptimizedCompoundFormat.DATA_EXTENSION);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
@@ -131,14 +131,13 @@ class LuceneOptimizedWrappedDirectory extends Directory {
      * Opens a lazy input with performing a seek.
      *
      * @param name name
-     * @param ioContext ioContext
      * @param initialOffset offset
      * @param position current position
      * @return IndexInput
      * @throws IOException exception
      */
-    public IndexInput openLazyInput(@Nonnull final String name, @Nonnull final IOContext ioContext, long initialOffset, long position) throws IOException {
-        return fdbDirectory.openLazyInput(name, ioContext, initialOffset, position);
+    public IndexInput openLazyInput(@Nonnull final String name, long initialOffset, long position) throws IOException {
+        return fdbDirectory.openLazyInput(name, initialOffset, position);
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -580,6 +580,7 @@ public class FDBDirectory extends Directory {
      */
     @Override
     @Nonnull
+    @SuppressWarnings("java:S2093")
     public IndexOutput createOutput(@Nonnull final String name, @Nullable final IOContext ioContext) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("createOutput",
@@ -682,7 +683,7 @@ public class FDBDirectory extends Directory {
         return new FDBIndexInput(name, this);
     }
 
-    public IndexInput openLazyInput(@Nonnull final String name, @Nonnull final IOContext ioContext, long initialOffset, long position) throws IOException {
+    public IndexInput openLazyInput(@Nonnull final String name, long initialOffset, long position) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("openInput",
                     LuceneLogMessageKeys.FILE_NAME, name));

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.record.lucene.LuceneAnalyzerWrapper;
+import com.apple.foundationdb.record.lucene.LuceneEvents;
 import com.apple.foundationdb.record.lucene.LuceneLoggerInfoStream;
 import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
 import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCodec;
@@ -103,6 +104,7 @@ class FDBDirectoryWrapper implements AutoCloseable {
         })
         @Override
         public synchronized void merge(final MergeSource mergeSource, final MergeTrigger trigger) throws IOException {
+            long startTime = System.nanoTime();
             if (state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MULTIPLE_MERGE_OPTIMIZATION_ENABLED) && trigger == MergeTrigger.FULL_FLUSH) {
                 if (ThreadLocalRandom.current().nextInt(mergeDirectoryCount) == 0) {
                     if (LOGGER.isTraceEnabled()) {
@@ -128,6 +130,7 @@ class FDBDirectoryWrapper implements AutoCloseable {
                 }
                 super.merge(mergeSource, trigger);
             }
+            state.context.record(LuceneEvents.Events.LUCENE_MERGE, System.nanoTime() - startTime);
         }
     }
 


### PR DESCRIPTION
Created new events for Merge and CreateOutput.
Some metrics (delete/rename) have a WAIT event associated with them. The event doesn't always trigger (likely due to the use of context.asynctosync) so a counter event was added for them.