### PR TITLE
Resolves #2237: Remove unnecessary async code from writeSchema

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Remove unnecessary supplyAsync from FDBDirectory.writeSchema [(Issue #2237)](https://github.com/FoundationDB/fdb-record-layer/issues/2237)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedWrappedDirectory.java
@@ -42,7 +42,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import static com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCompoundFormat.DATA_EXTENSION;
 
@@ -108,21 +107,14 @@ class LuceneOptimizedWrappedDirectory extends Directory {
             return new LuceneOptimizedWrappedIndexOutput(name) {
                 @Override
                 public void close() throws IOException {
-                    try {
-                        FDBLuceneFileReference reference = new FDBLuceneFileReference(-1, -1, -1, -1);
-                        List<Long> words = getBitSetWords(fieldInfos);
-                        reference.setBitSetWords(words);
-                        byte[] schema = fdbDirectory.readSchema(words);
-                        if (schema == null) {
-                            fdbDirectory.writeSchema(words, outputStream.toByteArray()).get();
-                        }
-                        ((FDBDirectory)FilterDirectory.unwrap(fdbDirectory)).writeFDBLuceneFileReference(name, reference);
-                    } catch (InterruptedException ie) {
-                        LOG.error("interrupted exception during close", ie);
-                        Thread.currentThread().interrupt();
-                    } catch (ExecutionException e) {
-                        throw new IOException(e);
+                    FDBLuceneFileReference reference = new FDBLuceneFileReference(-1, -1, -1, -1);
+                    List<Long> words = getBitSetWords(fieldInfos);
+                    reference.setBitSetWords(words);
+                    byte[] schema = fdbDirectory.readSchema(words);
+                    if (schema == null) {
+                        fdbDirectory.writeSchema(words, outputStream.toByteArray());
                     }
+                    ((FDBDirectory)FilterDirectory.unwrap(fdbDirectory)).writeFDBLuceneFileReference(name, reference);
                 }
             };
         } else {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -387,18 +387,16 @@ public class FDBDirectory extends Directory  {
         });
     }
 
-    public CompletableFuture<Integer> writeSchema(@Nonnull List<Long> bitSetWords, @Nonnull final byte[] value) {
-        return CompletableFuture.supplyAsync( () -> {
-            context.increment(LuceneEvents.Counts.LUCENE_WRITE_SIZE, value.length);
-            context.increment(LuceneEvents.Counts.LUCENE_WRITE_CALL);
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(getLogMessage("Write lucene data",
-                        LuceneLogMessageKeys.DATA_SIZE, value.length,
-                        LuceneLogMessageKeys.ENCODED_DATA_SIZE, value.length));
-            }
-            context.ensureActive().set(schemaSubspace.pack(Tuple.from(bitSetWords)), value);
-            return value.length;
-        });
+    public int writeSchema(@Nonnull List<Long> bitSetWords, @Nonnull final byte[] value) {
+        context.increment(LuceneEvents.Counts.LUCENE_WRITE_SIZE, value.length);
+        context.increment(LuceneEvents.Counts.LUCENE_WRITE_CALL);
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace(getLogMessage("Write lucene data",
+                    LuceneLogMessageKeys.DATA_SIZE, value.length,
+                    LuceneLogMessageKeys.ENCODED_DATA_SIZE, value.length));
+        }
+        context.ensureActive().set(schemaSubspace.pack(Tuple.from(bitSetWords)), value);
+        return value.length;
     }
 
     /**


### PR DESCRIPTION
it used supplyAsync, but always called get immediately on the result