### PR TITLE
Add a special secondary sub-index for Lucene documents per segment…

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -139,7 +139,9 @@ public class LuceneEvents {
         /** Wait for lucene to load the file cache. */
         WAIT_LUCENE_LOAD_FILE_CACHE("lucene load file cache"),
         /** Create a file from FDBDirectory. */
-        WAIT_LUCENE_CREATE_OUTPUT("lucene create output")
+        WAIT_LUCENE_CREATE_OUTPUT("lucene create output"),
+        /** Look up primary key segment. */
+        WAIT_LUCENE_FIND_PRIMARY_KEY("lucene find primary key")
         ;
 
         private final String title;
@@ -200,6 +202,14 @@ public class LuceneEvents {
         LUCENE_DELETE_FILE("lucene delete file", false),
         /** Number of file delete operations on the FDBDirectory. */
         LUCENE_RENAME_FILE("lucene rename file", false),
+        /** Number of times query is needed for document delete. */
+        LUCENE_DELETE_DOCUMENT_BY_QUERY("lucene delete document by query", false),
+        /** Number of times primary key index used for document delete. */
+        LUCENE_DELETE_DOCUMENT_BY_PRIMARY_KEY("lucene delete document by primary key", false),
+        /** Number of documents merged. */
+        LUCENE_MERGE_DOCUMENTS("lucene merge document", false),
+        /** Number of segments merged. */
+        LUCENE_MERGE_SEGMENTS("lucene merge segment", false)
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -264,7 +264,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         return map;
     }
 
-    @SuppressWarnings("PMD.CloseResource")
+    @SuppressWarnings({"PMD.CloseResource", "java:S2095"})
     private void deleteDocument(Tuple groupingKey, Tuple primaryKey) throws IOException {
         final IndexWriter oldWriter = directoryManager.getIndexWriter(groupingKey, indexAnalyzerSelector.provideIndexAnalyzer(""));
         final DirectoryReader directoryReader = DirectoryReader.open(oldWriter);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
@@ -72,6 +72,7 @@ public class LuceneIndexOptions {
     public static final String PRIMARY_KEY_SERIALIZATION_FORMAT = "primaryKeySerializationFormat";
     /**
      * Whether a separate B-tree index gives a direct mapping of live documents to segment by record primary key.
+     * Boolean string ({@code true} or {@code false}).
      */
     public static final String PRIMARY_KEY_SEGMENT_INDEX_ENABLED = "primaryKeySegmentIndexEnabled";
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
@@ -70,6 +70,10 @@ public class LuceneIndexOptions {
      */
     public static final String TEXT_SYNONYM_SET_NAME_OPTION = "textSynonymSetName";
     public static final String PRIMARY_KEY_SERIALIZATION_FORMAT = "primaryKeySerializationFormat";
+    /**
+     * Whether a separate B-tree index gives a direct mapping of live documents to segment by record primary key.
+     */
+    public static final String PRIMARY_KEY_SEGMENT_INDEX_ENABLED = "primaryKeySegmentIndexEnabled";
 
     private LuceneIndexOptions() {
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
@@ -1,0 +1,335 @@
+/*
+ * LucenePrimaryKeySegmentIndex.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
+import com.apple.foundationdb.record.provider.foundationdb.KeyValueCursor;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.apple.foundationdb.tuple.Tuple;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.StandardDirectoryReader;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.Bits;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Maintain a B-tree index of primary key to segment and doc id.
+ * This allows for efficient deleting of a document given that key, such as when doing index maintenance from an update.
+ */
+public class LucenePrimaryKeySegmentIndex {
+    @Nonnull
+    private final FDBDirectory directory;
+    @Nonnull
+    private final Subspace subspace;
+
+    public LucenePrimaryKeySegmentIndex(@Nonnull FDBDirectory directory, @Nonnull Subspace subspace) {
+        this.directory = directory;
+        this.subspace = subspace;
+    }
+
+    /**
+     * Get all stored primary key index entries.
+     * Really only useful for small-scale debugging.
+     * @return a list of Tuple-decoded key entries
+     */
+    public List<List<Object>> readAllEntries() {
+        List<Tuple> tuples;
+        try (KeyValueCursor kvs = KeyValueCursor.Builder.newBuilder(subspace)
+                .setContext(directory.getContext())
+                .setScanProperties(ScanProperties.FORWARD_SCAN)
+                .build();
+                RecordCursor<Tuple> entries = kvs.map(kv -> subspace.unpack(kv.getKey()))) {
+            tuples = directory.getContext().asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList());
+        }
+        return tuples.stream().map(t -> {
+            List<Object> items = t.getItems();
+            // Replace segment id with segment name to make inspection easier.
+            String name = directory.primaryKeySegmentName((Long)items.get(items.size() - 2));
+            if (name != null) {
+                items.set(items.size() - 2, name);
+            }
+            items.set(items.size() - 1, ((Long)items.get(items.size() - 1)).intValue());
+            return items;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Result of {@link #findDocument}.
+     */
+    // TODO: Can be a record.
+    public static class DocumentIndexEntry {
+        @Nonnull
+        public final Tuple primaryKey;
+        @Nonnull
+        public final byte[] entryKey;
+        @Nonnull
+        public final IndexReader indexReader;
+        public final int docId;
+
+        public DocumentIndexEntry(@Nonnull final Tuple primaryKey, @Nonnull final byte[] entryKey, @Nonnull final IndexReader indexReader, final int docId) {
+            this.primaryKey = primaryKey;
+            this.entryKey = entryKey;
+            this.indexReader = indexReader;
+            this.docId = docId;
+        }
+    }
+
+    /**
+     * Find document in index for direct delete.
+     * @param directoryReader a NRT reader
+     * @param primaryKey the document's record's primary key
+     * @return an entry with the leaf reader and document id in that segment or {@code null} if not found
+     * @see IndexWriter#tryDeleteDocument
+     */
+    @Nullable
+    public DocumentIndexEntry findDocument(@Nonnull DirectoryReader directoryReader, @Nonnull Tuple primaryKey) {
+        final SegmentInfos segmentInfos = ((StandardDirectoryReader)FilterDirectoryReader.unwrap(directoryReader)).getSegmentInfos();
+        final Subspace keySubspace = subspace.subspace(primaryKey);
+        try (KeyValueCursor kvs = KeyValueCursor.Builder.newBuilder(keySubspace)
+                .setContext(directory.getContext())
+                .setScanProperties(ScanProperties.FORWARD_SCAN)
+                .build();
+                RecordCursor<DocumentIndexEntry> documents = kvs.map(kv -> {
+                    final Tuple segdoc = keySubspace.unpack(kv.getKey());
+                    final long segid = segdoc.getLong(0);
+                    final String segmentName = directory.primaryKeySegmentName(segid);
+                    if (segmentName == null) {
+                        return null;
+                    }
+                    for (int i = 0; i < segmentInfos.size(); i++) {
+                        SegmentInfo segmentInfo = segmentInfos.info(i).info;
+                        if (segmentInfo.name.equals(segmentName)) {
+                            final int docid = (int)segdoc.getLong(1);
+                            return new DocumentIndexEntry(primaryKey, kv.getKey(),
+                                    directoryReader.leaves().get(i).reader(), docid);
+                        }
+                    }
+                    return null;
+                }).filter(Objects::nonNull)) {
+            return directory.getContext().asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
+                    documents.first()).orElse(null);
+        }
+    }
+
+    /**
+     * Hook for getting back segment info during merge.
+     */
+    public interface StoredFieldsReaderSegmentInfo {
+        SegmentInfo getSegmentInfo();
+    }
+
+    /**
+     * Hook the fields writer to also record primary keys in index.
+     * @param storedFieldsWriter normal field writer
+     * @param si segment info for current writer
+     * @return a wrapped writer
+     */
+    @Nonnull
+    public StoredFieldsWriter wrapFieldsWriter(@Nonnull StoredFieldsWriter storedFieldsWriter, @Nonnull SegmentInfo si) throws IOException {
+        final long segmentId = directory.primaryKeySegmentId(si.name, true);
+        return new WrappedFieldsWriter(storedFieldsWriter, segmentId);
+    }
+
+    class WrappedFieldsWriter extends StoredFieldsWriter {
+        @Nonnull
+        private final StoredFieldsWriter inner;
+        @Nonnull
+        private final long segmentId;
+
+        private int documentId;
+
+        WrappedFieldsWriter(@Nonnull StoredFieldsWriter inner, long segmentId) {
+            this.inner = inner;
+            this.segmentId = segmentId;
+        }
+
+        @Override
+        public void startDocument() throws IOException {
+            inner.startDocument();
+        }
+
+        @Override
+        public void finishDocument() throws IOException {
+            inner.finishDocument();
+            documentId++;
+        }
+
+        @Override
+        public void writeField(FieldInfo info, IndexableField field) throws IOException {
+            inner.writeField(info, field);
+            if (info.name.equals(LuceneIndexMaintainer.PRIMARY_KEY_FIELD_NAME)) {
+                final byte[] primaryKey = field.binaryValue().bytes;
+                addOrDeletePrimaryKeyEntry(primaryKey, segmentId, documentId, true);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("PMD.CloseResource")
+        public int merge(MergeState mergeState) throws IOException {
+            final int docCount = inner.merge(mergeState);
+
+            final int segmentCount = mergeState.storedFieldsReaders.length;
+            final PrimaryKeyVisitor visitor = new PrimaryKeyVisitor();
+            for (int i = 0; i < segmentCount; i++) {
+                final StoredFieldsReader storedFieldsReader = mergeState.storedFieldsReaders[i];
+                final SegmentInfo mergedSegmentInfo = ((StoredFieldsReaderSegmentInfo)storedFieldsReader).getSegmentInfo();
+                final long mergedSegmentId = directory.primaryKeySegmentId(mergedSegmentInfo.name, false);
+                final Bits liveDocs = mergeState.liveDocs[i];
+                final MergeState.DocMap docMap = mergeState.docMaps[i];
+                final int maxDoc = mergeState.maxDocs[i];
+                for (int j = 0; j < maxDoc; j++) {
+                    storedFieldsReader.visitDocument(j, visitor);
+                    final byte[] primaryKey = visitor.getPrimaryKey();
+                    if (primaryKey != null) {
+                        if (liveDocs == null || liveDocs.get(j)) {
+                            int docId = docMap.get(j);
+                            if (docId >= 0) {
+                                addOrDeletePrimaryKeyEntry(primaryKey, segmentId, docId, true);
+                            }
+                        }
+                        // TODO: Is doing this right away safe enough? Does transaction isolation protect against all cases where
+                        //  the source segment is used after a merge?
+                        addOrDeletePrimaryKeyEntry(primaryKey, mergedSegmentId, j, false);
+                        visitor.reset();
+                    }
+                }
+            }
+
+            directory.getContext().increment(LuceneEvents.Counts.LUCENE_MERGE_DOCUMENTS, docCount);
+            directory.getContext().increment(LuceneEvents.Counts.LUCENE_MERGE_SEGMENTS, segmentCount);
+
+            return docCount;
+        }
+
+        @Override
+        public void finish(FieldInfos fis, int numDocs) throws IOException {
+            inner.finish(fis, numDocs);
+        }
+
+        @Override
+        public void close() throws IOException {
+            inner.close();
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return inner.ramBytesUsed();
+        }
+
+        @Override
+        public Collection<Accountable> getChildResources() {
+            return inner.getChildResources();
+        }
+    }
+
+    /**
+     * Reconcile primary key index entries for a segment.
+     * Delete those for a segment that is about to be deleted or add for a segment that has been filled without going through the wrapper.
+     * The primary keys are gotten from the stored fields, so this must complete and not yet have been removed.
+     * @param reader a reader for the target segment
+     * @param add {@code true} to add entries; {@code false} to delete them
+     * @throws IOException if the stored fields gets an error
+     */
+    @SuppressWarnings("PMD.CloseResource")
+    public void addOrDeleteDocumentPrimaryKeys(@Nonnull SegmentReader reader, boolean add) throws IOException {
+        final int maxDoc = reader.maxDoc();
+        final PrimaryKeyVisitor visitor = new PrimaryKeyVisitor();
+        final long segmentId = directory.primaryKeySegmentId(reader.getSegmentName(), add);
+        try (StoredFieldsReader storedFields = reader.getFieldsReader()) {
+            for (int documentId = 0; documentId < maxDoc; documentId++) {
+                storedFields.visitDocument(documentId, visitor);
+                final byte[] primaryKey = visitor.getPrimaryKey();
+                if (primaryKey != null) {
+                    addOrDeletePrimaryKeyEntry(primaryKey, segmentId, documentId, add);
+                    visitor.reset();
+                }
+            }
+        }
+    }
+
+    void addOrDeletePrimaryKeyEntry(@Nonnull byte[] primaryKey, long segmentId, int docId, boolean add) {
+        final byte[] entryKey = ByteArrayUtil.join(subspace.getKey(), primaryKey, Tuple.from(segmentId, docId).pack());
+        if (add) {
+            directory.getContext().ensureActive().set(entryKey, new byte[0]);
+        } else {
+            directory.getContext().ensureActive().clear(entryKey);
+        }
+    }
+
+    /**
+     * Get the primary key byte array from a document's stored fields.
+     * After calling {@link StoredFieldsReader#visitDocument}, any primary key will be in {@link #getPrimaryKey}.
+     */
+    static class PrimaryKeyVisitor extends StoredFieldVisitor {
+        @Nullable
+        private byte[] primaryKey = null;
+
+        @Nullable
+        public byte[] getPrimaryKey() {
+            return primaryKey;
+        }
+
+        public void reset() {
+            primaryKey = null;
+        }
+
+        @Override
+        public Status needsField(final FieldInfo fieldInfo) {
+            if (fieldInfo.name.equals(LuceneIndexMaintainer.PRIMARY_KEY_FIELD_NAME)) {
+                return Status.YES;
+            } else if (primaryKey != null) {
+                return Status.STOP;
+            } else {
+                return Status.NO;
+            }
+        }
+
+        @Override
+        public void binaryField(final FieldInfo fieldInfo, final byte[] value) {
+            if (fieldInfo.name.equals(LuceneIndexMaintainer.PRIMARY_KEY_FIELD_NAME)) {
+                primaryKey = value;
+            }
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.provider.foundationdb.KeyValueCursor;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.index.DirectoryReader;
@@ -73,6 +74,7 @@ public class LucenePrimaryKeySegmentIndex {
      * Really only useful for small-scale debugging.
      * @return a list of Tuple-decoded key entries
      */
+    @VisibleForTesting
     public List<List<Object>> readAllEntries() {
         List<Tuple> tuples;
         try (KeyValueCursor kvs = KeyValueCursor.Builder.newBuilder(subspace)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
@@ -230,8 +230,8 @@ public class LucenePrimaryKeySegmentIndex {
                                 addOrDeletePrimaryKeyEntry(primaryKey, segmentId, docId, true);
                             }
                         }
-                        // TODO: Is doing this right away safe enough? Does transaction isolation protect against all cases where
-                        //  the source segment is used after a merge?
+                        // Deleting the index entry at worst triggers a fallback to search.
+                        // Ordinarily, though, transaction isolation means that the entry is there along with the pre-merge segment.
                         addOrDeletePrimaryKeyEntry(primaryKey, mergedSegmentId, j, false);
                         visitor.reset();
                     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -62,6 +62,11 @@ public final class LuceneRecordContextProperties {
     public static final RecordLayerPropertyKey<Double> LUCENE_MERGE_MAX_SIZE = RecordLayerPropertyKey.doublePropertyKey("com.apple.foundationdb.record.lucene.mergeMaxSize", 5.0);
 
     /**
+     * Count of segments after which to merge for ordinary full-text search with Lucene.
+     */
+    public static final RecordLayerPropertyKey<Double> LUCENE_MERGE_SEGMENTS_PER_TIER = RecordLayerPropertyKey.doublePropertyKey("com.apple.foundationdb.record.lucene.mergeSegmentsPerTier", 10.0);
+
+    /**
      * This controls whether Lucene indexes' directories (and their directories for auto-complete) should be merged based on probability to reduce multiple merges per transaction.
      */
     public static final RecordLayerPropertyKey<Boolean> LUCENE_MULTIPLE_MERGE_OPTIMIZATION_ENABLED = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.multipleMerge.optimizationEnabled", true);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -158,8 +158,9 @@ public class FDBDirectory extends Directory  {
     @Nullable
     private LucenePrimaryKeySegmentIndex primaryKeySegmentIndex;
 
-    public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context) {
-        this(subspace, context, null, null, false);
+    public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context,
+                        boolean primaryKeySegmentIndexEnabled) {
+        this(subspace, context, null, null, primaryKeySegmentIndexEnabled);
     }
 
     public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context,
@@ -860,9 +861,11 @@ public class FDBDirectory extends Directory  {
         if (!primaryKeySegmentIndexEnabled) {
             return null;
         }
-        if (primaryKeySegmentIndex == null) {
-            final Subspace primaryKeySubspace = subspace.subspace(Tuple.from(PRIMARY_KEY_SUBSPACE));
-            primaryKeySegmentIndex = new LucenePrimaryKeySegmentIndex(this, primaryKeySubspace);
+        synchronized (this) {
+            if (primaryKeySegmentIndex == null) {
+                final Subspace primaryKeySubspace = subspace.subspace(Tuple.from(PRIMARY_KEY_SUBSPACE));
+                primaryKeySegmentIndex = new LucenePrimaryKeySegmentIndex(this, primaryKeySubspace);
+            }
         }
         return primaryKeySegmentIndex;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -624,6 +624,7 @@ public class FDBDirectory extends Directory  {
             return false;
         }
         context.ensureActive().clear(metaSubspace.pack(name));
+        // Nothing stored here currently.
         context.ensureActive().clear(dataSubspace.subspace(Tuple.from(value.getId())).range());
         return true;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.lucene.LuceneEvents;
 import com.apple.foundationdb.record.lucene.LuceneIndexTypes;
 import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
+import com.apple.foundationdb.record.lucene.LucenePrimaryKeySegmentIndex;
 import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
 import com.apple.foundationdb.record.lucene.codec.PrefetchableBufferedChecksumIndexInput;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
@@ -107,6 +108,7 @@ public class FDBDirectory extends Directory  {
     private static final int META_SUBSPACE = 1;
     private static final int DATA_SUBSPACE = 2;
     private static final int SCHEMA_SUBSPACE = 3;
+    private static final int PRIMARY_KEY_SUBSPACE = 4;
     public static final int DEFAULT_MAXIMUM_FIELD_INFO_CACHE_SIZE = 64;
     private final AtomicLong nextTempFileCounter = new AtomicLong();
     private final FDBRecordContext context;
@@ -152,25 +154,24 @@ public class FDBDirectory extends Directory  {
 
     private final Map<BitSet, byte[]> fieldInfosDataMap;
 
+    private final boolean primaryKeySegmentIndexEnabled;
+    @Nullable
+    private LucenePrimaryKeySegmentIndex primaryKeySegmentIndex;
+
     public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context) {
-        this(subspace, context, null, null);
+        this(subspace, context, null, null, false);
     }
 
     public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context,
-                        @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey) {
-        this(subspace, context, sharedCacheManager, sharedCacheKey, NoLockFactory.INSTANCE);
-    }
-
-    FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context,
-                 @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey,
-                 @Nonnull LockFactory lockFactory) {
-        this(subspace, context, sharedCacheManager, sharedCacheKey, lockFactory,
+                        @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey,
+                        boolean primaryKeySegmentIndexEnabled) {
+        this(subspace, context, sharedCacheManager, sharedCacheKey, primaryKeySegmentIndexEnabled, NoLockFactory.INSTANCE,
                 DEFAULT_BLOCK_SIZE, DEFAULT_INITIAL_CAPACITY, DEFAULT_MAXIMUM_SIZE, DEFAULT_CONCURRENCY_LEVEL);
     }
 
     FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context,
                  @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey,
-                 @Nonnull LockFactory lockFactory,
+                 boolean primaryKeySegmentIndexEnabled, @Nonnull LockFactory lockFactory,
                  int blockSize, final int initialCapacity, final int maximumSize, final int concurrencyLevel) {
         Verify.verify(subspace != null);
         Verify.verify(context != null);
@@ -195,6 +196,7 @@ public class FDBDirectory extends Directory  {
         this.fileSequenceCounter = new AtomicLong(-1);
         this.compressionEnabled = Objects.requireNonNullElse(context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED), false);
         this.encryptionEnabled = Objects.requireNonNullElse(context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_ENCRYPTION_ENABLED), false);
+        this.primaryKeySegmentIndexEnabled = primaryKeySegmentIndexEnabled;
         this.fileReferenceMapSupplier = Suppliers.memoize(this::loadFileReferenceCacheForMemoization);
         this.sharedCacheManager = sharedCacheManager;
         this.sharedCacheKey = sharedCacheKey;
@@ -501,8 +503,7 @@ public class FDBDirectory extends Directory  {
     public String[] listAll() {
         long startTime = System.nanoTime();
         try {
-            Set<String> outSet = getFileReferenceCache().keySet();
-            return outSet.toArray(new String[0]);
+            return getFileReferenceCache().keySet().stream().filter(name -> !name.endsWith(".pky")).toArray(String[]::new);
         } finally {
             context.record(LuceneEvents.Events.LUCENE_LIST_ALL, System.nanoTime() - startTime);
         }
@@ -596,23 +597,34 @@ public class FDBDirectory extends Directory  {
             return;
         }
         try {
-            boolean deleted = Objects.requireNonNull(context.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_DELETE_FILE, getFileReferenceCacheAsync().thenApply(cache -> {
-                FDBLuceneFileReference value = cache.get(name);
-                if (value == null) {
-                    return false;
-                }
-                context.ensureActive().clear(metaSubspace.pack(name));
-                context.ensureActive().clear(dataSubspace.subspace(Tuple.from(value.getId())).range());
-                cache.remove(name);
-                return true;
-            })));
+            boolean deleted = Objects.requireNonNull(context.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_DELETE_FILE, getFileReferenceCacheAsync()
+                    .thenApply(cache -> deleteFileInternal(cache, name))));
 
             if (!deleted) {
                 throw new NoSuchFileException(name);
             }
+
+            if (isCompoundFile(name)) {
+                Map<String, FDBLuceneFileReference> cache = fileReferenceCache.get();
+                String primaryKeyName = name.substring(0, name.length() - DATA_EXTENSION.length()) + "pky";
+                deleteFileInternal(cache, primaryKeyName);
+                // TODO: If the segment is being deleted because it no longer has any live docs, it won't be merged
+                //  so we might need to delete the primary key entries another way for case where tryDeleteDocument
+                //  wasn't used.
+            }
         } finally {
             context.increment(LuceneEvents.Counts.LUCENE_DELETE_FILE);
         }
+    }
+
+    private boolean deleteFileInternal(@Nonnull Map<String, FDBLuceneFileReference> cache, @Nonnull String name) {
+        FDBLuceneFileReference value = cache.remove(name);
+        if (value == null) {
+            return false;
+        }
+        context.ensureActive().clear(metaSubspace.pack(name));
+        context.ensureActive().clear(dataSubspace.subspace(Tuple.from(value.getId())).range());
+        return true;
     }
 
     /**
@@ -837,5 +849,51 @@ public class FDBDirectory extends Directory  {
 
     Cache<Pair<Long, Integer>, CompletableFuture<byte[]>> getBlockCache() {
         return blockCache;
+    }
+
+    /**
+     * Get a primary key segment index if enabled.
+     * @return index or {@code null} if not enabled
+     */
+    @Nullable
+    public LucenePrimaryKeySegmentIndex getPrimaryKeySegmentIndex() {
+        if (!primaryKeySegmentIndexEnabled) {
+            return null;
+        }
+        if (primaryKeySegmentIndex == null) {
+            final Subspace primaryKeySubspace = subspace.subspace(Tuple.from(PRIMARY_KEY_SUBSPACE));
+            primaryKeySegmentIndex = new LucenePrimaryKeySegmentIndex(this, primaryKeySubspace);
+        }
+        return primaryKeySegmentIndex;
+    }
+
+    // Map segment name to integer id.
+    // TODO: Could store this elsewhere, such as inside compound file.
+    public long primaryKeySegmentId(@Nonnull String segmentName, boolean create) throws IOException {
+        final String fileName = IndexFileNames.segmentFileName(segmentName, "", "pky");
+        FDBLuceneFileReference ref = getFDBLuceneFileReference(fileName);
+        if (ref == null) {
+            if (!create) {
+                throw new NoSuchFileException(segmentName);
+            }
+            ref = new FDBLuceneFileReference(getIncrement(), 0, 0, 0);
+            writeFDBLuceneFileReference(fileName, ref);
+        }
+        return ref.getId();
+    }
+
+    // Map stored segment id back to segment name.
+    @Nullable
+    public String primaryKeySegmentName(long segmentId) {
+        for (Map.Entry<String, FDBLuceneFileReference> entry : getFileReferenceCache().entrySet()) {
+            if (entry.getValue().getId() == segmentId) {
+                final String fileName = entry.getKey();
+                if (!fileName.endsWith(".pky")) {
+                    throw new IllegalArgumentException("Given segment id is not for a pky file: " + fileName);
+                }
+                return fileName.substring(0, fileName.length() - 4);
+            }
+        }
+        return null;
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -2598,7 +2598,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             assertEquals(20,
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN).getCount().join());
-            try (FDBDirectory directory = new FDBDirectory(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context)) {
+            try (FDBDirectory directory = new FDBDirectory(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, true)) {
                 assertEquals(21, directory.listAll().length);
             }
         }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -97,9 +97,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -521,7 +523,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "\"propose a Vision\""), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -538,7 +540,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createManyFieldsDocument(1623L, "propose a Vision", 1L,  true));
             recordStore.saveRecord(createManyFieldsDocument(1547L, "different smoochies", 2L, false));
 
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(1623L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(1623L)),
                     recordStore.scanIndex(MANY_FIELDS_INDEX, fullTextSearch(MANY_FIELDS_INDEX, "text0:Vision AND bool0: true"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -569,9 +571,9 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(doc2);
 
             // Make sure the text search for individual fields
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(11)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(11)),
                     recordStore.scanIndex(MANY_FIELDS_INDEX, fullTextSearch(MANY_FIELDS_INDEX, "text0:pineapple"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(387)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(387)),
                     recordStore.scanIndex(MANY_FIELDS_INDEX, fullTextSearch(MANY_FIELDS_INDEX, "text1:pineapple"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -599,9 +601,9 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(doc2);
 
             // Make sure the text search for individual fields
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(11)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(11)),
                     recordStore.scanIndex(MANY_FIELDS_INDEX, fullTextSearch(MANY_FIELDS_INDEX, "text0:pineapple"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(387)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(387)),
                     recordStore.scanIndex(MANY_FIELDS_INDEX, fullTextSearch(MANY_FIELDS_INDEX, "text4:pineapple"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -615,7 +617,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             //one document when the chars, one without
             recordStore.saveRecord(createSimpleDocument(1623L, String.format(baseText, specialCharacter, specialCharacter), 2));
             recordStore.saveRecord(createSimpleDocument(1547L, String.format(baseText, " ", " "), 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, specialCharacter), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -634,7 +636,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createComplexDocument(1623L, ENGINEER_JOKE, "propose a Vision", 2, true));
             recordStore.saveRecord(createComplexDocument(1547L, ENGINEER_JOKE, "different smoochies", 2, false));
 
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(2, 1623L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(2, 1623L)),
                     recordStore.scanIndex(TEXT_AND_BOOLEAN_INDEX, fullTextSearch(TEXT_AND_BOOLEAN_INDEX, "\"propose a Vision\" AND is_seen: true"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -653,7 +655,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createComplexDocument(1623L, ENGINEER_JOKE, "propose a Vision", 2, true));
             recordStore.saveRecord(createComplexDocument(1547L, ENGINEER_JOKE, "different smoochies", 2, false));
 
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(2, 1547L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(2, 1547L)),
                     recordStore.scanIndex(TEXT_AND_BOOLEAN_INDEX, fullTextSearch(TEXT_AND_BOOLEAN_INDEX, "\"propose a Vision\" AND NOT is_seen: true"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -672,7 +674,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createComplexDocument(1623L, ENGINEER_JOKE, "propose a Vision", 2, true));
             recordStore.saveRecord(createComplexDocument(1547L, ENGINEER_JOKE, "different smoochies", 2, false));
 
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(2, 1623L), Tuple.from(2, 1547L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(2, 1623L), Tuple.from(2, 1547L)),
                     recordStore.scanIndex(TEXT_AND_BOOLEAN_INDEX, fullTextSearch(TEXT_AND_BOOLEAN_INDEX, "\"propose a Vision\" AND is_seen: [false TO true]"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(2, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -691,7 +693,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createComplexDocument(1623L, ENGINEER_JOKE, "propose a Vision", 2, true));
             recordStore.saveRecord(createComplexDocument(1547L, ENGINEER_JOKE, "different smoochies", 2, false));
 
-            assertIndexEntryPrimaryKeyTuples(List.of(),
+            assertIndexEntryPrimaryKeyTuples(Set.of(),
                     recordStore.scanIndex(TEXT_AND_BOOLEAN_INDEX, fullTextSearch(TEXT_AND_BOOLEAN_INDEX, "\"propose a Vision\" AND is_seen: true AND is_seen: false"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(TEXT_AND_BOOLEAN_INDEX), context, "_0.cfs", true);
@@ -709,7 +711,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createComplexDocument(1623L, ENGINEER_JOKE, "propose a Vision", 2, true));
             recordStore.saveRecord(createComplexDocument(1547L, ENGINEER_JOKE, "different smoochies", 2, false));
 
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(2, 1623L), Tuple.from(2, 1547L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(2, 1623L), Tuple.from(2, 1547L)),
                     recordStore.scanIndex(TEXT_AND_BOOLEAN_INDEX, fullTextSearch(TEXT_AND_BOOLEAN_INDEX, "\"propose a Vision\" AND (is_seen: true OR is_seen: false)"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(2, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -728,7 +730,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createSimpleDocument(1547L, ENGINEER_JOKE, 1));
             recordStore.saveRecord(createSimpleDocument(1548L, ENGINEER_JOKE, null));
 
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(TEXT_AND_NUMBER_INDEX, fullTextSearch(TEXT_AND_NUMBER_INDEX, "\"propose a Vision\" AND group:2"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -746,7 +748,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createSimpleDocument(1241L, "{to: aburritoofjoy@tacos.com, from: tacosareevil@badfoodtakes.net}", 1));
             recordStore.saveRecord(createSimpleDocument(1342L, "{to: aburritoofjoy@tacos.com, from: tacosareevil@badfoodtakes.net}", 2));
 
-            assertIndexEntryPrimaryKeys(List.of(1241L),
+            assertIndexEntryPrimaryKeys(Set.of(1241L),
                     recordStore.scanIndex(TEXT_AND_NUMBER_INDEX, fullTextSearch(TEXT_AND_NUMBER_INDEX, "aburritoofjoy@tacos.com* AND group: 1"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -761,7 +763,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(1547L, ENGINEER_JOKE, 1));
 
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(TEXT_AND_NUMBER_INDEX, fullTextSearch(TEXT_AND_NUMBER_INDEX, "\"propose a Vision\" AND group:[2 TO 4]"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -780,12 +782,12 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createSimpleDocument(1547L, ENGINEER_JOKE, 1));
 
             //positive infinity
-            assertIndexEntryPrimaryKeys(List.of(),
+            assertIndexEntryPrimaryKeys(Set.of(),
                     recordStore.scanIndex(TEXT_AND_NUMBER_INDEX, fullTextSearch(TEXT_AND_NUMBER_INDEX, "\"propose a Vision\" AND group:{" + Long.MAX_VALUE + " TO " + Long.MAX_VALUE + "]"), null, ScanProperties.FORWARD_SCAN));
 
 
             //negative infinite
-            assertIndexEntryPrimaryKeys(List.of(),
+            assertIndexEntryPrimaryKeys(Set.of(),
                     recordStore.scanIndex(TEXT_AND_NUMBER_INDEX, fullTextSearch(TEXT_AND_NUMBER_INDEX, "\"propose a Vision\" AND group:[" + Long.MIN_VALUE + " TO " + Long.MIN_VALUE + "}"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(TEXT_AND_NUMBER_INDEX), context, "_0.cfs", true);
@@ -894,7 +896,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -916,7 +918,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                     .setScore(0.21973526F)
                     .setShard(0)
                     .build();
-            assertIndexEntryPrimaryKeys(List.of(1625L, 1626L),
+            assertIndexEntryPrimaryKeys(Set.of(1625L, 1626L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), continuation.toByteArray(), ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", true);
@@ -929,7 +931,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             recordStore.saveRecord(createSimpleDocument(1623L, 2));
             recordStore.saveRecord(createSimpleDocument(1632L, ENGINEER_JOKE, 2));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "*:* AND NOT text:[* TO *]"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", true);
@@ -1035,7 +1037,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, MAP_DOC, MAP_ON_VALUE_INDEX);
             recordStore.saveRecord(createComplexMapDocument(1623L, ENGINEER_JOKE, "sampleTextSong", 2));
             recordStore.saveRecord(createComplexMapDocument(1547L, WAYLON, "sampleTextPhrase", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(MAP_ON_VALUE_INDEX, groupedTextSearch(MAP_ON_VALUE_INDEX, "entry_value:Vision", "sampleTextSong"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -1048,7 +1050,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, MAP_DOC, MAP_ON_VALUE_INDEX);
             recordStore.saveRecord(createMultiEntryMapDoc(1623L, ENGINEER_JOKE, "sampleTextPhrase", WAYLON, "sampleTextSong", 2));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(MAP_ON_VALUE_INDEX, groupedTextSearch(MAP_ON_VALUE_INDEX, "entry_value:Vision", "sampleTextPhrase"), null, ScanProperties.FORWARD_SCAN));
             assertEquals(1, getCounter(context, FDBStoreTimer.Counts.LOAD_SCAN_ENTRY).getCount());
 
@@ -1062,7 +1064,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_MULTIPLE_TEXT_INDEXES);
             recordStore.saveRecord(createComplexDocument(1623L, ENGINEER_JOKE, "john_leach@apple.com", 2));
             recordStore.saveRecord(createComplexDocument(1547L, WAYLON, "hering@gmail.com", 2));
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(2L, 1623L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(2L, 1623L)),
                     recordStore.scanIndex(COMPLEX_MULTIPLE_TEXT_INDEXES, fullTextSearch(COMPLEX_MULTIPLE_TEXT_INDEXES, "text:\"Vision\" AND text2:\"john_leach@apple.com\""), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(COMPLEX_MULTIPLE_TEXT_INDEXES), context, "_0.cfs", true);
@@ -1075,7 +1077,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_MULTIPLE_TEXT_INDEXES);
             recordStore.saveRecord(createComplexDocument(1623L, ENGINEER_JOKE, "john_leach@apple.com", 2));
             recordStore.saveRecord(createComplexDocument(1547L, WAYLON, "hering@gmail.com", 2));
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(2L, 1623L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(2L, 1623L)),
                     recordStore.scanIndex(COMPLEX_MULTIPLE_TEXT_INDEXES, fullTextSearch(COMPLEX_MULTIPLE_TEXT_INDEXES, "text:\"Vision\" AND text2:jonleach@apple.com~"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(COMPLEX_MULTIPLE_TEXT_INDEXES), context, "_0.cfs", true);
@@ -1089,10 +1091,10 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(1624L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 2));
-            assertIndexEntryPrimaryKeys(List.of(1623L, 1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L, 1624L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
             assertTrue(recordStore.deleteRecord(Tuple.from(1624L)));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", true);
@@ -1121,7 +1123,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", false);
@@ -1130,7 +1132,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         }
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", true);
@@ -1143,7 +1145,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", false);
@@ -1153,10 +1155,10 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             recordStore.saveRecord(createSimpleDocument(1547L, WAYLON, 1));
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(SIMPLE_TEXT_SUFFIXES, fullTextSearch(SIMPLE_TEXT_SUFFIXES, "Vision"), null, ScanProperties.FORWARD_SCAN));
 
             assertEntriesAndSegmentInfoStoredInCompoundFile(recordStore.indexSubspace(SIMPLE_TEXT_SUFFIXES), context, "_0.cfs", true);
@@ -1211,11 +1213,11 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
-            assertIndexEntryPrimaryKeys(List.of(1002L), // 18
+            assertIndexEntryPrimaryKeys(Set.of(1002L), // 18
                     recordStore.scanIndex(index, fullTextSearch(index, "three"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1000L, 1004L),  // 16,20
+            assertIndexEntryPrimaryKeys(Set.of(1000L, 1004L),  // 16,20
                     recordStore.scanIndex(index, fullTextSearch(index, "four"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(),
+            assertIndexEntryPrimaryKeys(Set.of(),
                     recordStore.scanIndex(index, fullTextSearch(index, "seven"), null, ScanProperties.FORWARD_SCAN));
 
             if (primaryKeySegmentIndexEnabled) {
@@ -1254,10 +1256,10 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         }
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
-            assertIndexEntryPrimaryKeys(List.of(1623L, 1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L, 1624L),
                     recordStore.scanIndex(index, fullTextSearch(index, "Vision"), null, ScanProperties.FORWARD_SCAN));
             assertTrue(recordStore.deleteRecord(Tuple.from(1624L)));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(index, fullTextSearch(index, "Vision"), null, ScanProperties.FORWARD_SCAN));
             assertThat(timer.getCount(LuceneEvents.Counts.LUCENE_DELETE_DOCUMENT_BY_QUERY), equalTo(0));
             assertThat(timer.getCount(LuceneEvents.Counts.LUCENE_DELETE_DOCUMENT_BY_PRIMARY_KEY), equalTo(1));
@@ -1265,15 +1267,15 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         timer.reset();
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
-            assertIndexEntryPrimaryKeys(List.of(1623L, 1624L, 1547L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L, 1624L, 1547L),
                     recordStore.scanIndex(index, fullTextSearch(index, "way"), null, ScanProperties.FORWARD_SCAN));
             assertTrue(recordStore.deleteRecord(Tuple.from(1547L)));
-            assertIndexEntryPrimaryKeys(List.of(1623L, 1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L, 1624L),
                     recordStore.scanIndex(index, fullTextSearch(index, "way"), null, ScanProperties.FORWARD_SCAN));
             assertThat(timer.getCount(LuceneEvents.Counts.LUCENE_DELETE_DOCUMENT_BY_QUERY), equalTo(0));
             assertThat(timer.getCount(LuceneEvents.Counts.LUCENE_DELETE_DOCUMENT_BY_PRIMARY_KEY), equalTo(1));
             recordStore.saveRecord(createSimpleDocument(1547L, ENGINEER_JOKE, 2));
-            assertIndexEntryPrimaryKeys(List.of(1623L, 1624L, 1547L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L, 1624L, 1547L),
                     recordStore.scanIndex(index, fullTextSearch(index, "Vision"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1340,22 +1342,22 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, QUERY_ONLY_SYNONYM_LUCENE_INDEX);
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello record layer", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "hullo record layer"), null, ScanProperties.FORWARD_SCAN));
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello recor layer", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "hullo record layer"), null, ScanProperties.FORWARD_SCAN));
             // "hullo" is synonym of "hello"
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello record layer", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, matchAll("hullo", "record", "layer")), null, ScanProperties.FORWARD_SCAN));
             // it doesn't match due to the "recor"
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello record layer", 1));
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, matchAll("hullo", "recor", "layer")), null, ScanProperties.FORWARD_SCAN));
             // "hullo" is synonym of "hello", and "show" is synonym of "record"
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello record layer", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, matchAll("hullo", "show", "layer")), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1395,45 +1397,45 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             // Save a document to verify synonym search based on the group {'motivation','motive','need'}
             recordStore.saveRecord(createSimpleDocument(1623L, "I think you need to search with Lucene index", 1));
             // Search for original phrase
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"you need to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with changed order of tokens, no match is expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"need you to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motivation" as synonym of "need"
             // "Motivation" is the authoritative term of the group {'motivation','motive','need'}
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"you motivation to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motivation" with changed order of tokens, no match is expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"motivation you to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motive" as synonym of "need"
             // "Motive" is not the authoritative term of the group {'motivation','motive','need'}
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"you motive to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motive" with changed order of tokens, no match is expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"motive you to\""), null, ScanProperties.FORWARD_SCAN));
             // Term query rather than phrase query, so match is expected although the order is changed
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "motivation you to"), null, ScanProperties.FORWARD_SCAN));
 
             // Save a document to verify synonym search based on the group {'departure','going','going away','leaving'}
             // This group contains multi-word term "going away", and also the single-word term "going"
             recordStore.saveRecord(createSimpleDocument(1624L, "He is leaving for New York next week", 1));
-            assertIndexEntryPrimaryKeys(List.of(1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1624L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"is departure for\""), null, ScanProperties.FORWARD_SCAN));
 
             // Search for phrase with "going away"
-            assertIndexEntryPrimaryKeys(List.of(1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1624L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"is going away for\""), null, ScanProperties.FORWARD_SCAN));
 
             //Search for phrase with "going"
-            assertIndexEntryPrimaryKeys(List.of(1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1624L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"is going for\""), null, ScanProperties.FORWARD_SCAN));
 
             // Search for phrase with only "away", no match is expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"is away for\""), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1445,45 +1447,45 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             // Save a document to verify synonym search based on the group {'motivation','motive','need'}
             recordStore.saveRecord(createSimpleDocument(1623L, "I think you need to search with Lucene index", 1));
             // Search for original phrase
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"you need to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with changed order of tokens, no match is expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"need you to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motivation" as synonym of "need"
             // "Motivation" is the authoritative term of the group {'motivation','motive','need'}
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"you motivation to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motivation" with changed order of tokens, no match is expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"motivation you to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motive" as synonym of "need"
             // "Motive" is not the authoritative term of the group {'motivation','motive','need'}
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"you motive to\""), null, ScanProperties.FORWARD_SCAN));
             // Search for phrase with "motive" with changed order of tokens, no match is expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"motive you to\""), null, ScanProperties.FORWARD_SCAN));
             // Term query rather than phrase query, so match is expected although the order is changed
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "motivation you to"), null, ScanProperties.FORWARD_SCAN));
 
             // Save a document to verify synonym search based on the group {'departure','going','going away','leaving'}
             // This group contains multi-word term "going away", and also the single-word term "going"
             recordStore.saveRecord(createSimpleDocument(1624L, "He is leaving for New York next week", 1));
-            assertIndexEntryPrimaryKeys(List.of(1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1624L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"is departure for\""), null, ScanProperties.FORWARD_SCAN));
 
             // Search for phrase with "going away"
-            assertIndexEntryPrimaryKeys(List.of(1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1624L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"is going away for\""), null, ScanProperties.FORWARD_SCAN));
 
             //Search for phrase with "going"
-            assertIndexEntryPrimaryKeys(List.of(1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1624L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"is going for\""), null, ScanProperties.FORWARD_SCAN));
 
             // Search for phrase with only "away", the correct behavior is to return no match. But match is still hit due to the poor handling of positional data for multi-word synonym by this analyzer
-            assertIndexEntryPrimaryKeys(List.of(1624L),
+            assertIndexEntryPrimaryKeys(Set.of(1624L),
                     recordStore.scanIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, fullTextSearch(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX, "\"is away for\""), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1539,9 +1541,9 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                 metaDataBuilder.addIndex(SIMPLE_DOC, QUERY_ONLY_SYNONYM_LUCENE_COMBINED_SETS_INDEX);
             });
             recordStore.saveRecord(createSimpleDocument(1623L, "synonym is fun", 1));
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, matchAll("nonsynonym", "is", "fun")), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_COMBINED_SETS_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_COMBINED_SETS_INDEX, matchAll("nonsynonym", "is", "fun")), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1553,7 +1555,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
 
             // Both "hello" and "record" have multi-word synonyms
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello FoundationDB record layer", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, fullTextSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"hello record\"~10"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1565,7 +1567,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
 
             // Both "hello" and "record" have multi-word synonyms
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello FoundationDB record layer", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX, specificFieldSearch(QUERY_ONLY_SYNONYM_LUCENE_INDEX, "\"hello record\"~10", "text"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1575,22 +1577,22 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, NGRAM_LUCENE_INDEX);
             recordStore.saveRecord(createSimpleDocument(1623L, "Hello record layer", 1));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "hello record layer"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "hello"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "hel"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "ell"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "ecord"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "hel ord aye"), null, ScanProperties.FORWARD_SCAN));
-            assertIndexEntryPrimaryKeys(List.of(1623L),
+            assertIndexEntryPrimaryKeys(Set.of(1623L),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "ello record"), null, ScanProperties.FORWARD_SCAN));
             // The term "ella" is not expected
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(NGRAM_LUCENE_INDEX, fullTextSearch(NGRAM_LUCENE_INDEX, "ella"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -1622,7 +1624,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                 metaDataBuilder.addIndex(SIMPLE_DOC, SIMPLE_TEXT_WITH_AUTO_COMPLETE);
             });
 
-            assertIndexEntryPrimaryKeys(Collections.emptyList(),
+            assertIndexEntryPrimaryKeys(Collections.emptySet(),
                     recordStore.scanIndex(SIMPLE_TEXT_WITH_AUTO_COMPLETE, autoCompleteBounds(SIMPLE_TEXT_WITH_AUTO_COMPLETE, "hello", ImmutableSet.of("text")), null, ScanProperties.FORWARD_SCAN));
             assertEquals(0, Verify.verifyNotNull(context.getTimer()).getCount(LuceneEvents.Counts.LUCENE_SCAN_MATCHED_AUTO_COMPLETE_SUGGESTIONS));
         }
@@ -2324,16 +2326,16 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, COMPLEX_DOC, MULTIPLE_ANALYZER_LUCENE_INDEX);
             recordStore.saveRecord(createComplexDocument(1623L, "Hello, I am working on record layer", "Hello, I am working on FoundationDB", 1));
             // text field uses the default SYNONYM analyzer, so "hullo" should have match
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(1L, 1623L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(1L, 1623L)),
                     recordStore.scanIndex(MULTIPLE_ANALYZER_LUCENE_INDEX, fullTextSearch(MULTIPLE_ANALYZER_LUCENE_INDEX, "text:hullo"), null, ScanProperties.FORWARD_SCAN));
             // text2 field has NGRAM analyzer override, so "hullo" should not have match
-            assertIndexEntryPrimaryKeyTuples(Collections.emptyList(),
+            assertIndexEntryPrimaryKeyTuples(Collections.emptySet(),
                     recordStore.scanIndex(MULTIPLE_ANALYZER_LUCENE_INDEX, fullTextSearch(MULTIPLE_ANALYZER_LUCENE_INDEX, "text2:hullo"), null, ScanProperties.FORWARD_SCAN));
             // text field uses the default SYNONYM analyzer, so "orkin" should not have match
-            assertIndexEntryPrimaryKeyTuples(Collections.emptyList(),
+            assertIndexEntryPrimaryKeyTuples(Collections.emptySet(),
                     recordStore.scanIndex(MULTIPLE_ANALYZER_LUCENE_INDEX, fullTextSearch(MULTIPLE_ANALYZER_LUCENE_INDEX, "text:orkin"), null, ScanProperties.FORWARD_SCAN));
             // text2 field has NGRAM analyzer override, so "orkin" should have match
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(1L, 1623L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(1L, 1623L)),
                     recordStore.scanIndex(MULTIPLE_ANALYZER_LUCENE_INDEX, fullTextSearch(MULTIPLE_ANALYZER_LUCENE_INDEX, "text2:orkin"), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -2344,7 +2346,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             rebuildIndexMetaData(context, COMPLEX_DOC, AUTO_COMPLETE_SIMPLE_LUCENE_INDEX);
             recordStore.saveRecord(createComplexDocument(1623L, "Hello, I am working on record layer", "Hello, I am working on FoundationDB", 1));
             // text field has auto-complete enabled, so the auto-complete query for "record layer" should have match
-            assertIndexEntryPrimaryKeyTuples(List.of(Tuple.from(1L, 1623L)),
+            assertIndexEntryPrimaryKeyTuples(Set.of(Tuple.from(1L, 1623L)),
                     recordStore.scanIndex(AUTO_COMPLETE_SIMPLE_LUCENE_INDEX, autoCompleteBounds(AUTO_COMPLETE_SIMPLE_LUCENE_INDEX, "record layer", ImmutableSet.of("text")), null, ScanProperties.FORWARD_SCAN));
         }
     }
@@ -2751,16 +2753,16 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         this.planner = pair.getRight();
     }
 
-    private void assertIndexEntryPrimaryKeys(List<Long> primaryKeys, RecordCursor<IndexEntry> cursor) {
+    private void assertIndexEntryPrimaryKeys(Collection<Long> primaryKeys, RecordCursor<IndexEntry> cursor) {
         List<IndexEntry> indexEntries = cursor.asList().join();
-        assertEquals(primaryKeys.stream().map(Tuple::from).collect(Collectors.toList()),
-                indexEntries.stream().map(IndexEntry::getPrimaryKey).collect(Collectors.toList()));
+        assertEquals(primaryKeys.stream().map(Tuple::from).collect(Collectors.toSet()),
+                indexEntries.stream().map(IndexEntry::getPrimaryKey).collect(Collectors.toSet()));
     }
 
-    private void assertIndexEntryPrimaryKeyTuples(List<Tuple> primaryKeys, RecordCursor<IndexEntry> cursor) {
+    private void assertIndexEntryPrimaryKeyTuples(Set<Tuple> primaryKeys, RecordCursor<IndexEntry> cursor) {
         List<IndexEntry> indexEntries = cursor.asList().join();
         assertEquals(primaryKeys,
-                indexEntries.stream().map(IndexEntry::getPrimaryKey).collect(Collectors.toList()));
+                indexEntries.stream().map(IndexEntry::getPrimaryKey).collect(Collectors.toSet()));
     }
 
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
@@ -59,7 +59,7 @@ public abstract class FDBDirectoryBaseTest {
             return null;
         });
         FDBRecordContext context = fdb.openContext(getContextConfig());
-        directory = new FDBDirectory(subspace, context);
+        directory = new FDBDirectory(subspace, context, false);
     }
 
     private FDBRecordContextConfig getContextConfig() {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -72,7 +72,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         directory.getContext().commit();
 
         try (FDBRecordContext context = fdb.openContext()) {
-            directory = new FDBDirectory(subspace, context);
+            directory = new FDBDirectory(subspace, context, false);
             assertEquals(3, directory.getIncrement());
         }
     }
@@ -91,7 +91,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         directory.getContext().commit();
 
         try (FDBRecordContext context = fdb.openContext()) {
-            directory = new FDBDirectory(subspace, context);
+            directory = new FDBDirectory(subspace, context, false);
             assertEquals(threads + 1, directory.getIncrement());
         }
     }
@@ -164,7 +164,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
         final FDBStoreTimer timer = new FDBStoreTimer();
         try (FDBRecordContext context = fdb.openContext(null, timer)) {
-            directory = new FDBDirectory(subspace, context);
+            directory = new FDBDirectory(subspace, context, false);
             assertArrayEquals(new String[0], directory.listAll());
             assertEquals(1, timer.getCount(LuceneEvents.Events.LUCENE_LIST_ALL));
             assertEquals(1, timer.getCount(LuceneEvents.Events.LUCENE_LOAD_FILE_CACHE));
@@ -196,7 +196,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
         final FDBStoreTimer timer = new FDBStoreTimer();
         try (FDBRecordContext context = fdb.openContext(null, timer)) {
-            directory = new FDBDirectory(subspace, context);
+            directory = new FDBDirectory(subspace, context, false);
             long fileSize2 = directory.fileLength("test1");
             assertEquals(expectedSize, fileSize2);
             assertEquals(1, timer.getCount(LuceneEvents.Events.LUCENE_GET_FILE_LENGTH));


### PR DESCRIPTION
… by record primary key.

Use this to speed up deletes / updates.