### PR TITLE
Resolves #2336: PlanOrderingKey.mergedComparisonKey too strict about fields between requested ordering and primary key

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** The old planner chooses a better plan ordering key for union comparisons to allow ordered union plans in more cases [(Issue #2336)](https://github.com/FoundationDB/fdb-record-layer/issues/2336)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -1797,14 +1797,7 @@ public class RecordQueryPlanner implements QueryPlanner {
 
     @Nullable
     private ScoredPlan planOrderedUnion(@Nonnull PlanContext planContext, @Nonnull List<ScoredPlan> subplans) {
-        final KeyExpression sort = planContext.query.getSort();
-        KeyExpression candidateKey = planContext.commonPrimaryKey;
-        boolean candidateOnly = false;
-        if (sort != null) {
-            candidateKey = getKeyForMerge(sort, candidateKey);
-            candidateOnly = true;
-        }
-        KeyExpression comparisonKey = PlanOrderingKey.mergedComparisonKey(subplans, candidateKey, candidateOnly);
+        KeyExpression comparisonKey = PlanOrderingKey.mergedComparisonKey(subplans, planContext.query.getSort(), false);
         if (comparisonKey == null) {
             return null;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -2349,7 +2349,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
                     queryComplexDocumentsWithOr((OrComponent) Query.or(
                             Query.field("text").text().containsAll("unit named after"),
                             Query.field("text").text().containsPhrase("אן ארמיי און פלאט")
-                    ), 0, -1558384887));
+                    ), 0, -396375489));
 
             assertEquals(Collections.singletonList(Tuple.from(1L, 5L)),
                     queryComplexDocumentsWithIndex(


### PR DESCRIPTION
This adjusts the way the plan ordering key is constructed for unions and intersections so that it can accept additional columns in the order. Effectively, in the case where you have an index on `[a, b, c, d]` with an equality on `a`, a disjunct of equalities on `b`, and a primary key `k` (the hypothetical raised in the original issue), then this will construct an ordered union between multiple scans of the index (one leg for each member of the disjunction on `b`) and will use the comparison key `[c, d, k]` to ensure that the results are processed in an expected order.

This resolves #2336.