### PR TITLE
Resolve #2224: Lucene: allow skipping checkIntegrity for all Postings…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,7 +24,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Lucene: allow skipping checkIntegrity for all PostingsFormat inheritors [(Issue #2224)](https://github.com/FoundationDB/fdb-record-layer/issues/2224)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundReader.java
@@ -163,7 +163,9 @@ final class LuceneOptimizedCompoundReader extends CompoundDirectory {
 
     @Override
     public void checkIntegrity() throws IOException {
-        CodecUtil.checksumEntireFile(handle);
+        if (LuceneOptimizedPostingsFormat.allowCheckDataIntegrity) {
+            CodecUtil.checksumEntireFile(handle);
+        }
     }
 
     public Directory getDirectory() {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedDocValuesFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedDocValuesFormat.java
@@ -113,7 +113,9 @@ public class LuceneOptimizedDocValuesFormat extends DocValuesFormat {
 
         @Override
         public void checkIntegrity() throws IOException {
-            docValuesProducer.get().checkIntegrity();
+            if (LuceneOptimizedPostingsFormat.allowCheckDataIntegrity) {
+                docValuesProducer.get().checkIntegrity();
+            }
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormat.java
@@ -75,7 +75,9 @@ public class LuceneOptimizedPointsFormat extends PointsFormat {
 
         @Override
         public void checkIntegrity() throws IOException {
-            pointsReader.get().checkIntegrity();
+            if (LuceneOptimizedPostingsFormat.allowCheckDataIntegrity) {
+                pointsReader.get().checkIntegrity();
+            }
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
@@ -44,7 +44,7 @@ import java.util.function.Supplier;
 @AutoService(PostingsFormat.class)
 public class LuceneOptimizedPostingsFormat extends PostingsFormat {
     PostingsFormat postingsFormat;
-    private static boolean allowCheckDataIntegrity = true;
+    static boolean allowCheckDataIntegrity = true;
 
     public LuceneOptimizedPostingsFormat() {
         this(new Lucene84PostingsFormat());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
@@ -98,7 +98,9 @@ public class LuceneOptimizedStoredFieldsFormat extends StoredFieldsFormat {
 
         @Override
         public void checkIntegrity() throws IOException {
-            storedFieldsReader.get().checkIntegrity();
+            if (LuceneOptimizedPostingsFormat.allowCheckDataIntegrity) {
+                storedFieldsReader.get().checkIntegrity();
+            }
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/main/java/org/apache/lucene/codecs/lucene84/LuceneOptimizedPostingsReader.java
+++ b/fdb-record-layer-lucene/src/main/java/org/apache/lucene/codecs/lucene84/LuceneOptimizedPostingsReader.java
@@ -2016,6 +2016,7 @@ public final class LuceneOptimizedPostingsReader extends PostingsReaderBase {
 
     @Override
     public void checkIntegrity() throws IOException {
+        // Should this checksum verification be skipped for fdb?
         if (docIn != null) {
             CodecUtil.checksumEntireFile(docIn.get());
         }


### PR DESCRIPTION
…Format inheritors

Note to reviewer: The implementation is a little ugly. 
The idea is that: 
1. This is compatible with the existing optimization in `LuceneOptimizedPostingsFormat`  (no changes are required from the users)
2. After testing, if this optimization fixes the performance problems, we may remove the condition and make our `checkIntegrity` implementations a constant no-op. 
