### PR TITLE
Resolve #2240: Indexing throttle: reduce limit faster during repeatin…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Indexing throttle: reduce limit faster during repeating failures [(Issue #2240)](https://github.com/FoundationDB/fdb-record-layer/issues/2240)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -667,8 +667,8 @@ public abstract class IndexingBase {
         return throttle.buildCommitRetryAsync(buildFunction, null, additionalLogMessageKeyValues, duringRangesIteration);
     }
 
-    public long getTotalRecordsScannedScuccessfully() {
-        return throttle.getTotalRecordsScannedScuccessfully();
+    public long getTotalRecordsScannedSuccessfully() {
+        return throttle.getTotalRecordsScannedSuccessfully();
     }
 
     protected void timerIncrement(FDBStoreTimer.Counts event) {


### PR DESCRIPTION
…g failures

   The current algorithm has a hidden conjecture - assuming that the majority of the indexing time is spent during records iterations. Lucene index
   seems to change that, and spend a lot of time at transaction commit (merging?). To address slow responses for repeating failures, track consecutive
   indexing failures and decrease limit more aggressively when it happens.
   Also: for debugging, log store timer diff between failures.