### PR TITLE
Resolve #2234: Fix readSchema deadlock.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Resolve Lucene readSchema deadlock [(Issue #2234)](https://github.com/FoundationDB/fdb-record-layer/issues/2234)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -45,7 +45,6 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
@@ -71,10 +70,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -152,10 +150,7 @@ public class FDBDirectory extends Directory  {
     // True if sharedCacheManager is present until sharedCache has been set (or not).
     private boolean sharedCachePending;
 
-    // FieldInfo Cache attempting to optimize schema lookup per segment
-    private final Cache<BitSet, FieldInfos> fieldInfosCache;
-
-    private final Cache<BitSet, byte[]> fieldInfosDataCache;
+    private final Map<BitSet, byte[]> fieldInfosDataMap;
 
     public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context) {
         this(subspace, context, null, null);
@@ -196,12 +191,7 @@ public class FDBDirectory extends Directory  {
                 .maximumSize(maximumSize)
                 .recordStats()
                 .build();
-        this.fieldInfosCache = CacheBuilder.newBuilder()
-                .maximumSize(DEFAULT_MAXIMUM_FIELD_INFO_CACHE_SIZE)
-                .build();
-        this.fieldInfosDataCache = CacheBuilder.newBuilder()
-                .maximumSize(DEFAULT_MAXIMUM_FIELD_INFO_CACHE_SIZE)
-                .build();
+        this.fieldInfosDataMap = new ConcurrentHashMap<>();
         this.fileSequenceCounter = new AtomicLong(-1);
         this.compressionEnabled = Objects.requireNonNullElse(context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED), false);
         this.encryptionEnabled = Objects.requireNonNullElse(context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_ENCRYPTION_ENABLED), false);
@@ -488,7 +478,14 @@ public class FDBDirectory extends Directory  {
 
     public byte[] readSchema(List<Long> bitSetWords) throws IOException {
         BitSet bitSet = BitSet.valueOf(ArrayUtils.toPrimitive(bitSetWords.toArray(new Long[0])));
-        return fieldInfosDataCache.asMap().computeIfAbsent(bitSet, ignore -> context.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_SCHEMA, readSchemaAsync(bitSetWords)));
+        // In order to avoid a deadlock, and since the readSchema is idempotent, perform a non-blocking, non-atomic cache
+        // population. There may be a few threads that make calls to FDB, but they should all be returning the same result
+        byte[] value = fieldInfosDataMap.get(bitSet);
+        if (value == null) {
+            value = context.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_SCHEMA, readSchemaAsync(bitSetWords));
+            fieldInfosDataMap.put(bitSet, value);
+        }
+        return value;
     }
 
     /**
@@ -530,11 +527,6 @@ public class FDBDirectory extends Directory  {
                     displayList.add(entry.getKey());
                     totalSize += entry.getValue().getSize();
                     actualTotalSize += entry.getValue().getActualSize();
-                    try {
-                        readSchema(entry.getValue().getBitSetWords());
-                    } catch (IOException ioe) {
-                        LOGGER.error("read schema cache attemp failed", ioe);
-                    }
                 }
                 LOGGER.debug(getLogMessage("listAllFiles",
                         LuceneLogMessageKeys.FILE_COUNT, displayList.size(),
@@ -844,9 +836,5 @@ public class FDBDirectory extends Directory  {
 
     Cache<Pair<Long, Integer>, CompletableFuture<byte[]>> getBlockCache() {
         return blockCache;
-    }
-
-    public FieldInfos getFieldInfos(BitSet bitSet, Callable<FieldInfos> loader) throws ExecutionException {
-        return fieldInfosCache.get(bitSet, loader);
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -483,7 +483,10 @@ public class FDBDirectory extends Directory  {
         byte[] value = fieldInfosDataMap.get(bitSet);
         if (value == null) {
             value = context.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_SCHEMA, readSchemaAsync(bitSetWords));
-            fieldInfosDataMap.put(bitSet, value);
+            // don't populate if no values in DB
+            if (value != null) {
+                fieldInfosDataMap.put(bitSet, value);
+            }
         }
         return value;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -107,6 +107,7 @@ public class FDBIndexInput extends IndexInput {
     /**
      * Constructor that is utilized by splice calls to take into account initial offsets and modifications to length.
      *
+     * @param nestedResourceDescription opaque description of file; used for logging
      * @param resourceDescription opaque description of file; used for logging
      * @param fdbDirectory FDB directory mapping
      * @param reference future Reference


### PR DESCRIPTION
Make the byte[] schema perform a non-atomic cache population.
Remove the parsed fieldInfo caching (so it always reads from the byte[] cache).
