### PR TITLE
Make `FieldCopier.copy` thread-safe

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/TupleFieldsHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/TupleFieldsHelper.java
@@ -172,7 +172,7 @@ public class TupleFieldsHelper {
      */
     @Nonnull
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public static Message toProto(@Nonnull Object value, @Nonnull Descriptors.Descriptor descriptor) {
+    public static Message toProto(@Nonnull Object value, @Nonnull final Descriptors.Descriptor descriptor) {
         if (descriptor == TupleFieldsProto.UUID.getDescriptor()) {
             return toProto((UUID)value);
         } else if (descriptor == TupleFieldsProto.NullableDouble.getDescriptor()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
@@ -174,7 +174,7 @@ public class IndexKeyValueToPartialRecord {
         }
 
         @Override
-        public boolean copy(@Nonnull Descriptors.Descriptor recordDescriptor, @Nonnull Message.Builder recordBuilder,
+        public synchronized boolean copy(@Nonnull Descriptors.Descriptor recordDescriptor, @Nonnull Message.Builder recordBuilder,
                             @Nonnull IndexEntry kv) {
             final Tuple tuple = (source == TupleSource.KEY ? kv.getKey() : kv.getValue());
             if (!copyIfPredicate.test(tuple)) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/IndexKeyValueToPartialRecordTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/IndexKeyValueToPartialRecordTest.java
@@ -1,0 +1,107 @@
+/*
+ * IndexKeyValueToPartialRecordTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.primitives.ImmutableIntArray;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+class IndexKeyValueToPartialRecordTest {
+
+    @Nonnull
+    private static final Random random = new Random();
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Nonnull
+    private static final IndexKeyValueToPartialRecord plan = IndexKeyValueToPartialRecord.newBuilder(TestRecords1Proto.MySimpleRecord.getDescriptor())
+            .addField("num_value_2", IndexKeyValueToPartialRecord.TupleSource.VALUE, ignored -> true, ImmutableIntArray.of(0))
+            .build();
+
+    @Nonnull
+    private static Descriptors.Descriptor evolveMessage(@Nonnull final Descriptors.Descriptor originalDescriptor) {
+        final var descriptorWithNewFieldProto = DescriptorProtos.DescriptorProto.newBuilder(originalDescriptor.toProto())
+                .addField(DescriptorProtos.FieldDescriptorProto
+                        .newBuilder()
+                        .setName("NewField")
+                        .setNumber(100)
+                        .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_BOOL)
+                        .build())
+                .build();
+        final var fileProto = DescriptorProtos.FileDescriptorProto.newBuilder().setName("synthetic.proto").addMessageType(descriptorWithNewFieldProto).build();
+        final Descriptors.FileDescriptor descriptorWithNewField;
+        try {
+            descriptorWithNewField = Descriptors.FileDescriptor.buildFrom(fileProto, new Descriptors.FileDescriptor[] {});
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new RuntimeException(String.format("Could not construct descriptor from synthetic descriptor proto for %s", originalDescriptor.getName()), e);
+        }
+        return descriptorWithNewField.findMessageTypeByName(descriptorWithNewFieldProto.getName());
+    }
+
+    @Nonnull
+    private static final Descriptors.Descriptor originalDescriptor = TestRecords1Proto.MySimpleRecord.getDescriptor();
+
+    @Nonnull
+    private static final Descriptors.Descriptor newDescriptor = evolveMessage(originalDescriptor);
+
+    @Nonnull
+    private static IndexEntry randomIndexEntry() {
+        return new IndexEntry(new Index("foo", "bar"), Tuple.from("num_value_2"), Tuple.from(42L));
+    }
+
+    void executePlan() {
+        final var tossedCoinIsTails = random.nextBoolean();
+        final var chosenDescriptor = tossedCoinIsTails ? originalDescriptor : newDescriptor;
+        plan.toRecord(chosenDescriptor, randomIndexEntry());
+    }
+
+    @Test
+    void race() throws InterruptedException {
+        ExecutorService service = Executors.newFixedThreadPool(3);
+        int numTasks = 1000;
+        CountDownLatch latch = new CountDownLatch(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            service.submit(() -> {
+                try {
+                    executePlan();
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                    throw new RuntimeException(e);
+                }
+                latch.countDown();
+            });
+        }
+        boolean completed = latch.await(2L, TimeUnit.SECONDS);
+        service.shutdown();
+        Assertions.assertTrue(completed);
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/IndexKeyValueToPartialRecordTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/IndexKeyValueToPartialRecordTest.java
@@ -85,7 +85,7 @@ class IndexKeyValueToPartialRecordTest {
     }
 
     @Test
-    void race() throws InterruptedException {
+    void convertIndexToPartialRecordConcurrently() throws InterruptedException {
         ExecutorService service = Executors.newFixedThreadPool(3);
         int numTasks = 1000;
         CountDownLatch latch = new CountDownLatch(numTasks);


### PR DESCRIPTION
`FieldCopier.copy` is not thread-safe. This could cause problems in situations where we have multiple threads trying to reuse a physical plan but with slight differences in their record descriptors.

**Setup**
-: We have two threads, `T1` and `T2` and a physical plan that comprises an operator that leverages `IndexKeyValueToPartialRecord` such as `RecordQueryCoveringIndexPlan`.
- `T1` is operating on a version of record store metadata that contains the following record:
```
message R1 {
  optional int32 x = 1;
}
```
- `T2` is operating on another record store metadata that contains an _evolved_ version the same record:
```
message R1 {
  optional int32 x = 1;
  optional int32 y = 2;
}
```
Let's call this message `R1'` for clarity.
Here is a schedule that shows depicts the race-condition (scroll to the write to see the full schedule):
```java
@Override  
public synchronized boolean copy(...) {                                                              
    final Tuple tuple = (source == TupleSource.KEY ? kv.getKey() : kv.getValue());  
    if (!copyIfPredicate.test(tuple)) {  
        return false;  
    }  
  
    Object value = getForOrdinalPath(tuple, ordinalPath);  
    if (value == null) {  
        return true;  
    }  
    if (!containingType.equals(recordDescriptor)) {  
        containingType = recordDescriptor;  
        fieldDescriptor = recordDescriptor.findFieldByName(field);                                      [1] fieldDescriptor=R1.X                                      
                                                                                                                                                                    [2] fieldDescriptor=R1'.X
    }  
    switch (fieldDescriptor.getType()) {  
        case INT32:  
            value = ((Long)value).intValue();  
            break;  
        case BYTES:  
            value = ZeroCopyByteString.wrap((byte[])value);  
            break;  
        case MESSAGE:  
            value = TupleFieldsHelper.toProto(value, fieldDescriptor.getMessageType());  
            break;  
        case ENUM:  
            value = fieldDescriptor.getEnumType().findValueByNumber(((Long)value).intValue());  
            break;  
        default:  
            break;  
    }  
    recordBuilder.setField(fieldDescriptor, value);                                                                                                                 [3] recordBuilder=R1', fieldDescriptor=R1'.X
                                                                                                        [4] recordBuilder=R1, fieldDescriptor=R1'.X -> ERROR
    return true;  
}
```

The error we get at step 4 results from [this](https://github.com/protocolbuffers/protobuf/blob/743bf9214601eddaf13456b1029247e0a6d9a92f/java/core/src/main/java/com/google/protobuf/DynamicMessage.java#L500C35-L500C35) check in ProtoBuf which is trying to compare the field's containing type with the message type:

```java
  /** Verifies that the field is a field of this message. */
  private void verifyContainingType(FieldDescriptor field) {
    if (field.getContainingType() != type) {
      throw new IllegalArgumentException("FieldDescriptor does not match message type.");
    }
  }
```

Although the field correctly belongs to the evolved message descriptor.

The included test exposes this race condition, it will fail if one makes the method `copy` not reentrant.
