### PR TITLE
addressed #2305: multidimensional index planning in the heuristic planner

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RTree.java
@@ -663,6 +663,7 @@ public class RTree {
      *         As a side effect of calling this method the child slot is removed from {@code toBeProcessed}.
      */
     @Nullable
+    @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
     private static ChildSlot resolveNextIdForFetch(@Nonnull final List<Deque<ChildSlot>> toBeProcessed,
                                                    @Nonnull final Predicate<Rectangle> mbrPredicate,
                                                    @Nonnull final BiPredicate<Tuple, Tuple> suffixPredicate) {
@@ -1671,7 +1672,7 @@ public class RTree {
     private <N extends Node> N checkNode(@Nonnull final N node) {
         if (node.size() < config.getMinM() || node.size() > config.getMaxM()) {
             if (!node.isRoot()) {
-                throw new IllegalStateException("packing of non-root packing is out of valid range");
+                throw new IllegalStateException("packing of non-root is out of valid range");
             }
         }
         return node;
@@ -2412,6 +2413,7 @@ public class RTree {
         /**
          * Method to determine if (during a scan a suffix predicate can be applied). A suffix predicate can only
          * be applied, if the smallest and largest hilbert value as well as the non-suffix part of the key are the same.
+         * @return {@code true} if a suffix predicate can be applied on this child slot
          */
         public boolean suffixPredicateCanBeApplied() {
             final int hilbertValueCompare = getSmallestHilbertValue().compareTo(getLargestHilbertValue());

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RTree.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.async;
 
+import com.apple.foundationdb.Database;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.ReadTransaction;
@@ -37,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +63,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -320,6 +323,7 @@ public class RTree {
      *
      * @see #newConfigBuilder
      */
+    @CanIgnoreReturnValue
     public static class ConfigBuilder {
         private int minM = DEFAULT_MIN_M;
         private int maxM = DEFAULT_MAX_M;
@@ -344,24 +348,27 @@ public class RTree {
             return minM;
         }
 
-        public void setMinM(final int minM) {
+        public ConfigBuilder setMinM(final int minM) {
             this.minM = minM;
+            return this;
         }
 
         public int getMaxM() {
             return maxM;
         }
 
-        public void setMaxM(final int maxM) {
+        public ConfigBuilder setMaxM(final int maxM) {
             this.maxM = maxM;
+            return this;
         }
 
         public int getSplitS() {
             return splitS;
         }
 
-        public void setSplitS(final int splitS) {
+        public ConfigBuilder setSplitS(final int splitS) {
             this.splitS = splitS;
+            return this;
         }
 
         @Nonnull
@@ -369,16 +376,18 @@ public class RTree {
             return storage;
         }
 
-        public void setStorage(@Nonnull final Storage storage) {
+        public ConfigBuilder setStorage(@Nonnull final Storage storage) {
             this.storage = storage;
+            return this;
         }
 
         public boolean isStoreHilbertValues() {
             return storeHilbertValues;
         }
 
-        public void setStoreHilbertValues(final boolean storeHilbertValues) {
+        public ConfigBuilder setStoreHilbertValues(final boolean storeHilbertValues) {
             this.storeHilbertValues = storeHilbertValues;
+            return this;
         }
 
         public Config build() {
@@ -477,12 +486,14 @@ public class RTree {
      * (this allows for efficient scans for {@code ORDER BY x, y LIMIT n} queries).
      * @param readTransaction the transaction to use
      * @param mbrPredicate a predicate on an mbr {@link Rectangle}
+     * @param suffixKeyPredicate a predicate on the suffix key
      * @return an {@link AsyncIterator} of {@link ItemSlot}s.
      */
     @Nonnull
     public AsyncIterator<ItemSlot> scan(@Nonnull final ReadTransaction readTransaction,
-                                        @Nonnull final Predicate<Rectangle> mbrPredicate) {
-        return scan(readTransaction, null, null, mbrPredicate);
+                                        @Nonnull final Predicate<Rectangle> mbrPredicate,
+                                        @Nonnull final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
+        return scan(readTransaction, null, null, mbrPredicate, suffixKeyPredicate);
     }
 
     /**
@@ -500,17 +511,19 @@ public class RTree {
      * @param lastHilbertValue the last Hilbert value that was returned by a previous call to this method
      * @param lastKey the last key that was returned by a previous call to this method
      * @param mbrPredicate a predicate on an mbr {@link Rectangle}
+     * @param suffixKeyPredicate a predicate on the suffix key
      * @return an {@link AsyncIterator} of {@link ItemSlot}s.
      */
     @Nonnull
     public AsyncIterator<ItemSlot> scan(@Nonnull final ReadTransaction readTransaction,
                                         @Nullable final BigInteger lastHilbertValue,
                                         @Nullable final Tuple lastKey,
-                                        @Nonnull final Predicate<Rectangle> mbrPredicate) {
+                                        @Nonnull final Predicate<Rectangle> mbrPredicate,
+                                        @Nonnull final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
         Preconditions.checkArgument((lastHilbertValue == null && lastKey == null) ||
                                     (lastHilbertValue != null && lastKey != null));
         AsyncIterator<LeafNode> leafIterator =
-                new LeafIterator(readTransaction, rootId, lastHilbertValue, lastKey, mbrPredicate);
+                new LeafIterator(readTransaction, rootId, lastHilbertValue, lastKey, mbrPredicate, suffixKeyPredicate);
         return new ItemSlotIterator(leafIterator);
     }
 
@@ -520,8 +533,13 @@ public class RTree {
      * comparing nodes (the left one being the smaller, the right one being the greater).
      * @param readTransaction the transaction to use 
      * @param nodeId node id to start from. This may be the actual root of the tree or some other node within the tree.
+     * @param lastHilbertValue hilbert value serving as a watermark to return only items that are larger than the
+     *        {@code (lastHilbertValue, lastKey)} pair
+     * @param lastKey key serving as a watermark to return only items that are larger than the
+     *        {@code (lastHilbertValue, lastKey)} pair
      * @param mbrPredicate a predicate on an mbr {@link Rectangle}. This predicate is evaluated on the way down to the
      *        leaf node.
+     * @param suffixPredicate predicate to be invoked on a range of suffixes
      * @return a {@link TraversalState} of the left-most path from {@code nodeId} to a {@link LeafNode} whose
      *         {@link Node}s all pass the mbr predicate test.
      */
@@ -530,7 +548,8 @@ public class RTree {
                                                                       @Nonnull final byte[] nodeId,
                                                                       @Nullable final BigInteger lastHilbertValue,
                                                                       @Nullable final Tuple lastKey,
-                                                                      @Nonnull final Predicate<Rectangle> mbrPredicate) {
+                                                                      @Nonnull final Predicate<Rectangle> mbrPredicate,
+                                                                      @Nonnull final BiPredicate<Tuple, Tuple> suffixPredicate) {
         final AtomicReference<byte[]> currentId = new AtomicReference<>(nodeId);
         final List<Deque<ChildSlot>> toBeProcessed = Lists.newArrayList();
         final AtomicReference<LeafNode> leafNode = new AtomicReference<>(null);
@@ -543,7 +562,8 @@ public class RTree {
                             final ChildSlot childSlot = iterator.next();
                             if (lastHilbertValue != null &&
                                     lastKey != null) {
-                                final int hilbertValueAndKeyCompare = childSlot.compareHilbertValueAndKey(lastHilbertValue, lastKey);
+                                final int hilbertValueAndKeyCompare =
+                                        childSlot.compareLargestHilbertValueAndKey(lastHilbertValue, lastKey);
                                 if (hilbertValueAndKeyCompare < 0) {
                                     //
                                     // The (lastHilbertValue, lastKey) pair is larger than the
@@ -554,14 +574,23 @@ public class RTree {
                                 }
                             }
 
-                            if (mbrPredicate.test(childSlot.getMbr())) {
-                                toBeProcessedThisLevel.addLast(childSlot);
-                                iterator.forEachRemaining(toBeProcessedThisLevel::addLast);
+                            if (!mbrPredicate.test(childSlot.getMbr())) {
+                                continue;
                             }
+
+                            if (childSlot.suffixPredicateCanBeApplied()) {
+                                if (!suffixPredicate.test(childSlot.getSmallestKeySuffix(),
+                                        childSlot.getLargestKeySuffix())) {
+                                    continue;
+                                }
+                            }
+
+                            toBeProcessedThisLevel.addLast(childSlot);
+                            iterator.forEachRemaining(toBeProcessedThisLevel::addLast);
                         }
                         toBeProcessed.add(toBeProcessedThisLevel);
 
-                        final ChildSlot nextChildSlot = resolveNextIdForFetch(toBeProcessed, mbrPredicate);
+                        final ChildSlot nextChildSlot = resolveNextIdForFetch(toBeProcessed, mbrPredicate, suffixPredicate);
                         if (nextChildSlot == null) {
                             return false;
                         }
@@ -584,7 +613,7 @@ public class RTree {
      * being the greater).
      * @param readTransaction the transaction to use
      * @param traversalState traversal state to start from. The initial traversal state is always obtained by initially
-     *        calling {@link #fetchLeftmostPathToLeaf(ReadTransaction, byte[], BigInteger, Tuple, Predicate)}.
+     *        calling {@link #fetchLeftmostPathToLeaf(ReadTransaction, byte[], BigInteger, Tuple, Predicate, BiPredicate)}.
      * @param mbrPredicate a predicate on an mbr {@link Rectangle}. This predicate is evaluated for each node that
      *        is processed.
      * @return a {@link TraversalState} of the left-most path from {@code nodeId} to a {@link LeafNode} whose
@@ -595,20 +624,21 @@ public class RTree {
                                                                   @Nonnull final TraversalState traversalState,
                                                                   @Nullable final BigInteger lastHilbertValue,
                                                                   @Nullable final Tuple lastKey,
-                                                                  @Nonnull final Predicate<Rectangle> mbrPredicate) {
+                                                                  @Nonnull final Predicate<Rectangle> mbrPredicate,
+                                                                  @Nonnull final BiPredicate<Tuple, Tuple> suffixPredicate) {
 
         final List<Deque<ChildSlot>> toBeProcessed = traversalState.getToBeProcessed();
         final AtomicReference<LeafNode> leafNode = new AtomicReference<>(null);
 
         return AsyncUtil.whileTrue(() -> {
-            final ChildSlot nextChildSlot = resolveNextIdForFetch(toBeProcessed, mbrPredicate);
+            final ChildSlot nextChildSlot = resolveNextIdForFetch(toBeProcessed, mbrPredicate, suffixPredicate);
             if (nextChildSlot == null) {
                 return AsyncUtil.READY_FALSE;
             }
 
             // fetch the left-most path rooted at the current child to its left-most leaf and concatenate the paths
             return fetchLeftmostPathToLeaf(readTransaction, nextChildSlot.getChildId(), lastHilbertValue,
-                    lastKey, mbrPredicate)
+                    lastKey, mbrPredicate, suffixPredicate)
                     .thenApply(nestedTraversalState -> {
                         if (nestedTraversalState.isEnd()) {
                             // no more data in this subtree
@@ -634,16 +664,24 @@ public class RTree {
      */
     @Nullable
     private static ChildSlot resolveNextIdForFetch(@Nonnull final List<Deque<ChildSlot>> toBeProcessed,
-                                                   @Nonnull final Predicate<Rectangle> mbrPredicate) {
+                                                   @Nonnull final Predicate<Rectangle> mbrPredicate,
+                                                   @Nonnull final BiPredicate<Tuple, Tuple> suffixPredicate) {
         for (int level = toBeProcessed.size() - 1; level >= 0; level--) {
             final Deque<ChildSlot> toBeProcessedThisLevel = toBeProcessed.get(level);
 
             while (!toBeProcessedThisLevel.isEmpty()) {
-                final ChildSlot nextChild = toBeProcessedThisLevel.pollFirst();
-                if (mbrPredicate.test(nextChild.getMbr())) {
-                    toBeProcessed.subList(level + 1, toBeProcessed.size()).clear();
-                    return nextChild;
+                final ChildSlot childSlot = toBeProcessedThisLevel.pollFirst();
+                if (!mbrPredicate.test(childSlot.getMbr())) {
+                    continue;
                 }
+                if (childSlot.suffixPredicateCanBeApplied()) {
+                    if (!suffixPredicate.test(childSlot.getSmallestKeySuffix(),
+                            childSlot.getLargestKeySuffix())) {
+                        continue;
+                    }
+                }
+                toBeProcessed.subList(level + 1, toBeProcessed.size()).clear();
+                return childSlot;
             }
         }
         return null;
@@ -924,13 +962,16 @@ public class RTree {
                 }
 
                 //
-                // Manufacture a new slot for the splitNode;the caller will then use that slot to insert it into the
+                // Manufacture a new slot for the splitNode; the caller will then use that slot to insert it into the
                 // parent.
                 //
-                final var lastSlotOfSplitNode = splitNode.getSlots().get(splitNode.size() - 1);
-                return new NodeOrAdjust(new ChildSlot(lastSlotOfSplitNode.getHilbertValue(),
-                        lastSlotOfSplitNode.getKey(), splitNode.getId(), computeMbr(splitNode.getSlots())), splitNode,
-                        true);
+                final NodeSlot firstSlotOfSplitNode = splitNode.getSlots().get(0);
+                final NodeSlot lastSlotOfSplitNode = splitNode.getSlots().get(splitNode.size() - 1);
+                return new NodeOrAdjust(
+                        new ChildSlot(firstSlotOfSplitNode.getSmallestHilbertValue(), firstSlotOfSplitNode.getSmallestKey(),
+                                lastSlotOfSplitNode.getLargestHilbertValue(), lastSlotOfSplitNode.getLargestKey(),
+                                splitNode.getId(), computeMbr(splitNode.getSlots())),
+                        splitNode, true);
             });
         }
     }
@@ -954,15 +995,19 @@ public class RTree {
         final ArrayList<? extends NodeSlot> rightSlots = Lists.newArrayList(oldRootNode.getSlots().subList(leftSize, leftSize + rightSize));
         rightNode.setSlots(rightSlots);
 
+        final NodeSlot firstSlotOfLeftNode = leftSlots.get(0);
         final NodeSlot lastSlotOfLeftNode = leftSlots.get(leftSlots.size() - 1);
+        final NodeSlot firstSlotOfRightNode = rightSlots.get(0);
         final NodeSlot lastSlotOfRightNode = rightSlots.get(rightSlots.size() - 1);
 
         final ArrayList<ChildSlot> rootNodeSlots =
                 Lists.newArrayList(
-                        new ChildSlot(lastSlotOfLeftNode.getHilbertValue(), lastSlotOfLeftNode.getKey(), leftNode.getId(),
-                                computeMbr(leftNode.getSlots())),
-                        new ChildSlot(lastSlotOfRightNode.getHilbertValue(), lastSlotOfRightNode.getKey(), rightNode.getId(),
-                                computeMbr(rightNode.getSlots())));
+                        new ChildSlot(firstSlotOfLeftNode.getSmallestHilbertValue(), firstSlotOfLeftNode.getSmallestKey(),
+                                lastSlotOfLeftNode.getLargestHilbertValue(), lastSlotOfLeftNode.getLargestKey(),
+                                leftNode.getId(), computeMbr(leftNode.getSlots())),
+                        new ChildSlot(firstSlotOfRightNode.getSmallestHilbertValue(), firstSlotOfRightNode.getSmallestKey(),
+                                lastSlotOfRightNode.getLargestHilbertValue(), lastSlotOfRightNode.getLargestKey(),
+                                rightNode.getId(), computeMbr(rightNode.getSlots())));
         final IntermediateNode newRootNode = new IntermediateNode(rootId, rootNodeSlots);
 
         storageAdapter.writeNodes(transaction, Lists.newArrayList(leftNode, rightNode, newRootNode));
@@ -1297,11 +1342,18 @@ public class RTree {
         final Rectangle newMbr = computeMbr(targetNode.getSlots());
         slotHasChanged = !childSlot.getMbr().equals(newMbr);
         childSlot.setMbr(newMbr);
+
+        final NodeSlot firstSlotOfTargetNode = targetNode.getSlots().get(0);
+        slotHasChanged |= !childSlot.getSmallestHilbertValue().equals(firstSlotOfTargetNode.getSmallestHilbertValue());
+        childSlot.setSmallestHilbertValue(firstSlotOfTargetNode.getSmallestHilbertValue());
+        slotHasChanged |= !childSlot.getSmallestKey().equals(firstSlotOfTargetNode.getSmallestKey());
+        childSlot.setSmallestKey(firstSlotOfTargetNode.getSmallestKey());
+
         final NodeSlot lastSlotOfTargetNode = targetNode.getSlots().get(targetNode.size() - 1);
-        slotHasChanged |= !childSlot.getLargestHilbertValue().equals(lastSlotOfTargetNode.getHilbertValue());
-        childSlot.setLargestHilbertValue(lastSlotOfTargetNode.getHilbertValue());
-        slotHasChanged |= !childSlot.getKey().equals(lastSlotOfTargetNode.getKey());
-        childSlot.setLargestKey(lastSlotOfTargetNode.getKey());
+        slotHasChanged |= !childSlot.getLargestHilbertValue().equals(lastSlotOfTargetNode.getLargestHilbertValue());
+        childSlot.setLargestHilbertValue(lastSlotOfTargetNode.getLargestHilbertValue());
+        slotHasChanged |= !childSlot.getLargestKey().equals(lastSlotOfTargetNode.getLargestKey());
+        childSlot.setLargestKey(lastSlotOfTargetNode.getLargestKey());
         return slotHasChanged;
     }
 
@@ -1438,15 +1490,41 @@ public class RTree {
 
     /**
      * Method to validate the Hilbert R-tree.
+     * @param db the database to use
+     */
+    public void validate(@Nonnull final Database db) {
+        validate(db, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Method to validate the Hilbert R-tree.
+     * @param db the database to use
+     * @param maxNumNodesToBeValidated a maximum number of nodes this call should attempt to validate
+     */
+    public void validate(@Nonnull final Database db,
+                         final int maxNumNodesToBeValidated) {
+        ArrayDeque<ParentNodeAndChildId> toBeProcessed = new ArrayDeque<>();
+        toBeProcessed.addLast(new ParentNodeAndChildId(null, rootId));
+
+        while (!toBeProcessed.isEmpty()) {
+            db.run(tr -> validate(tr, maxNumNodesToBeValidated, toBeProcessed).join());
+        }
+    }
+
+    /**
+     * Method to validate the Hilbert R-tree.
      * @param transaction the transaction to use
-     * @return a completable future that completes successfully if the tree is valid, completes with failure otherwise
+     * @param maxNumNodesToBeValidated a maximum number of nodes this call should attempt to validate
+     * @param toBeProcessed a deque with node information that still needs to be processed
+     * @return a completable future that completes successfully with the current deque of to-be-processed nodes if the
+     *         portion of the tree that was validated is in fact valid, completes with failure otherwise
      */
     @Nonnull
-    public CompletableFuture<Void> validate(@Nonnull final Transaction transaction) {
-        final ArrayDeque<ParentNodeAndChildId> toBeProcessed = new ArrayDeque<>();
+    private CompletableFuture<ArrayDeque<ParentNodeAndChildId>> validate(@Nonnull final Transaction transaction,
+                                                                         final int maxNumNodesToBeValidated,
+                                                                         @Nonnull final ArrayDeque<ParentNodeAndChildId> toBeProcessed) {
+        final AtomicInteger numNodesEnqueued = new AtomicInteger(0);
         final List<CompletableFuture<List<ParentNodeAndChildId>>> working = Lists.newArrayList();
-
-        toBeProcessed.addLast(new ParentNodeAndChildId(null, rootId));
 
         // Fetch the entire tree.
         return AsyncUtil.whileTrue(() -> {
@@ -1459,57 +1537,102 @@ public class RTree {
                 }
             }
             
-            while (working.size() <= MAX_CONCURRENT_READS) {
+            while (working.size() <= MAX_CONCURRENT_READS && numNodesEnqueued.get() < maxNumNodesToBeValidated) {
                 final ParentNodeAndChildId currentParentNodeAndChildId = toBeProcessed.pollFirst();
                 if (currentParentNodeAndChildId == null) {
                     break;
                 }
 
-                working.add(onReadListener.onAsyncRead(fetchNode(transaction, currentParentNodeAndChildId.getChildId())).thenApply(childNode -> {
+                final IntermediateNode parentNode = currentParentNodeAndChildId.getParentNode();
+                final ChildSlot childSlotInParentNode;
+                final int slotIndexInParent;
+                if (parentNode != null) {
+                    List<ChildSlot> slots = parentNode.getSlots();
+                    int slotIndex;
+                    ChildSlot childSlot = null;
+                    for (slotIndex = 0; slotIndex < slots.size(); slotIndex++) {
+                        childSlot = slots.get(slotIndex);
+                        if (Arrays.equals(childSlot.getChildId(), currentParentNodeAndChildId.getChildId())) {
+                            break;
+                        }
+                    }
+
+                    if (slotIndex == slots.size()) {
+                        throw new IllegalStateException("child slot not found in parent for child node");
+                    } else {
+                        childSlotInParentNode = childSlot;
+                        slotIndexInParent = slotIndex;
+                    }
+                } else {
+                    childSlotInParentNode = null;
+                    slotIndexInParent = -1;
+                }
+
+                final CompletableFuture<Node> fetchedNodeFuture =
+                        onReadListener.onAsyncRead(fetchNode(transaction, currentParentNodeAndChildId.getChildId())
+                                .thenApply(node -> {
+                                    if (parentNode != null) {
+                                        node.linkToParent(parentNode, slotIndexInParent);
+                                    }
+                                    return node;
+                                }));
+                working.add(fetchedNodeFuture.thenApply(childNode -> {
                     BigInteger lastHilbertValue = null;
                     Tuple lastKey = null;
 
-                    // check that all (hilbert values;key pairs) are monotonically increasing
+                    // check that all (hilbert values; key pairs) are monotonically increasing
                     for (final NodeSlot nodeSlot : childNode.getSlots()) {
                         if (lastHilbertValue != null) {
-                            final int hilbertValueCompare = nodeSlot.getHilbertValue().compareTo(lastHilbertValue);
+                            final int hilbertValueCompare = nodeSlot.getSmallestHilbertValue().compareTo(lastHilbertValue);
                             Verify.verify(hilbertValueCompare >= 0,
-                                    "(hilbertValue, key) pairs are not monotonically increasing (hilbertValueCheck)");
+                                    "smallest (hilbertValue, key) pairs are not monotonically increasing (hilbertValueCheck)");
                             if (hilbertValueCompare == 0) {
-                                Verify.verify(TupleHelpers.compare(nodeSlot.getKey(), lastKey) >= 0,
-                                        "(hilbertValue, key) pairs are not monotonically increasing (keyCheck)");
+                                Verify.verify(TupleHelpers.compare(nodeSlot.getSmallestKey(), lastKey) >= 0,
+                                        "smallest (hilbertValue, key) pairs are not monotonically increasing (keyCheck)");
                             }
                         }
-                        lastHilbertValue = nodeSlot.getHilbertValue();
-                        lastKey = nodeSlot.getKey();
+                        lastHilbertValue =  nodeSlot.getSmallestHilbertValue();
+                        lastKey = nodeSlot.getSmallestKey();
+                        final int hilbertValueCompare = nodeSlot.getLargestHilbertValue().compareTo(lastHilbertValue);
+                        Verify.verify(hilbertValueCompare >= 0,
+                                "largest (hilbertValue, key) pairs are not monotonically increasing (hilbertValueCheck)");
+                        if (hilbertValueCompare == 0) {
+                            Verify.verify(TupleHelpers.compare(nodeSlot.getLargestKey(), lastKey) >= 0,
+                                    "largest (hilbertValue, key) pairs are not monotonically increasing (keyCheck)");
+                        }
+
+                        lastHilbertValue = nodeSlot.getLargestHilbertValue();
+                        lastKey = nodeSlot.getLargestKey();
                     }
 
-                    final IntermediateNode parentNode = currentParentNodeAndChildId.getParentNode();
                     if (parentNode == null) {
                         // child is root
                         Verify.verify(childNode.isRoot());
                     } else {
-                        final ChildSlot childSlotInParentNode =
-                                parentNode.getSlots()
-                                        .stream()
-                                        .filter(childSlot -> Arrays.equals(childSlot.getChildId(), childNode.getId()))
-                                        .findFirst()
-                                        .orElseThrow(() -> new IllegalStateException("child slot not found in parent for child node"));
-
                         // Recompute the mbr of the child and compare it to the mbr the parent has.
                         final Rectangle computedMbr = computeMbr(childNode.getSlots());
                         Verify.verify(childSlotInParentNode.getMbr().equals(computedMbr),
                                 "computed mbr does not match mbr from node");
 
-                        // Verify that the largest hilbert value in the parent node is indeed the hilbert value of
-                        // the right-most child in childNode.
-                        Verify.verify(childSlotInParentNode.getLargestHilbertValue().equals(childNode.getSlots().get(childNode.size() - 1).getHilbertValue()),
-                                "expected largest hilbert does not match the actual hilbert value of the last child in childNode");
+                        // Verify that the smallest hilbert value in the parent node is indeed the smallest hilbert value of
+                        // the left-most child in childNode.
+                        Verify.verify(childSlotInParentNode.getSmallestHilbertValue().equals(childNode.getSlots().get(0).getSmallestHilbertValue()),
+                                "expected smallest hilbert value does not match the actual smallest hilbert value of the first child in childNode");
 
-                        // Verify that the largest hilbert value in the parent node is indeed the hilbert value of
+                        // Verify that the smallest key in the parent node is indeed the smallest key of
+                        // the left-most child in childNode.
+                        Verify.verify(TupleHelpers.equals(childSlotInParentNode.getSmallestKey(), childNode.getSlots().get(0).getSmallestKey()),
+                                "expected smallest key does not match the actual smallest key of the first child in childNode");
+
+                        // Verify that the largest hilbert value in the parent node is indeed the largest hilbert value of
                         // the right-most child in childNode.
-                        Verify.verify(TupleHelpers.equals(childSlotInParentNode.getLargestKey(), childNode.getSlots().get(childNode.size() - 1).getKey()),
-                                "expected largest key does not match the actual key of the last child in childNode");
+                        Verify.verify(childSlotInParentNode.getLargestHilbertValue().equals(childNode.getSlots().get(childNode.size() - 1).getLargestHilbertValue()),
+                                "expected largest hilbert value does not match the actual hilbert value of the last child in childNode");
+
+                        // Verify that the largest key in the parent node is indeed the largest key of the right-most\
+                        // child in childNode.
+                        Verify.verify(TupleHelpers.equals(childSlotInParentNode.getLargestKey(), childNode.getSlots().get(childNode.size() - 1).getLargestKey()),
+                                "expected largest key does not match the actual largest key of the last child in childNode");
                     }
 
                     // add all children to the to be processed queue
@@ -1522,13 +1645,14 @@ public class RTree {
                         return ImmutableList.of();
                     }
                 }));
+                numNodesEnqueued.addAndGet(1);
             }
 
             if (working.isEmpty()) {
                 return AsyncUtil.READY_FALSE;
             }
             return AsyncUtil.whenAny(working).thenApply(v -> true);
-        }, executor).thenApply(vignore -> null);
+        }, executor).thenApply(vignore -> toBeProcessed);
     }
 
     @Nonnull
@@ -1976,29 +2100,112 @@ public class RTree {
         public IntermediateNode newOfSameKind(@Nonnull final byte[] nodeId) {
             return new IntermediateNode(nodeId, Lists.newArrayList());
         }
-
-        @Nonnull
-        public String getPlotMbrs() {
-            return getSlots().stream()
-                    .map(child -> child.getMbr().toPlotString())
-                    .collect(Collectors.joining("\n"));
-        }
     }
 
     /**
      * Abstract base class for all node slots. Holds a Hilbert value and a key. The semantics of these attributes
      * is refined in the subclasses {@link ItemSlot} and {@link ChildSlot}.
      */
-    public abstract static class NodeSlot {
+    public interface NodeSlot {
         @Nonnull
-        protected BigInteger hilbertValue;
+        BigInteger getSmallestHilbertValue();
 
         @Nonnull
-        protected Tuple key;
+        BigInteger getLargestHilbertValue();
 
-        protected NodeSlot(@Nonnull final BigInteger hilbertValue, @Nonnull final Tuple key) {
+        @Nonnull
+        Tuple getSmallestKey();
+
+        @Nonnull
+        default Tuple getSmallestKeySuffix() {
+            return getSmallestKey().getNestedTuple(1);
+        }
+
+        @Nonnull
+        Tuple getLargestKey();
+
+        @Nonnull
+        default Tuple getLargestKeySuffix() {
+            return getLargestKey().getNestedTuple(1);
+        }
+
+        /**
+         * Create a tuple for the key part of this slot. This tuple is used when the slot is persisted in the database.
+         * Note that the serialization format is not yet finalized.
+         * @param storeHilbertValues indicator if the hilbert value should be encoded into the slot key or null-ed out
+         * @return a new tuple
+         */
+        @Nonnull
+        Tuple getSlotKey(boolean storeHilbertValues);
+
+        /**
+         * Create a tuple for the value part of this slot. This tuple is used when the slot is persisted in the database.
+         * Note that the serialization format is not yet finalized.
+         * @return a new tuple
+         */
+        @Nonnull
+        Tuple getSlotValue();
+
+        /**
+         * Compare this node slot's smallest {@code (hilbertValue, key)} pair with another {@code (hilbertValue, key)}
+         * pair. We do not use a proper {@link java.util.Comparator} as we don't want to wrap the pair in another object.
+         * @param hilbertValue Hilbert value
+         * @param key first key
+         * @return {@code -1, 0, 1} if this node slot's pair is less/equal/greater than the pair passed in
+         */
+        default int compareSmallestHilbertValueAndKey(@Nonnull final BigInteger hilbertValue,
+                                                      @Nonnull final Tuple key) {
+            final int hilbertValueCompare = getSmallestHilbertValue().compareTo(hilbertValue);
+            if (hilbertValueCompare != 0) {
+                return hilbertValueCompare;
+            }
+            return TupleHelpers.compare(getSmallestKey(), key);
+        }
+
+        /**
+         * Compare this node slot's largest {@code (hilbertValue, key)} pair with another {@code (hilbertValue, key)}
+         * pair. We do not use a proper {@link java.util.Comparator} as we don't want to wrap the pair in another object.
+         * @param hilbertValue Hilbert value
+         * @param key first key
+         * @return {@code -1, 0, 1} if this node slot's pair is less/equal/greater than the pair passed in
+         */
+        default int compareLargestHilbertValueAndKey(@Nonnull final BigInteger hilbertValue,
+                                                     @Nonnull final Tuple key) {
+            final int hilbertValueCompare = getLargestHilbertValue().compareTo(hilbertValue);
+            if (hilbertValueCompare != 0) {
+                return hilbertValueCompare;
+            }
+            return TupleHelpers.compare(getLargestKey(), key);
+        }
+    }
+
+    /**
+     * An item slot that is used by {@link LeafNode}s. Holds the actual data of the item as well as the items Hilbert
+     * value and its key.
+     */
+    public static class ItemSlot implements NodeSlot {
+        private static final Comparator<ItemSlot> comparator =
+                Comparator.comparing(ItemSlot::getHilbertValue).thenComparing(ItemSlot::getKey);
+
+        public static final int SLOT_KEY_TUPLE_SIZE = 2;
+        public static final int SLOT_VALUE_TUPLE_SIZE = 1;
+
+        @Nonnull
+        private final BigInteger hilbertValue;
+        @Nonnull
+        private final Tuple key;
+
+        @Nonnull
+        private final Tuple value;
+        @Nonnull
+        private final Point position;
+
+        public ItemSlot(@Nonnull final BigInteger hilbertValue, @Nonnull final Point position, @Nonnull final Tuple key,
+                        @Nonnull final Tuple value) {
             this.hilbertValue = hilbertValue;
             this.key = key;
+            this.value = value;
+            this.position = position;
         }
 
         @Nonnull
@@ -2016,60 +2223,6 @@ public class RTree {
             return key.getNestedTuple(1);
         }
 
-        /**
-         * Create a tuple for the key part of this slot. This tuple is used when the slot is persisted in the database.
-         * Note that the serialization format is not yet finalized.
-         * @param storeHilbertValues indicator if the hilbert value should be encoded into the slot key or null-ed out
-         * @return a new tuple
-         */
-        @Nonnull
-        protected abstract Tuple getSlotKey(boolean storeHilbertValues);
-
-        /**
-         * Create a tuple for the value part of this slot. This tuple is used when the slot is persisted in the database.
-         * Note that the serialization format is not yet finalized.
-         * @return a new tuple
-         */
-        @Nonnull
-        protected abstract Tuple getSlotValue();
-
-        /**
-         * Compare this node slot's {@code (hilbertValue, key)} pair with another {@code (hilbertValue, key)} pair.
-         * We do not use a proper {@link java.util.Comparator} as we don't want to wrap the pair in another object.
-         * @param hilbertValue Hilbert value
-         * @param key first key
-         * @return {@code -1, 0, 1} if this node slot's pair is less/equal/greater than the pair passed in
-         */
-        public int compareHilbertValueAndKey(@Nonnull final BigInteger hilbertValue,
-                                             @Nonnull final Tuple key) {
-            final int hilbertValueCompare = getHilbertValue().compareTo(hilbertValue);
-            if (hilbertValueCompare != 0) {
-                return hilbertValueCompare;
-            }
-            return TupleHelpers.compare(getKey(), key);
-        }
-    }
-
-    /**
-     * An item slot that is used by {@link LeafNode}s. Holds the actual data of the item as well as the items Hilbert
-     * value and its key.
-     */
-    public static class ItemSlot extends NodeSlot {
-        public static final int SLOT_KEY_TUPLE_SIZE = 2;
-        public static final int SLOT_VALUE_TUPLE_SIZE = 1;
-
-        @Nonnull
-        private final Tuple value;
-        @Nonnull
-        private final Point position;
-
-        public ItemSlot(@Nonnull final BigInteger hilbertValue, @Nonnull final Point position, @Nonnull final Tuple key,
-                        @Nonnull final Tuple value) {
-            super(hilbertValue, key);
-            this.value = value;
-            this.position = position;
-        }
-
         @Nonnull
         public Tuple getValue() {
             return value;
@@ -2082,14 +2235,54 @@ public class RTree {
 
         @Nonnull
         @Override
-        protected Tuple getSlotKey(final boolean storeHilbertValues) {
+        public BigInteger getSmallestHilbertValue() {
+            return hilbertValue;
+        }
+
+        @Nonnull
+        @Override
+        public BigInteger getLargestHilbertValue() {
+            return hilbertValue;
+        }
+
+        @Nonnull
+        @Override
+        public Tuple getSmallestKey() {
+            return key;
+        }
+
+        @Nonnull
+        @Override
+        public Tuple getLargestKey() {
+            return key;
+        }
+
+        @Nonnull
+        @Override
+        public Tuple getSlotKey(final boolean storeHilbertValues) {
             return Tuple.from(storeHilbertValues ? getHilbertValue() : null, getKey());
         }
 
         @Nonnull
         @Override
-        protected Tuple getSlotValue() {
+        public Tuple getSlotValue() {
             return Tuple.from(getValue());
+        }
+
+        /**
+         * Compare this node slot's {@code (hilbertValue, key)} pair with another {@code (hilbertValue, key)}
+         * pair. We do not use a proper {@link java.util.Comparator} as we don't want to wrap the pair in another object.
+         * @param hilbertValue Hilbert value
+         * @param key first key
+         * @return {@code -1, 0, 1} if this node slot's pair is less/equal/greater than the pair passed in
+         */
+        public int compareHilbertValueAndKey(@Nonnull final BigInteger hilbertValue,
+                                             @Nonnull final Tuple key) {
+            final int hilbertValueCompare = getHilbertValue().compareTo(hilbertValue);
+            if (hilbertValueCompare != 0) {
+                return hilbertValueCompare;
+            }
+            return TupleHelpers.compare(getKey(), key);
         }
 
         @Override
@@ -2119,8 +2312,8 @@ public class RTree {
      * hilbert value of its child, the largest key of its child and an mbr that encompasses all points in the subtree
      * rooted at the child.
      */
-    public static class ChildSlot extends NodeSlot {
-        public static final int SLOT_KEY_TUPLE_SIZE = 2;
+    public static class ChildSlot implements NodeSlot {
+        public static final int SLOT_KEY_TUPLE_SIZE = 4;
         public static final int SLOT_VALUE_TUPLE_SIZE = 2;
 
         @Nonnull
@@ -2128,10 +2321,23 @@ public class RTree {
         @Nonnull
         private Rectangle mbr;
 
+        @Nonnull
+        private BigInteger smallestHilbertValue;
+        @Nonnull
+        private Tuple smallestKey;
+        @Nonnull
+        private BigInteger largestHilbertValue;
+        @Nonnull
+        private Tuple largestKey;
+
         @SpotBugsSuppressWarnings("EI_EXPOSE_REP2")
-        public ChildSlot(@Nonnull final BigInteger largestHilbertValue, @Nonnull final Tuple largestKey,
+        public ChildSlot(@Nonnull final BigInteger smallestHilbertValue, @Nonnull final Tuple smallestKey,
+                         @Nonnull final BigInteger largestHilbertValue, @Nonnull final Tuple largestKey,
                          @Nonnull final byte[] childId, @Nonnull final Rectangle mbr) {
-            super(largestHilbertValue, largestKey);
+            this.smallestHilbertValue = smallestHilbertValue;
+            this.smallestKey = smallestKey;
+            this.largestHilbertValue = largestHilbertValue;
+            this.largestKey = largestKey;
             this.childId = childId;
             this.mbr = mbr;
         }
@@ -2142,22 +2348,44 @@ public class RTree {
             return childId;
         }
 
-        public void setLargestHilbertValue(@Nonnull final BigInteger largestHilbertValue) {
-            this.hilbertValue = largestHilbertValue;
+        public void setSmallestHilbertValue(@Nonnull final BigInteger smallestHilbertValue) {
+            this.smallestHilbertValue = smallestHilbertValue;
         }
 
         @Nonnull
+        @Override
+        public BigInteger getSmallestHilbertValue() {
+            return smallestHilbertValue;
+        }
+
+        public void setSmallestKey(@Nonnull final Tuple smallestKey) {
+            this.smallestKey = smallestKey;
+        }
+
+        @Nonnull
+        @Override
+        public Tuple getSmallestKey() {
+            return smallestKey;
+        }
+
+        public void setLargestHilbertValue(@Nonnull final BigInteger largestHilbertValue) {
+            this.largestHilbertValue = largestHilbertValue;
+        }
+
+        @Nonnull
+        @Override
         public BigInteger getLargestHilbertValue() {
-            return hilbertValue;
+            return largestHilbertValue;
         }
 
         public void setLargestKey(@Nonnull final Tuple largestKey) {
-            this.key = largestKey;
+            this.largestKey = largestKey;
         }
 
         @Nonnull
+        @Override
         public Tuple getLargestKey() {
-            return key;
+            return largestKey;
         }
 
         public void setMbr(@Nonnull final Rectangle mbr) {
@@ -2171,21 +2399,37 @@ public class RTree {
 
         @Nonnull
         @Override
-        protected Tuple getSlotKey(final boolean storeHilbertValue) {
-            return Tuple.from(getLargestHilbertValue(), getLargestKey());
+        public Tuple getSlotKey(final boolean storeHilbertValue) {
+            return Tuple.from(getSmallestHilbertValue(), getSmallestKey(), getLargestHilbertValue(), getLargestKey());
         }
 
         @Nonnull
         @Override
-        protected Tuple getSlotValue() {
+        public Tuple getSlotValue() {
             return Tuple.from(getChildId(), getMbr().getRanges());
+        }
+
+        /**
+         * Method to determine if (during a scan a suffix predicate can be applied). A suffix predicate can only
+         * be applied, if the smallest and largest hilbert value as well as the non-suffix part of the key are the same.
+         */
+        public boolean suffixPredicateCanBeApplied() {
+            final int hilbertValueCompare = getSmallestHilbertValue().compareTo(getLargestHilbertValue());
+            Verify.verify(hilbertValueCompare <= 0);
+            if (hilbertValueCompare != 0) {
+                return false;
+            }
+
+            int positionTupleCompare =
+                    TupleHelpers.compare(getSmallestKey().getNestedTuple(0), getLargestKey().getNestedTuple(0)) ;
+            Verify.verify(positionTupleCompare <= 0);
+            return positionTupleCompare == 0;
         }
 
         @Nonnull
         @Override
         public String toString() {
-            //return "[" + getMbr() + ";" + getLargestHilbertValue() + "]";
-            return getMbr().toString();
+            return "[" + getMbr() + ";" + getSmallestHilbertValue() + "; " + getLargestHilbertValue() + "]";
         }
 
         @Nonnull
@@ -2193,6 +2437,7 @@ public class RTree {
             Verify.verify(keyTuple.size() == SLOT_KEY_TUPLE_SIZE);
             Verify.verify(valueTuple.size() == SLOT_VALUE_TUPLE_SIZE);
             return new ChildSlot(keyTuple.getBigInteger(0), keyTuple.getNestedTuple(1),
+                    keyTuple.getBigInteger(2), keyTuple.getNestedTuple(3),
                     valueTuple.getBytes(0), new Rectangle(valueTuple.getNestedTuple(1)));
         }
     }
@@ -2270,10 +2515,6 @@ public class RTree {
      * Storage adapter that normalizes internal nodes such that each node slot is a key/value pair in the database.
      */
     public static class BySlotStorageAdapter implements StorageAdapter {
-        private static final Comparator<ItemSlot> comparator =
-                Comparator.<RTree.ItemSlot, BigInteger>comparing(NodeSlot::getHilbertValue)
-                        .thenComparing(NodeSlot::getKey);
-
         @Nonnull
         private final Subspace subspace;
         private final boolean storeHilbertValues;
@@ -2415,7 +2656,7 @@ public class RTree {
                 // We need to sort the slots by the computed Hilbert value/key. This is not necessary when we store
                 // the Hilbert value as fdb does the sorting for us.
                 //
-                itemSlots.sort(comparator);
+                itemSlots.sort(ItemSlot.comparator);
             }
 
             return nodeKind == Kind.LEAF
@@ -2619,8 +2860,8 @@ public class RTree {
     /**
      * An {@link AsyncIterator} over the leaf nodes that represent the result of a scan over the tree. This iterator
      * interfaces with the scan logic
-     * (see {@link #fetchLeftmostPathToLeaf(ReadTransaction, byte[], BigInteger, Tuple, Predicate)} and
-     * {@link #fetchNextPathToLeaf(ReadTransaction, TraversalState, BigInteger, Tuple, Predicate)}) and wraps
+     * (see {@link #fetchLeftmostPathToLeaf(ReadTransaction, byte[], BigInteger, Tuple, Predicate, BiPredicate)} and
+     * {@link #fetchNextPathToLeaf(ReadTransaction, TraversalState, BigInteger, Tuple, Predicate, BiPredicate)}) and wraps
      * intermediate {@link TraversalState}s created by these methods.
      */
     public class LeafIterator implements AsyncIterator<LeafNode> {
@@ -2634,6 +2875,8 @@ public class RTree {
         private final Tuple lastKey;
         @Nonnull
         private final Predicate<Rectangle> mbrPredicate;
+        @Nonnull
+        private final BiPredicate<Tuple, Tuple> suffixKeyPredicate;
 
         @Nullable
         private TraversalState currentState;
@@ -2643,7 +2886,7 @@ public class RTree {
         @SpotBugsSuppressWarnings("EI_EXPOSE_REP2")
         public LeafIterator(@Nonnull final ReadTransaction readTransaction, @Nonnull final byte[] rootId,
                             @Nullable final BigInteger lastHilbertValue, @Nullable final Tuple lastKey,
-                            @Nonnull final Predicate<Rectangle> mbrPredicate) {
+                            @Nonnull final Predicate<Rectangle> mbrPredicate, @Nonnull final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
             Preconditions.checkArgument((lastHilbertValue == null && lastKey == null) ||
                                         (lastHilbertValue != null && lastKey != null));
             this.readTransaction = readTransaction;
@@ -2651,6 +2894,7 @@ public class RTree {
             this.lastHilbertValue = lastHilbertValue;
             this.lastKey = lastKey;
             this.mbrPredicate = mbrPredicate;
+            this.suffixKeyPredicate = suffixKeyPredicate;
             this.currentState = null;
             this.nextStateFuture = null;
         }
@@ -2659,9 +2903,11 @@ public class RTree {
         public CompletableFuture<Boolean> onHasNext() {
             if (nextStateFuture == null) {
                 if (currentState == null) {
-                    nextStateFuture = fetchLeftmostPathToLeaf(readTransaction, rootId, lastHilbertValue, lastKey, mbrPredicate);
+                    nextStateFuture = fetchLeftmostPathToLeaf(readTransaction, rootId, lastHilbertValue, lastKey,
+                            mbrPredicate, suffixKeyPredicate);
                 } else {
-                    nextStateFuture = fetchNextPathToLeaf(readTransaction, currentState, lastHilbertValue, lastKey, mbrPredicate);
+                    nextStateFuture = fetchNextPathToLeaf(readTransaction, currentState, lastHilbertValue, lastKey,
+                            mbrPredicate, suffixKeyPredicate);
                 }
             }
             return nextStateFuture.thenApply(traversalState -> !traversalState.isEnd());
@@ -3047,23 +3293,21 @@ public class RTree {
         @Nonnull
         public String toPlotString() {
             final StringBuilder builder = new StringBuilder();
-            builder.append("rectangle(");
             for (int d = 0; d < getNumDimensions(); d++) {
                 builder.append(((Number)getLow(d)).longValue());
                 if (d + 1 < getNumDimensions()) {
-                    builder.append("|");
+                    builder.append(",");
                 }
             }
 
-            builder.append(" ");
+            builder.append(",");
 
             for (int d = 0; d < getNumDimensions(); d++) {
-                builder.append(((Number)getHigh(d)).longValue() - ((Number)getLow(d)).longValue());
+                builder.append(((Number)getHigh(d)).longValue());
                 if (d + 1 < getNumDimensions()) {
-                    builder.append(" ");
+                    builder.append(",");
                 }
             }
-            builder.append(")#");
             return builder.toString();
         }
 
@@ -3090,36 +3334,25 @@ public class RTree {
      */
     public interface OnWriteListener {
         OnWriteListener NOOP = new OnWriteListener() {
-            @Override
-            public <T> CompletableFuture<T> onAsyncReadForWrite(@Nonnull final CompletableFuture<T> future) {
-                return future;
-            }
-
-            @Override
-            public void onNodeWritten(@Nonnull final Node node) {
-                // nothing
-            }
-
-            @Override
-            public void onKeyValueWritten(@Nonnull final Node node, @Nullable final byte[] key, @Nullable final byte[] value) {
-                // nothing
-            }
-
-            @Override
-            public void onNodeCleared(@Nonnull final Node node) {
-                // nothing
-            }
         };
 
-        <T> CompletableFuture<T> onAsyncReadForWrite(@Nonnull CompletableFuture<T> future);
+        default <T extends Node> CompletableFuture<T> onAsyncReadForWrite(@Nonnull CompletableFuture<T> future) {
+            return future;
+        }
 
-        void onNodeWritten(@Nonnull Node node);
+        default void onNodeWritten(@Nonnull Node node) {
+            // nothing
+        }
 
-        void onKeyValueWritten(@Nonnull Node node,
-                               @Nullable byte[] key,
-                               @Nullable byte[] value);
+        default void onKeyValueWritten(@Nonnull Node node,
+                                       @Nullable byte[] key,
+                                       @Nullable byte[] value) {
+            // nothing
+        }
 
-        void onNodeCleared(@Nonnull Node node);
+        default void onNodeCleared(@Nonnull Node node) {
+            // nothing
+        }
     }
 
     /**
@@ -3127,28 +3360,20 @@ public class RTree {
      */
     public interface OnReadListener {
         OnReadListener NOOP = new OnReadListener() {
-            @Override
-            public <T> CompletableFuture<T> onAsyncRead(@Nonnull final CompletableFuture<T> future) {
-                return future;
-            }
-
-            @Override
-            public void onNodeRead(@Nonnull final Node node) {
-                // nothing
-            }
-
-            @Override
-            public void onKeyValueRead(@Nonnull final Node node, @Nullable final byte[] key, @Nullable final byte[] value) {
-                // nothing
-            }
         };
 
-        <T> CompletableFuture<T> onAsyncRead(@Nonnull CompletableFuture<T> future);
+        default <T extends Node> CompletableFuture<T> onAsyncRead(@Nonnull CompletableFuture<T> future) {
+            return future;
+        }
 
-        void onNodeRead(@Nonnull Node node);
+        default void onNodeRead(@Nonnull Node node) {
+            // nothing
+        }
 
-        void onKeyValueRead(@Nonnull Node node,
-                            @Nullable byte[] key,
-                            @Nullable byte[] value);
+        default void onKeyValueRead(@Nonnull Node node,
+                                    @Nullable byte[] key,
+                                    @Nullable byte[] value) {
+            // nothing
+        }
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RTreeScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RTreeScanTest.java
@@ -161,7 +161,7 @@ public class RTreeScanTest extends FDBTestBase {
 
         final AtomicLong nresults = new AtomicLong(0L);
         db.run(tr -> {
-            AsyncUtil.forEachRemaining(rt.scan(tr, mbrPredicate), itemSlot -> {
+            AsyncUtil.forEachRemaining(rt.scan(tr, mbrPredicate, (s, l) -> true), itemSlot -> {
                 if (query.contains(itemSlot.getPosition())) {
                     nresults.incrementAndGet();
                 }
@@ -208,7 +208,8 @@ public class RTreeScanTest extends FDBTestBase {
                 onReadCounters);
         final AtomicLong nresults = new AtomicLong(0L);
         db.run(tr -> {
-            AsyncUtil.forEachRemaining(rt.scan(tr, topNTraversal), itemSlot -> {
+            final AsyncIterator<RTree.ItemSlot> scan = rt.scan(tr, topNTraversal, (s, l) -> true);
+            AsyncUtil.forEachRemaining(scan, itemSlot -> {
                 if (query.contains(itemSlot.getPosition())) {
                     topNTraversal.addItemSlot(itemSlot);
                     nresults.incrementAndGet();
@@ -338,7 +339,7 @@ public class RTreeScanTest extends FDBTestBase {
         }
 
         @Override
-        public <T> CompletableFuture<T> onAsyncRead(@Nonnull final CompletableFuture<T> future) {
+        public <T extends RTree.Node> CompletableFuture<T> onAsyncRead(@Nonnull final CompletableFuture<T> future) {
             return future;
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/TupleRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/TupleRange.java
@@ -243,13 +243,13 @@ public class TupleRange {
                 break;
             case RANGE_INCLUSIVE:
             case RANGE_EXCLUSIVE:
-                final Tuple dimensionLow = Objects.requireNonNull(getLow());
+                final Tuple low = Objects.requireNonNull(getLow());
                 if (getLowEndpoint() == EndpointType.RANGE_INCLUSIVE &&
-                        TupleHelpers.compare(highTuple, dimensionLow) < 0) {
+                        TupleHelpers.compare(highTuple, low) < 0) {
                     return false;
                 }
                 if (getLowEndpoint() == EndpointType.RANGE_EXCLUSIVE &&
-                        TupleHelpers.compare(highTuple, dimensionLow) <= 0) {
+                        TupleHelpers.compare(highTuple, low) <= 0) {
                     return false;
                 }
                 break;
@@ -265,13 +265,13 @@ public class TupleRange {
                 break;
             case RANGE_INCLUSIVE:
             case RANGE_EXCLUSIVE:
-                final Tuple dimensionHigh = Objects.requireNonNull(getHigh());
+                final Tuple high = Objects.requireNonNull(getHigh());
                 if (getHighEndpoint() == EndpointType.RANGE_INCLUSIVE &&
-                        TupleHelpers.compare(lowTuple, dimensionHigh) > 0) {
+                        TupleHelpers.compare(lowTuple, high) > 0) {
                     return false;
                 }
                 if (getHighEndpoint() == EndpointType.RANGE_EXCLUSIVE &&
-                        TupleHelpers.compare(highTuple, dimensionHigh) >= 0) {
+                        TupleHelpers.compare(highTuple, high) >= 0) {
                     return false;
                 }
                 break;
@@ -295,13 +295,13 @@ public class TupleRange {
                 break;
             case RANGE_INCLUSIVE:
             case RANGE_EXCLUSIVE:
-                final Tuple dimensionLow = Objects.requireNonNull(getLow());
+                final Tuple low = Objects.requireNonNull(getLow());
                 if (getLowEndpoint() == EndpointType.RANGE_INCLUSIVE &&
-                        TupleHelpers.compare(tuple, dimensionLow) < 0) {
+                        TupleHelpers.compare(tuple, low) < 0) {
                     return false;
                 }
                 if (getLowEndpoint() == EndpointType.RANGE_EXCLUSIVE &&
-                        TupleHelpers.compare(tuple, dimensionLow) <= 0) {
+                        TupleHelpers.compare(tuple, low) <= 0) {
                     return false;
                 }
                 break;
@@ -317,13 +317,13 @@ public class TupleRange {
                 break;
             case RANGE_INCLUSIVE:
             case RANGE_EXCLUSIVE:
-                final Tuple dimensionHigh = Objects.requireNonNull(getHigh());
+                final Tuple high = Objects.requireNonNull(getHigh());
                 if (getHighEndpoint() == EndpointType.RANGE_INCLUSIVE &&
-                        TupleHelpers.compare(tuple, dimensionHigh) > 0) {
+                        TupleHelpers.compare(tuple, high) > 0) {
                     return false;
                 }
                 if (getHighEndpoint() == EndpointType.RANGE_EXCLUSIVE &&
-                        TupleHelpers.compare(tuple, dimensionHigh) >= 0) {
+                        TupleHelpers.compare(tuple, high) >= 0) {
                     return false;
                 }
                 break;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/DimensionsKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/DimensionsKeyExpression.java
@@ -136,6 +136,12 @@ public class DimensionsKeyExpression extends BaseKeyExpression implements KeyExp
 
     @Nonnull
     @Override
+    protected KeyExpression getSubKeyImpl(final int start, final int end) {
+        return getWholeKey().getSubKey(start, end);
+    }
+
+    @Nonnull
+    @Override
     public <S extends KeyExpressionVisitor.State, R> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
         return visitor.visitExpression(this);
     }
@@ -172,6 +178,11 @@ public class DimensionsKeyExpression extends BaseKeyExpression implements KeyExp
     @Nonnull
     public KeyExpression getDimensionsSubKey() {
         return getWholeKey().getSubKey(prefixSize, dimensionsSize);
+    }
+
+    @Nonnull
+    public KeyExpression getPrefixAndDimensionsKeyExpression() {
+        return getWholeKey().getSubKey(0, prefixSize + dimensionsSize);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -736,6 +736,7 @@ public class FDBStoreTimer extends StoreTimer {
         MULTIDIMENSIONAL_INTERMEDIATE_NODE_READ_BYTES("intermediate node bytes read", true),
         MULTIDIMENSIONAL_INTERMEDIATE_NODE_WRITES("intermediate nodes written", false),
         MULTIDIMENSIONAL_INTERMEDIATE_NODE_WRITE_BYTES("intermediate node bytes written", true),
+        MULTIDIMENSIONAL_CHILD_NODE_DISCARDS("child node discards", false),
         ;
 
         private final String title;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanBounds.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanBounds.java
@@ -49,9 +49,15 @@ public class MultidimensionalIndexScanBounds implements IndexScanBounds {
     @Nonnull
     private final SpatialPredicate spatialPredicate;
 
-    public MultidimensionalIndexScanBounds(@Nonnull final TupleRange prefixRange, @Nonnull final SpatialPredicate spatialPredicate) {
+    @Nonnull
+    private final TupleRange suffixRange;
+
+    public MultidimensionalIndexScanBounds(@Nonnull final TupleRange prefixRange,
+                                           @Nonnull final SpatialPredicate spatialPredicate,
+                                           @Nonnull final TupleRange suffixRange) {
         this.prefixRange = prefixRange;
         this.spatialPredicate = spatialPredicate;
+        this.suffixRange = suffixRange;
     }
 
     @Nonnull
@@ -68,6 +74,11 @@ public class MultidimensionalIndexScanBounds implements IndexScanBounds {
     @Nonnull
     public SpatialPredicate getSpatialPredicate() {
         return spatialPredicate;
+    }
+
+    @Nonnull
+    public TupleRange getSuffixRange() {
+        return suffixRange;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
@@ -1,0 +1,270 @@
+/*
+ * MultidimensionalIndexScanComparisons.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.MultidimensionalIndexScanBounds.Hypercube;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.TranslationMap;
+import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@link ScanComparisons} for use in a multidimensional index scan.
+ */
+@API(API.Status.MAINTAINED)
+public class MultidimensionalIndexScanComparisons implements IndexScanParameters {
+    @Nonnull
+    private final ScanComparisons prefixScanComparisons;
+    @Nonnull
+    private final List<ScanComparisons> dimensionsScanComparisons;
+    @Nonnull
+    private final ScanComparisons suffixScanComparisons;
+
+    public MultidimensionalIndexScanComparisons(@Nonnull final ScanComparisons prefixScanComparisons,
+                                                @Nonnull final List<ScanComparisons> dimensionsScanComparisons,
+                                                @Nonnull final ScanComparisons suffixKeyComparisonRanges) {
+        this.prefixScanComparisons = prefixScanComparisons;
+        this.dimensionsScanComparisons = dimensionsScanComparisons;
+        this.suffixScanComparisons = suffixKeyComparisonRanges;
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanType getScanType() {
+        return IndexScanType.BY_VALUE;
+    }
+
+    @Nonnull
+    public ScanComparisons getPrefixScanComparisons() {
+        return prefixScanComparisons;
+    }
+
+    @Nonnull
+    public List<ScanComparisons> getDimensionsScanComparisons() {
+        return dimensionsScanComparisons;
+    }
+
+    @Nonnull
+    public ScanComparisons getSuffixScanComparisons() {
+        return suffixScanComparisons;
+    }
+
+    @Nonnull
+    @Override
+    public MultidimensionalIndexScanBounds bind(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Index index,
+                                                @Nonnull final EvaluationContext context) {
+        final ImmutableList.Builder<TupleRange> dimensionsTupleRangeBuilder = ImmutableList.builder();
+        for (final ScanComparisons dimensionScanComparison : dimensionsScanComparisons) {
+            dimensionsTupleRangeBuilder.add(dimensionScanComparison.toTupleRange(store, context));
+        }
+        final Hypercube hypercube = new Hypercube(dimensionsTupleRangeBuilder.build());
+        return new MultidimensionalIndexScanBounds(prefixScanComparisons.toTupleRange(store, context), hypercube, TupleRange.ALL);
+    }
+
+    @Override
+    public int planHash(@Nonnull PlanHashKind hashKind) {
+        return PlanHashable.objectsPlanHash(hashKind, prefixScanComparisons, dimensionsScanComparisons);
+    }
+
+    @Override
+    public boolean isUnique(@Nonnull Index index) {
+        return prefixScanComparisons.isEquality() && prefixScanComparisons.size() == index.getColumnSize();
+    }
+
+    @Nonnull
+    @Override
+    public String getScanDetails() {
+        @Nullable final TupleRange tupleRange = prefixScanComparisons.toTupleRangeWithoutContext();
+        return tupleRange == null ? prefixScanComparisons.toString() : tupleRange.toString();
+    }
+
+    @Override
+    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+        @Nullable TupleRange tupleRange = prefixScanComparisons.toTupleRangeWithoutContext();
+        if (tupleRange != null) {
+            detailsBuilder.add("prefix: " + tupleRange.getLowEndpoint().toString(false) + "{{plow}}, {{phigh}}" + tupleRange.getHighEndpoint().toString(true));
+            attributeMapBuilder.put("plow", Attribute.gml(tupleRange.getLow() == null ? "-∞" : tupleRange.getLow().toString()));
+            attributeMapBuilder.put("phigh", Attribute.gml(tupleRange.getHigh() == null ? "∞" : tupleRange.getHigh().toString()));
+        } else {
+            detailsBuilder.add("prefix comparisons: {{pcomparisons}}");
+            attributeMapBuilder.put("pcomparisons", Attribute.gml(prefixScanComparisons.toString()));
+        }
+
+        for (int d = 0; d < dimensionsScanComparisons.size(); d++) {
+            final ScanComparisons dimensionScanComparisons = dimensionsScanComparisons.get(d);
+            tupleRange = dimensionScanComparisons.toTupleRangeWithoutContext();
+            if (tupleRange != null) {
+                detailsBuilder.add("dim" + d + ": " + tupleRange.getLowEndpoint().toString(false) + "{{dlow" + d + "}}, {{dhigh" + d + "}}" + tupleRange.getHighEndpoint().toString(true));
+                attributeMapBuilder.put("dlow" + d, Attribute.gml(tupleRange.getLow() == null ? "-∞" : tupleRange.getLow().toString()));
+                attributeMapBuilder.put("dhigh" + d, Attribute.gml(tupleRange.getHigh() == null ? "∞" : tupleRange.getHigh().toString()));
+            } else {
+                detailsBuilder.add("suffix comparisons: {{dcomparisons" + d + "}}");
+                attributeMapBuilder.put("dcomparisons" + d, Attribute.gml(suffixScanComparisons.toString()));
+            }
+        }
+
+        tupleRange = suffixScanComparisons.toTupleRangeWithoutContext();
+        if (tupleRange != null) {
+            detailsBuilder.add("suffix: " + tupleRange.getLowEndpoint().toString(false) + "{{slow}}, {{shigh}}" + tupleRange.getHighEndpoint().toString(true));
+            attributeMapBuilder.put("slow", Attribute.gml(tupleRange.getLow() == null ? "-∞" : tupleRange.getLow().toString()));
+            attributeMapBuilder.put("shigh", Attribute.gml(tupleRange.getHigh() == null ? "∞" : tupleRange.getHigh().toString()));
+        } else {
+            detailsBuilder.add("suffix comparisons: {{scomparisons}}");
+            attributeMapBuilder.put("scomparisons", Attribute.gml(suffixScanComparisons.toString()));
+        }
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        final ImmutableSet.Builder<CorrelationIdentifier> correlatedToBuilder = ImmutableSet.builder();
+        correlatedToBuilder.addAll(prefixScanComparisons.getCorrelatedTo());
+        correlatedToBuilder.addAll(dimensionsScanComparisons.stream()
+                .flatMap(dimensionScanComparison -> dimensionScanComparison.getCorrelatedTo().stream()).iterator());
+        correlatedToBuilder.addAll(suffixScanComparisons.getCorrelatedTo());
+        return correlatedToBuilder.build();
+    }
+
+    @Nonnull
+    @Override
+    public IndexScanParameters rebase(@Nonnull final AliasMap translationMap) {
+        return translateCorrelations(TranslationMap.rebaseWithAliasMap(translationMap));
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        final MultidimensionalIndexScanComparisons that = (MultidimensionalIndexScanComparisons)other;
+
+        if (!prefixScanComparisons.semanticEquals(that.prefixScanComparisons, aliasMap)) {
+            return false;
+        }
+        if (dimensionsScanComparisons.size() != that.dimensionsScanComparisons.size()) {
+            return false;
+        }
+        for (int i = 0; i < dimensionsScanComparisons.size(); i++) {
+            final ScanComparisons dimensionScanComparison = dimensionsScanComparisons.get(i);
+            final ScanComparisons otherDimensionScanComparison = that.dimensionsScanComparisons.get(i);
+            if (!dimensionScanComparison.semanticEquals(otherDimensionScanComparison, aliasMap)) {
+                return false;
+            }
+        }
+        return suffixScanComparisons.semanticEquals(that.suffixScanComparisons, aliasMap);
+    }
+
+    @Override
+    public int semanticHashCode() {
+        int hashCode = prefixScanComparisons.semanticHashCode();
+        for (final ScanComparisons dimensionScanComparison : dimensionsScanComparisons) {
+            hashCode = 31 * hashCode + dimensionScanComparison.semanticHashCode();
+        }
+        return 31 * hashCode + suffixScanComparisons.semanticHashCode();
+    }
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap) {
+        final ScanComparisons translatedPrefixScanComparisons = prefixScanComparisons.translateCorrelations(translationMap);
+
+        final ImmutableList.Builder<ScanComparisons> translatedDimensionScanComparisonBuilder = ImmutableList.builder();
+        boolean isSameDimensionsScanComparisons = true;
+        for (final ScanComparisons dimensionScanComparisons : dimensionsScanComparisons) {
+            final ScanComparisons translatedDimensionScanComparison = dimensionScanComparisons.translateCorrelations(translationMap);
+            if (translatedDimensionScanComparison != dimensionScanComparisons) {
+                isSameDimensionsScanComparisons = false;
+            }
+            translatedDimensionScanComparisonBuilder.add(translatedDimensionScanComparison);
+        }
+
+        final ScanComparisons translatedSuffixKeyScanComparisons = suffixScanComparisons.translateCorrelations(translationMap);
+
+        if (translatedPrefixScanComparisons != prefixScanComparisons || !isSameDimensionsScanComparisons ||
+                translatedSuffixKeyScanComparisons != suffixScanComparisons) {
+            return withComparisons(translatedPrefixScanComparisons, translatedDimensionScanComparisonBuilder.build(),
+                    translatedSuffixKeyScanComparisons);
+        }
+        return this;
+    }
+
+    @Nonnull
+    protected MultidimensionalIndexScanComparisons withComparisons(@Nonnull final ScanComparisons prefixScanComparisons,
+                                                                   @Nonnull final List<ScanComparisons> dimensionsComparisonRanges,
+                                                                   @Nonnull final ScanComparisons suffixKeyScanComparisons) {
+        return new MultidimensionalIndexScanComparisons(prefixScanComparisons, dimensionsComparisonRanges,
+                suffixKeyScanComparisons);
+    }
+
+    @Override
+    public String toString() {
+        return "BY_VALUE(MD):" + prefixScanComparisons + ":" + dimensionsScanComparisons;
+    }
+
+    @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(final Object o) {
+        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
+    }
+
+    @Nonnull
+    public static MultidimensionalIndexScanComparisons byValue(@Nullable ScanComparisons prefixScanComparisons,
+                                                               @Nonnull final List<ScanComparisons> dimensionsComparisonRanges,
+                                                               @Nullable ScanComparisons suffixKeyScanComparisons) {
+        if (prefixScanComparisons == null) {
+            prefixScanComparisons = ScanComparisons.EMPTY;
+        }
+
+        if (suffixKeyScanComparisons == null) {
+            suffixKeyScanComparisons = ScanComparisons.EMPTY;
+        }
+
+        return new MultidimensionalIndexScanComparisons(prefixScanComparisons, dimensionsComparisonRanges, suffixKeyScanComparisons);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * {@link ScanComparisons} for use in a multidimensional index scan.
@@ -92,7 +93,8 @@ public class MultidimensionalIndexScanComparisons implements IndexScanParameters
             dimensionsTupleRangeBuilder.add(dimensionScanComparison.toTupleRange(store, context));
         }
         final Hypercube hypercube = new Hypercube(dimensionsTupleRangeBuilder.build());
-        return new MultidimensionalIndexScanBounds(prefixScanComparisons.toTupleRange(store, context), hypercube, TupleRange.ALL);
+        return new MultidimensionalIndexScanBounds(prefixScanComparisons.toTupleRange(store, context),
+                hypercube, suffixScanComparisons.toTupleRange(store, context));
     }
 
     @Override
@@ -108,8 +110,21 @@ public class MultidimensionalIndexScanComparisons implements IndexScanParameters
     @Nonnull
     @Override
     public String getScanDetails() {
-        @Nullable final TupleRange tupleRange = prefixScanComparisons.toTupleRangeWithoutContext();
-        return tupleRange == null ? prefixScanComparisons.toString() : tupleRange.toString();
+        @Nullable TupleRange tupleRange = prefixScanComparisons.toTupleRangeWithoutContext();
+        final String prefix = tupleRange == null ? prefixScanComparisons.toString() : tupleRange.toString();
+
+        final String dimensions =
+                dimensionsScanComparisons.stream()
+                        .map(dimensionScanComparisons -> {
+                            @Nullable final TupleRange dimensionTupleRange = dimensionScanComparisons.toTupleRangeWithoutContext();
+                            return dimensionTupleRange == null ? dimensionScanComparisons.toString() : dimensionTupleRange.toString();
+                        })
+                        .collect(Collectors.joining(","));
+
+        tupleRange = suffixScanComparisons.toTupleRangeWithoutContext();
+        final String suffix = tupleRange == null ? suffixScanComparisons.toString() : tupleRange.toString();
+
+        return prefix + ":{" + dimensions + "}:" + suffix;
     }
 
     @Override
@@ -238,7 +253,7 @@ public class MultidimensionalIndexScanComparisons implements IndexScanParameters
 
     @Override
     public String toString() {
-        return "BY_VALUE(MD):" + prefixScanComparisons + ":" + dimensionsScanComparisons;
+        return "BY_VALUE(MD):" + prefixScanComparisons + ":" + dimensionsScanComparisons + ":" + suffixScanComparisons;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
@@ -132,6 +133,9 @@ public class PlanOrderingKey {
             }
             final int prefixSize;
             if (indexPlan instanceof RecordQueryIndexPlan) {
+                if (index.getType().equals(IndexTypes.MULTIDIMENSIONAL)) {
+                    return null;
+                }
                 if (!((RecordQueryIndexPlan)indexPlan).hasScanComparisons()) {
                     return null;
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
@@ -133,7 +133,7 @@ public class PlanOrderingKey {
             }
             final int prefixSize;
             if (indexPlan instanceof RecordQueryIndexPlan) {
-                if (index.getType().equals(IndexTypes.MULTIDIMENSIONAL)) {
+                if (IndexTypes.MULTIDIMENSIONAL.equals(index.getType())) {
                     return null;
                 }
                 if (!((RecordQueryIndexPlan)indexPlan).hasScanComparisons()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
@@ -206,6 +206,11 @@ public class ScanComparisons implements PlanHashable, Correlated<ScanComparisons
             super(new ArrayList<>(), new HashSet<>());
         }
 
+        public void clear() {
+            this.equalityComparisons.clear();
+            this.inequalityComparisons.clear();
+        }
+
         @Nonnull
         public Builder addEqualityComparison(@Nonnull Comparisons.Comparison comparison) {
             if (!inequalityComparisons.isEmpty()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
@@ -31,6 +31,9 @@ import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
 import com.google.protobuf.Message;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -39,7 +42,6 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -72,8 +74,7 @@ import java.util.stream.Collectors;
  *
  * <p>
  * A {@code ComparisonRange} is an immutable object that provides a variety of methods for producing new range from the
- * current one and some {@link Comparisons.Comparison} objects. For example, see {@link #tryToAdd(Comparisons.Comparison)}
- * and {@link #from(Comparisons.Comparison)}.
+ * current one and some {@link Comparisons.Comparison} objects.
  * </p>
  */
 @API(API.Status.EXPERIMENTAL)
@@ -87,7 +88,6 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
      *     <li>Equality ranges, to which only the same (equality) comparison can be added.</li>
      *     <li>Inequality ranges, to which any other comparison can be added.</li>
      * </ul>
-     * This behavior is defined in {@link #tryToAdd(Comparisons.Comparison)}.
      *
      * <p>
      * Furthermore, the planner uses this trichotomy of range types to determine other planning behavior. For example,
@@ -111,14 +111,14 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
         this.inequalityComparisons = null;
     }
 
-    private ComparisonRange(@Nonnull Comparisons.Comparison equalityComparison) {
+    private ComparisonRange(@Nonnull final Comparisons.Comparison equalityComparison) {
         this.equalityComparison = equalityComparison;
         this.inequalityComparisons = null;
     }
 
-    private ComparisonRange(@Nonnull List<Comparisons.Comparison> inequalityComparisons) {
+    private ComparisonRange(@Nonnull final Iterable<Comparisons.Comparison> inequalityComparisons) {
         this.equalityComparison = null;
-        this.inequalityComparisons = inequalityComparisons;
+        this.inequalityComparisons = Lists.newArrayList(inequalityComparisons);
     }
 
     public boolean isEmpty() {
@@ -152,7 +152,7 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
         return equalityComparison;
     }
 
-    @Nullable
+    @Nonnull
     public List<Comparisons.Comparison> getInequalityComparisons() {
         if (inequalityComparisons == null) {
             throw new RecordCoreException("tried to get non-existent inequality comparisons from ComparisonRange");
@@ -177,7 +177,6 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
 
     @Nonnull
     @Override
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public ComparisonRange rebase(@Nonnull final AliasMap aliasMap) {
         return translateCorrelations(TranslationMap.rebaseWithAliasMap(aliasMap));
     }
@@ -222,7 +221,7 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
     }
 
     @Override
-    @SuppressWarnings({"UnstableApiUsage", "PMD.CompareObjectsWithEquals"})
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
         if (this == other) {
             return true;
@@ -313,33 +312,21 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
     }
 
     @Nonnull
-    public Optional<ComparisonRange> tryToAdd(@Nonnull Comparisons.Comparison comparison) {
+    public ScanComparisons toScanComparisons() {
         if (isEmpty()) {
-            return from(comparison);
-        } else if (isEquality() && getEqualityComparison().equals(comparison)) {
-            return Optional.of(this);
-        } else if (isInequality()) {
-            Objects.requireNonNull(inequalityComparisons);
-            switch (ScanComparisons.getComparisonType(comparison)) {
-                case INEQUALITY:
-                    if (inequalityComparisons.contains(comparison)) {
-                        return Optional.of(this);
-                    } else {
-                        return Optional.of(new ComparisonRange(ImmutableList.<Comparisons.Comparison>builder()
-                                .addAll(inequalityComparisons)
-                                .add(comparison)
-                                .build()));
-                    }
-                case EQUALITY:
-                    // TODO normalize in this case
-                    break;
-                case NONE:
-                default:
-                    break;
-            }
+            return ScanComparisons.EMPTY;
         }
-        // TODO there are some subtle cases to handle. For example, != 3 and >= 3 is the same as > 3.
-        return Optional.empty();
+
+        final List<Comparisons.Comparison> equalityComparisons = Lists.newArrayList();
+        final Set<Comparisons.Comparison> inequalityComparisons = Sets.newHashSet();
+
+        if (isEquality()) {
+            equalityComparisons.add(getEqualityComparison());
+        } else {
+            inequalityComparisons.addAll(getInequalityComparisons());
+        }
+
+        return new ScanComparisons(equalityComparisons, inequalityComparisons);
     }
 
     /**
@@ -358,7 +345,7 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
         }
 
         if (isEmpty()) {
-            return MergeResult.of(from(comparison).orElseThrow(() -> new RecordCoreException("expected non-empty comparison")));
+            return MergeResult.of(from(comparison));
         } else if (isEquality()) {
             switch (comparisonType) {
                 case INEQUALITY:
@@ -386,8 +373,7 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
                                         .build()));
                     }
                 case EQUALITY:
-                    return MergeResult.of(from(comparison).orElseThrow(() -> new RecordCoreException("expected non-empty comparison")),
-                            inequalityComparisons);
+                    return MergeResult.of(from(comparison), inequalityComparisons);
                 default:
                     break;
             }
@@ -450,17 +436,23 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
     }
 
     @Nonnull
-    public static Optional<ComparisonRange> from(@Nonnull Comparisons.Comparison comparison) {
+    public static ComparisonRange from(@Nonnull Comparisons.Comparison comparison) {
         switch (ScanComparisons.getComparisonType(comparison)) {
             case EQUALITY:
-                return Optional.of(new ComparisonRange(comparison));
+                return new ComparisonRange(comparison);
             case INEQUALITY:
-                return Optional.of(new ComparisonRange(Collections.singletonList(comparison)));
+                return ComparisonRange.fromInequalities(Collections.singletonList(comparison));
             case NONE:
-                return Optional.empty();
             default:
                 throw new RecordCoreException("unexpected comparison type");
         }
+    }
+
+    @Nonnull
+    public static ComparisonRange fromInequalities(@Nonnull Iterable<Comparisons.Comparison> comparisons) {
+        Verify.verify(Streams.stream(comparisons)
+                .allMatch(comparison -> ScanComparisons.getComparisonType(comparison) == ScanComparisons.ComparisonType.INEQUALITY));
+        return new ComparisonRange(comparisons);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
@@ -82,7 +82,8 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
     public static final ComparisonRange EMPTY = new ComparisonRange();
 
     /**
-     * Comparison ranges can be divided into three types, with distinct planning behaviour:
+     * Comparison ranges can be divided into three types. These types represent distinct planning behaviour when
+     * matching query predicates or filters to index expressions:
      * <ul>
      *     <li>Empty ranges, to which any comparison can be added.</li>
      *     <li>Equality ranges, to which only the same (equality) comparison can be added.</li>

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRanges.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
@@ -53,6 +54,11 @@ public class ComparisonRanges implements PlanHashable, Correlated<ComparisonRang
 
     public ComparisonRanges(@Nonnull final List<ComparisonRange> ranges) {
         this.ranges = Lists.newArrayList(ranges);
+        this.sealedSize = 0;
+    }
+
+    public void clear() {
+        ranges.clear();
         this.sealedSize = 0;
     }
 
@@ -121,6 +127,7 @@ public class ComparisonRanges implements PlanHashable, Correlated<ComparisonRang
         return i;
     }
 
+    @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
     boolean isPrefixRanges() {
         for (int i = 0; i < ranges.size(); i++) {
             final ComparisonRange comparisonRange = ranges.get(i);
@@ -235,6 +242,7 @@ public class ComparisonRanges implements PlanHashable, Correlated<ComparisonRang
     }
 
     @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
         if (this == other) {
             return true;
@@ -269,6 +277,7 @@ public class ComparisonRanges implements PlanHashable, Correlated<ComparisonRang
     }
 
     @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
         return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRanges.java
@@ -1,0 +1,306 @@
+/*
+ * ComparisonRanges.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class that operates on lists of {@link ComparisonRange}s.
+ */
+public class ComparisonRanges implements PlanHashable, Correlated<ComparisonRanges> {
+    @Nonnull
+    private final List<ComparisonRange> ranges;
+
+    private int sealedSize;
+
+    public ComparisonRanges() {
+        this.ranges = Lists.newArrayList();
+    }
+
+    public ComparisonRanges(@Nonnull final List<ComparisonRange> ranges) {
+        this.ranges = Lists.newArrayList(ranges);
+        this.sealedSize = 0;
+    }
+
+    public boolean isEmpty() {
+        return ranges.isEmpty();
+    }
+
+    public void commitAndAdvance() {
+        sealedSize = ranges.size();
+    }
+
+    public int uncommittedComparisonRangesSize() {
+        return ranges.size() - sealedSize;
+    }
+
+    @Nonnull
+    public List<ComparisonRange> getUncommittedComparisonRanges() {
+        return ranges.subList(sealedSize, ranges.size());
+    }
+
+    public void addEqualityComparison(@Nonnull final Comparisons.Comparison comparison) {
+        Verify.verify(sealedSize == ranges.size());
+        final ComparisonRange newComparisonRange = ComparisonRange.from(comparison);
+        Verify.verify(newComparisonRange.isEquality());
+        ranges.add(newComparisonRange);
+    }
+
+    public void addInequalityComparison(@Nonnull final Comparisons.Comparison comparison) {
+        final ComparisonRange newComparisonRange = ComparisonRange.from(comparison);
+        Verify.verify(newComparisonRange.isInequality());
+        if (sealedSize < ranges.size()) {
+            final ComparisonRange currentComparisonRange = ranges.get(sealedSize);
+            Verify.verify(!currentComparisonRange.isEquality());
+            final ComparisonRange.MergeResult mergeResult =
+                    Objects.requireNonNull(currentComparisonRange).merge(newComparisonRange);
+            Verify.verify(mergeResult.getResidualComparisons().isEmpty());
+            ranges.set(sealedSize, mergeResult.getComparisonRange());
+        } else {
+            ranges.add(newComparisonRange);
+        }
+    }
+
+    public void addEmptyRanges(final int n) {
+        for (int i = 0; i < n; i++) {
+            ranges.add(ComparisonRange.EMPTY);
+        }
+    }
+
+    public void addAll(@Nonnull ComparisonRanges comparisonRanges) {
+        Preconditions.checkArgument(isEqualities());
+        ranges.addAll(comparisonRanges.ranges);
+    }
+
+    public boolean isEqualities() {
+        return ranges.stream().allMatch(ComparisonRange::isEquality);
+    }
+
+    public int getEqualitiesSize() {
+        int i;
+        for (i = 0; i < ranges.size(); i++) {
+            final ComparisonRange range = ranges.get(i);
+            if (!range.isEquality()) {
+                return i;
+            }
+        }
+        return i;
+    }
+
+    boolean isPrefixRanges() {
+        for (int i = 0; i < ranges.size(); i++) {
+            final ComparisonRange comparisonRange = ranges.get(i);
+            if (comparisonRange.isEquality()) {
+                continue;
+            }
+            if (!comparisonRange.isInequality()) {
+                // range is none
+                return false;
+            }
+            return i + 1 == ranges.size();
+        }
+        return true;
+    }
+
+    @Nonnull
+    public ComparisonRanges toPrefixRanges() {
+        int last;
+        for (last = 0; last < ranges.size(); last++) {
+            final ComparisonRange comparisonRange = ranges.get(last);
+            if (!comparisonRange.isEquality()) {
+                // if none don't take the none; if inequality take it
+                if (comparisonRange.isInequality()) {
+                    last ++;
+                }
+                break;
+            }
+        }
+
+        return new ComparisonRanges(ranges.subList(0, last));
+    }
+
+    @Nonnull
+    public ScanComparisons toScanComparisons() {
+        final ComparisonRanges prefixRanges = toPrefixRanges();
+
+        final List<Comparisons.Comparison> equalityComparisons = Lists.newArrayList();
+        final Set<Comparisons.Comparison> inequalityComparisons = Sets.newHashSet();
+
+        for (final ComparisonRange range : prefixRanges.ranges) {
+            if (range.isEquality()) {
+                equalityComparisons.add(range.getEqualityComparison());
+            } else {
+                inequalityComparisons.addAll(range.getInequalityComparisons());
+            }
+        }
+
+        return new ScanComparisons(equalityComparisons, inequalityComparisons);
+    }
+
+    public int size() {
+        return ranges.size();
+    }
+
+    public int totalSize() {
+        return ranges.stream()
+                .mapToInt(range -> {
+                    switch (range.getRangeType()) {
+                        case EMPTY:
+                            return 0;
+                        case EQUALITY:
+                            return 1;
+                        case INEQUALITY:
+                            return Objects.requireNonNull(range.getInequalityComparisons()).size();
+                        default:
+                            throw new RecordCoreException("unsupported range type");
+                    }
+                })
+                .sum();
+    }
+
+    @Nonnull
+    public List<ComparisonRange> getRanges() {
+        return ranges;
+    }
+
+    @Nonnull
+    public List<ComparisonRange> subRanges(final int startInclusive, final int endExclusive) {
+        return ranges.subList(startInclusive, endExclusive);
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedTo() {
+        return ranges.stream()
+                .flatMap(range -> range.getCorrelatedTo().stream())
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+    @Nonnull
+    @Override
+    public ComparisonRanges rebase(@Nonnull final AliasMap aliasMap) {
+        return translateCorrelations(TranslationMap.rebaseWithAliasMap(aliasMap));
+    }
+
+    @Nonnull
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public ComparisonRanges translateCorrelations(@Nonnull final TranslationMap translationMap) {
+        final ImmutableList.Builder<ComparisonRange> rebasedRangesBuilder = ImmutableList.builder();
+        boolean isSame = true;
+        for (final ComparisonRange range : ranges) {
+            final ComparisonRange rebasedRange = range.translateCorrelations(translationMap);
+            if (rebasedRange != range) {
+                isSame = false;
+            }
+            rebasedRangesBuilder.add(rebasedRange);
+        }
+        if (isSame) {
+            return this;
+        }
+        return new ComparisonRanges(rebasedRangesBuilder.build());
+    }
+
+    @Override
+    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        final ComparisonRanges otherComparisonRanges = (ComparisonRanges)other;
+        if (size() != otherComparisonRanges.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < ranges.size(); i++) {
+            final ComparisonRange range = ranges.get(i);
+            final ComparisonRange otherRange = otherComparisonRanges.ranges.get(i);
+
+            if (!range.semanticEquals(otherRange, aliasMap)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int semanticHashCode() {
+        int hashCode = 0;
+        for (final ComparisonRange range : ranges) {
+            hashCode = 31 * hashCode + range.semanticHashCode();
+        }
+        return hashCode;
+    }
+
+    @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(final Object o) {
+        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+    }
+
+    @Override
+    public int hashCode() {
+        return ranges.hashCode();
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashKind hashKind) {
+        return PlanHashable.objectPlanHash(hashKind, ranges);
+    }
+
+    @Override
+    public String toString() {
+        return "{" + ranges.stream().map(ComparisonRange::toString).collect(Collectors.joining("; ")) + "}";
+    }
+
+    @Nonnull
+    public static ComparisonRanges fromScanComparisons(@Nonnull final ScanComparisons scanComparisons) {
+        final ImmutableList.Builder<ComparisonRange> rangesBuilder = ImmutableList.builder();
+
+        for (final Comparisons.Comparison comparison : scanComparisons.getEqualityComparisons()) {
+            rangesBuilder.add(ComparisonRange.from(comparison));
+        }
+
+        if (!scanComparisons.isEquality()) {
+            rangesBuilder.add(ComparisonRange.fromInequalities(scanComparisons.getInequalityComparisons()));
+        }
+
+        return new ComparisonRanges(rangesBuilder.build());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -181,6 +181,7 @@ public interface MatchCandidate {
      * @param partialMatch the match to be used
      * @param planContext the plan context
      * @param memoizer the memoizer
+     * @param reverseScanOrder {@code true} if and only if a reverse scan is to be built
      * @return a new {@link RecordQueryPlan}
      */
     @SuppressWarnings("java:S135")
@@ -215,6 +216,7 @@ public interface MatchCandidate {
      * @param planContext the plan context
      * @param memoizer the memoizer
      * @param comparisonRanges a {@link List} of {@link ComparisonRange}s to be applied
+     * @param reverseScanOrder {@code true} if and only if a reverse scan is to be built
      * @return a new {@link RecordQueryPlan}
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -22,6 +22,8 @@ package com.apple.foundationdb.record.query.plan.cascades.matching.structure;
 
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
+import com.apple.foundationdb.record.provider.foundationdb.MultidimensionalIndexScanComparisons;
 import com.apple.foundationdb.record.query.combinatorics.CrossProduct;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
@@ -80,6 +82,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.all;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.ofTypeOwning;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.SetMatcher.exactlyInAnyOrder;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.TypedMatcher.typed;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.TypedMatcherWithExtractAndDownstream.typedWithDownstream;
 
 /**
@@ -267,6 +270,41 @@ public class RecordQueryPlanMatchers {
         return typedWithDownstream(RecordQueryPlanWithIndex.class,
                 Extractor.of(RecordQueryPlanWithIndex::getScanType, name -> "indexScanType(" + name + ")"),
                 PrimitiveMatchers.equalsObject(scanType));
+    }
+
+    @Nonnull
+    public static BindingMatcher<RecordQueryIndexPlan> indexScanParameters(@Nonnull final BindingMatcher<? extends IndexScanParameters> downstream) {
+        return typedWithDownstream(RecordQueryIndexPlan.class,
+                Extractor.of(RecordQueryIndexPlan::getScanParameters, name -> "indexScanParameters(" + name + ")"),
+                downstream);
+    }
+
+    @Nonnull
+    public static BindingMatcher<MultidimensionalIndexScanComparisons> multidimensional() {
+        return typed(MultidimensionalIndexScanComparisons.class);
+    }
+
+    @Nonnull
+    public static BindingMatcher<MultidimensionalIndexScanComparisons> prefix(@Nonnull final BindingMatcher<? extends ScanComparisons> downstream) {
+        return typedWithDownstream(MultidimensionalIndexScanComparisons.class,
+                Extractor.of(MultidimensionalIndexScanComparisons::getPrefixScanComparisons, name -> "prefix(" + name + ")"),
+                downstream);
+    }
+
+    @Nonnull
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static BindingMatcher<MultidimensionalIndexScanComparisons> dimensions(@Nonnull final BindingMatcher<? extends ScanComparisons>... downstreams) {
+        return typedWithDownstream(MultidimensionalIndexScanComparisons.class,
+                Extractor.of(MultidimensionalIndexScanComparisons::getDimensionsScanComparisons, name -> "dimensions(" + name + ")"),
+                ListMatcher.exactly(downstreams));
+    }
+
+    @Nonnull
+    public static BindingMatcher<MultidimensionalIndexScanComparisons> suffix(@Nonnull final BindingMatcher<? extends ScanComparisons> downstream) {
+        return typedWithDownstream(MultidimensionalIndexScanComparisons.class,
+                Extractor.of(MultidimensionalIndexScanComparisons::getSuffixScanComparisons, name -> "suffix(" + name + ")"),
+                downstream);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -297,7 +297,7 @@ public class RecordQueryPlanMatchers {
     public static BindingMatcher<MultidimensionalIndexScanComparisons> dimensions(@Nonnull final BindingMatcher<? extends ScanComparisons>... downstreams) {
         return typedWithDownstream(MultidimensionalIndexScanComparisons.class,
                 Extractor.of(MultidimensionalIndexScanComparisons::getDimensionsScanComparisons, name -> "dimensions(" + name + ")"),
-                ListMatcher.exactly(downstreams));
+                exactly(downstreams));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
@@ -39,6 +39,7 @@ import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.ComparisonRanges;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
 import com.apple.foundationdb.record.query.plan.cascades.Memoizer;
@@ -337,5 +338,16 @@ public class RecordQueryAggregateIndexPlan implements RecordQueryPlanWithNoChild
     @Override
     public ScanComparisons getScanComparisons() {
         return indexPlan.getScanComparisons();
+    }
+
+    @Override
+    public boolean hasComparisonRanges() {
+        return indexPlan.hasComparisonRanges();
+    }
+
+    @Nonnull
+    @Override
+    public ComparisonRanges getComparisonRanges() {
+        return indexPlan.getComparisonRanges();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.ComparisonRanges;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Memoizer;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -190,6 +191,12 @@ public class RecordQueryScanPlan implements RecordQueryPlanWithNoChildren, Recor
     @Override
     public ScanComparisons getScanComparisons() {
         return comparisons;
+    }
+
+    @Nonnull
+    @Override
+    public ComparisonRanges getComparisonRanges() {
+        return ComparisonRanges.fromScanComparisons(comparisons);
     }
 
     @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexTest.java
@@ -580,7 +580,7 @@ class MultidimensionalIndexTest extends FDBRecordStoreQueryTestBase {
         final RecordQueryIndexPlan indexPlan =
                 new RecordQueryIndexPlan("EventIntervals",
                         new CompositeScanParameters(
-                                new MultidimensionalIndexScanBounds(TupleRange.allOf(Tuple.from("business")), andBounds)),
+                                new MultidimensionalIndexScanBounds(TupleRange.allOf(Tuple.from("business")), andBounds, TupleRange.ALL)),
                         false);
         final Set<Message> actualResults = getResults(additionalIndexes, indexPlan);
 
@@ -933,7 +933,7 @@ class MultidimensionalIndexTest extends FDBRecordStoreQueryTestBase {
         final RecordQueryIndexPlan indexPlan =
                 new RecordQueryIndexPlan("EventIntervals",
                         new CompositeScanParameters(
-                                new MultidimensionalIndexScanBounds(TupleRange.allOf(Tuple.from(null, "business")), bounds)),
+                                new MultidimensionalIndexScanBounds(TupleRange.allOf(Tuple.from(null, "business")), bounds, TupleRange.ALL)),
                         false);
 
         final Set<Message> actualResults = getResults(additionalIndexes, indexPlan);
@@ -1009,7 +1009,7 @@ class MultidimensionalIndexTest extends FDBRecordStoreQueryTestBase {
             }
 
             return new MultidimensionalIndexScanBounds(TupleRange.betweenInclusive(Tuple.from(minCalendarName), Tuple.from(maxCalendarName)),
-                    new MultidimensionalIndexScanBounds.Hypercube(tupleRangesBuilder.build()));
+                    new MultidimensionalIndexScanBounds.Hypercube(tupleRangesBuilder.build()), TupleRange.ALL);
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -154,7 +154,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         if (filterMask.allSatisfied()) {
             filterMask.setSatisfied(true);
         }
-        return new ScoredPlan(plan, filterMask.getUnsatisfiedFilters(), Collections.emptyList(), computeSargedComparisons(plan),  11 - filterMask.getUnsatisfiedFilters().size(),
+        return new ScoredPlan(plan, null, filterMask.getUnsatisfiedFilters(), Collections.emptyList(), computeSargedComparisons(plan),  11 - filterMask.getUnsatisfiedFilters().size(),
                 state.repeated, false, null);
     }
 


### PR DESCRIPTION
- heuristic planner support for multidimensional indexes
   - `AndWithThenPlanner` is kept largely identical for regular value indexes
   - `MultidimensionalAndWithThenPlanner` for multidimensional indexes
- filter nodes during a scan based on a `TupleRange` on the suffix key part that is only applied if the R-tree sub tree only contains data using the same point coordinates
- lots of new tests
- tests adapted to also test plans generated by the planner
- dumping of R-tree information across transactions
- fixed a bug in `TupleRange` that incorrectly determined overlap and containment for a subset of cases.