### PR TITLE
Fix unstable in hash code of `RecordQueryAbstractDataModificationPlan`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix hash code instability in `RecordQueryAbstractDataModificationPlan` [(Issue #2325)](https://github.com/FoundationDB/fdb-record-layer/issues/2325)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Rethrow original IOExceptions exceptions in lucene code [(Issue #2293)](https://github.com/FoundationDB/fdb-record-layer/issues/2293)
 * **Bug fix** Add proper clone to LuceneStoredFieldsReader [(Issue #2297)](https://github.com/FoundationDB/fdb-record-layer/issues/2297)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -44,7 +44,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -490,7 +489,6 @@ public class MessageHelpers {
     /**
      * Trie data structure of {@link Type.Record.Field}s to {@link Value}s.
      */
-    @SuppressWarnings({"squid:S1206", "squid:S2160", "PMD.OverrideBothEqualsAndHashcode"})
     public static class TransformationTrieNode extends TrieNode<Integer, Value, TransformationTrieNode> {
 
         public TransformationTrieNode(@Nullable final Value value, @Nullable final Map<Integer, TransformationTrieNode> childrenMap) {
@@ -501,19 +499,6 @@ public class MessageHelpers {
         @Override
         public TransformationTrieNode getThis() {
             return this;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof TransformationTrieNode)) {
-                return false;
-            }
-            final TransformationTrieNode transformationTrieNode = (TransformationTrieNode)o;
-            return Objects.equals(getValue(), transformationTrieNode.getValue()) &&
-                   Objects.equals(getChildrenMap(), transformationTrieNode.getChildrenMap());
         }
 
         @SuppressWarnings("PMD.CompareObjectsWithEquals")
@@ -565,7 +550,6 @@ public class MessageHelpers {
      * Trie data structure of {@link Type.Record.Field}s to conversion functions used to coerce an object of a certain type into
      * an object of another type.
      */
-    @SuppressWarnings({"squid:S1206", "squid:S2160", "PMD.OverrideBothEqualsAndHashcode"})
     public static class CoercionTrieNode extends TrieNode<Integer, BiFunction<Descriptors.Descriptor, Object, Object>, CoercionTrieNode> {
         public CoercionTrieNode(@Nullable final BiFunction<Descriptors.Descriptor, Object, Object> value, @Nullable final Map<Integer, CoercionTrieNode> childrenMap) {
             super(value, childrenMap);
@@ -576,19 +560,5 @@ public class MessageHelpers {
         public CoercionTrieNode getThis() {
             return this;
         }
-
-        @Override
-        public boolean equals(final Object other) {
-            if (this == other) {
-                return true;
-            }
-            if (!(other instanceof CoercionTrieNode)) {
-                return false;
-            }
-            final CoercionTrieNode otherCoercionTrieNode = (CoercionTrieNode)other;
-            return Objects.equals(getValue(), otherCoercionTrieNode.getValue()) &&
-                   Objects.equals(getChildrenMap(), otherCoercionTrieNode.getChildrenMap());
-        }
-
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -558,11 +558,6 @@ public class MessageHelpers {
             }
             return nonNullableTest.apply(self, other);
         }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(getValue(), getChildrenMap());
-        }
     }
 
     /**
@@ -578,6 +573,19 @@ public class MessageHelpers {
         @Override
         public CoercionTrieNode getThis() {
             return this;
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof CoercionTrieNode)) {
+                return false;
+            }
+            final CoercionTrieNode otherCoercionTrieNode = (CoercionTrieNode)other;
+            return Objects.equals(getValue(), otherCoercionTrieNode.getValue()) &&
+                   Objects.equals(getChildrenMap(), otherCoercionTrieNode.getChildrenMap());
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -490,6 +490,7 @@ public class MessageHelpers {
     /**
      * Trie data structure of {@link Type.Record.Field}s to {@link Value}s.
      */
+    @SuppressWarnings({"squid:S1206", "squid:S2160", "PMD.OverrideBothEqualsAndHashcode"})
     public static class TransformationTrieNode extends TrieNode<Integer, Value, TransformationTrieNode> {
 
         public TransformationTrieNode(@Nullable final Value value, @Nullable final Map<Integer, TransformationTrieNode> childrenMap) {
@@ -564,6 +565,7 @@ public class MessageHelpers {
      * Trie data structure of {@link Type.Record.Field}s to conversion functions used to coerce an object of a certain type into
      * an object of another type.
      */
+    @SuppressWarnings({"squid:S1206", "squid:S2160", "PMD.OverrideBothEqualsAndHashcode"})
     public static class CoercionTrieNode extends TrieNode<Integer, BiFunction<Descriptors.Descriptor, Object, Object>, CoercionTrieNode> {
         public CoercionTrieNode(@Nullable final BiFunction<Descriptors.Descriptor, Object, Object> value, @Nullable final Map<Integer, CoercionTrieNode> childrenMap) {
             super(value, childrenMap);
@@ -587,5 +589,6 @@ public class MessageHelpers {
             return Objects.equals(getValue(), otherCoercionTrieNode.getValue()) &&
                    Objects.equals(getChildrenMap(), otherCoercionTrieNode.getChildrenMap());
         }
+
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.util;
 
 import com.apple.foundationdb.record.query.plan.cascades.TreeLike;
+import com.apple.foundationdb.record.query.plan.cascades.values.MessageHelpers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
@@ -29,6 +30,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -76,5 +78,23 @@ public abstract class TrieNode<D, T, N extends TrieNode<D, T, N>> implements Tre
         return Streams.stream(inPreOrder())
                 .flatMap(trie -> trie.getValue() == null ? Stream.of() : Stream.of(trie.getValue()))
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof TrieNode)) {
+            return false;
+        }
+        final TrieNode<?, ?, ?> otherTrieNode = (TrieNode<?, ?, ?>)other;
+        return Objects.equals(getValue(), otherTrieNode.getValue()) &&
+               Objects.equals(getChildrenMap(), otherTrieNode.getChildrenMap());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue(), getChildrenMap());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.util;
 
 import com.apple.foundationdb.record.query.plan.cascades.TreeLike;
-import com.apple.foundationdb.record.query.plan.cascades.values.MessageHelpers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
@@ -84,7 +84,10 @@ public abstract class TrieNode<D, T, N extends TrieNode<D, T, N>> implements Tre
         if (this == other) {
             return true;
         }
-        if (!(other instanceof TrieNode)) {
+        if (other == null) {
+            return false;
+        }
+        if (getClass() != other.getClass()) {
             return false;
         }
         final TrieNode<?, ?, ?> otherTrieNode = (TrieNode<?, ?, ?>)other;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelperTests.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelperTests.java
@@ -1,5 +1,5 @@
 /*
- * TransformationTrieNodeTests.java
+ * MessageHelperTests.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelperTests.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelperTests.java
@@ -1,0 +1,172 @@
+/*
+ * TransformationTrieNodeTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.values;
+
+import com.apple.foundationdb.record.TestRecordsTransformProto;
+import com.apple.foundationdb.record.query.plan.cascades.PromoteValue;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+/**
+ * Tests for {@link MessageHelpers.TransformationTrieNode} and {@link MessageHelpers.CoercionTrieNode} hashing
+ * and equality semantics.
+ */
+public class MessageHelperTests {
+
+    private static Type.Record someRecordType() {
+        final var aaType = Type.Record.fromFields(ImmutableList.of(
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("aaa")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("aab")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("aac"))));
+
+        final var aType = Type.Record.fromFields(ImmutableList.of(
+                Type.Record.Field.of(aaType, Optional.of("aa")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("ab")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("ac"))));
+
+        final var xType = Type.Record.fromFields(ImmutableList.of(
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("xa")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("xb")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("xc"))));
+
+        return Type.Record.fromFields(ImmutableList.of(
+                Type.Record.Field.of(aType, Optional.of("a")),
+                Type.Record.Field.of(xType, Optional.of("x")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("z"))));
+    }
+
+    private static Type.Record someOtherRecordType() {
+        final var bbType = Type.Record.fromFields(ImmutableList.of(
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("bba")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("bbb")),
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("bbc"))));
+
+        return Type.Record.fromFields(ImmutableList.of(
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("z")),
+                Type.Record.Field.of(bbType, Optional.of("a"))));
+    }
+
+    private static MessageHelpers.CoercionTrieNode someCoercionTrieNode() {
+        final var recordType = someRecordType();
+        final var inValue = QuantifiedObjectValue.of(Quantifier.current(), recordType);
+        final var a_aa_aaa = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "aa", "aaa"));
+        final var a_aa_aab = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "aa", "aab"));
+        final var a_ab = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "ab"));
+
+        final var transformMap =
+                ImmutableMap.<FieldValue.FieldPath, Value>of(a_aa_aaa.getFieldPath(), new LiteralValue<>("1"),
+                        a_aa_aab.getFieldPath(), new LiteralValue<>(2),
+                        a_ab.getFieldPath(), new LiteralValue<>(3));
+
+        final var coercedType = Type.Record.fromDescriptor(TestRecordsTransformProto.TransformMessageMaxTypes.getDescriptor());
+        final var transformationsTrie =
+                RecordQueryUpdatePlan.computeTrieForFieldPaths(RecordQueryUpdatePlan.checkAndPrepareOrderedFieldPaths(transformMap),
+                        transformMap);
+
+        return PromoteValue.computePromotionsTrie(coercedType, inValue.getResultType(), transformationsTrie);
+    }
+
+    private static MessageHelpers.CoercionTrieNode someOtherCoercionTrieNode() {
+        final var recordType = someOtherRecordType();
+        final var inValue = QuantifiedObjectValue.of(Quantifier.current(), recordType);
+        final var a_bbb = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "bbb"));
+
+        final var transformMap = ImmutableMap.<FieldValue.FieldPath, Value>of(a_bbb.getFieldPath(), new LiteralValue<>(1.0d));
+
+        final var coercedType = Type.Record.fromDescriptor(TestRecordsTransformProto.OtherTransformMessageMaxTypes.getDescriptor());
+        final var transformationsTrie =
+                RecordQueryUpdatePlan.computeTrieForFieldPaths(RecordQueryUpdatePlan.checkAndPrepareOrderedFieldPaths(transformMap),
+                        transformMap);
+
+        return PromoteValue.computePromotionsTrie(coercedType, inValue.getResultType(), transformationsTrie);
+    }
+
+    private static MessageHelpers.TransformationTrieNode someTransformationTrieNode() {
+        final var recordType = someRecordType();
+        final var inValue = QuantifiedObjectValue.of(Quantifier.current(), recordType);
+        final var a_aa_aaa = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "aa", "aaa"));
+        final var a_aa_aab = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "aa", "aab"));
+        final var a_ab = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "ab"));
+
+        final var transformMap = ImmutableMap.<FieldValue.FieldPath, Value>of(a_aa_aaa.getFieldPath(), new LiteralValue<>("1"),
+                        a_aa_aab.getFieldPath(), new LiteralValue<>(2),
+                        a_ab.getFieldPath(), new LiteralValue<>(3));
+
+        return RecordQueryUpdatePlan.computeTrieForFieldPaths(RecordQueryUpdatePlan.checkAndPrepareOrderedFieldPaths(transformMap),
+                        transformMap);
+    }
+
+    private static MessageHelpers.TransformationTrieNode someOtherTransformationTrieNode() {
+        final var recordType = someOtherRecordType();
+        final var inValue = QuantifiedObjectValue.of(Quantifier.current(), recordType);
+        final var a_bba = FieldValue.ofFieldNames(inValue, ImmutableList.of("a", "bba"));
+
+        final var transformMap = ImmutableMap.<FieldValue.FieldPath, Value>of(a_bba.getFieldPath(), new LiteralValue<>("1"));
+
+        return RecordQueryUpdatePlan.computeTrieForFieldPaths(RecordQueryUpdatePlan.checkAndPrepareOrderedFieldPaths(transformMap),
+                transformMap);
+    }
+
+    @Test
+    public void testSelfEqualityAndHashCodeTransformationTrieNode() {
+        final var transformTrie = someTransformationTrieNode();
+        Assertions.assertEquals(transformTrie.hashCode(), transformTrie.hashCode());
+        Assertions.assertEquals(transformTrie, transformTrie);
+    }
+
+    @Test
+    public void testSelfEqualityAndHashCodeCoercionTrieNode() {
+        final var coercionNode = someCoercionTrieNode();
+        Assertions.assertEquals(coercionNode.hashCode(), coercionNode.hashCode());
+        Assertions.assertEquals(coercionNode, coercionNode);
+    }
+
+    @Test
+    public void testEqualityWithOtherTransformationTrieNode() {
+        final var transformTrie = someTransformationTrieNode();
+        final var sameTransformTrie = someTransformationTrieNode();
+        final var differentTransformTie = someOtherTransformationTrieNode();
+
+        Assertions.assertEquals(transformTrie.hashCode(), sameTransformTrie.hashCode());
+        Assertions.assertEquals(transformTrie, sameTransformTrie);
+
+        Assertions.assertNotEquals(differentTransformTie, transformTrie);
+    }
+
+    @Test
+    public void testEqualityWithOtherCoercionTrieNode() {
+        final var coercionTrie = someCoercionTrieNode();
+        final var sameCoercionTrie = someCoercionTrieNode();
+        final var differentCoercionTie = someOtherCoercionTrieNode();
+
+        Assertions.assertEquals(coercionTrie.hashCode(), sameCoercionTrie.hashCode());
+        Assertions.assertEquals(coercionTrie, sameCoercionTrie);
+
+        Assertions.assertNotEquals(differentCoercionTie, coercionTrie);
+    }
+}

--- a/fdb-record-layer-core/src/test/proto/test_records_transform.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_transform.proto
@@ -73,3 +73,14 @@ message TransformMessageMaxTypes {
   required MessageX x = 2;
   required string z = 3;
 }
+
+message OtherTransformMessageMaxTypes {
+  message MessageB {
+    required string bba = 1;
+    required double bbb = 2;
+    optional string bbc = 3;
+  }
+
+  required string z = 1;
+  required MessageB a = 2;
+}


### PR DESCRIPTION
The hash code calculation of the `RecordQueryAbstractDataModificationPlan` is not stable. This is causing discrepancies in the optimiser choosing optimal `UPDATE` plans pseudo-randomly when multiple equivalent alternatives exist and the plan hash code is used as a costing tie-breaker.

This happens because the `MessageHelpers#CoercionTrieNode` class does not override `equals` and `hashCode`, despite it being used in `computeHashCodeWithoutChildren` of `RecordQueryAbstractDataModificationPlan`.

The provided fix implements `hashCode` and `equals` properly for this class, and adds a number of unit tests for equality and hash code calculation for `MessageHelpers#CoercionTrieNode` and `MessageHelpers#TransformationTrieNode`, it also adds an integration test for that examines the stability of plan hash of an `UPDATE` plan (which leverages the `RecordQueryAbstractDataModificationPlan` physical operator).

This fixes #2325.