### PR TITLE
Get scan order from query rather than indexes

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -273,12 +273,8 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
     public RecordQueryPlan toEquivalentPlan(@Nonnull final PartialMatch partialMatch,
                                             @Nonnull final PlanContext planContext,
                                             @Nonnull final Memoizer memoizer,
-                                            @Nonnull final List<ComparisonRange> comparisonRanges) {
-        final var reverseScanOrder =
-                partialMatch.getMatchInfo()
-                        .deriveReverseScanOrder()
-                        .orElseThrow(() -> new RecordCoreException("match info should unambiguously indicate reversed-ness of scan"));
-
+                                            @Nonnull final List<ComparisonRange> comparisonRanges,
+                                            final boolean reverseScanOrder) {
         final var baseRecordType = Type.Record.fromFieldDescriptorsMap(RecordMetaData.getFieldDescriptorMapFromTypes(recordTypes));
 
         // reset indexes of all fields, such that we can normalize them

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -349,8 +349,7 @@ public class CascadesPlanner implements QueryPlanner {
                                     recordStoreState,
                                     rootReference,
                                     allowedIndexesOptional,
-                                    indexQueryabilityFilter,
-                                    false
+                                    indexQueryabilityFilter
                             ),
                     evaluationContext);
             final var plan = resultOrFail();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -337,34 +337,9 @@ public class CascadesPlanner implements QueryPlanner {
     }
 
     @Nonnull
-    @Deprecated(forRemoval = true)
-    public RecordQueryPlan planGraph(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier,
-                                     @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
-                                     @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
-                                     final boolean isSortReverse,
-                                     @Nonnull ParameterRelationshipGraph ignored) {
-        try {
-            planPartial(expressionRefSupplier,
-                    rootReference ->
-                            MetaDataPlanContext.forRootReference(configuration,
-                                    metaData,
-                                    recordStoreState,
-                                    rootReference,
-                                    allowedIndexesOptional,
-                                    indexQueryabilityFilter,
-                                    isSortReverse),
-                    EvaluationContext.empty());
-            return resultOrFail();
-        } finally {
-            Debugger.withDebugger(Debugger::onDone);
-        }
-    }
-
-    @Nonnull
     public QueryPlanResult planGraph(@Nonnull Supplier<GroupExpressionRef<RelationalExpression>> expressionRefSupplier,
                                      @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
                                      @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
-                                     final boolean isSortReverse,
                                      @Nonnull final EvaluationContext evaluationContext) {
         try {
             planPartial(expressionRefSupplier,
@@ -375,7 +350,7 @@ public class CascadesPlanner implements QueryPlanner {
                                     rootReference,
                                     allowedIndexesOptional,
                                     indexQueryabilityFilter,
-                                    isSortReverse
+                                    false
                             ),
                     evaluationContext);
             final var plan = resultOrFail();
@@ -384,7 +359,6 @@ public class CascadesPlanner implements QueryPlanner {
         } finally {
             Debugger.withDebugger(Debugger::onDone);
         }
-
     }
 
     private RecordQueryPlan resultOrFail() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -178,15 +178,17 @@ public interface MatchCandidate {
 
     /**
      * Creates a {@link RecordQueryPlan} that represents a scan over the materialized candidate data.
+     *
      * @param partialMatch the match to be used
      * @param planContext the plan context
      * @param memoizer the memoizer
+     *
      * @return a new {@link RecordQueryPlan}
      */
     @SuppressWarnings("java:S135")
     default RecordQueryPlan toEquivalentPlan(@Nonnull final PartialMatch partialMatch,
                                              @Nonnull final PlanContext planContext,
-                                             @Nonnull final Memoizer memoizer) {
+                                             @Nonnull final Memoizer memoizer, final boolean reverseScanOrder) {
         final var matchInfo = partialMatch.getMatchInfo();
         final var prefixMap = computeBoundParameterPrefixMap(matchInfo);
 
@@ -204,23 +206,26 @@ public interface MatchCandidate {
             comparisonRangesForScanBuilder.add(prefixMap.get(parameterAlias));
         }
 
-        return toEquivalentPlan(partialMatch, planContext, memoizer, comparisonRangesForScanBuilder.build());
+        return toEquivalentPlan(partialMatch, planContext, memoizer, comparisonRangesForScanBuilder.build(), reverseScanOrder);
     }
 
     /**
      * Creates a {@link RecordQueryPlan} that represents a scan over the materialized candidate data. This method is
      * expected to be implemented by specific implementations of {@link MatchCandidate}.
+     *
      * @param partialMatch the {@link PartialMatch} that matched the query and the candidate
      * @param planContext the plan context
      * @param memoizer the memoizer
      * @param comparisonRanges a {@link List} of {@link ComparisonRange}s to be applied
+     *
      * @return a new {@link RecordQueryPlan}
      */
     @Nonnull
     RecordQueryPlan toEquivalentPlan(@Nonnull PartialMatch partialMatch,
                                      @Nonnull PlanContext planContext,
                                      @Nonnull Memoizer memoizer,
-                                     @Nonnull List<ComparisonRange> comparisonRanges);
+                                     @Nonnull List<ComparisonRange> comparisonRanges,
+                                     boolean reverseScanOrder);
 
     @Nonnull
     @SuppressWarnings("java:S1452")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -178,17 +178,16 @@ public interface MatchCandidate {
 
     /**
      * Creates a {@link RecordQueryPlan} that represents a scan over the materialized candidate data.
-     *
      * @param partialMatch the match to be used
      * @param planContext the plan context
      * @param memoizer the memoizer
-     *
      * @return a new {@link RecordQueryPlan}
      */
     @SuppressWarnings("java:S135")
     default RecordQueryPlan toEquivalentPlan(@Nonnull final PartialMatch partialMatch,
                                              @Nonnull final PlanContext planContext,
-                                             @Nonnull final Memoizer memoizer, final boolean reverseScanOrder) {
+                                             @Nonnull final Memoizer memoizer,
+                                             final boolean reverseScanOrder) {
         final var matchInfo = partialMatch.getMatchInfo();
         final var prefixMap = computeBoundParameterPrefixMap(matchInfo);
 
@@ -212,12 +211,10 @@ public interface MatchCandidate {
     /**
      * Creates a {@link RecordQueryPlan} that represents a scan over the materialized candidate data. This method is
      * expected to be implemented by specific implementations of {@link MatchCandidate}.
-     *
      * @param partialMatch the {@link PartialMatch} that matched the query and the candidate
      * @param planContext the plan context
      * @param memoizer the memoizer
      * @param comparisonRanges a {@link List} of {@link ComparisonRange}s to be applied
-     *
      * @return a new {@link RecordQueryPlan}
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
@@ -154,34 +154,6 @@ public class MatchInfo {
         return remainingComputationValueOptional;
     }
 
-    /**
-     * Derive if a scan is reverse by looking at all the bound key parts in this match info. The planner structures
-     * are laid out in a way that they could theoretically support a scan direction by key part. In reality, we only
-     * support a direction for a scan. Consequently, we only allow that either none or all of the key parts indicate
-     * {@link OrderingPart#isReverse()}.
-     * @return {@code Optional.of(false)} if all bound key parts indicate a forward ordering,
-     *         {@code Optional.of(true)} if all bound key parts indicate a reverse ordering,
-     *         {@code Optional.empty()} otherwise. The caller should deal with that result accordingly.
-     *         Note that if there are no bound key parts at all, this method will return {@code Optional.of(false)}.
-     */
-    @Nonnull
-    public Optional<Boolean> deriveReverseScanOrder() {
-        var numReverse  = 0;
-        for (var orderingPart : matchedOrderingParts) {
-            if (orderingPart.isReverse()) {
-                numReverse ++;
-            }
-        }
-
-        if (numReverse == 0) {
-            return Optional.of(false); // forward
-        } else if (numReverse == matchedOrderingParts.size()) {
-            return Optional.of(true); // reverse
-        } else {
-            return Optional.empty();
-        }
-    }
-
     @Nonnull
     public MatchInfo withOrderingInfo(@Nonnull final List<MatchedOrderingPart> matchedOrderingParts) {
         return new MatchInfo(parameterBindingMap,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
@@ -170,8 +170,7 @@ public class MetaDataPlanContext implements PlanContext {
                                                @Nonnull final RecordStoreState recordStoreState,
                                                @Nonnull final ExpressionRef<? extends RelationalExpression> rootReference,
                                                @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
-                                               @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
-                                               final boolean isSortReverse) {
+                                               @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter) {
         final var queriedRecordTypeNames = RecordTypesProperty.evaluate(rootReference);
 
         if (queriedRecordTypeNames.isEmpty()) {
@@ -200,7 +199,7 @@ public class MetaDataPlanContext implements PlanContext {
         final ImmutableSet.Builder<MatchCandidate> matchCandidatesBuilder = ImmutableSet.builder();
         for (final var index : indexList) {
             final Iterable<MatchCandidate> candidatesForIndex =
-                    MatchCandidate.fromIndexDefinition(metaData, index, isSortReverse);
+                    MatchCandidate.fromIndexDefinition(metaData, index, false);
             matchCandidatesBuilder.addAll(candidatesForIndex);
         }
 
@@ -208,7 +207,7 @@ public class MetaDataPlanContext implements PlanContext {
             MatchCandidate.fromPrimaryDefinition(metaData,
                             ImmutableSet.of(recordType.getName()),
                             recordType.getPrimaryKey(),
-                            isSortReverse)
+                            false)
                     .ifPresent(matchCandidatesBuilder::add);
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryScanMatchCandidate.java
@@ -180,12 +180,8 @@ public class PrimaryScanMatchCandidate implements MatchCandidate, ValueIndexLike
     public RecordQueryPlan toEquivalentPlan(@Nonnull PartialMatch partialMatch,
                                             @Nonnull final PlanContext planContext,
                                             @Nonnull final Memoizer memoizer,
-                                            @Nonnull final List<ComparisonRange> comparisonRanges) {
-        final var reverseScanOrder =
-                partialMatch.getMatchInfo()
-                        .deriveReverseScanOrder()
-                        .orElseThrow(() -> new RecordCoreException("match info should unambiguously indicate reversed-ness of scan"));
-
+                                            @Nonnull final List<ComparisonRange> comparisonRanges,
+                                            final boolean reverseScanOrder) {
         final var availableRecordTypeNames = getAvailableRecordTypeNames();
         final var availableType =
                 Type.Record.fromFieldDescriptorsMap(RecordMetaData.getFieldDescriptorMapFromTypes(getAvailableRecordTypes()))

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -223,12 +222,9 @@ public class ValueIndexScanMatchCandidate implements ScanWithFetchMatchCandidate
     public RecordQueryPlan toEquivalentPlan(@Nonnull final PartialMatch partialMatch,
                                             @Nonnull final PlanContext planContext,
                                             @Nonnull final Memoizer memoizer,
-                                            @Nonnull final List<ComparisonRange> comparisonRanges) {
+                                            @Nonnull final List<ComparisonRange> comparisonRanges,
+                                            final boolean reverseScanOrder) {
         final var matchInfo = partialMatch.getMatchInfo();
-        final var reverseScanOrder =
-                matchInfo
-                        .deriveReverseScanOrder()
-                        .orElseThrow(() -> new RecordCoreException("match info should unambiguously indicate reversed-ness of scan"));
 
         final var baseRecordType =
                 Type.Record.fromFieldDescriptorsMap(RecordMetaData.getFieldDescriptorMapFromTypes(queriedRecordTypes));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.record.IndexScanType;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
@@ -348,12 +347,8 @@ public class WindowedIndexScanMatchCandidate implements ScanWithFetchMatchCandid
     public RecordQueryPlan toEquivalentPlan(@Nonnull final PartialMatch partialMatch,
                                             @Nonnull final PlanContext planContext,
                                             @Nonnull final Memoizer memoizer,
-                                            @Nonnull final List<ComparisonRange> comparisonRanges) {
-        final var reverseScanOrder =
-                partialMatch.getMatchInfo()
-                        .deriveReverseScanOrder()
-                        .orElseThrow(() -> new RecordCoreException("match info should unambiguously indicate reversed-ness of scan"));
-
+                                            @Nonnull final List<ComparisonRange> comparisonRanges,
+                                            final boolean reverseScanOrder) {
         final var baseRecordType = Type.Record.fromFieldDescriptorsMap(RecordMetaData.getFieldDescriptorMapFromTypes(queriedRecordTypes));
         return tryFetchCoveringIndexScan(partialMatch, planContext, memoizer, comparisonRanges, reverseScanOrder, baseRecordType)
                 .orElseGet(() ->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -249,6 +249,13 @@ public class RecordQueryPlanMatchers {
     }
 
     @Nonnull
+    public static BindingMatcher<RecordQueryPlan> isReverse() {
+        return typedWithDownstream(RecordQueryPlan.class,
+                Extractor.of(RecordQueryPlan::isReverse, name -> "isReversed(" + name + ")"),
+                PrimitiveMatchers.equalsObject(true));
+    }
+
+    @Nonnull
     public static BindingMatcher<RecordQueryPlanWithIndex> indexName(@Nonnull String indexName) {
         return typedWithDownstream(RecordQueryPlanWithIndex.class,
                 Extractor.of(RecordQueryPlanWithIndex::getIndexName, name -> "indexName(" + name + ")"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
@@ -253,30 +253,21 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
      * Private helper method to eliminate {@link PartialMatch}es whose coverage is entirely contained in other matches
      * (among the matches given).
      * @param matches candidate matches
-     * @param interestedOrderings a set of interesting orderings
+     * @param requestedOrderings a set of interesting orderings
      * @return a collection of {@link PartialMatch}es that are the maximum coverage matches among the matches handed in
      */
     @Nonnull
     @SuppressWarnings({"java:S1905", "java:S135"})
     private static List<PartialMatchWithCompensation> maximumCoverageMatches(@Nonnull final Collection<? extends PartialMatch> matches,
-                                                                             @Nonnull final Set<RequestedOrdering> interestedOrderings) {
+                                                                             @Nonnull final Set<RequestedOrdering> requestedOrderings) {
         final List<PartialMatchWithCompensation> partialMatchesWithCompensation = new ArrayList<>();
         for (final var partialMatch: matches) {
-            final var orderings = satisfiedOrderings(partialMatch, interestedOrderings);
-            if (orderings.isEmpty()) {
+            final var ordering = satisfiedOrderings(partialMatch, requestedOrderings);
+            if (ordering.isEmpty()) {
                 continue;
             }
-            boolean reverse = false;
-            for (final var ordering: orderings) {
-                // Ignore orderings without parts (only containing preserve_distinctness for example)
-                if (!ordering.getOrderingParts().isEmpty()) {
-                    // If one is reverse, they are all reverse
-                    reverse = ordering.getOrderingParts().get(0).isReverse();
-                    break;
-                }
-            }
             partialMatchesWithCompensation.add(new PartialMatchWithCompensation(
-                    partialMatch, partialMatch.compensate(), reverse));
+                    partialMatch, partialMatch.compensate(), ordering.get()));
         }
         partialMatchesWithCompensation.sort(
                 Comparator.comparing((Function<PartialMatchWithCompensation, Integer>)
@@ -321,13 +312,12 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
      * if the given {@link PartialMatch} were to be planned.
      * @param partialMatch a partial match
      * @param requestedOrderings a set of {@link Ordering}s
-     * @return a subset of {@code requestedOrderings} where each contained {@link Ordering} would be satisfied by the
-     *         given partial match
+     * @return an optional boolean that is empty if no orderings was satisfied, true if there was a descending match, and false if there was an ascending match
      */
     @Nonnull
     @SuppressWarnings("java:S135")
-    private static Set<RequestedOrdering> satisfiedOrderings(@Nonnull final PartialMatch partialMatch, @Nonnull final Set<RequestedOrdering> requestedOrderings) {
-        return requestedOrderings
+    private static Optional<Boolean> satisfiedOrderings(@Nonnull final PartialMatch partialMatch, @Nonnull final Set<RequestedOrdering> requestedOrderings) {
+        Set<RequestedOrdering> satisfiedOrderings = requestedOrderings
                 .stream()
                 .filter(requestedOrdering -> {
                     if (requestedOrdering.isPreserve()) {
@@ -374,6 +364,17 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
                     return true;
                 })
                 .collect(ImmutableSet.toImmutableSet());
+        if (satisfiedOrderings.isEmpty()) {
+            return Optional.empty();
+        }
+        for (final var ordering: satisfiedOrderings) {
+            // Ignore orderings without parts (only containing preserve_distinctness for example)
+            if (!ordering.getOrderingParts().isEmpty()) {
+                // If one is reverse, they are all reverse
+                return Optional.of(ordering.getOrderingParts().get(0).isReverse());
+            }
+        }
+        return Optional.of(false);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/DataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/DataAccessRule.java
@@ -59,7 +59,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * </ul>
  *
  * The logic that this rules delegates to actually create the expressions can be found in
- * {@link MatchCandidate#toEquivalentPlan(PartialMatch, PlanContext, Memoizer)}
+ * {@link MatchCandidate#toEquivalentPlan(PartialMatch, PlanContext, Memoizer, boolean)}
  *
  */
 @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBModificationQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBModificationQueryTest.java
@@ -100,7 +100,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     FDBModificationQueryTest::insertGraph,
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
             fetchResultValues(context, plan, Function.identity(), c -> { });
 
@@ -139,7 +138,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     },
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
 
             assertMatchesExactly(plan,
@@ -163,7 +161,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
             final var selectPlan = cascadesPlanner.planGraph(() -> selectRecordsGraph(cascadesPlanner.getRecordMetaData(), FDBModificationQueryTest::whereReviewsIsEmptyGraph),
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
             resultValues = fetchResultValues(context, selectPlan, record -> {
                 final var recordDescriptor = record.getDescriptorForType();
@@ -203,7 +200,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     FDBModificationQueryTest::insertGraph,
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
 
             assertMatchesExactly(plan, insertPlan(explodePlan()).where(target(equalsObject("RestaurantRecord"))));
@@ -229,7 +225,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
             final var selectPlan = cascadesPlanner.planGraph(() -> selectRecordsGraph(cascadesPlanner.getRecordMetaData(), FDBModificationQueryTest::whereReviewsIsEmptyGraph),
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
             resultValues = fetchResultValues(context, selectPlan, record -> {
                 final var recordDescriptor = record.getDescriptorForType();
@@ -324,7 +319,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         Assertions.assertThrows(RecordCoreException.class, () -> fetchResultValues(plan, this::openNestedRecordStore, Function.identity()));
@@ -390,7 +384,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     FDBModificationQueryTest::insertGraph,
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
             fetchResultValues(context, plan, Function.identity(), c -> { });
 
@@ -433,7 +426,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     },
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
 
             assertMatchesExactly(plan,
@@ -467,7 +459,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
             final var selectPlan = cascadesPlanner.planGraph(() -> selectRecordsGraph(cascadesPlanner.getRecordMetaData(), FDBModificationQueryTest::whereReviewsIsEmptyGraph),
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
             resultValues = fetchResultValues(context, selectPlan, record -> {
                 final var recordDescriptor = record.getDescriptorForType();
@@ -534,7 +525,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     FDBModificationQueryTest::insertGraph,
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
             fetchResultValues(context, plan, Function.identity(), c -> { });
 
@@ -607,7 +597,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     },
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
 
             assertMatchesExactly(plan,
@@ -637,7 +626,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
             final var selectPlan = cascadesPlanner.planGraph(() -> selectRecordsGraph(cascadesPlanner.getRecordMetaData(), FDBModificationQueryTest::whereReviewsIsEmptyGraph),
                     Optional.empty(),
                     IndexQueryabilityFilter.TRUE,
-                    false,
                     EvaluationContext.empty()).getPlan();
             resultValues = fetchResultValues(context, selectPlan, record -> {
                 final var recordDescriptor = record.getDescriptorForType();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -189,7 +189,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         assertMatchesExactly(plan,
@@ -223,7 +222,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
         assertMatchesExactly(plan,
                 mapPlan(
@@ -262,7 +260,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 allowedIndexesOptional,
                 IndexQueryabilityFilter.TRUE,
-                false,
                 parameterRelationshipGraph));
     }
 
@@ -292,7 +289,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         final BindingMatcher<? extends RecordQueryPlan> planMatcher =
@@ -346,7 +342,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty());
 
         final BindingMatcher<? extends RecordQueryPlan> planMatcher =
@@ -408,7 +403,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         final BindingMatcher<? extends RecordQueryPlan> planMatcher =
@@ -494,7 +488,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty());
 
         // TODO write a matcher when this plan becomes more stable
@@ -572,7 +565,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         // TODO write a matcher when this plan becomes more stable
@@ -604,7 +596,6 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                 },
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         assertMatchesExactly(plan,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBVersionsQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBVersionsQueryTest.java
@@ -500,7 +500,7 @@ public class FDBVersionsQueryTest extends FDBRecordStoreQueryTestBase {
 
                 AliasMap aliasMap = AliasMap.of(select.getAlias(), Quantifier.current());
                 return GroupExpressionRef.of(new LogicalSortExpression(List.of(FieldValue.ofFieldName(select.getFlowedObjectValue(), "version").rebase(aliasMap)), false, select));
-            }, Optional.empty(), IndexQueryabilityFilter.DEFAULT, false, EvaluationContext.empty()).getPlan();
+            }, Optional.empty(), IndexQueryabilityFilter.DEFAULT, EvaluationContext.empty()).getPlan();
 
             assertMatchesExactly(plan, mapPlan(
                     indexPlan()
@@ -572,7 +572,7 @@ public class FDBVersionsQueryTest extends FDBRecordStoreQueryTestBase {
                 var select = Quantifier.forEach(GroupExpressionRef.of(outerGraphBuilder.build().buildSelect()));
 
                 return GroupExpressionRef.of(new LogicalSortExpression(List.of(), false, select));
-            }, Optional.empty(), IndexQueryabilityFilter.DEFAULT, false, EvaluationContext.empty()).getPlan();
+            }, Optional.empty(), IndexQueryabilityFilter.DEFAULT, EvaluationContext.empty()).getPlan();
 
             assertMatchesExactly(plan, mapPlan(
                     predicatesFilterPlan(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
@@ -86,7 +86,6 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
                 () -> constructGroupByPlan(false, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         assertMatchesExactly(plan,
@@ -107,7 +106,6 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
                 () -> constructGroupByPlan(false, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()), "Cascades planner could not plan query");
     }
 
@@ -119,7 +117,6 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
                 () -> constructGroupByPlan(false, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         assertMatchesExactly(plan, mapPlan(aggregateIndexPlan()));
@@ -133,7 +130,6 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
                 () -> constructGroupByPlan(true, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         assertMatchesExactly(plan,
@@ -154,7 +150,6 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
                 () -> constructGroupByPlan(true, false),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         assertMatchesExactly(plan, mapPlan(aggregateIndexPlan().where(scanComparisons(range("[[42],>")))));
@@ -168,7 +163,6 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
                 () -> constructGroupByPlan(true, true),
                 Optional.empty(),
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
 
         assertMatchesExactly(plan, mapPlan(aggregateIndexPlan().where(scanComparisons(range("[[42],[44]]")))));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/SparseIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/SparseIndexTest.java
@@ -221,7 +221,6 @@ public class SparseIndexTest extends FDBRecordStoreQueryTestBase {
                 () -> constructQueryWithPredicate(planner.getRecordMetaData(), addQueryPredicate),
                 allowedIndexes,
                 IndexQueryabilityFilter.TRUE,
-                false,
                 EvaluationContext.empty()).getPlan();
     }
 }


### PR DESCRIPTION
Indexes can be read top down or bottom up. The reverse scan requirement should not come from indexes but from the query itself