### PR TITLE
Make it possible to reset IndexMaintainerRegistryImpl for testing purposes #2303

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
@@ -45,7 +45,7 @@ public class IndexMaintainerRegistryImpl implements IndexMaintainerRegistry {
     protected static final IndexMaintainerRegistryImpl INSTANCE = new IndexMaintainerRegistryImpl();
 
     @Nonnull
-    private final Map<String, IndexMaintainerFactory> registry;
+    private Map<String, IndexMaintainerFactory> registry;
 
     @Nonnull
     public static IndexMaintainerRegistry instance() {
@@ -70,6 +70,10 @@ public class IndexMaintainerRegistryImpl implements IndexMaintainerRegistry {
     }
 
     protected IndexMaintainerRegistryImpl() {
+        registry = initRegistry();
+    }
+
+    public final void reset() {
         registry = initRegistry();
     }
 


### PR DESCRIPTION
IndexMaintainerRegistryImpl can only be initialized once because it uses a static instance.

This can create problems during testing.

This change adds a reset method that re-initializes the registry.