### PR TITLE
mutateRecord in RecordQueryAbstractDataModificationPlan fails when underlying metadata ref changes.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** mutateRecord in RecordQueryAbstractDataModificationPlan fails when underlying metadata ref changes. [(Issue #2337)](https://github.com/FoundationDB/fdb-record-layer/issues/2337)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/InsertExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/InsertExpression.java
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.protobuf.Descriptors;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -58,20 +57,16 @@ public class InsertExpression implements RelationalExpressionWithChildren, Plann
     private final String targetRecordType;
     @Nonnull
     private final Type.Record targetType;
-    @Nonnull
-    private final Descriptors.Descriptor targetDescriptor;
 
     @Nonnull
     private final Value resultValue;
 
     public InsertExpression(@Nonnull final Quantifier.ForEach inner,
                             @Nonnull final String targetRecordType,
-                            @Nonnull final Type.Record targetType,
-                            @Nonnull final Descriptors.Descriptor targetDescriptor) {
+                            @Nonnull final Type.Record targetType) {
         this.inner = inner;
         this.targetRecordType = targetRecordType;
         this.targetType = targetType;
-        this.targetDescriptor = targetDescriptor;
         this.resultValue = new QueriedValue(targetType);
     }
 
@@ -96,7 +91,7 @@ public class InsertExpression implements RelationalExpressionWithChildren, Plann
     @Nonnull
     @Override
     public InsertExpression translateCorrelations(@Nonnull final TranslationMap translationMap, @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
-        return new InsertExpression(inner, targetRecordType, targetType, targetDescriptor);
+        return new InsertExpression(inner, targetRecordType, targetType);
     }
 
     @Nonnull
@@ -111,7 +106,6 @@ public class InsertExpression implements RelationalExpressionWithChildren, Plann
         return RecordQueryInsertPlan.insertPlan(physicalInner,
                 targetRecordType,
                 targetType,
-                targetDescriptor,
                 makeComputationValue(targetType));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/UpdateExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/UpdateExpression.java
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.protobuf.Descriptors;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -69,8 +68,6 @@ public class UpdateExpression implements RelationalExpressionWithChildren, Plann
     private final String targetRecordType;
     @Nonnull
     private final Type.Record targetType;
-    @Nonnull
-    private final Descriptors.Descriptor targetDescriptor;
 
     @Nonnull
     private final Value resultValue;
@@ -87,12 +84,10 @@ public class UpdateExpression implements RelationalExpressionWithChildren, Plann
     public UpdateExpression(@Nonnull final Quantifier.ForEach inner,
                             @Nonnull final String targetRecordType,
                             @Nonnull final Type.Record targetType,
-                            @Nonnull final Descriptors.Descriptor targetDescriptor,
                             @Nonnull final Map<FieldValue.FieldPath, Value> transformMap) {
         this.inner = inner;
         this.targetRecordType = targetRecordType;
         this.targetType = targetType;
-        this.targetDescriptor = targetDescriptor;
         this.resultValue = new QueriedValue(computeResultType(inner.getFlowedObjectType(), targetType));
         this.transformMap = ImmutableMap.copyOf(transformMap);
         this.correlatedToWithoutChildrenSupplier = Suppliers.memoize(this::computeCorrelatedToWithoutChildren);
@@ -136,7 +131,7 @@ public class UpdateExpression implements RelationalExpressionWithChildren, Plann
         for (final var entry : transformMap.entrySet()) {
             translatedTransformMapBuilder.put(entry.getKey(), entry.getValue().translateCorrelations(translationMap));
         }
-        return new UpdateExpression(inner, targetRecordType, targetType, targetDescriptor, translatedTransformMapBuilder.build());
+        return new UpdateExpression(inner, targetRecordType, targetType, translatedTransformMapBuilder.build());
     }
 
     @Nonnull
@@ -151,7 +146,6 @@ public class UpdateExpression implements RelationalExpressionWithChildren, Plann
         return RecordQueryUpdatePlan.updatePlan(physicalInner,
                 targetRecordType,
                 targetType,
-                targetDescriptor,
                 transformMap,
                 makeComputationValue(physicalInner, targetType));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInsertPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInsertPlan.java
@@ -39,7 +39,6 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,10 +63,9 @@ public class RecordQueryInsertPlan extends RecordQueryAbstractDataModificationPl
     private RecordQueryInsertPlan(@Nonnull final Quantifier.Physical inner,
                                   @Nonnull final String recordType,
                                   @Nonnull final Type.Record targetType,
-                                  @Nonnull final Descriptors.Descriptor targetDescriptor,
                                   @Nullable final MessageHelpers.CoercionTrieNode coercionsTrie,
                                   @Nonnull final Value computationValue) {
-        super(inner, recordType, targetType, targetDescriptor, null, coercionsTrie, computationValue);
+        super(inner, recordType, targetType, null, coercionsTrie, computationValue);
     }
 
     @Override
@@ -93,7 +91,6 @@ public class RecordQueryInsertPlan extends RecordQueryAbstractDataModificationPl
                 Iterables.getOnlyElement(translatedQuantifiers).narrow(Quantifier.Physical.class),
                 getTargetRecordType(),
                 getTargetType(),
-                getTargetDescriptor(),
                 getCoercionTrie(),
                 getComputationValue());
     }
@@ -104,7 +101,6 @@ public class RecordQueryInsertPlan extends RecordQueryAbstractDataModificationPl
         return new RecordQueryInsertPlan(Quantifier.physical(childRef),
                 getTargetRecordType(),
                 getTargetType(),
-                getTargetDescriptor(),
                 getCoercionTrie(),
                 getComputationValue());
     }
@@ -157,7 +153,6 @@ public class RecordQueryInsertPlan extends RecordQueryAbstractDataModificationPl
      * @param inner an input value to transform
      * @param recordType the name of the record type this update modifies
      * @param targetType a target type to coerce the current record to prior to the update
-     * @param targetDescriptor a descriptor to coerce the current record to prior to the update
      * @param computationValue a value to be computed based on the {@code inner} and
      * {@link RecordQueryAbstractDataModificationPlan#currentModifiedRecordAlias()}
      *
@@ -167,12 +162,10 @@ public class RecordQueryInsertPlan extends RecordQueryAbstractDataModificationPl
     public static RecordQueryInsertPlan insertPlan(@Nonnull final Quantifier.Physical inner,
                                                    @Nonnull final String recordType,
                                                    @Nonnull final Type.Record targetType,
-                                                   @Nonnull final Descriptors.Descriptor targetDescriptor,
                                                    @Nonnull final Value computationValue) {
         return new RecordQueryInsertPlan(inner,
                 recordType,
                 targetType,
-                targetDescriptor,
                 PromoteValue.computePromotionsTrie(targetType, inner.getFlowedObjectType(), null),
                 computationValue);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUpdatePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUpdatePlan.java
@@ -46,7 +46,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,11 +72,10 @@ public class RecordQueryUpdatePlan extends RecordQueryAbstractDataModificationPl
     private RecordQueryUpdatePlan(@Nonnull final Quantifier.Physical inner,
                                   @Nonnull final String targetRecordType,
                                   @Nonnull final Type.Record targetType,
-                                  @Nonnull final Descriptors.Descriptor targetDescriptor,
                                   @Nullable final TransformationTrieNode transformationsTrie,
                                   @Nullable final MessageHelpers.CoercionTrieNode coercionsTrie,
                                   @Nonnull final Value computationValue) {
-        super(inner, targetRecordType, targetType, targetDescriptor, transformationsTrie, coercionsTrie, computationValue);
+        super(inner, targetRecordType, targetType, transformationsTrie, coercionsTrie, computationValue);
     }
 
     @Override
@@ -103,7 +101,6 @@ public class RecordQueryUpdatePlan extends RecordQueryAbstractDataModificationPl
                 Iterables.getOnlyElement(translatedQuantifiers).narrow(Quantifier.Physical.class),
                 getTargetRecordType(),
                 getTargetType(),
-                getTargetDescriptor(),
                 translateTransformationsTrie(translationMap),
                 getCoercionTrie(),
                 getComputationValue().translateCorrelations(translationMap));
@@ -141,7 +138,6 @@ public class RecordQueryUpdatePlan extends RecordQueryAbstractDataModificationPl
         return new RecordQueryUpdatePlan(Quantifier.physical(childRef),
                 getTargetRecordType(),
                 getTargetType(),
-                getTargetDescriptor(),
                 getTransformationsTrie(),
                 getCoercionTrie(),
                 getComputationValue());
@@ -207,7 +203,6 @@ public class RecordQueryUpdatePlan extends RecordQueryAbstractDataModificationPl
      * @param inner an input value to transform
      * @param targetRecordType the name of the record type this update modifies
      * @param targetType a target type to coerce the current record to prior to the update
-     * @param targetDescriptor a descriptor to coerce the current record to prior to the update
      * @param transformMap a map of field paths to values.
      * @param computationValue a value to be computed based on the {@code inner} and
      *        {@link RecordQueryAbstractDataModificationPlan#currentModifiedRecordAlias()}
@@ -217,14 +212,12 @@ public class RecordQueryUpdatePlan extends RecordQueryAbstractDataModificationPl
     public static RecordQueryUpdatePlan updatePlan(@Nonnull final Quantifier.Physical inner,
                                                    @Nonnull final String targetRecordType,
                                                    @Nonnull final Type.Record targetType,
-                                                   @Nonnull final Descriptors.Descriptor targetDescriptor,
                                                    @Nonnull final Map<FieldValue.FieldPath, Value> transformMap,
                                                    @Nonnull final Value computationValue) {
         final var transformationsTrie = computeTrieForFieldPaths(checkAndPrepareOrderedFieldPaths(transformMap), transformMap);
         return new RecordQueryUpdatePlan(inner,
                 targetRecordType,
                 targetType,
-                targetDescriptor,
                 transformationsTrie,
                 PromoteValue.computePromotionsTrie(targetType, inner.getFlowedObjectType(), transformationsTrie),
                 computationValue);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBModificationQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBModificationQueryTest.java
@@ -372,8 +372,7 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
 
         qun = Quantifier.forEach(GroupExpressionRef.of(new InsertExpression(qun,
                 "RestaurantRecord",
-                Type.Record.fromDescriptor(TestRecords4Proto.RestaurantRecord.getDescriptor()),
-                TestRecords4Proto.RestaurantRecord.getDescriptor())));
+                Type.Record.fromDescriptor(TestRecords4Proto.RestaurantRecord.getDescriptor()))));
         return GroupExpressionRef.of(new LogicalSortExpression(ImmutableList.of(), false, qun));
     }
 
@@ -416,8 +415,7 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
 
                     qun = Quantifier.forEach(GroupExpressionRef.of(new InsertExpression(qun,
                             "RestaurantRecord",
-                            Type.Record.fromDescriptor(TestRecords4Proto.RestaurantRecord.getDescriptor()),
-                            TestRecords4Proto.RestaurantRecord.getDescriptor())));
+                            Type.Record.fromDescriptor(TestRecords4Proto.RestaurantRecord.getDescriptor()))));
                     return GroupExpressionRef.of(new LogicalSortExpression(ImmutableList.of(), false, qun));
                 },
                 Optional.empty(),
@@ -523,7 +521,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                         qun = Quantifier.forEach(GroupExpressionRef.of(new UpdateExpression(qun,
                                 "RestaurantRecord",
                                 restaurantType,
-                                TestRecords4Proto.RestaurantRecord.getDescriptor(),
                                 ImmutableMap.of(updatePath, updateValue))));
 
                         return GroupExpressionRef.of(new LogicalSortExpression(ImmutableList.of(), false, qun));
@@ -718,7 +715,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                         final var innerQun = Quantifier.existential(GroupExpressionRef.of(new UpdateExpression(qun,
                                 "RestaurantRecord",
                                 restaurantType,
-                                TestRecords4Proto.RestaurantRecord.getDescriptor(),
                                 ImmutableMap.of(namePath, LiteralValue.ofScalar("McDonald's")))));
 
                         graphExpansionBuilder = GraphExpansion.builder();
@@ -729,8 +725,7 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
 
                         qun = Quantifier.forEach(GroupExpressionRef.of(new InsertExpression(qun,
                                 "RestaurantRecord",
-                                Type.Record.fromDescriptor(TestRecords4Proto.RestaurantRecord.getDescriptor()),
-                                TestRecords4Proto.RestaurantRecord.getDescriptor())));
+                                Type.Record.fromDescriptor(TestRecords4Proto.RestaurantRecord.getDescriptor()))));
 
                         return GroupExpressionRef.of(new LogicalSortExpression(ImmutableList.of(), false, qun));
                     },
@@ -836,7 +831,6 @@ public class FDBModificationQueryTest extends FDBRecordStoreQueryTestBase {
                     qun = Quantifier.forEach(GroupExpressionRef.of(new UpdateExpression(qun,
                             "RestaurantReviewer",
                             reviewerType,
-                            TestRecords4Proto.RestaurantReviewer.getDescriptor(),
                             ImmutableMap.of(updatePath, updateValue))));
 
                     return GroupExpressionRef.of(new LogicalSortExpression(ImmutableList.of(), false, qun));


### PR DESCRIPTION
fixes #2337