### PR TITLE
Fixes #2377: NPE during maintenance of synthetic indexes if some types have only disabled indexes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Synthetic record type plans are now only generated if the type has at least one index that requires maintenance [(Issue #2377)](https://github.com/FoundationDB/fdb-record-layer/issues/2377)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -601,6 +601,8 @@ public class FDBStoreTimer extends StoreTimer {
         /** The number of query plans that include a {@link com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan}. */
         PLAN_SORT("number of sort plans", false),
         PLAN_DAM("number of dam plans", false),
+        /** The number of synthetic record type plans. */
+        PLAN_SYNTHETIC_TYPE("number of synthetic record types plans", false),
         /** The number of records given given to any filter within any plan. */
         QUERY_FILTER_GIVEN("number of records given to any filter within any plan", false),
         /** The number of records passed by any filter within any plan. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -905,7 +905,7 @@ public abstract class IndexingBase {
             }
             if (indexContext.isSynthetic) {
                 // This particular index is synthetic, handle with care
-                final SyntheticRecordPlanner syntheticPlanner = new SyntheticRecordPlanner(store.getRecordMetaData(), store.getRecordStoreState().withWriteOnlyIndexes(Collections.singletonList(indexContext.index.getName())));
+                final SyntheticRecordPlanner syntheticPlanner = new SyntheticRecordPlanner(store.getRecordMetaData(), store.getRecordStoreState().withWriteOnlyIndexes(Collections.singletonList(indexContext.index.getName())), store.getTimer());
                 final SyntheticRecordFromStoredRecordPlan syntheticPlan = syntheticPlanner.forIndex(indexContext.index);
                 final IndexMaintainer maintainer = store.getIndexMaintainer(indexContext.index);
                 return syntheticPlan.execute(store, rec).forEachAsync(syntheticRecord -> maintainer.update(null, syntheticRecord), 1);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -136,7 +136,7 @@ public class IndexingCommon {
             }
             boolean isSynthetic = false;
             if (types.stream().anyMatch(RecordType::isSynthetic)) {
-                types = new SyntheticRecordPlanner(metaData, new RecordStoreState(null, null))
+                types = new SyntheticRecordPlanner(metaData, new RecordStoreState(null, null), getRunner().getTimer())
                         .storedRecordTypesForIndex(targetIndex, types);
                 isSynthetic = true;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -949,7 +949,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
             }
             if (recordTypes.stream().anyMatch(RecordType::isSynthetic)) {
                 // The (stored) types to scan, not the (synthetic) types that are indexed.
-                recordTypes = new SyntheticRecordPlanner(metaData, new RecordStoreState(null, null))
+                recordTypes = new SyntheticRecordPlanner(metaData, new RecordStoreState(null, null), getTimer())
                         .storedRecordTypesForIndex(index, recordTypes);
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
@@ -73,6 +73,7 @@ public class SyntheticRecordPlanner {
      * Initialize a new planner.
      * @param recordMetaData meta-data to use for planning
      * @param storeState index enabling state to use for planning
+     * @param timer store timer for collecting metrics during planning
      */
     public SyntheticRecordPlanner(@Nonnull RecordMetaData recordMetaData, @Nonnull RecordStoreState storeState, @Nullable FDBStoreTimer timer) {
         this.recordMetaData = recordMetaData;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.SyntheticRecordType;
 import com.apple.foundationdb.record.metadata.UnnestedRecordType;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
@@ -65,15 +66,18 @@ public class SyntheticRecordPlanner {
     private final RecordMetaData recordMetaData;
     @Nonnull
     private final RecordQueryPlanner queryPlanner;
+    @Nullable
+    private final FDBStoreTimer timer;
 
     /**
      * Initialize a new planner.
      * @param recordMetaData meta-data to use for planning
      * @param storeState index enabling state to use for planning
      */
-    public SyntheticRecordPlanner(@Nonnull RecordMetaData recordMetaData, @Nonnull RecordStoreState storeState) {
+    public SyntheticRecordPlanner(@Nonnull RecordMetaData recordMetaData, @Nonnull RecordStoreState storeState, @Nullable FDBStoreTimer timer) {
         this.recordMetaData = recordMetaData;
         this.queryPlanner = new RecordQueryPlanner(recordMetaData, storeState);
+        this.timer = timer;
     }
 
     /**
@@ -81,7 +85,7 @@ public class SyntheticRecordPlanner {
      * @param store a record store
      */
     public SyntheticRecordPlanner(@Nonnull FDBRecordStore store) {
-        this(store.getRecordMetaData(), store.getRecordStoreState());
+        this(store.getRecordMetaData(), store.getRecordStoreState(), store.getTimer());
     }
 
     /**
@@ -181,8 +185,11 @@ public class SyntheticRecordPlanner {
         Set<String> syntheticRecordTypes = new HashSet<>();
         boolean needDistinct = false;
         for (SyntheticRecordType<?> syntheticRecordType : recordMetaData.getSyntheticRecordTypes().values()) {
-            if (onlyIfIndexed && syntheticRecordType.getIndexes().isEmpty() && syntheticRecordType.getMultiTypeIndexes().isEmpty()) {
+            if (onlyIfIndexed && allIndexesDisabled(syntheticRecordType)) {
                 continue;
+            }
+            if (timer != null) {
+                timer.increment(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE);
             }
             for (SyntheticRecordType.Constituent constituent : syntheticRecordType.getConstituents()) {
                 if (constituent.getRecordType() == storedRecordType) {
@@ -209,6 +216,17 @@ public class SyntheticRecordPlanner {
         } else {
             return new SyntheticRecordConcatPlan(subPlans, needDistinct);
         }
+    }
+
+    private boolean allIndexesDisabled(SyntheticRecordType<?> syntheticRecordType) {
+        return allIndexesDisabled(syntheticRecordType.getIndexes()) && allIndexesDisabled(syntheticRecordType.getMultiTypeIndexes());
+    }
+
+    private boolean allIndexesDisabled(@Nonnull Collection<Index> indexes) {
+        if (indexes.isEmpty()) {
+            return true;
+        }
+        return indexes.stream().allMatch(index -> queryPlanner.getRecordStoreState().isDisabled(index));
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
@@ -1217,10 +1217,6 @@ public class SyntheticRecordPlannerTest {
                     .setOtherRecNo(1415L)
                     .setStrValue("foo")
                     .build();
-            TestRecordsJoinIndexProto.MyOtherRecord otherRecord = TestRecordsJoinIndexProto.MyOtherRecord.newBuilder()
-                    .setRecNo(1415L)
-                    .setNumValue3(42)
-                    .build();
             recordStore.saveRecord(simpleRecord);
             assertEquals(2L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
 
@@ -1228,6 +1224,10 @@ public class SyntheticRecordPlannerTest {
             recordStore.markIndexDisabled(joined2Index).join();
 
             timer.reset();
+            TestRecordsJoinIndexProto.MyOtherRecord otherRecord = TestRecordsJoinIndexProto.MyOtherRecord.newBuilder()
+                    .setRecNo(1415L)
+                    .setNumValue3(42)
+                    .build();
             recordStore.saveRecord(otherRecord);
             assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlannerTest.java
@@ -42,6 +42,7 @@ import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.JoinedRecordType;
 import com.apple.foundationdb.record.metadata.JoinedRecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.SyntheticRecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.AbsoluteValueFunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.IntWrappingFunction;
@@ -68,6 +69,7 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Reco
 import com.apple.foundationdb.record.query.plan.match.PlanMatchers;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
 import com.apple.test.Tags;
 import com.google.common.base.Verify;
 import com.google.common.collect.HashMultiset;
@@ -107,8 +109,10 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlanOf;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.scanComparisons;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link SyntheticRecordPlanner}.
@@ -264,6 +268,7 @@ public class SyntheticRecordPlannerTest {
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).create();
 
+            timer.reset();
             for (int i = 0; i < 3; i++) {
                 TestRecordsJoinIndexProto.MySimpleRecord.Builder simple = TestRecordsJoinIndexProto.MySimpleRecord.newBuilder();
                 simple.setRecNo(i);
@@ -279,6 +284,9 @@ public class SyntheticRecordPlannerTest {
             recordStore.saveRecord(joining.build());
             joining.setRecNo(102).setSimpleRecNo(2).setOtherRecNo(1002);
             recordStore.saveRecord(joining.build());
+
+            // Because there are no indexes defined on the joined index, none of these updates should actually result in planning
+            assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
 
             context.commit();
         }
@@ -1042,6 +1050,92 @@ public class SyntheticRecordPlannerTest {
     }
 
     @Test
+    void indexUpdatesOnSameSyntheticTypeSharePlans() {
+        String index1Name = addJoinedIndexToMetaData();
+        SyntheticRecordTypeBuilder<?> syntheticType = metaDataBuilder.getSyntheticRecordType("MultiNestedFieldJoin");
+        String index2Name = "quantityByCity";
+        metaDataBuilder.addIndex(syntheticType, new Index(index2Name, field("order").nest("quantity").groupBy(field("cust").nest("city")), IndexTypes.SUM));
+
+        try (FDBRecordContext context = openContext()) {
+            final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).create();
+            timer.reset();
+
+            TestRecordsJoinIndexProto.CustomerWithHeader customer = TestRecordsJoinIndexProto.CustomerWithHeader.newBuilder()
+                    .setHeader(TestRecordsJoinIndexProto.Header.newBuilder()
+                            .setZKey(42)
+                            .setIntRecId(1066L)
+                    )
+                    .setName("Scott")
+                    .setCity("Toronto")
+                    .build();
+            recordStore.saveRecord(customer);
+            // Two indexes should be updated, but only one synthetic type plan should be needed
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+            timer.reset();
+
+            TestRecordsJoinIndexProto.OrderWithHeader order1 = TestRecordsJoinIndexProto.OrderWithHeader.newBuilder()
+                    .setHeader(TestRecordsJoinIndexProto.Header.newBuilder()
+                            .setZKey(customer.getHeader().getZKey())
+                            .setRecId("id2")
+                    )
+                    .setOrderNo(101)
+                    .setQuantity(10)
+                    .setCustRef(TestRecordsJoinIndexProto.Ref.newBuilder().setStringValue("i:1066"))
+                    .build();
+            recordStore.saveRecord(order1);
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+            timer.reset();
+
+            TestRecordsJoinIndexProto.OrderWithHeader order2 = TestRecordsJoinIndexProto.OrderWithHeader.newBuilder()
+                    .setHeader(TestRecordsJoinIndexProto.Header.newBuilder()
+                            .setZKey(customer.getHeader().getZKey())
+                            .setRecId("id3")
+                    )
+                    .setOrderNo(102)
+                    .setQuantity(15)
+                    .setCustRef(TestRecordsJoinIndexProto.Ref.newBuilder().setStringValue("i:1066"))
+                    .build();
+            recordStore.saveRecord(order2);
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+            timer.reset();
+
+            context.commit();
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
+
+            final Index index1 = recordStore.getRecordMetaData().getIndex(index1Name);
+            try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(index1, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                List<IndexEntry> index2Entries = cursor.asList().join();
+                assertThat(index2Entries, hasSize(2));
+
+                IndexEntry entry1 = index2Entries.get(0);
+                assertEquals(index1, entry1.getIndex());
+                assertEquals(Tuple.from("Scott", 101L, -1L, Tuple.from(42L, "id2"), Tuple.from(42L, 1066L)), entry1.getKey());
+                assertEquals(TupleHelpers.EMPTY, entry1.getValue());
+
+                IndexEntry entry2 = index2Entries.get(1);
+                assertEquals(index1, entry2.getIndex());
+                assertEquals(Tuple.from("Scott", 102L, -1L, Tuple.from(42L, "id3"), Tuple.from(42L, 1066L)), entry2.getKey());
+                assertEquals(TupleHelpers.EMPTY, entry2.getValue());
+            }
+
+            final Index index2 = recordStore.getRecordMetaData().getIndex(index2Name);
+            try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(index2, IndexScanType.BY_GROUP, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                List<IndexEntry> index2Entries = cursor.asList().join();
+                assertThat(index2Entries, hasSize(1));
+                IndexEntry entry = index2Entries.get(0);
+                assertEquals(index2, entry.getIndex());
+                assertEquals(Tuple.from("Toronto"), entry.getKey());
+                assertEquals(Tuple.from(25L), entry.getValue());
+            }
+
+            context.commit();
+        }
+    }
+
+    @Test
     void wontUpdateSyntheticTypeIfUnderlyingIndexesAreDisabled() throws Exception {
         /*
          * If the underlying indexes that are to be updated are not writable, then the synthetic update
@@ -1061,6 +1155,7 @@ public class SyntheticRecordPlannerTest {
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
 
+            timer.reset();
             TestRecordsJoinIndexProto.CustomerWithHeader customer = TestRecordsJoinIndexProto.CustomerWithHeader.newBuilder()
                     .setHeader(TestRecordsJoinIndexProto.Header.newBuilder().setZKey(1).setIntRecId(1L))
                     .setName("Scott")
@@ -1076,6 +1171,7 @@ public class SyntheticRecordPlannerTest {
                     .build();
             recordStore.saveRecord(order);
 
+            assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
             context.commit();
         }
 
@@ -1091,6 +1187,77 @@ public class SyntheticRecordPlannerTest {
             try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(joinIndex, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
                 Assertions.assertEquals(0, cursor.getCount().get(), "Wrote records to a disabled index!");
             }
+        }
+    }
+
+    @Test
+    void updateOnlyNonDisabledSyntheticTypes() {
+        // Create two synthetic record types, each with one index
+        final JoinedRecordTypeBuilder joined1 = metaDataBuilder.addJoinedRecordType("FirstJoinedType");
+        joined1.addConstituent("simple", "MySimpleRecord");
+        joined1.addConstituent("other", "MyOtherRecord");
+        joined1.addJoin("simple", "other_rec_no", "other", "rec_no");
+        final Index joined1Index = new Index("joined1_index", concat(field("simple").nest("str_value"), field("other").nest("num_value_3")));
+        metaDataBuilder.addIndex(joined1, joined1Index);
+
+        final JoinedRecordTypeBuilder joined2 = metaDataBuilder.addJoinedRecordType("SecondJoinedType");
+        joined2.addConstituent("simple", "MySimpleRecord");
+        joined2.addConstituent("other", "MyOtherRecord");
+        joined2.addJoin("simple", "other_rec_no", "other", "rec_no");
+        final Index joined2Index = new Index("joined2_index", concat(field("other").nest("num_value_3"), field("simple").nest("str_value")));
+        metaDataBuilder.addIndex(joined2, joined2Index);
+
+        metaDataBuilder.addIndex("MySimpleRecord", "other_rec_no"); // To facilitate join lookups
+
+        try (FDBRecordContext context = openContext()) {
+            final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).create();
+
+            TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = TestRecordsJoinIndexProto.MySimpleRecord.newBuilder()
+                    .setRecNo(1066L)
+                    .setOtherRecNo(1415L)
+                    .setStrValue("foo")
+                    .build();
+            TestRecordsJoinIndexProto.MyOtherRecord otherRecord = TestRecordsJoinIndexProto.MyOtherRecord.newBuilder()
+                    .setRecNo(1415L)
+                    .setNumValue3(42)
+                    .build();
+            recordStore.saveRecord(simpleRecord);
+            assertEquals(2L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+
+            // Disable the index on joined2, but leave the index on joined1
+            recordStore.markIndexDisabled(joined2Index).join();
+
+            timer.reset();
+            recordStore.saveRecord(otherRecord);
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+
+            context.commit();
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
+
+            try (RecordCursor<IndexEntry> joined1Cursor = recordStore.scanIndex(joined1Index, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                RecordCursorResult<IndexEntry> firstResult = joined1Cursor.getNext();
+                assertTrue(firstResult.hasNext());
+                IndexEntry entry = firstResult.get();
+                assertEquals(joined1Index, entry.getIndex());
+                assertEquals(Tuple.from("foo", 42L, -1L, Tuple.from(1066L), Tuple.from(1415L)), entry.getKey());
+                assertEquals(Tuple.from(), entry.getValue());
+
+                RecordCursorResult<IndexEntry> secondResult = joined1Cursor.getNext();
+                assertFalse(secondResult.hasNext());
+                assertEquals(RecordCursor.NoNextReason.SOURCE_EXHAUSTED, secondResult.getNoNextReason());
+            }
+
+            recordStore.uncheckedMarkIndexReadable(joined2Index.getName()).join();
+            try (RecordCursor<IndexEntry> joined2Cursor = recordStore.scanIndex(joined2Index, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                RecordCursorResult<IndexEntry> firstResult = joined2Cursor.getNext();
+                assertFalse(firstResult.hasNext());
+                assertEquals(RecordCursor.NoNextReason.SOURCE_EXHAUSTED, firstResult.getNoNextReason());
+            }
+
+            context.commit();
         }
     }
 
@@ -1132,6 +1299,7 @@ public class SyntheticRecordPlannerTest {
         //update the record
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
+            timer.reset();
             //changing the join key should mean deleting it from the synthetic index, unless the index is disabled
             recordStore.deleteRecord(pk);
 
@@ -1142,6 +1310,8 @@ public class SyntheticRecordPlannerTest {
                     .setCustRef(TestRecordsJoinIndexProto.Ref.newBuilder().setStringValue("i:2"))
                     .build();
             recordStore.saveRecord(order);
+
+            assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
 
             context.commit();
         }
@@ -1199,6 +1369,8 @@ public class SyntheticRecordPlannerTest {
         //update the record
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
+            timer.reset();
+
             //changing the join key should mean deleting it from the synthetic index, unless the index is disabled
             recordStore.saveRecord(customer.toBuilder().setName("Bob").build());
 
@@ -1209,6 +1381,8 @@ public class SyntheticRecordPlannerTest {
                     .setCustRef(TestRecordsJoinIndexProto.Ref.newBuilder().setStringValue("i:2"))
                     .build();
             recordStore.saveRecord(order);
+
+            assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
 
             context.commit();
         }
@@ -1229,7 +1403,7 @@ public class SyntheticRecordPlannerTest {
     }
 
     @Test
-    void updateSyntheticIndexesWhenWriteOnly() throws Exception {
+    void updateRecordWhenSyntheticIndexesIsWriteOnly() throws Exception {
         String indexName = addJoinedIndexToMetaData();
 
         TestRecordsJoinIndexProto.CustomerWithHeader customer = TestRecordsJoinIndexProto.CustomerWithHeader.newBuilder()
@@ -1255,7 +1429,7 @@ public class SyntheticRecordPlannerTest {
             context.commit();
         }
 
-        //disabling the index should force the index to be treated as empty
+        // Mark the index as write only. The index should not be readable, but it should still get updated when records change
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
             recordStore.markIndexWriteOnly(indexName).get();
@@ -1266,8 +1440,12 @@ public class SyntheticRecordPlannerTest {
         //update the record
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
+            timer.reset();
+
             //changing the join key should mean deleting it from the synthetic index, unless the index is disabled
             recordStore.saveRecord(customer.toBuilder().setName("Bob").build());
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+            timer.reset();
 
             TestRecordsJoinIndexProto.OrderWithHeader order = TestRecordsJoinIndexProto.OrderWithHeader.newBuilder()
                     .setHeader(TestRecordsJoinIndexProto.Header.newBuilder().setZKey(1).setRecId("33"))
@@ -1276,6 +1454,7 @@ public class SyntheticRecordPlannerTest {
                     .setCustRef(TestRecordsJoinIndexProto.Ref.newBuilder().setStringValue("i:2"))
                     .build();
             recordStore.saveRecord(order);
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
 
             context.commit();
         }
@@ -1296,7 +1475,7 @@ public class SyntheticRecordPlannerTest {
     }
 
     @Test
-    void updateSyntheticIndexesWhenInWriteOnly() throws Exception {
+    void insertRecordWhenSyntheticIndexIsWriteOnly() throws Exception {
         String indexName = addJoinedIndexToMetaData();
 
         //write some data
@@ -1331,12 +1510,16 @@ public class SyntheticRecordPlannerTest {
 
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore recordStore = recordStoreBuilder.setContext(context).open();
+            timer.reset();
+
             TestRecordsJoinIndexProto.CustomerWithHeader customer = TestRecordsJoinIndexProto.CustomerWithHeader.newBuilder()
                     .setHeader(TestRecordsJoinIndexProto.Header.newBuilder().setZKey(1).setIntRecId(2L))
                     .setName("Scott")
                     .setCity("Toronto")
                     .build();
             recordStore.saveRecord(customer);
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+            timer.reset();
 
             TestRecordsJoinIndexProto.OrderWithHeader order = TestRecordsJoinIndexProto.OrderWithHeader.newBuilder()
                     .setHeader(TestRecordsJoinIndexProto.Header.newBuilder().setZKey(1).setRecId("33"))
@@ -1345,6 +1528,7 @@ public class SyntheticRecordPlannerTest {
                     .setCustRef(TestRecordsJoinIndexProto.Ref.newBuilder().setStringValue("i:2"))
                     .build();
             recordStore.saveRecord(order);
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
 
             context.commit();
         }
@@ -1410,7 +1594,10 @@ public class SyntheticRecordPlannerTest {
                 pk = messageFDBStoredRecord.getPrimaryKey();
             }
 
+            timer.reset();
             recordStore.deleteRecord(pk);
+            assertEquals(1L, timer.getCount(FDBStoreTimer.Counts.PLAN_SYNTHETIC_TYPE));
+
             context.commit();
         }
 


### PR DESCRIPTION
Now, when we go to index a record of a synthetic type, we only go through the process of generating a plan if there is at least one non-disabled index defined on it. Previously, we would generate the plan if there was any index defined on it, and then we would filter out any types without any non-disabled indexes later. The logic for that later filtering could result in a null pointer exception, though, so this updated approach aligns what gets planned with what is actually necessary to execute. This also can save on planning time if there are disabled indexes.

This fixes #2377.