### PR TITLE
change error code when function not defined

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/SemanticException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/SemanticException.java
@@ -46,6 +46,7 @@ public class SemanticException extends RecordCoreException {
         ARGUMENT_TO_ARITHMETIC_OPERATOR_IS_OF_COMPLEX_TYPE(6, "The argument to an arithmetic operator expecting an argument of a primitive type, is invoked with an argument of a complex type, e.g. an array or a record."),
         OPERAND_OF_LIKE_OPERATOR_IS_NOT_STRING(7, "The like operator expects string operands but was invoked with an operand of another type."),
         ESCAPE_CHAR_OF_LIKE_OPERATOR_IS_NOT_SINGLE_CHAR(8, "The like operator expects an escape character of length 1."),
+        FUNCTION_UNDEFINED_FOR_GIVEN_ARGUMENT_TYPES(9, "The function is not defined for the given argument types"),
 
         // insert, update, deletes
         UPDATE_TRANSFORM_AMBIGUOUS(1_000, "The transformations used in an UPDATE statement are ambiguous."),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
@@ -161,8 +161,7 @@ public class VariadicFunctionValue extends AbstractValue {
         }
 
         final PhysicalOperator physicalOperator = getOperatorMap().get(Pair.of((((ComparisonFn)builtInFunction).getComparisonFunction()), resultType.getTypeCode()));
-
-        Verify.verifyNotNull(physicalOperator, "unable to encapsulate scalar function due to type mismatch(es)");
+        SemanticException.check(physicalOperator != null, SemanticException.ErrorCode.FUNCTION_UNDEFINED_FOR_GIVEN_ARGUMENT_TYPES);
 
         final ImmutableList.Builder<Value> promotedArgs = ImmutableList.builder();
         for (final var arg: arguments) {


### PR DESCRIPTION
Introduces a new semantic exception that is thrown when a Variadic Function is not defined for a type. This replaces throwing "ARGUMENT_TO_ARITHMETIC_OPERATOR_IS_OF_COMPLEX_TYPE" which was more explicit but used for function values. 

By throwing specific errors, it can be better handled 1-1 in the upstream with their native error codes