### PR TITLE
Enfoce limit checks when iterating over a new record.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiter.java
@@ -51,6 +51,8 @@ public interface RecordScanLimiter {
      */
     boolean tryRecordScan();
 
+    public boolean isStopped();
+
     /**
      * Get the record scan limit. In particular, this will return the target
      * number of records that this limiter is being used to enforce.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiterFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordScanLimiterFactory.java
@@ -89,6 +89,11 @@ public class RecordScanLimiterFactory {
         }
 
         @Override
+        public boolean isStopped() {
+            return allowedRecordScansRemaining.get() <= 0;
+        }
+
+        @Override
         public int getLimit() {
             return originalLimit;
         }
@@ -128,6 +133,11 @@ public class RecordScanLimiterFactory {
         }
 
         @Override
+        public boolean isStopped() {
+            return false;
+        }
+
+        @Override
         public int getLimit() {
             return Integer.MAX_VALUE;
         }
@@ -161,6 +171,11 @@ public class RecordScanLimiterFactory {
         @Override
         public boolean tryRecordScan() {
             return true;
+        }
+
+        @Override
+        public boolean isStopped() {
+            return false;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/CursorLimitManager.java
@@ -111,6 +111,10 @@ public class CursorLimitManager {
      * @return a reason for a limit that has been exceeded or <code>Optional.empty()</code> if no limit has been exceeded
      */
     public Optional<RecordCursor.NoNextReason> getStoppedReason() {
+        haltedDueToRecordScanLimit = recordScanLimiter != null && recordScanLimiter.isStopped()
+                                     && (usedInitialPass || failOnScanLimitReached);
+        haltedDueToByteScanLimit = byteScanLimiter != null && !byteScanLimiter.hasBytesRemaining() && usedInitialPass;
+        haltedDueToTimeLimit = timeScanLimiter != null && !timeScanLimiter.tryRecordScan() && usedInitialPass;
         if (haltedDueToRecordScanLimit) {
             return SCAN_LIMIT_REACHED;
         } else if (haltedDueToByteScanLimit) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -880,18 +880,6 @@ public class SplitHelper {
                         });
                     }
 
-                    if (limitManager.isStopped()) {
-                        final NoNextReason noNextReason = mergeNoNextReason();
-                        if (noNextReason.isSourceExhausted()) {
-                            // Can happen if the limit is reached while reading the final record, so the inner cursor
-                            // completes with SOURCE_EXHAUSTED
-                            nextResult = RecordCursorResult.exhausted();
-                        } else {
-                            nextResult = RecordCursorResult.withoutNextValue(continuation, mergeNoNextReason());
-                        }
-                        return nextResult;
-                    }
-
                     if (next == null) { // no next result
                         nextResult = RecordCursorResult.withoutNextValue(continuation, mergeNoNextReason());
                         if (LOGGER.isTraceEnabled()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -880,6 +880,18 @@ public class SplitHelper {
                         });
                     }
 
+                    if (limitManager.isStopped()) {
+                        final NoNextReason noNextReason = mergeNoNextReason();
+                        if (noNextReason.isSourceExhausted()) {
+                            // Can happen if the limit is reached while reading the final record, so the inner cursor
+                            // completes with SOURCE_EXHAUSTED
+                            nextResult = RecordCursorResult.exhausted();
+                        } else {
+                            nextResult = RecordCursorResult.withoutNextValue(continuation, mergeNoNextReason());
+                        }
+                        return nextResult;
+                    }
+
                     if (next == null) { // no next result
                         nextResult = RecordCursorResult.withoutNextValue(continuation, mergeNoNextReason());
                         if (LOGGER.isTraceEnabled()) {


### PR DESCRIPTION
It broke the following tests:

```
[FDBRecordStoreIndexTest](classes/com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreIndexTest.html). [testIndexMissingValidation()](classes/com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreIndexTest.html#testIndexMissingValidation())
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2, readLimit = 1, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[10])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2, readLimit = 2, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[11])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2, readLimit = 2, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[12])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2, readLimit = 7, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[13])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2, readLimit = 7, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[14])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 7, readLimit = 1, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[17])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 7, readLimit = 1, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[18])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 7, readLimit = 2, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[19])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 1, readLimit = 1, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[1])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 7, readLimit = 2, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[20])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 7, readLimit = 7, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[21])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 7, readLimit = 7, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[22])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2147483647, readLimit = 1, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[25])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2147483647, readLimit = 1, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[26])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2147483647, readLimit = 2, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[27])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2147483647, readLimit = 2, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[28])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2147483647, readLimit = 7, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[29])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 1, readLimit = 1, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[2])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2147483647, readLimit = 7, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[30])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 1, readLimit = 2, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[3])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 1, readLimit = 2, reverse = true]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[4])
- [SplitHelperTest](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html). [scanContinuations [returnLimit = 2, readLimit = 1, reverse = false]](classes/com.apple.foundationdb.record.provider.foundationdb.SplitHelperTest.html#scanContinuations(int, int, boolean)[9])
- [SortCursorTests](classes/com.apple.foundationdb.record.provider.foundationdb.cursors.SortCursorTests.html). [memoryDamContinuations()](classes/com.apple.foundationdb.record.provider.foundationdb.cursors.SortCursorTests.html#memoryDamContinuations())
- [SortCursorTests](classes/com.apple.foundationdb.record.provider.foundationdb.cursors.SortCursorTests.html). [memorySortContinuations()](classes/com.apple.foundationdb.record.provider.foundationdb.cursors.SortCursorTests.html#memorySortContinuations())
- [FDBRecordStoreByteLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html). [[1] false](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html#testHitExhaustedDuringSplit(boolean)[1])
- [FDBRecordStoreByteLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html). [[2] true](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html#testHitExhaustedDuringSplit(boolean)[2])
- [FDBRecordStoreByteLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html). [plansByContinuation() [1] full record scan](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html#testPlansReturnSameRecordsRegardlessOfLimit(String, boolean, RecordQueryPlan)[1])
- [FDBRecordStoreByteLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html). [plansByContinuation() [4] filter on scan plan](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html#testPlansReturnSameRecordsRegardlessOfLimit(String, boolean, RecordQueryPlan)[4])
- [FDBRecordStoreByteLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html). [plansByContinuation() [6] type filter on scan plan](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html#testPlansReturnSameRecordsRegardlessOfLimit(String, boolean, RecordQueryPlan)[6])
- [FDBRecordStoreByteLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html). [testSplitContinuation()](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreByteLimitTest.html#testSplitContinuation())
- [FDBRecordStoreScanLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html). [plansByContinuation() [1] full record scan](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html#plansByContinuation(String, boolean, RecordQueryPlan)[1])
- [FDBRecordStoreScanLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html). [plansByContinuation() [4] filter on scan plan](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html#plansByContinuation(String, boolean, RecordQueryPlan)[4])
- [FDBRecordStoreScanLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html). [plansByContinuation() [6] type filter on scan plan](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html#plansByContinuation(String, boolean, RecordQueryPlan)[6])
- [FDBRecordStoreScanLimitTest](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html). [testSplitContinuation()](classes/com.apple.foundationdb.record.provider.foundationdb.limits.FDBRecordStoreScanLimitTest.html#testSplitContinuation())
```