### PR TITLE
Resolve #2265: Provide support for alternative implementations of ServiceLoader for example for Dependency Injection

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FunctionKeyExpression.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.query.plan.cascades.KeyExpressionVisitor;
 import com.apple.foundationdb.record.util.HashUtils;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
@@ -42,7 +43,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
 import java.util.function.BiFunction;
 
 /**
@@ -421,7 +421,7 @@ public abstract class FunctionKeyExpression extends BaseKeyExpression implements
         private static Map<String, Builder> initRegistry() {
             try {
                 Map<String, Builder> functions = new HashMap<>();
-                for (Factory factory : ServiceLoader.load(Factory.class)) {
+                for (Factory factory : ServiceLoaderProvider.load(Factory.class)) {
                     for (Builder function : factory.getBuilders()) {
                         if (functions.containsKey(function.getName())) {
                             throw new RecordCoreException("Function already defined").addLogInfo(

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextTokenizerRegistryImpl.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexMaintainer;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,6 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.ServiceLoader;
 
 /**
  * Default implementation of the {@link TextTokenizerRegistry}. It uses the class
@@ -58,7 +58,7 @@ public class TextTokenizerRegistryImpl implements TextTokenizerRegistry {
     @Nonnull
     private static Map<String, TextTokenizerFactory> initRegistry() {
         final Map<String, TextTokenizerFactory> registry = new HashMap<>();
-        for (TextTokenizerFactory factory : ServiceLoader.load(TextTokenizerFactory.class)) {
+        for (TextTokenizerFactory factory : ServiceLoaderProvider.load(TextTokenizerFactory.class)) {
             final String name = factory.getName();
             if (registry.containsKey(name)) {
                 if (LOGGER.isWarnEnabled()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
@@ -26,13 +26,13 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.ServiceLoader;
 
 /**
  * A singleton {@link IndexMaintainerRegistry} that finds {@link IndexMaintainerFactory} classes in the classpath.
@@ -55,7 +55,7 @@ public class IndexMaintainerRegistryImpl implements IndexMaintainerRegistry {
     @Nonnull
     protected static Map<String, IndexMaintainerFactory> initRegistry() {
         final Map<String, IndexMaintainerFactory> registry = new HashMap<>();
-        for (IndexMaintainerFactory factory : ServiceLoader.load(IndexMaintainerFactory.class)) {
+        for (IndexMaintainerFactory factory : ServiceLoaderProvider.load(IndexMaintainerFactory.class)) {
             for (String type : factory.getIndexTypes()) {
                 if (registry.containsKey(type)) {
                     if (LOGGER.isWarnEnabled()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FunctionCatalog.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FunctionCatalog.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.cascades.values;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
 /**
@@ -59,8 +59,8 @@ public class FunctionCatalog {
     @SuppressWarnings({"unchecked", "rawtypes", "java:S3457"})
     private static Map<FunctionKey, BuiltInFunction<? extends Typed>> loadFunctions() {
         final ImmutableMap.Builder<FunctionKey, BuiltInFunction<? extends Typed>> catalogBuilder = ImmutableMap.builder();
-        final ServiceLoader<BuiltInFunction> loader
-                = ServiceLoader.load(BuiltInFunction.class);
+        final Iterable<BuiltInFunction> loader
+                = ServiceLoaderProvider.load(BuiltInFunction.class);
 
         loader.forEach(builtInFunction -> {
             catalogBuilder.put(new FunctionKey(builtInFunction.getFunctionName(), builtInFunction.getParameterTypes().size(), builtInFunction.hasVariadicSuffix()), builtInFunction);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/ServiceLoaderProvider.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/ServiceLoaderProvider.java
@@ -1,0 +1,67 @@
+/*
+ * ServiceLoaderProvider.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.util;
+
+import java.util.ServiceLoader;
+import java.util.function.Function;
+
+/**
+ * A singleton that supports alternatives to {@link java.util.ServiceLoader}, for example if you want to
+ * use a dependency injection framework.
+ */
+public final class ServiceLoaderProvider {
+    public static final Function<Class<?>, Iterable<?>> DEFAULT_LOADER = ServiceLoader::load;
+    private static Function<Class<?>, Iterable<?>> temp = DEFAULT_LOADER;
+
+    private static final class Holder {
+        static final Function<Class<?>, Iterable<?>> serviceLoader = ServiceLoaderProvider.temp;
+    }
+
+    private ServiceLoaderProvider() {
+        // Singleton utility class
+    }
+
+    /**
+     * Replaces the default service loader.
+     * This must be called BEFORE ServiceLoaderProvider.load() is called.
+     *
+     * @param serviceLoader Replacement service loader.
+     * @throws IllegalStateException if called while the application is already running
+     */
+    public static void initialize(final Function<Class<?>, Iterable<?>> serviceLoader) {
+        temp = serviceLoader;
+        if (!Holder.serviceLoader.equals(serviceLoader)) {
+            throw new IllegalStateException("ServiceLoaderProvider already initialized");
+        }
+    }
+
+    /**
+     * Creates an Iterable of services instances for the given service.
+     *
+     * @param clazz class
+     * @param <T> type
+     * @return service loader
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Iterable<T> load(final Class<T> clazz) {
+        return (Iterable<T>) Holder.serviceLoader.apply(clazz);
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
 import com.apple.foundationdb.record.query.plan.cascades.debug.RestartException;
 import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraphProperty;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import com.google.common.cache.Cache;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -58,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.IntUnaryOperator;
@@ -601,8 +601,8 @@ public class PlannerRepl implements Debugger {
     @SuppressWarnings({"unchecked", "rawtypes"})
     private static ImmutableMap<String, Commands.Command<Event>> loadCommands() {
         final ImmutableMap.Builder<String, Commands.Command<Event>> commandsMapBuilder = ImmutableMap.builder();
-        final ServiceLoader<Commands.Command> loader
-                = ServiceLoader.load(Commands.Command.class);
+        final Iterable<Commands.Command> loader
+                = ServiceLoaderProvider.load(Commands.Command.class);
 
         loader.forEach(command -> {
             commandsMapBuilder.put(command.getCommandToken(), command);
@@ -621,8 +621,8 @@ public class PlannerRepl implements Debugger {
     @Nonnull
     private static SetMultimap<Class<? extends Event>, Processors.Processor<? extends Event>> loadProcessors() {
         SetMultimap<Class<? extends Event>, Processors.Processor<? extends Event>> processorsMap = HashMultimap.create();
-        final ServiceLoader<Processors.Processor> loader
-                = ServiceLoader.load(Processors.Processor.class);
+        final Iterable<Processors.Processor> loader
+                = ServiceLoaderProvider.load(Processors.Processor.class);
 
         loader.forEach(processor -> {
             processorsMap.put(processor.getEventType(), processor);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.lucene.exact.ExactTokenAnalyzerFactory;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.ServiceLoader;
 import java.util.TreeMap;
 
 /**
@@ -56,7 +56,7 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
     @Nonnull
     private static Map<LuceneAnalyzerType, Map<String, LuceneAnalyzerFactory>> initRegistry() {
         final Map<LuceneAnalyzerType, Map<String, LuceneAnalyzerFactory>> registry = new HashMap<>();
-        for (LuceneAnalyzerFactory factory : ServiceLoader.load(LuceneAnalyzerFactory.class)) {
+        for (LuceneAnalyzerFactory factory : ServiceLoaderProvider.load(LuceneAnalyzerFactory.class)) {
             final String name = factory.getName();
             final LuceneAnalyzerType type = factory.getType();
             if (registry.containsKey(type) && registry.get(type).containsKey(name)) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactoryProvider.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactoryProvider.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene.search;
 
 import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import com.google.common.base.Suppliers;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -30,7 +31,6 @@ import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
 /**
@@ -64,7 +64,7 @@ public class LuceneQueryParserFactoryProvider {
     @Nonnull
     private static LuceneQueryParserFactory initRegistry() {
         LuceneQueryParserFactory first = null;
-        for (LuceneQueryParserFactory factory : ServiceLoader.load(LuceneQueryParserFactory.class)) {
+        for (LuceneQueryParserFactory factory : ServiceLoaderProvider.load(LuceneQueryParserFactory.class)) {
             if (first == null) {
                 first = factory;
             } else {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistryImpl.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -41,7 +42,6 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.ServiceLoader;
 
 /**
  * Registry for {@link SynonymMap}s.
@@ -76,7 +76,7 @@ public class SynonymMapRegistryImpl implements SynonymMapRegistry {
     @Nonnull
     private static Map<String, SynonymMap> initRegistry() {
         final Map<String, SynonymMap> registry = new HashMap<>();
-        for (SynonymMapConfig config : ServiceLoader.load(SynonymMapConfig.class)) {
+        for (SynonymMapConfig config : ServiceLoaderProvider.load(SynonymMapConfig.class)) {
             if (registry.containsKey(config.getName())) {
                 if (LOGGER.isWarnEnabled()) {
                     LOGGER.warn(KeyValueLogMessage.of("duplicate synonym map", LogMessageKeys.SYNONYM_NAME, config.getName()));


### PR DESCRIPTION
This allows the standard Java ServiceLoader to replaced by another one for example a dependency injection aware version of ServiceLoader. 