### PR TITLE
Support ReadBlock Tracing not just from the file (.cfs) but to the reference (.fnm, etc.). #2226

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -423,14 +423,31 @@ public class FDBDirectory extends Directory  {
     @API(API.Status.INTERNAL)
     @Nonnull
     public CompletableFuture<byte[]> readBlock(@Nonnull String resourceDescription, @Nonnull CompletableFuture<FDBLuceneFileReference> referenceFuture, int block) {
-        return referenceFuture.thenCompose(reference -> readBlock(resourceDescription, reference, block));
+        return referenceFuture.thenCompose(reference -> readBlock(resourceDescription, resourceDescription, reference, block));
+    }
+
+    /**
+     * Reads known data from the directory.
+     * @param nestedResourceDescription Description should be non-null, opaque string describing this nestedResource; used for logging
+     * @param resourceDescription Description should be non-null, opaque string describing this resource; used for logging
+     * @param referenceFuture the reference where the data supposedly lives
+     * @param block the block where the data is stored
+     * @return Completable future of the data returned
+     * @throws RecordCoreException if blockCache fails to get the data from the block
+     * @throws RecordCoreArgumentException if a reference with that id hasn't been written yet.
+     */
+    @API(API.Status.INTERNAL)
+    @Nonnull
+    public CompletableFuture<byte[]> readBlock(@Nonnull String nestedResourceDescription, @Nonnull String resourceDescription, @Nonnull CompletableFuture<FDBLuceneFileReference> referenceFuture, int block) {
+        return referenceFuture.thenCompose(reference -> readBlock(nestedResourceDescription, resourceDescription, reference, block));
     }
 
     @Nonnull
-    private CompletableFuture<byte[]> readBlock(@Nonnull String resourceDescription, @Nullable FDBLuceneFileReference reference, int block) {
+    private CompletableFuture<byte[]> readBlock(@Nonnull String nestedResourceDescription, @Nonnull String resourceDescription, @Nullable FDBLuceneFileReference reference, int block) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("readBlock",
                     LuceneLogMessageKeys.FILE_NAME, resourceDescription,
+                    LuceneLogMessageKeys.FILE_REFERENCE, nestedResourceDescription,
                     LuceneLogMessageKeys.BLOCK_NUMBER, block));
         }
         if (reference == null) {


### PR DESCRIPTION
Example log message

2023-07-12 15:14:32,464 [TRACE] c.a.f.r.l.d.FDBDirectory - readBlock block_number="25" compression_supposed="true" encryption_supposed="false" file_name="_5c.cfs" file_reference="_5c_RLLucene84_0.tim" subspace="Subspace(rawPrefix=\x15>\x15'\x15\x1d\x15\x02\x02Simple$text_suffixes\x00)"

Notice how it shows just not the file "_5c.cfs" but also the file_reference "_5c_RLLucene84_0.tim".