### PR TITLE
Resolves #2293: Rethrow original IOExceptions in lucene code

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,6 +20,8 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Rethrow original IOExceptions exceptions in lucene code [(Issue #2293)](https://github.com/FoundationDB/fdb-record-layer/issues/2293)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,6 +22,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Rethrow original IOExceptions exceptions in lucene code [(Issue #2293)](https://github.com/FoundationDB/fdb-record-layer/issues/2293)
+* **Bug fix** Add proper clone to LuceneStoredFieldsReader [(Issue #2297)](https://github.com/FoundationDB/fdb-record-layer/issues/2297)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
 import static org.junit.jupiter.params.ParameterizedTest.ARGUMENTS_WITH_NAMES_PLACEHOLDER;
 
 /**
- * A test for the Remote Fetch with large records that are split (more than just hte version split).
+ * A test for the Remote Fetch with large records that are split (more than just the version split).
  */
 @Tag(Tags.RequiresFDB)
 class RemoteFetchSplitRecordsTest extends RemoteFetchTestBase {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyCloseable.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyCloseable.java
@@ -1,0 +1,92 @@
+/*
+ * LazyCloseable.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import com.google.common.base.Supplier;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Similar to {@link LazyOpener}, but that is also {@link Closeable}.
+ * <p>
+ *     Calling {@link #close()} on this object will not call the opener, and only close the stored value if it was
+ *     already opened.
+ * </p>
+ * @param <T> the value opened
+ */
+public class LazyCloseable<T extends Closeable> implements Closeable {
+    private final LazyOpener<T> opener;
+    private boolean initialized;
+
+    /**
+     * Create a new {@link LazyCloseable} for the given {@link LazyOpener.Opener}.
+     * <p>
+     *     The {@code opener} will be called at most once; see {@link com.google.common.base.Suppliers#memoize(Supplier)}.
+     * </p>
+     * @param opener a function to "open" a resource
+     * @param <U> the return type of the {@code opener}
+     * @return a new lazily opened object
+     */
+    public static <U extends Closeable> LazyCloseable<U> supply(LazyOpener.Opener<U> opener) {
+        return new LazyCloseable<>(opener);
+    }
+
+    private LazyCloseable(LazyOpener.Opener<T> opener) {
+        this.initialized = false;
+        this.opener = LazyOpener.supply(() -> {
+            final T result = opener.open();
+            initialized = true;
+            return result;
+        });
+    }
+
+    /**
+     * Get the object returned by the {@code opener}.
+     * @return the object returned by the {@code opener}
+     * @throws IOException if calling {@link LazyOpener.Opener#open()} threw an {@link IOException}
+     */
+    public T get() throws IOException {
+        return opener.get();
+    }
+
+    /**
+     * Get the object returned by the {@code opener}, throwing {@link java.io.UncheckedIOException} if the
+     * {@link LazyOpener.Opener#open()} method threw {@link IOException}.
+     * @return the object returned by the {@code opener}
+     */
+    public T getUnchecked() {
+        return opener.getUnchecked();
+    }
+
+    /**
+     * Calls close on the result of the {@code opener} if it was already accessed through {@link #get} or
+     * {@link #getUnchecked}.
+     * @throws IOException if the underlying {@code close} throws {@link IOException}.
+     */
+    @Override
+    public void close() throws IOException {
+        if (initialized) {
+            opener.get().close();
+        }
+    }
+
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyCloseable.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyCloseable.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  * @param <T> the value opened
  */
 public class LazyCloseable<T extends Closeable> implements Closeable {
-    private final LazyOpener<T> opener;
+    private final LazyOpener<T> lazyOpener;
     private boolean initialized;
 
     /**
@@ -52,7 +52,7 @@ public class LazyCloseable<T extends Closeable> implements Closeable {
 
     private LazyCloseable(LazyOpener.Opener<T> opener) {
         this.initialized = false;
-        this.opener = LazyOpener.supply(() -> {
+        this.lazyOpener = LazyOpener.supply(() -> {
             final T result = opener.open();
             initialized = true;
             return result;
@@ -65,7 +65,7 @@ public class LazyCloseable<T extends Closeable> implements Closeable {
      * @throws IOException if calling {@link LazyOpener.Opener#open()} threw an {@link IOException}
      */
     public T get() throws IOException {
-        return opener.get();
+        return lazyOpener.get();
     }
 
     /**
@@ -74,7 +74,7 @@ public class LazyCloseable<T extends Closeable> implements Closeable {
      * @return the object returned by the {@code opener}
      */
     public T getUnchecked() {
-        return opener.getUnchecked();
+        return lazyOpener.getUnchecked();
     }
 
     /**
@@ -85,7 +85,7 @@ public class LazyCloseable<T extends Closeable> implements Closeable {
     @Override
     public void close() throws IOException {
         if (initialized) {
-            opener.get().close();
+            lazyOpener.get().close();
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
@@ -1,0 +1,94 @@
+/*
+ * LazyOpener.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * Class to lazily "open" something that may throw an IOException when opening.
+ * @param <T> the type of object that the opener returns
+ */
+public class LazyOpener<T> {
+
+    private final Supplier<T> opener;
+
+    private LazyOpener(final Opener<T> opener) {
+        this.opener = Suppliers.memoize(() -> {
+            try {
+                return opener.open();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    /**
+     * Create a new {@link LazyOpener} for the given {@link LazyOpener.Opener}.
+     * <p>
+     *     The {@code opener} will be called at most once; see {@link Suppliers#memoize(Supplier)}.
+     * </p>
+     * @param <U> the return type of the {@code opener}
+     * @param opener a function to "open" a resource
+     * @return a new lazily opened object
+     */
+    public static <U> LazyOpener<U> supply(LazyOpener.Opener<U> opener) {
+        return new LazyOpener<U>(opener);
+    }
+
+    /**
+     * Get the object returned by the {@code opener}.
+     * @return the object returned by the {@code opener}
+     * @throws IOException if calling {@link Opener#open()} threw an {@link IOException}
+     */
+    public T get() throws IOException {
+        try {
+            return opener.get();
+        } catch (UncheckedIOException e) {
+            final IOException cause = e.getCause();
+            cause.addSuppressed(e);
+            throw cause;
+        }
+    }
+
+    /**
+     * Get the object returned by the {@code opener}, throwing {@link UncheckedIOException} if the {@link Opener#open()}
+     * method threw {@link IOException}.
+     * @return the object returned by the {@code opener}
+     */
+    public T getUnchecked() {
+        return opener.get();
+    }
+
+    /**
+     * A function that returns an object, but may throw an {@link IOException}.
+     * @param <T> the type returned
+     */
+    @FunctionalInterface
+    public interface Opener<T> {
+        @Nonnull
+        T open() throws IOException;
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
@@ -46,6 +46,7 @@ public class LazyOpener<T> {
     private static final Executor executor = Runnable::run;
 
     private LazyOpener(final Opener<T> opener) {
+        // Empty future that will gate the completion of the opener task
         starter = new CompletableFuture<>();
         future = starter.thenApplyAsync(ignored -> {
             try {
@@ -74,6 +75,7 @@ public class LazyOpener<T> {
      * @return the object returned by the {@code opener}
      * @throws IOException if calling {@link Opener#open()} threw an {@link IOException}
      */
+    @SuppressWarnings("PMD.PreserveStackTrace")
     public T get() throws IOException {
         try {
             return getInternal();
@@ -92,6 +94,7 @@ public class LazyOpener<T> {
      * method threw {@link IOException}.
      * @return the object returned by the {@code opener}
      */
+    @SuppressWarnings("PMD.PreserveStackTrace")
     public T getUnchecked() {
         try {
             return getInternal();
@@ -106,6 +109,7 @@ public class LazyOpener<T> {
     }
 
     private T getInternal() throws ExecutionException {
+        // Once "opening" is required, complete the starter future to initiate the realization of the future
         starter.complete(null);
         try {
             return future.get();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.lucene.codec;
 
 import com.google.auto.service.AutoService;
-import com.google.common.base.Suppliers;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.PostingsFormat;
@@ -34,9 +33,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Terms;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Iterator;
-import java.util.function.Supplier;
 
 /**
  * {@code PostingsFormat} optimized for FDB storage.
@@ -72,28 +69,19 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
 
     private static class LazyFieldsProducer extends FieldsProducer {
 
-        private final Supplier<FieldsProducer> fieldsProducer;
-
-        private boolean initialized;
+        private final LazyCloseable<FieldsProducer> fieldsProducer;
 
         private LazyFieldsProducer(final SegmentReadState state) {
-            fieldsProducer = Suppliers.memoize(() -> {
-                try {
-                    PostingsReaderBase postingsReader = new LuceneOptimizedPostingsReader(state);
-                    BlockTreeTermsReader blockTreeTermsReader = new BlockTreeTermsReader(postingsReader, state);
-                    initialized = true;
-                    return blockTreeTermsReader;
-                } catch (IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
+            fieldsProducer = LazyCloseable.supply(() -> {
+                PostingsReaderBase postingsReader = new LuceneOptimizedPostingsReader(state);
+                BlockTreeTermsReader blockTreeTermsReader = new BlockTreeTermsReader(postingsReader, state);
+                return blockTreeTermsReader;
             });
         }
 
         @Override
         public void close() throws IOException {
-            if (initialized) {
-                fieldsProducer.get().close();
-            }
+            fieldsProducer.close();
         }
 
         @Override
@@ -105,7 +93,7 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
 
         @Override
         public Iterator<String> iterator() {
-            return fieldsProducer.get().iterator();
+            return fieldsProducer.getUnchecked().iterator();
         }
 
         @Override
@@ -115,12 +103,12 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
 
         @Override
         public int size() {
-            return fieldsProducer.get().size();
+            return fieldsProducer.getUnchecked().size();
         }
 
         @Override
         public long ramBytesUsed() {
-            return fieldsProducer.get().ramBytesUsed();
+            return fieldsProducer.getUnchecked().ramBytesUsed();
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormat.java
@@ -74,8 +74,7 @@ public class LuceneOptimizedPostingsFormat extends PostingsFormat {
         private LazyFieldsProducer(final SegmentReadState state) {
             fieldsProducer = LazyCloseable.supply(() -> {
                 PostingsReaderBase postingsReader = new LuceneOptimizedPostingsReader(state);
-                BlockTreeTermsReader blockTreeTermsReader = new BlockTreeTermsReader(postingsReader, state);
-                return blockTreeTermsReader;
+                return new BlockTreeTermsReader(postingsReader, state);
             });
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
@@ -69,16 +69,18 @@ public class LuceneOptimizedStoredFieldsFormat extends StoredFieldsFormat {
         private IOContext context;
 
         public LazyStoredFieldsReader(final Directory directory, final SegmentInfo si, final FieldInfos fn, final IOContext context) {
+            this(directory, si, fn, context,
+                    LazyCloseable.supply(() -> storedFieldsFormat.fieldsReader(directory, si, fn, context)));
+        }
+
+        private LazyStoredFieldsReader(final Directory directory, final SegmentInfo si, final FieldInfos fn, final IOContext context,
+                                       LazyCloseable<StoredFieldsReader> storedFieldsReader) {
+
             this.directory = directory;
             this.si = si;
             this.fn = fn;
             this.context = context;
-            storedFieldsReader = LazyCloseable.supply(() -> storedFieldsFormat.fieldsReader(directory, si, fn, context));
-        }
-
-        public LazyStoredFieldsReader(LazyStoredFieldsReader lazyStoredFieldsReader) {
-            this(lazyStoredFieldsReader.directory, lazyStoredFieldsReader.si, lazyStoredFieldsReader.fn,
-                    lazyStoredFieldsReader.context);
+            this.storedFieldsReader = storedFieldsReader;
         }
 
         @Override
@@ -87,9 +89,9 @@ public class LuceneOptimizedStoredFieldsFormat extends StoredFieldsFormat {
         }
 
         @Override
-        @SuppressWarnings({"java:S1182", "java:S2975", "PMD.ProperCloneImplementation"})
         public LazyStoredFieldsReader clone() {
-            return new LazyStoredFieldsReader(this);
+            return new LazyStoredFieldsReader(directory, si, fn, context,
+                    LazyCloseable.supply(() -> storedFieldsReader.get().clone()));
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
@@ -89,7 +89,7 @@ public class LuceneOptimizedStoredFieldsFormat extends StoredFieldsFormat {
         }
 
         @Override
-        @SuppressWarnings("PMD.ProperCloneImplementation")
+        @SuppressWarnings({"PMD.ProperCloneImplementation", "java:S2975"})
         public LazyStoredFieldsReader clone() {
             return new LazyStoredFieldsReader(directory, si, fn, context,
                     LazyCloseable.supply(() -> storedFieldsReader.get().clone()));

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
@@ -89,6 +89,7 @@ public class LuceneOptimizedStoredFieldsFormat extends StoredFieldsFormat {
         }
 
         @Override
+        @SuppressWarnings("PMD.ProperCloneImplementation")
         public LazyStoredFieldsReader clone() {
             return new LazyStoredFieldsReader(directory, si, fn, context,
                     LazyCloseable.supply(() -> storedFieldsReader.get().clone()));

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.common.text.AllSuffixesTextTokenizer;
 import com.apple.foundationdb.record.provider.common.text.TextSamples;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
@@ -88,6 +89,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -803,45 +805,50 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
     @MethodSource("threadCount")
     void threadedLuceneScanDoesntBreakPlannerAndSearch(@Nonnull Integer value) throws Exception {
         final Executor oldExecutor = FDBDatabaseFactory.instance().getExecutor();
-        // limit the FJP size to try and force the # segments to exceed the # threads
-        FDBDatabaseFactory.instance().setExecutor(new ForkJoinPool(PARALLELISM,
-                ForkJoinPool.defaultForkJoinWorkerThreadFactory,
-                null, false));
-        CountingThreadFactory threadFactory = new CountingThreadFactory();
-        executorService = Executors.newFixedThreadPool(value, threadFactory);
-        initializeFlat();
-        for (int i = 0; i < 200; i++) {
+        final ExecutorService oldExecutorService = executorService;
+        try {
+            // limit the FJP size to try and force the # segments to exceed the # threads
+            FDBDatabaseFactory.instance().setExecutor(new ForkJoinPool(PARALLELISM,
+                    ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+                    null, false));
+            CountingThreadFactory threadFactory = new CountingThreadFactory();
+            executorService = Executors.newFixedThreadPool(value, threadFactory);
+            initializeFlat();
+            for (int i = 0; i < 200; i++) {
+                try (FDBRecordContext context = openContext()) {
+                    openRecordStore(context);
+                    String[] randomWords = LuceneIndexTestUtils.generateRandomWords(500);
+                    final TestRecordsTextProto.SimpleDocument dylan = TestRecordsTextProto.SimpleDocument.newBuilder()
+                            .setDocId(i)
+                            .setText(randomWords[1])
+                            .setGroup(2)
+                            .build();
+                    recordStore.saveRecord(dylan);
+                    commit(context);
+                }
+            }
             try (FDBRecordContext context = openContext()) {
                 openRecordStore(context);
-                String[] randomWords = LuceneIndexTestUtils.generateRandomWords(500);
-                final TestRecordsTextProto.SimpleDocument dylan = TestRecordsTextProto.SimpleDocument.newBuilder()
-                        .setDocId(i)
-                        .setText(randomWords[1])
-                        .setGroup(2)
+                final QueryComponent filter1 = new LuceneQueryComponent("*:*", Lists.newArrayList("text"), false);
+                RecordQuery query = RecordQuery.newBuilder()
+                        .setRecordType(TextIndexTestUtils.SIMPLE_DOC)
+                        .setFilter(filter1)
                         .build();
-                recordStore.saveRecord(dylan);
-                commit(context);
+                setDeferFetchAfterUnionAndIntersection(false);
+                RecordQueryPlan plan = planner.plan(query);
+                try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan)) {
+                    @SuppressWarnings("unused") List<Long> ignored = cursor //this is here to make sure that we iterate the cursor
+                            .map(FDBQueriedRecord::getPrimaryKey)
+                            .map(t -> t.getLong(0))
+                            .asList().get();
+                    assertThat(threadFactory.threadCounts, aMapWithSize(greaterThan(0)));
+                }
             }
+        } finally {
+            // Restore the old executor so as not to disrupt other tests
+            FDBDatabaseFactory.instance().setExecutor(oldExecutor);
+            executorService = oldExecutorService;
         }
-        try (FDBRecordContext context = openContext()) {
-            openRecordStore(context);
-            final QueryComponent filter1 = new LuceneQueryComponent("*:*", Lists.newArrayList("text"), false);
-            RecordQuery query = RecordQuery.newBuilder()
-                    .setRecordType(TextIndexTestUtils.SIMPLE_DOC)
-                    .setFilter(filter1)
-                    .build();
-            setDeferFetchAfterUnionAndIntersection(false);
-            RecordQueryPlan plan = planner.plan(query);
-            try (RecordCursor<FDBQueriedRecord<Message>> cursor = recordStore.executeQuery(plan)) {
-                @SuppressWarnings("unused") List<Long> ignored = cursor //this is here to make sure that we iterate the cursor
-                        .map(FDBQueriedRecord::getPrimaryKey)
-                        .map(t -> t.getLong(0))
-                        .asList().get();
-                assertThat(threadFactory.threadCounts, aMapWithSize(greaterThan(0)));
-            }
-        }
-        // Restore the old executor so as not to disrupt other tests
-        FDBDatabaseFactory.instance().setExecutor(oldExecutor);
     }
 
     static class CountingThreadFactory implements ThreadFactory {
@@ -1300,36 +1307,42 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         // (random words) rather than using random English words from a canned text. With English text, Lucene compression
         // reduces the size of the segment such that we need many more records to create the required number of segments
         final Executor oldExecutor = FDBDatabaseFactory.instance().getExecutor();
-        // limit the FJP size to try and force the # segments to exceed the # threads
-        FDBDatabaseFactory.instance().setExecutor(new ForkJoinPool(PARALLELISM,
-                ForkJoinPool.defaultForkJoinWorkerThreadFactory,
-                null, false));
-        FDBDatabaseFactory.instance().getDatabase().setAsyncToSyncTimeout( event -> {
-            // Make AsyncToSync calls timeout after one second, otherwise a deadlock would just result in the test taking forever
-            return new ImmutablePair<>(1L, TimeUnit.SECONDS);
-        });
-        // Save many records (create many segments)
-        for (long i = 0 ; i < 20 ; i++) {
+        final Function<StoreTimer.Wait, Pair<Long, TimeUnit>> oldAsyncToSyncTimeout =
+                FDBDatabaseFactory.instance().getDatabase().getAsyncToSyncTimeout();
+        try {
+            // limit the FJP size to try and force the # segments to exceed the # threads
+            FDBDatabaseFactory.instance().setExecutor(new ForkJoinPool(PARALLELISM,
+                    ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+                    null, false));
+            FDBDatabaseFactory.instance().getDatabase().setAsyncToSyncTimeout(event -> {
+                // Make AsyncToSync calls timeout after one second, otherwise a deadlock would just result in the test taking forever
+                return new ImmutablePair<>(1L, TimeUnit.SECONDS);
+            });
+            // Save many records (create many segments)
+            for (long i = 0; i < 20; i++) {
+                try (FDBRecordContext context = openContext()) {
+                    openRecordStore(context);
+                    for (int j = 0; j < 10; j++) {
+                        TestRecordsTextProto.SimpleDocument document1 = TestRecordsTextProto.SimpleDocument.newBuilder()
+                                .setDocId(i * 1000 + j)
+                                .setGroup(1)
+                                .setText(LuceneIndexTestUtils.generateRandomWords(1000)[1])
+                                .build();
+                        recordStore.saveRecord(document1);
+                    }
+                    commit(context);
+                }
+            }
+            // Run a query
             try (FDBRecordContext context = openContext()) {
                 openRecordStore(context);
-                for (int j = 0 ; j < 10 ; j++) {
-                    TestRecordsTextProto.SimpleDocument document1 = TestRecordsTextProto.SimpleDocument.newBuilder()
-                            .setDocId(i * 1000 + j)
-                            .setGroup(1)
-                            .setText(LuceneIndexTestUtils.generateRandomWords(1000)[1])
-                            .build();
-                    recordStore.saveRecord(document1);
-                }
-                commit(context);
+                // Random words are up to 10 characters long, so this would never match
+                assertPrimaryKeys("text:morningstart", false, Set.of());
             }
+        } finally {
+            // Restore the old executor so as not to disrupt other tests
+            FDBDatabaseFactory.instance().setExecutor(oldExecutor);
+            FDBDatabaseFactory.instance().getDatabase().setAsyncToSyncTimeout(oldAsyncToSyncTimeout);
         }
-        // Run a query
-        try (FDBRecordContext context = openContext()) {
-            openRecordStore(context);
-            // Random words are up to 10 characters long, so this would never match
-            assertPrimaryKeys("text:morningstart", false, Set.of());
-        }
-        // Restore the old executor so as not to disrupt other tests
-        FDBDatabaseFactory.instance().setExecutor(oldExecutor);
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -802,7 +802,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
     @ParameterizedTest(name = "threadedLuceneScanDoesntBreakPlannerAndSearch-PoolThreadCount={0}")
     @MethodSource("threadCount")
     void threadedLuceneScanDoesntBreakPlannerAndSearch(@Nonnull Integer value) throws Exception {
-        Executor oldExecutor = FDBDatabaseFactory.instance().getExecutor();
+        final Executor oldExecutor = FDBDatabaseFactory.instance().getExecutor();
         // limit the FJP size to try and force the # segments to exceed the # threads
         FDBDatabaseFactory.instance().setExecutor(new ForkJoinPool(PARALLELISM,
                 ForkJoinPool.defaultForkJoinWorkerThreadFactory,
@@ -1299,7 +1299,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         // Since the test tries to create many segments (each one opens in its own thread), we need to use random data
         // (random words) rather than using random English words from a canned text. With English text, Lucene compression
         // reduces the size of the segment such that we need many more records to create the required number of segments
-        Executor oldExecutor = FDBDatabaseFactory.instance().getExecutor();
+        final Executor oldExecutor = FDBDatabaseFactory.instance().getExecutor();
         // limit the FJP size to try and force the # segments to exceed the # threads
         FDBDatabaseFactory.instance().setExecutor(new ForkJoinPool(PARALLELISM,
                 ForkJoinPool.defaultForkJoinWorkerThreadFactory,

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
@@ -1,0 +1,85 @@
+package com.apple.foundationdb.record.lucene.codec;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LazyCloseableTest {
+
+    @Test
+    void testOpensLazilyExactlyOnce() throws IOException {
+        final AtomicInteger openCounter = new AtomicInteger(0);
+        final AtomicInteger closeCounter = new AtomicInteger(0);
+        try (LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(
+                () -> new CountingCloseable(openCounter.incrementAndGet(), closeCounter))) {
+            assertEquals(0, openCounter.get());
+            assertEquals(1, opener.get().openCounts);
+            assertEquals(1, opener.get().openCounts);
+            assertEquals(1, opener.getUnchecked().openCounts);
+            assertSame(opener.get(), opener.get());
+            assertEquals(1, openCounter.get());
+        }
+        assertEquals(1, closeCounter.get());
+    }
+
+    @Test
+    void testCloseDoesNotOpen() throws IOException {
+        final AtomicInteger openCounter = new AtomicInteger(0);
+        final AtomicInteger closeCounter = new AtomicInteger(0);
+        LazyCloseable.supply(() -> new CountingCloseable(openCounter.incrementAndGet(), closeCounter)).close();
+        assertEquals(0, openCounter.get());
+    }
+
+    @Test
+    void testCloseCloses() throws IOException {
+        final AtomicInteger openCounter = new AtomicInteger(0);
+        final AtomicInteger closeCounter = new AtomicInteger(0);
+        try (LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(() -> new CountingCloseable(openCounter.incrementAndGet(), closeCounter))) {
+            opener.get();
+        }
+        assertEquals(1, openCounter.get());
+        assertEquals(1, closeCounter.get());
+    }
+
+    @Test
+    void testThrowsIOException() {
+        IOException thrownException = new IOException("test foo");
+        final LazyCloseable<Closeable> opener = LazyCloseable.supply(() -> {
+            throw thrownException;
+        });
+        final IOException resultingException = assertThrows(IOException.class, opener::get);
+        assertSame(thrownException, resultingException);
+    }
+
+    @Test
+    void testThrowsUncheckedIOException() {
+        IOException thrownException = new IOException("test foo");
+        final LazyCloseable<Closeable> opener = LazyCloseable.supply(() -> {
+            throw thrownException;
+        });
+        final UncheckedIOException resultingException = assertThrows(UncheckedIOException.class, opener::getUnchecked);
+        assertSame(thrownException, resultingException.getCause());
+    }
+
+    private static class CountingCloseable implements Closeable {
+        final int openCounts;
+        final AtomicInteger closeCounter;
+
+        private CountingCloseable(final int openCounts, final AtomicInteger closeCounter) {
+            this.openCounts = openCounts;
+            this.closeCounter = closeCounter;
+        }
+
+        @Override
+        public void close() {
+            closeCounter.incrementAndGet();
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
@@ -1,3 +1,23 @@
+/*
+ * LazyCloseableTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.apple.foundationdb.record.lucene.codec;
 
 import org.junit.jupiter.api.Test;
@@ -49,7 +69,7 @@ class LazyCloseableTest {
     }
 
     @Test
-    void testThrowsIOException() {
+    void testThrowsIoException() {
         IOException thrownException = new IOException("test foo");
         final LazyCloseable<Closeable> opener = LazyCloseable.supply(() -> {
             throw thrownException;
@@ -59,7 +79,7 @@ class LazyCloseableTest {
     }
 
     @Test
-    void testThrowsUncheckedIOException() {
+    void testThrowsUncheckedIoException() {
         IOException thrownException = new IOException("test foo");
         final LazyCloseable<Closeable> opener = LazyCloseable.supply(() -> {
             throw thrownException;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
@@ -107,7 +107,7 @@ class LazyCloseableTest {
         LazyCloseable<Closeable> initial = LazyCloseable.supply(() -> {
             int openCount = openCounter.incrementAndGet();
             try {
-                return CompletableFuture.runAsync(() -> {}, forkJoinPool)
+                return CompletableFuture.runAsync(() -> { }, forkJoinPool)
                         .thenCompose(ignored -> MoreAsyncUtil.delayedFuture(2, TimeUnit.SECONDS))
                         .thenApplyAsync(v -> new Closeable() {
                             @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
@@ -20,13 +20,21 @@
 
 package com.apple.foundationdb.record.lucene.codec;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,7 +46,7 @@ class LazyCloseableTest {
         final AtomicInteger openCounter = new AtomicInteger(0);
         final AtomicInteger closeCounter = new AtomicInteger(0);
         try (LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(
-                () -> new CountingCloseable(openCounter.incrementAndGet(), closeCounter))) {
+                () -> new CountingCloseable(openCounter, closeCounter))) {
             assertEquals(0, openCounter.get());
             assertEquals(1, opener.get().openCounts);
             assertEquals(1, opener.get().openCounts);
@@ -50,10 +58,40 @@ class LazyCloseableTest {
     }
 
     @Test
+    void testOpensLazilyExactlyOnceThreaded() {
+        AtomicInteger starts = new AtomicInteger(0);
+        AtomicInteger ends = new AtomicInteger(0);
+        AtomicInteger opens = new AtomicInteger(0);
+        AtomicInteger closes = new AtomicInteger(0);
+        final int concurrency = 100;
+        final LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(() -> {
+            starts.incrementAndGet();
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                throw new AssertionError("Timed out waiting for latch");
+            }
+            ends.incrementAndGet();
+            return new CountingCloseable(opens, closes);
+        });
+        ConcurrentHashMap<Thread, Integer> threads = new ConcurrentHashMap<>();
+        final List<CountingCloseable> allValues = IntStream.range(0, concurrency)
+                .parallel()
+                .mapToObj(i -> {
+                    threads.compute(Thread.currentThread(), (k, v) -> v == null ? 1 : v + 1);
+                    return opener.getUnchecked();
+                })
+                .collect(Collectors.toList());
+        MatcherAssert.assertThat(allValues, Matchers.everyItem(Matchers.sameInstance(allValues.get(0))));
+        // Stream.parallel doesn't guarantee that it will run in 100 parallel threads
+        MatcherAssert.assertThat(threads.keySet(), Matchers.hasSize(Matchers.greaterThan(10)));
+    }
+
+    @Test
     void testCloseDoesNotOpen() throws IOException {
         final AtomicInteger openCounter = new AtomicInteger(0);
         final AtomicInteger closeCounter = new AtomicInteger(0);
-        LazyCloseable.supply(() -> new CountingCloseable(openCounter.incrementAndGet(), closeCounter)).close();
+        LazyCloseable.supply(() -> new CountingCloseable(openCounter, closeCounter)).close();
         assertEquals(0, openCounter.get());
     }
 
@@ -61,7 +99,7 @@ class LazyCloseableTest {
     void testCloseCloses() throws IOException {
         final AtomicInteger openCounter = new AtomicInteger(0);
         final AtomicInteger closeCounter = new AtomicInteger(0);
-        try (LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(() -> new CountingCloseable(openCounter.incrementAndGet(), closeCounter))) {
+        try (LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(() -> new CountingCloseable(openCounter, closeCounter))) {
             opener.get();
         }
         assertEquals(1, openCounter.get());
@@ -69,37 +107,92 @@ class LazyCloseableTest {
     }
 
     @Test
-    void testThrowsIoException() {
-        IOException thrownException = new IOException("test foo");
-        final LazyCloseable<Closeable> opener = LazyCloseable.supply(() -> {
-            throw thrownException;
-        });
-        final IOException resultingException = assertThrows(IOException.class, opener::get);
-        assertSame(thrownException, resultingException);
+    void testCloseMultipleTimes() throws IOException {
+        final AtomicInteger openCounter = new AtomicInteger(0);
+        final AtomicInteger closeCounter = new AtomicInteger(0);
+        LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(() -> new CountingCloseable(openCounter, closeCounter));
+        try {
+            opener.get();
+        } finally {
+            for (int i = 0; i < 5; i++) {
+                opener.close();
+            }
+        }
+        assertEquals(1, openCounter.get());
+        assertEquals(5, closeCounter.get());
     }
 
     @Test
-    void testThrowsUncheckedIoException() {
+    void testCloseFails() throws IOException {
+        final AtomicInteger openCounter = new AtomicInteger(0);
+        final AtomicInteger closeCounter = new AtomicInteger(0);
+        LazyCloseable<CountingCloseable> opener = LazyCloseable.supply(() -> new CountingCloseable(openCounter, closeCounter, true));
+        try {
+            opener.get();
+        } finally {
+            assertThrows(IOException.class, opener::close, "an error");
+            assertThrows(IOException.class, opener::close, "an error");
+        }
+        assertEquals(1, openCounter.get());
+        assertEquals(0, closeCounter.get());
+    }
+
+    @Test
+    void testThrowsIoException() throws IOException {
         IOException thrownException = new IOException("test foo");
-        final LazyCloseable<Closeable> opener = LazyCloseable.supply(() -> {
+        try (LazyCloseable<Closeable> opener = failingOpener(thrownException)) {
+            final IOException resultingException = assertThrows(IOException.class, opener::get);
+            assertSame(thrownException, resultingException);
+        } // close should not throw
+    }
+
+    @Test
+    void testThrowsUncheckedIoException() throws IOException {
+        IOException thrownException = new IOException("test foo");
+        try (LazyCloseable<Closeable> opener = failingOpener(thrownException)) {
+            UncheckedIOException resultingException = assertThrows(UncheckedIOException.class, opener::getUnchecked);
+            assertSame(thrownException, resultingException.getCause());
+        } // close should not throw
+    }
+
+    @Test
+    void testUnusedDoesNotThrowOnClose() {
+        IOException thrownException = new IOException("test foo");
+        LazyCloseable<Closeable> opener = failingOpener(thrownException);
+        assertDoesNotThrow(opener::close);
+    }
+
+    @Nonnull
+    private static LazyCloseable<Closeable> failingOpener(final IOException thrownException) {
+        return LazyCloseable.supply(() -> {
             throw thrownException;
         });
-        final UncheckedIOException resultingException = assertThrows(UncheckedIOException.class, opener::getUnchecked);
-        assertSame(thrownException, resultingException.getCause());
     }
 
     private static class CountingCloseable implements Closeable {
         final int openCounts;
         final AtomicInteger closeCounter;
+        final boolean failOnClose;
 
-        private CountingCloseable(final int openCounts, final AtomicInteger closeCounter) {
-            this.openCounts = openCounts;
+        private CountingCloseable(final AtomicInteger openCounter, final AtomicInteger closeCounter) {
+            this.openCounts = openCounter.incrementAndGet();
             this.closeCounter = closeCounter;
+            this.failOnClose = false;
+        }
+
+        private CountingCloseable(final AtomicInteger openCounter, final AtomicInteger closeCounter, boolean failOnClose) {
+            this.openCounts = openCounter.incrementAndGet();
+            this.closeCounter = closeCounter;
+            this.failOnClose = failOnClose;
         }
 
         @Override
-        public void close() {
-            closeCounter.incrementAndGet();
+        public void close() throws IOException {
+            if (failOnClose) {
+                throw new IOException("an error");
+            } else {
+                closeCounter.incrementAndGet();
+            }
         }
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.lucene.codec;
 
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -29,7 +31,12 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -85,6 +92,44 @@ class LazyCloseableTest {
         MatcherAssert.assertThat(allValues, Matchers.everyItem(Matchers.sameInstance(allValues.get(0))));
         // Stream.parallel doesn't guarantee that it will run in 100 parallel threads
         MatcherAssert.assertThat(threads.keySet(), Matchers.hasSize(Matchers.greaterThan(10)));
+    }
+
+    @Test
+    void testForkJoinPoolDeadlock() throws ExecutionException, InterruptedException, TimeoutException {
+        // Lucene heavily uses `LazyCloseable` to Lazily open inputs from FDB. For StoredFieldsFormat (at the time
+        // LazyCloseable was added), Lucene would "open" one, but not actually call get, it would then fork a bunch of
+        // threads, in a forkJoinPool, each of which would in turn, try to call get. This created a deadlock situation when
+        // LazyOpener was implemented with Suppliers.memoize. This test explicitly tests this, and with the previous
+        // attempt that had Suppliers.memoize, this test would timeout, instead of taking the 2 seconds in the delayed
+        // future.
+        final ForkJoinPool forkJoinPool = new ForkJoinPool(2);
+        final AtomicInteger openCounter = new AtomicInteger(0);
+        LazyCloseable<Closeable> initial = LazyCloseable.supply(() -> {
+            int openCount = openCounter.incrementAndGet();
+            try {
+                return CompletableFuture.runAsync(() -> {}, forkJoinPool)
+                        .thenCompose(ignored -> MoreAsyncUtil.delayedFuture(2, TimeUnit.SECONDS))
+                        .thenApplyAsync(v -> new Closeable() {
+                            @Override
+                            public void close() throws IOException {
+
+                            }
+
+                            @Override
+                            public String toString() {
+                                return "Opened " + openCount;
+                            }
+                        }, forkJoinPool).get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        final List<CompletableFuture<String>> result = IntStream.range(0, 50).parallel()
+                .mapToObj(i -> CompletableFuture.supplyAsync(() -> initial.getUnchecked().toString() + " " + i, forkJoinPool))
+                .collect(Collectors.toList());
+        final List<String> strings = AsyncUtil.getAll(result).get(10, TimeUnit.SECONDS);
+        MatcherAssert.assertThat(strings, Matchers.containsInAnyOrder(IntStream.range(0, 50)
+                .mapToObj(i -> Matchers.is("Opened 1 " + i)).collect(Collectors.toList())));
     }
 
     @Test

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
@@ -1,3 +1,23 @@
+/*
+ * LazyOpenerTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.apple.foundationdb.record.lucene.codec;
 
 import org.hamcrest.MatcherAssert;
@@ -58,7 +78,7 @@ class LazyOpenerTest {
     }
 
     @Test
-    void testThrowsIOException() {
+    void testThrowsIoException() {
         IOException thrownException = new IOException("test foo");
         final LazyOpener<Object> opener = LazyOpener.supply(() -> {
             throw thrownException;
@@ -68,7 +88,7 @@ class LazyOpenerTest {
     }
 
     @Test
-    void testThrowsUncheckedIOException() {
+    void testThrowsUncheckedIoException() {
         IOException thrownException = new IOException("test foo");
         final LazyOpener<Object> opener = LazyOpener.supply(() -> {
             throw thrownException;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
@@ -97,7 +97,7 @@ class LazyOpenerTest {
         LazyOpener<String> initial = LazyOpener.supply(() -> {
             int openCount = openCounter.incrementAndGet();
             try {
-                return CompletableFuture.runAsync(() -> {}, forkJoinPool)
+                return CompletableFuture.runAsync(() -> { }, forkJoinPool)
                         .thenCompose(ignored -> MoreAsyncUtil.delayedFuture(2, TimeUnit.SECONDS))
                         .thenApplyAsync(v -> "Opened " + openCount, forkJoinPool)
                         .get();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
@@ -1,0 +1,45 @@
+package com.apple.foundationdb.record.lucene.codec;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LazyOpenerTest {
+
+    @Test
+    void testOpensLazilyExactlyOnce() throws IOException {
+        AtomicInteger supplier = new AtomicInteger(0);
+        final LazyOpener<Integer> opener = LazyOpener.supply(supplier::incrementAndGet);
+        assertEquals(0, supplier.get());
+        assertEquals(1, opener.get());
+        assertEquals(1, opener.get());
+        assertEquals(1, opener.getUnchecked());
+        assertEquals(1, supplier.get());
+    }
+
+    @Test
+    void testThrowsIOException() {
+        IOException thrownException = new IOException("test foo");
+        final LazyOpener<Object> opener = LazyOpener.supply(() -> {
+            throw thrownException;
+        });
+        final IOException resultingException = assertThrows(IOException.class, opener::get);
+        assertSame(thrownException, resultingException);
+    }
+
+    @Test
+    void testThrowsUncheckedIOException() {
+        IOException thrownException = new IOException("test foo");
+        final LazyOpener<Object> opener = LazyOpener.supply(() -> {
+            throw thrownException;
+        });
+        final UncheckedIOException resultingException = assertThrows(UncheckedIOException.class, opener::getUnchecked);
+        assertSame(thrownException, resultingException.getCause());
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyOpenerTest.java
@@ -1,10 +1,16 @@
 package com.apple.foundationdb.record.lucene.codec;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -21,6 +27,34 @@ class LazyOpenerTest {
         assertEquals(1, opener.get());
         assertEquals(1, opener.getUnchecked());
         assertEquals(1, supplier.get());
+    }
+
+    @Test
+    void testOpensLazilyExactlyOnceThreaded() {
+        AtomicInteger starts = new AtomicInteger(0);
+        AtomicInteger ends = new AtomicInteger(0);
+        final int concurrency = 100;
+        final LazyOpener<Integer> opener = LazyOpener.supply(() -> {
+            starts.incrementAndGet();
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                throw new AssertionError("Timed out waiting for latch");
+            }
+            return ends.incrementAndGet();
+        });
+        ConcurrentHashMap<Thread, Integer> threads = new ConcurrentHashMap<>();
+        final List<Integer> allValues = IntStream.range(0, concurrency)
+                .parallel()
+                .map(i -> {
+                    threads.compute(Thread.currentThread(), (k, v) -> v == null ? 1 : v + 1);
+                    return opener.getUnchecked();
+                })
+                .boxed()
+                .collect(Collectors.toList());
+        MatcherAssert.assertThat(allValues, Matchers.everyItem(Matchers.is(1)));
+        // Stream.parallel doesn't guarantee that it will run in 100 parallel threads
+        MatcherAssert.assertThat(threads.keySet(), Matchers.hasSize(Matchers.greaterThan(10)));
     }
 
     @Test


### PR DESCRIPTION
We were wrapping them in UncheckedIOException, this creates two new helpers `LuceneOpener` and `LuceneCloseable` that make it easier to unwrap the exception appropriately, and close the lazily opened object correctly.