### PR TITLE
Limit parallel open of segment readers to settable number of threads.

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -70,4 +70,9 @@ public final class LuceneRecordContextProperties {
      * This controls the page size to scan the basic Lucene index.
      */
     public static final RecordLayerPropertyKey<Integer> LUCENE_INDEX_CURSOR_PAGE_SIZE = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.cursor.pageSize", 201);
+
+    /**
+     * This controls the number of threads used when opening segments in parallel.
+     */
+    public static final RecordLayerPropertyKey<Integer> LUCENE_OPEN_PARALLELISM = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.open.parallelism", 16);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -85,7 +85,8 @@ class FDBDirectoryWrapper implements AutoCloseable {
         IndexWriter indexWriter = writer;
         if (writer == null) {
             return StandardDirectoryReaderOptimization.open(directory, null, null,
-                    state.context.getExecutor());
+                    state.context.getExecutor(),
+                    state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_OPEN_PARALLELISM));
         } else {
             return DirectoryReader.open(indexWriter);
         }

--- a/fdb-record-layer-lucene/src/main/java/org/apache/lucene/index/StandardDirectoryReaderOptimization.java
+++ b/fdb-record-layer-lucene/src/main/java/org/apache/lucene/index/StandardDirectoryReaderOptimization.java
@@ -25,11 +25,12 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.IOUtils;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.Comparator;
-import java.util.List;
+import java.util.Deque;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * An optimization to open the segment readers in parallel when opening a directory.
@@ -46,11 +47,13 @@ public class StandardDirectoryReaderOptimization {
      * @param commit the index changes to open
      * @param leafSorter a comparator for sorting leaf readers
      * @param executor executor to use to run in parallel
+     * @param parallelism number of readers to open in parallel
      * @return an open directory reader
      * @throws IOException if there is a problem with the underlying implementation
      */
     public static DirectoryReader open(
-            final Directory directory, final IndexCommit commit, Comparator<LeafReader> leafSorter, Executor executor) throws IOException {
+            final Directory directory, final IndexCommit commit, final Comparator<LeafReader> leafSorter,
+            final Executor executor, final int parallelism) throws IOException {
         return new SegmentInfos.FindSegmentsFile<DirectoryReader>(directory) {
             @Override
             protected DirectoryReader doBody(String segmentFileName) throws IOException {
@@ -58,21 +61,21 @@ public class StandardDirectoryReaderOptimization {
                 final SegmentReader[] readers = new SegmentReader[sis.size()];
                 boolean success = false;
                 try {
-                    List<CompletableFuture<SegmentReader>>  futures = new ArrayList<>(sis.size());
-                    for (int i = sis.size() - 1; i >= 0; i--) {
-                        final SegmentCommitInfo info = sis.info(i);
-                        futures.add(CompletableFuture.supplyAsync( () -> {
-                            try {
-                                return new SegmentReader(info, sis.getIndexCreatedVersionMajor(), IOContext.READ);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        }, executor));
-                    }
-                    int j = 0;
-                    for (int i = sis.size() - 1; i >= 0; i--) {
-                        readers[i] = futures.get(j).join();
-                        j++;
+                    final Deque<SegmentReaderOpener> openers = new ArrayDeque<>(parallelism);
+                    int readerIndex = 0;
+                    while (true) {
+                        while (readerIndex < readers.length && openers.size() < parallelism) {
+                            final SegmentCommitInfo info = sis.info(sis.size() - 1 - readerIndex);
+                            final SegmentReaderOpener opener = new SegmentReaderOpener(readers, readerIndex,
+                                    info, sis.getIndexCreatedVersionMajor(), IOContext.READ);
+                            readerIndex++;
+                            openers.add(opener);
+                            opener.start(executor);
+                        }
+                        if (openers.isEmpty()) {
+                            break;
+                        }
+                        openers.pop().finish();
                     }
                     // This may throw CorruptIndexException if there are too many docs, so
                     // it must be inside try clause so we close readers in that case:
@@ -87,5 +90,61 @@ public class StandardDirectoryReaderOptimization {
                 }
             }
         }.run(commit);
+    }
+
+    static class SegmentReaderOpener {
+        private final SegmentReader[] segmentReaders;
+        private final int readerIndex;
+
+        private final SegmentCommitInfo segmentCommitInfo;
+        private final int createdVersionMajor;
+        private final IOContext ioContext;
+
+        private IOException ioException;
+        private CompletableFuture<Void> future;
+
+        SegmentReaderOpener(final SegmentReader[] segmentReaders, final int readerIndex,
+                            final SegmentCommitInfo segmentCommitInfo, final int createdVersionMajor, final IOContext ioContext) {
+            this.segmentReaders = segmentReaders;
+            this.readerIndex = readerIndex;
+            this.segmentCommitInfo = segmentCommitInfo;
+            this.createdVersionMajor = createdVersionMajor;
+            this.ioContext = ioContext;
+        }
+
+        public void start(final Executor executor) {
+            try {
+                future = CompletableFuture.supplyAsync(() -> {
+                    try {
+                        open();
+                    } catch (IOException ex) {
+                        ioException = ex;
+                    } catch (RejectedExecutionException ex) {
+                        // This happens when trying to block in openSchema and having run out of extra threads.
+                        segmentReaders[readerIndex] = null;
+                    }
+                    return null;
+                }, executor);
+            } catch (RejectedExecutionException ex) {
+                future = null;
+            }
+        }
+
+        @SuppressWarnings("PMD.PreserveStackTrace")
+        public void finish() throws IOException {
+            if (future != null) {
+                future.join();
+            }
+            if (ioException != null) {
+                throw ioException;
+            }
+            if (segmentReaders[readerIndex] == null) {
+                open();
+            }
+        }
+
+        private void open() throws IOException {
+            segmentReaders[readerIndex] = new SegmentReader(segmentCommitInfo, createdVersionMajor, ioContext);
+        }
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/org/apache/lucene/index/StandardDirectoryReaderOptimization.java
+++ b/fdb-record-layer-lucene/src/main/java/org/apache/lucene/index/StandardDirectoryReaderOptimization.java
@@ -114,7 +114,7 @@ public class StandardDirectoryReaderOptimization {
 
         public void start(final Executor executor) {
             try {
-                future = CompletableFuture.supplyAsync(() -> {
+                future = CompletableFuture.runAsync(() -> {
                     try {
                         open();
                     } catch (IOException ex) {
@@ -123,7 +123,6 @@ public class StandardDirectoryReaderOptimization {
                         // This happens when trying to block in openSchema and having run out of extra threads.
                         segmentReaders[readerIndex] = null;
                     }
-                    return null;
                 }, executor);
             } catch (RejectedExecutionException ex) {
                 future = null;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -2431,7 +2431,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             }
         }
         final RecordLayerPropertyStorage.Builder scanProps = RecordLayerPropertyStorage.newBuilder()
-                .addProp(LuceneRecordContextProperties.LUCENE_OPEN_PARALLELISM, 2); // Don't merge
+                .addProp(LuceneRecordContextProperties.LUCENE_OPEN_PARALLELISM, 2); // Decrease parallelism when opening segments
         try (FDBRecordContext context = openContext(scanProps)) {
             rebuildIndexMetaData(context, SIMPLE_DOC, SIMPLE_TEXT_SUFFIXES);
             assertEquals(20,


### PR DESCRIPTION
Additionally make it robust to running out of executor threads (which will be much less likely with the limit).

Fixes #2309.