### PR TITLE
Resolves #2333: Lucene: add metric to measure Lucene's find merges

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Lucene: add metric to measure Lucene's find merges [(Issue #2333)](https://github.com/FoundationDB/fdb-record-layer/issues/2333)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -57,7 +57,9 @@ public class LuceneEvents {
         /** Number of documents returned from a single Lucene spellcheck scan. */
         LUCENE_SPELLCHECK_SCAN("lucene search returned spellcheck suggestions"),
         /** Number of merge calls to the FDBDirectory. */
-        LUCENE_MERGE("Lucene merge")
+        LUCENE_MERGE("Lucene merge"),
+        /** Number of find merge calls (calculation of lucene's required merges). */
+        LUCENE_FIND_MERGES("Lucene find merges"),
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -152,7 +152,7 @@ class FDBDirectoryWrapper implements AutoCloseable {
             synchronized (this) {
                 if (writer == null || !writerAnalyzerId.equals(analyzerWrapper.getUniqueIdentifier())) {
                     final IndexDeferredMaintenancePolicy deferredMergePolicy = state.store.getIndexDeferredMaintenancePolicy();
-                    TieredMergePolicy tieredMergePolicy = new FDBTieredMergePolicy(deferredMergePolicy.shouldAutoMergeDuringCommit())
+                    TieredMergePolicy tieredMergePolicy = new FDBTieredMergePolicy(deferredMergePolicy.shouldAutoMergeDuringCommit(), state.context)
                             .setMaxMergedSegmentMB(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_MAX_SIZE))
                             .setSegmentsPerTier(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER));
                     tieredMergePolicy.setNoCFSRatio(1.00);


### PR DESCRIPTION
   Add `LUCENE_FIND_MERGES` matric.