### PR TITLE
Fixes #2353: DualPlannerTests are only running old planner if also marked as parameterized

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -72,7 +72,7 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
     protected FDBDatabase fdb;
     protected FDBRecordStore recordStore;
     protected FDBStoreTimer timer = new FDBStoreTimer();
-    protected boolean useRewritePlanner = false;
+    protected boolean useCascadesPlanner = false;
     protected QueryPlanner planner;
     protected final KeySpacePath path;
 
@@ -195,12 +195,12 @@ public abstract class FDBRecordStoreTestBase extends FDBTestBase {
         setupPlanner(null);
     }
 
-    public void setUseRewritePlanner(boolean useRewritePlanner) {
-        this.useRewritePlanner = useRewritePlanner;
+    public void setUseCascadesPlanner(boolean useCascadesPlanner) {
+        this.useCascadesPlanner = useCascadesPlanner;
     }
 
     public void setupPlanner(@Nullable PlannableIndexTypes indexTypes) {
-        if (useRewritePlanner) {
+        if (useCascadesPlanner) {
             planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
             if (Debugger.getDebugger() == null) {
                 Debugger.setDebugger(new DebuggerWithSymbolTables());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
@@ -57,7 +57,7 @@ public class QueryPlanFullySortedTest extends FDBRecordStoreQueryTestBase {
             hook.apply(builder);
         }
         metaData = builder.getRecordMetaData();
-        planner = useRewritePlanner ?
+        planner = useCascadesPlanner ?
                   new CascadesPlanner(metaData, new RecordStoreState(null, null)) :
                   new RecordQueryPlanner(metaData, new RecordStoreState(null, null));
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanResultTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanResultTest.java
@@ -43,7 +43,7 @@ public class QueryPlanResultTest extends FDBRecordStoreQueryTestBase {
 
     @BeforeEach
     public void setup() throws Exception {
-        setUseRewritePlanner(true);
+        setUseCascadesPlanner(true);
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/PlanComplexityExceededTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/PlanComplexityExceededTest.java
@@ -47,7 +47,7 @@ public class PlanComplexityExceededTest extends FDBRecordStoreQueryTestBase {
 
     @BeforeEach
     public void setup() throws Exception {
-        useRewritePlanner = true;
+        useCascadesPlanner = true;
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
         cascadesPlanner = (CascadesPlanner)planner;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -208,7 +208,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
     @Override
     public void setupPlanner(@Nullable PlannableIndexTypes indexTypes) {
-        if (useRewritePlanner) {
+        if (useCascadesPlanner) {
             planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
         } else {
             if (indexTypes == null) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenOnlineIndexingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenOnlineIndexingTest.java
@@ -94,7 +94,7 @@ class LucenOnlineIndexingTest extends FDBRecordStoreTestBase {
 
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useRewritePlanner);
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useCascadesPlanner);
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -2898,7 +2898,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
     }
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useRewritePlanner);
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useCascadesPlanner);
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
@@ -118,23 +118,17 @@ public class LuceneIndexTestUtils {
                 .build();
     }
 
-    static Pair<FDBRecordStore, QueryPlanner> rebuildIndexMetaData(final FDBRecordContext context,
-                                                                   final KeySpacePath path,
-                                                                   final String document,
-                                                                   final Index index) {
-        return rebuildIndexMetaData(context, path, document, index, false);
-    }
-
     public static Pair<FDBRecordStore, QueryPlanner> rebuildIndexMetaData(final FDBRecordContext context,
                                                                           final KeySpacePath path,
                                                                           final String document,
-                                                                          final Index index, boolean useRewritePlanner) {
+                                                                          final Index index,
+                                                                          boolean useCascadesPlanner) {
         FDBRecordStore store = openRecordStore(context, path, metaDataBuilder -> {
             metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
             metaDataBuilder.addIndex(document, index);
         });
 
-        QueryPlanner planner = setupPlanner(store, null, useRewritePlanner);
+        QueryPlanner planner = setupPlanner(store, null, useCascadesPlanner);
         return Pair.of(store, planner);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
@@ -77,7 +77,7 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
 
     @Override
     public void setupPlanner(@Nullable PlannableIndexTypes indexTypes) {
-        if (useRewritePlanner) {
+        if (useCascadesPlanner) {
             planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
         } else {
             if (indexTypes == null) {
@@ -110,7 +110,7 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
 
     @Test
     void selectsFromMultipleIndexes() throws Exception {
-        useRewritePlanner = false;
+        useCascadesPlanner = false;
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, metaData -> {
                 metaData.addIndex(TextIndexTestUtils.COMPLEX_DOC, textIndex);
@@ -132,7 +132,7 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
 
     @Test
     void selectsFromMultipleNestedIndexes() throws Exception {
-        useRewritePlanner = false;
+        useCascadesPlanner = false;
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, metaData -> {
                 metaData.addIndex(TextIndexTestUtils.COMPLEX_DOC, new Index(nestedDualIndex.toProto()));
@@ -154,7 +154,7 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
 
     @Test
     void notLucene() throws Exception {
-        useRewritePlanner = false;
+        useCascadesPlanner = false;
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, metaData -> {
                 metaData.addIndex(TextIndexTestUtils.COMPLEX_DOC, new Index(nestedDualIndex.toProto()));

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
@@ -360,7 +360,7 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
     }
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useRewritePlanner);
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useCascadesPlanner);
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/FDBLuceneHighlightingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/FDBLuceneHighlightingTest.java
@@ -381,7 +381,7 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
 
     @SuppressWarnings("SameParameterValue") //deliberately placed here to make it easier to add new tests
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useRewritePlanner);
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useCascadesPlanner);
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -224,7 +224,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
 
     @Override
     public void setupPlanner(@Nullable PlannableIndexTypes indexTypes) {
-        if (useRewritePlanner) {
+        if (useCascadesPlanner) {
             planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
         } else {
             if (indexTypes == null) {
@@ -577,7 +577,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
         }
 
         public void search() throws ExecutionException, InterruptedException {
-            useRewritePlanner = false;
+            useCascadesPlanner = false;
             try (FDBRecordContext context = openContext()) {
                 final FDBRecordStore store = openStore(context);
                 final String searchWord = searchWords.get(random.nextInt(searchWords.size()));


### PR DESCRIPTION
This updates the `DualPlannerTest` extension so that parameterized tests will run with both planners. This adjusts the work done in #2022 so that the Cascades planner is configured during test execution, which is what was missing with the previous approach. The rest of the changes here are in response to that, mainly fixing up the `FDBOrQueryToUnionTest` so that (1) tests have nice names that are easier to debug and (2) plan assertions that were failing are fixed.

This fixes #2353.