### PR TITLE
Constrain pipeline size to 1 for UPDATE operations

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/PipelineOperation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/PipelineOperation.java
@@ -54,6 +54,10 @@ public class PipelineOperation {
     public static final PipelineOperation SYNTHETIC_RECORD_JOIN = new PipelineOperation("SYNTHETIC_RECORD_JOIN");
     @Nonnull
     public static final PipelineOperation UPDATE = new PipelineOperation("UPDATE");
+    @Nonnull
+    public static final PipelineOperation DELETE = new PipelineOperation("DELETE");
+    @Nonnull
+    public static final PipelineOperation INSERT = new PipelineOperation("INSERT");
 
     private final String name;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -163,7 +163,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBRecordStore.class);
 
     public static final int DEFAULT_PIPELINE_SIZE = 10;
-    public static final PipelineSizer DEFAULT_PIPELINE_SIZER = pipelineOperation -> DEFAULT_PIPELINE_SIZE;
+    public static final PipelineSizer DEFAULT_PIPELINE_SIZER = pipelineOperation -> pipelineOperation == PipelineOperation.INSERT ? 1 : DEFAULT_PIPELINE_SIZE;
 
     // The maximum number of records to allow before triggering online index builds
     // instead of a transactional rebuild.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAbstractDataModificationPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAbstractDataModificationPlan.java
@@ -206,8 +206,10 @@ public abstract class RecordQueryAbstractDataModificationPlan implements RecordQ
                                     final var result = computationValue.eval(store, nestedContext);
                                     return QueryResult.ofComputed(result, null, storedRecord.getPrimaryKey(), null);
                                 }),
-                        store.getPipelineSize(PipelineOperation.UPDATE));
+                        store.getPipelineSize(getPipelineOperation()));
     }
+
+    public abstract PipelineOperation getPipelineOperation();
 
     @Nullable
     @SuppressWarnings("unchecked")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlan.java
@@ -104,7 +104,7 @@ public class RecordQueryDeletePlan implements RecordQueryPlanWithChild, PlannerG
                         RecordCursor.fromFuture(store.deleteRecordAsync(Verify.verifyNotNull(outerQueryResult.getPrimaryKey())))
                                 .filter(isDeleted -> isDeleted)
                                 .map(ignored -> outerQueryResult),
-                continuation, store.getPipelineSize(PipelineOperation.UPDATE));
+                continuation, store.getPipelineSize(PipelineOperation.DELETE));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInsertPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInsertPlan.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.plans;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PipelineOperation;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
@@ -67,6 +68,11 @@ public class RecordQueryInsertPlan extends RecordQueryAbstractDataModificationPl
                                   @Nullable final MessageHelpers.CoercionTrieNode coercionsTrie,
                                   @Nonnull final Value computationValue) {
         super(inner, recordType, targetType, targetDescriptor, null, coercionsTrie, computationValue);
+    }
+
+    @Override
+    public PipelineOperation getPipelineOperation() {
+        return PipelineOperation.INSERT;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUpdatePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUpdatePlan.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.plans;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PipelineOperation;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
@@ -77,6 +78,11 @@ public class RecordQueryUpdatePlan extends RecordQueryAbstractDataModificationPl
                                   @Nullable final MessageHelpers.CoercionTrieNode coercionsTrie,
                                   @Nonnull final Value computationValue) {
         super(inner, targetRecordType, targetType, targetDescriptor, transformationsTrie, coercionsTrie, computationValue);
+    }
+
+    @Override
+    public PipelineOperation getPipelineOperation() {
+        return PipelineOperation.UPDATE;
     }
 
     @Nonnull


### PR DESCRIPTION
The update pipeline is not thread safe and should not use a default size of 10
