### PR TITLE
Avoid introducing duplicates when splitting disjunction to union

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Splitting disjunction into union produces duplicates [(Issue #2230)](https://github.com/FoundationDB/fdb-record-layer/issues/2230)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -950,7 +950,7 @@ public class CascadesPlanner implements QueryPlanner {
                     taskStack.push(this);
                 }
                 for (final ExpressionRef<? extends RelationalExpression> reference : referencesWithPushedRequirements) {
-                    if (!((GroupExpressionRef<? extends RelationalExpression>)reference).needsExploration()) {
+                    if (!((GroupExpressionRef<? extends RelationalExpression>)reference).hasNeverBeenExplored()) {
                         taskStack.push(new ExploreGroup(context, reference, evaluationContext));
                     }
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -950,7 +950,9 @@ public class CascadesPlanner implements QueryPlanner {
                     taskStack.push(this);
                 }
                 for (final ExpressionRef<? extends RelationalExpression> reference : referencesWithPushedRequirements) {
-                    taskStack.push(new ExploreGroup(context, reference, evaluationContext));
+                    if (!((GroupExpressionRef<? extends RelationalExpression>)reference).needsExploration()) {
+                        taskStack.push(new ExploreGroup(context, reference, evaluationContext));
+                    }
                 }
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConstraintsMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConstraintsMap.java
@@ -202,6 +202,10 @@ public class ConstraintsMap {
         return watermarkGoalTick > watermarkCommittedTick;
     }
 
+    /**
+     * This method indicates whether a reference containing this map has not been explored yet.
+     * @return {@code true} if the associated reference has not been explored yet, {@code false} otherwise.
+     */
     public boolean hasNeverBeenExplored() {
         return watermarkCommittedTick < 0L;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConstraintsMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConstraintsMap.java
@@ -202,13 +202,17 @@ public class ConstraintsMap {
         return watermarkGoalTick > watermarkCommittedTick;
     }
 
+    public boolean hasNeverBeenExplored() {
+        return watermarkCommittedTick < 0L;
+    }
+
     /**
      * This method indicates whether the reference containing this map is currently being explored for the first time (a full
      * exploration). That means that the reference has started exploration but has not yet finished it.
      * @return {@code true} if the associated reference is currently being fully explored, {@code false} otherwise.
      */
     public boolean isFullyExploring() {
-        return watermarkCommittedTick < 0 && isExploring();
+        return hasNeverBeenExplored() && isExploring();
     }
 
     /**
@@ -219,7 +223,7 @@ public class ConstraintsMap {
      * @return {@code true} if the associated reference is currently being fully explored, {@code false} otherwise.
      */
     public boolean isExploredForAttributes(@Nonnull final Set<PlannerConstraint<?>> attributes) {
-        if (watermarkCommittedTick < 0) {
+        if (hasNeverBeenExplored()) {
             // never been planned
             return false;
         } else {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GroupExpressionRef.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GroupExpressionRef.java
@@ -338,6 +338,10 @@ public class GroupExpressionRef<T extends RelationalExpression> implements Expre
         return constraintsMap.isExploring();
     }
 
+    public boolean hasNeverBeenExplored() {
+        return constraintsMap.hasNeverBeenExplored();
+    }
+
     public boolean isFullyExploring() {
         return constraintsMap.isFullyExploring();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleSet.java
@@ -60,6 +60,7 @@ import com.apple.foundationdb.record.query.plan.cascades.rules.PushMapThroughFet
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushReferencedFieldsThroughDistinctRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushReferencedFieldsThroughFilterRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushReferencedFieldsThroughSelectRule;
+import com.apple.foundationdb.record.query.plan.cascades.rules.PushReferencedFieldsThroughUniqueRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughDeleteRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughDistinctRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughGroupByRule;
@@ -69,6 +70,7 @@ import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrde
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughSelectRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughSortRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughUnionRule;
+import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughUniqueRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushRequestedOrderingThroughUpdateRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushSetOperationThroughFetchRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushTypeFilterBelowFilterRule;
@@ -117,6 +119,7 @@ public class PlannerRuleSet {
             new PushReferencedFieldsThroughDistinctRule(),
             new PushReferencedFieldsThroughFilterRule(),
             new PushReferencedFieldsThroughSelectRule(),
+            new PushReferencedFieldsThroughUniqueRule(),
             new PushRequestedOrderingThroughSortRule(),
             new PushRequestedOrderingThroughDistinctRule(),
             new PushRequestedOrderingThroughUnionRule(),
@@ -126,7 +129,8 @@ public class PlannerRuleSet {
             new PushRequestedOrderingThroughGroupByRule(),
             new PushRequestedOrderingThroughDeleteRule(),
             new PushRequestedOrderingThroughInsertRule(),
-            new PushRequestedOrderingThroughUpdateRule()
+            new PushRequestedOrderingThroughUpdateRule(),
+            new PushRequestedOrderingThroughUniqueRule()
     );
 
     private static final List<CascadesRule<? extends RelationalExpression>> IMPLEMENTATION_RULES = ImmutableList.of(

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleSet.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementPhysical
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementSimpleSelectRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementStreamingAggregationRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementTypeFilterRule;
+import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementUniqueRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementUnorderedUnionRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementUpdateRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.InComparisonToExplodeRule;
@@ -137,6 +138,7 @@ public class PlannerRuleSet {
             new ImplementDistinctUnionRule(),
             new ImplementUnorderedUnionRule(),
             new ImplementDistinctRule(),
+            new ImplementUniqueRule(),
             new RemoveSortRule(),
             new PushDistinctBelowFilterRule(),
             new MergeFetchIntoCoveringIndexRule(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/NodeInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/NodeInfo.java
@@ -154,12 +154,6 @@ public class NodeInfo {
             NodeIcon.COMPUTATION_OPERATOR,
             "Unordered Distinct",
             "An unordered distinct operator processes its input records and returns the set of distinct records. It does not require its input records to be ordered but does impose a memory overhead as it needs to track records it has already encountered.");
-
-    public static final NodeInfo UNORDERED_UNIQUE_OPERATOR = new NodeInfo(
-            "Unique",
-            NodeIcon.COMPUTATION_OPERATOR,
-            "Unique",
-            "A unique operator that outputs a stream of unique records. It does not require input records to be ordered and does not reorder output records.");
     public static final NodeInfo UNORDERED_PRIMARY_KEY_DISTINCT_OPERATOR = new NodeInfo(
             "UnorderedPrimaryKeyDistinct",
             NodeIcon.COMPUTATION_OPERATOR,
@@ -248,7 +242,6 @@ public class NodeInfo {
                 TYPE_FILTER_OPERATOR,
                 UNION_OPERATOR,
                 UNORDERED_DISTINCT_OPERATOR,
-                UNORDERED_UNIQUE_OPERATOR,
                 UNORDERED_PRIMARY_KEY_DISTINCT_OPERATOR,
                 UNORDERED_UNION_OPERATOR);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/NodeInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/NodeInfo.java
@@ -154,6 +154,12 @@ public class NodeInfo {
             NodeIcon.COMPUTATION_OPERATOR,
             "Unordered Distinct",
             "An unordered distinct operator processes its input records and returns the set of distinct records. It does not require its input records to be ordered but does impose a memory overhead as it needs to track records it has already encountered.");
+
+    public static final NodeInfo UNORDERED_UNIQUE_OPERATOR = new NodeInfo(
+            "Unique",
+            NodeIcon.COMPUTATION_OPERATOR,
+            "Unique",
+            "A unique operator that outputs a stream of unique records. It does not require input records to be ordered and does not reorder output records.");
     public static final NodeInfo UNORDERED_PRIMARY_KEY_DISTINCT_OPERATOR = new NodeInfo(
             "UnorderedPrimaryKeyDistinct",
             NodeIcon.COMPUTATION_OPERATOR,
@@ -242,6 +248,7 @@ public class NodeInfo {
                 TYPE_FILTER_OPERATOR,
                 UNION_OPERATOR,
                 UNORDERED_DISTINCT_OPERATOR,
+                UNORDERED_UNIQUE_OPERATOR,
                 UNORDERED_PRIMARY_KEY_DISTINCT_OPERATOR,
                 UNORDERED_UNION_OPERATOR);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUniqueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUniqueExpression.java
@@ -40,22 +40,19 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * A relational planner expression representing a stream of distinct records. This expression has a single child which
- * is also a {@link RelationalExpression}. This expression represents this underlying expression with its result
- * set de-duplicated.
- *
- * @see com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan for the fallback implementation
+ * A relational planner expression representing a stream of unique records. This expression has a single child which
+ * is also a {@link RelationalExpression}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class LogicalDistinctExpression implements RelationalExpressionWithChildren, InternalPlannerGraphRewritable {
+public class LogicalUniqueExpression implements RelationalExpressionWithChildren, InternalPlannerGraphRewritable {
     @Nonnull
     private final Quantifier inner;
 
-    public LogicalDistinctExpression(@Nonnull ExpressionRef<RelationalExpression> innerRef) {
+    public LogicalUniqueExpression(@Nonnull ExpressionRef<RelationalExpression> innerRef) {
         this(Quantifier.forEach(innerRef));
     }
 
-    public LogicalDistinctExpression(@Nonnull Quantifier inner) {
+    public LogicalUniqueExpression(@Nonnull Quantifier inner) {
         this.inner = inner;
     }
 
@@ -78,8 +75,8 @@ public class LogicalDistinctExpression implements RelationalExpressionWithChildr
 
     @Nonnull
     @Override
-    public LogicalDistinctExpression translateCorrelations(@Nonnull final TranslationMap translationMap, @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
-        return new LogicalDistinctExpression(Iterables.getOnlyElement(translatedQuantifiers));
+    public LogicalUniqueExpression translateCorrelations(@Nonnull final TranslationMap translationMap, @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
+        return new LogicalUniqueExpression(Iterables.getOnlyElement(translatedQuantifiers));
     }
 
     @Nonnull
@@ -118,7 +115,7 @@ public class LogicalDistinctExpression implements RelationalExpressionWithChildr
     public PlannerGraph rewriteInternalPlannerGraph(@Nonnull final List<? extends PlannerGraph> childGraphs) {
         return PlannerGraph.fromNodeAndChildGraphs(
                 new PlannerGraph.LogicalOperatorNodeWithInfo(this,
-                        NodeInfo.UNORDERED_DISTINCT_OPERATOR,
+                        NodeInfo.UNORDERED_UNIQUE_OPERATOR,
                         ImmutableList.of(),
                         ImmutableMap.of()),
                 childGraphs);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUniqueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUniqueExpression.java
@@ -1,5 +1,5 @@
 /*
- * LogicalDistinctPlan.java
+ * LogicalUniqueExpression.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUniqueExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalUniqueExpression.java
@@ -26,12 +26,8 @@ import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
-import com.apple.foundationdb.record.query.plan.cascades.explain.InternalPlannerGraphRewritable;
-import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
-import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
@@ -44,7 +40,7 @@ import java.util.Set;
  * is also a {@link RelationalExpression}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class LogicalUniqueExpression implements RelationalExpressionWithChildren, InternalPlannerGraphRewritable {
+public class LogicalUniqueExpression implements RelationalExpressionWithChildren {
     @Nonnull
     private final Quantifier inner;
 
@@ -102,22 +98,11 @@ public class LogicalUniqueExpression implements RelationalExpressionWithChildren
 
     @Override
     public int hashCodeWithoutChildren() {
-        return 31;
+        return 251;
     }
 
     @Override
     public int hashCode() {
         return semanticHashCode();
-    }
-
-    @Nonnull
-    @Override
-    public PlannerGraph rewriteInternalPlannerGraph(@Nonnull final List<? extends PlannerGraph> childGraphs) {
-        return PlannerGraph.fromNodeAndChildGraphs(
-                new PlannerGraph.LogicalOperatorNodeWithInfo(this,
-                        NodeInfo.UNORDERED_UNIQUE_OPERATOR,
-                        ImmutableList.of(),
-                        ImmutableMap.of()),
-                childGraphs);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RelationalExpressionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RelationalExpressionMatchers.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalProj
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalUnionExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalUniqueExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.PrimaryScanExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpressionWithPredicates;
@@ -198,6 +199,11 @@ public class RelationalExpressionMatchers {
     @Nonnull
     public static BindingMatcher<LogicalUnionExpression> logicalUnionExpression(@Nonnull final CollectionMatcher<? extends Quantifier> downstream) {
         return ofTypeOwning(LogicalUnionExpression.class, downstream);
+    }
+
+    @Nonnull
+    public static BindingMatcher<LogicalUniqueExpression> logicalUniqueExpression(@Nonnull final CollectionMatcher<? extends Quantifier> downstream) {
+        return ofTypeOwning(LogicalUniqueExpression.class, downstream);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
@@ -41,6 +41,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalProj
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalUnionExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalUniqueExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.MatchableSortExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.PrimaryScanExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
@@ -505,6 +506,12 @@ public class CardinalitiesProperty implements ExpressionProperty<CardinalitiesPr
     @Override
     public Cardinalities visitLogicalIntersectionExpression(@Nonnull final LogicalIntersectionExpression logicalIntersectionExpression) {
         return intersectCardinalities(fromChildren(logicalIntersectionExpression));
+    }
+
+    @Nonnull
+    @Override
+    public Cardinalities visitLogicalUniqueExpression(@Nonnull final LogicalUniqueExpression logicalUniqueExpression) {
+        return fromChild(logicalUniqueExpression);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
@@ -1,0 +1,68 @@
+/*
+ * ImplementUniqueRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
+import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalUniqueExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.properties.DistinctRecordsProperty;
+import com.apple.foundationdb.record.query.plan.cascades.properties.PrimaryKeyProperty;
+
+import javax.annotation.Nonnull;
+
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.AnyMatcher.any;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.only;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierOverRef;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.anyPlanPartition;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.planPartitions;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.where;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.logicalUniqueExpression;
+
+/**
+ * This rule implements {@link LogicalUniqueExpression} by absorbing it if the inner reference is already distinct.
+ */
+public class ImplementUniqueRule extends CascadesRule<LogicalUniqueExpression> {
+
+    @Nonnull
+    private static final BindingMatcher<PlanPartition> anyPlanPartitionMatcher = anyPlanPartition();
+
+    @Nonnull
+    private static final BindingMatcher<ExpressionRef<? extends RelationalExpression>> innerReferenceMatcher = planPartitions(
+            where(planPartition -> planPartition.getAttributesMap().containsKey(DistinctRecordsProperty.DISTINCT_RECORDS)
+                                   && planPartition.getAttributeValue(PrimaryKeyProperty.PRIMARY_KEY).isPresent(), any(anyPlanPartitionMatcher)));
+
+    @Nonnull
+    private static final BindingMatcher<LogicalUniqueExpression> root = logicalUniqueExpression(only(forEachQuantifierOverRef(innerReferenceMatcher)));
+
+    public ImplementUniqueRule() {
+        super(root);
+    }
+
+    @Override
+    public void onMatch(@Nonnull final CascadesRuleCall call) {
+        final var innerPlanPartition = call.get(anyPlanPartitionMatcher);
+        call.yield(innerPlanPartition.getPlans());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
@@ -40,7 +40,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierOverRef;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.anyPlanPartition;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.planPartitions;
-import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.rollUpTo;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.rollUp;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.where;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.logicalUniqueExpression;
 
@@ -57,7 +57,7 @@ public class ImplementUniqueRule extends CascadesRule<LogicalUniqueExpression> {
     private static final BindingMatcher<ExpressionRef<? extends RelationalExpression>> innerReferenceMatcher = planPartitions(
             where(planPartition -> planPartition.getAttributesMap().containsKey(DistinctRecordsProperty.DISTINCT_RECORDS)
                                    && planPartition.getAttributeValue(PrimaryKeyProperty.PRIMARY_KEY).isPresent(),
-                    rollUpTo(anyPlanPartitionMatcher, ImmutableSet.of())));
+                    rollUp(anyPlanPartitionMatcher)));
 
     @Nonnull
     private static final BindingMatcher<LogicalUniqueExpression> root = logicalUniqueExpression(only(forEachQuantifierOverRef(innerReferenceMatcher)));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicateToLogicalUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicateToLogicalUnionRule.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
-import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.MatchPartition;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughUniqueRule.java
@@ -1,0 +1,74 @@
+/*
+ * PushReferencedFieldsThroughDistinctRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
+import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.ReferencedFieldsConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.ReferencedFieldsConstraint.ReferencedFields;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalUniqueExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.PlannerBindings;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierOverRef;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.logicalUniqueExpression;
+
+/**
+ * A rule that pushes a {@link ReferencedFieldsConstraint} through a {@link LogicalUniqueExpression}.
+ */
+@API(API.Status.EXPERIMENTAL)
+@SuppressWarnings("PMD.TooManyStaticImports")
+public class PushReferencedFieldsThroughUniqueRule extends CascadesRule<LogicalUniqueExpression> implements PreOrderRule {
+    private static final BindingMatcher<ExpressionRef<? extends RelationalExpression>> lowerRefMatcher = ReferenceMatchers.anyRef();
+    private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
+    private static final BindingMatcher<LogicalUniqueExpression> root =
+            logicalUniqueExpression(exactly(innerQuantifierMatcher));
+
+    public PushReferencedFieldsThroughUniqueRule() {
+        super(root, ImmutableSet.of(ReferencedFieldsConstraint.REFERENCED_FIELDS));
+    }
+
+    @Override
+    public void onMatch(@Nonnull final CascadesRuleCall call) {
+        final PlannerBindings bindings = call.getBindings();
+        final ExpressionRef<? extends RelationalExpression> lowerRef = bindings.get(lowerRefMatcher);
+        final Optional<ReferencedFields> referencedFieldsOptional = call.getPlannerConstraint(ReferencedFieldsConstraint.REFERENCED_FIELDS);
+
+        if (!referencedFieldsOptional.isPresent()) {
+            return;
+        }
+
+        call.pushConstraint(lowerRef,
+                ReferencedFieldsConstraint.REFERENCED_FIELDS,
+                referencedFieldsOptional.get());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughUniqueRule.java
@@ -1,5 +1,5 @@
 /*
- * PushReferencedFieldsThroughDistinctRule.java
+ * PushReferencedFieldsThroughUniqueRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUniqueRule.java
@@ -1,0 +1,71 @@
+/*
+ * PushRequestedOrderingThroughDistinctRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
+import com.apple.foundationdb.record.query.plan.cascades.ExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.RequestedOrderingConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalUniqueExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierOverRef;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.logicalUniqueExpression;
+
+/**
+ * A rule that pushes an {@link RequestedOrderingConstraint} through a {@link LogicalUniqueExpression}.
+ */
+@API(API.Status.EXPERIMENTAL)
+@SuppressWarnings("PMD.TooManyStaticImports")
+public class PushRequestedOrderingThroughUniqueRule extends CascadesRule<LogicalUniqueExpression> implements PreOrderRule {
+    private static final BindingMatcher<ExpressionRef<? extends RelationalExpression>> lowerRefMatcher = ReferenceMatchers.anyRef();
+    private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
+    private static final BindingMatcher<LogicalUniqueExpression> root =
+            logicalUniqueExpression(exactly(innerQuantifierMatcher));
+
+    public PushRequestedOrderingThroughUniqueRule() {
+        super(root, ImmutableSet.of(RequestedOrderingConstraint.REQUESTED_ORDERING));
+    }
+
+    @Override
+    public void onMatch(@Nonnull final CascadesRuleCall call) {
+        final var requestedOrderingsOptional = call.getPlannerConstraint(RequestedOrderingConstraint.REQUESTED_ORDERING);
+        if (requestedOrderingsOptional.isEmpty()) {
+            return;
+        }
+
+        final var bindings = call.getBindings();
+        final var lowerRef = bindings.get(lowerRefMatcher);
+
+        call.pushConstraint(lowerRef,
+                RequestedOrderingConstraint.REQUESTED_ORDERING,
+                requestedOrderingsOptional.get());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUniqueRule.java
@@ -1,5 +1,5 @@
 /*
- * PushRequestedOrderingThroughDistinctRule.java
+ * PushRequestedOrderingThroughUniqueRule.java
  *
  * This source file is part of the FoundationDB open source project
  *


### PR DESCRIPTION
This fixes the problem of potentially introducing duplicates when splitting a disjunction into a union as explained in #2230. The fix mainly introduces a new `LogicalUniqueExpression` that sits on top of each union leg and can only be implemented when underlying expression is distinct with primary key. a `LogicalDistinctExpression` is put on of the union expression to make sure we eliminate any duplicates.

This fixes #2230.