### PR TITLE
AUTO-COMPLETE does not complete phrases which contain stop words in them #2380

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAutoCompletedMatchesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAutoCompletedMatchesTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -154,5 +155,10 @@ class LuceneAutoCompletedMatchesTest {
         List<String> match =
                 LuceneAutoCompleteHelpers.computeAllMatchesForPhrase("text", analyzer, text, tokens, numAdditionalTokens);
         assertEquals(expectedMatches, match);
+    }
+
+    @Test
+    void autoCompleteMatchesWithStopWord() {
+        assertComputeAllMatchesForPhrase("United States of Ameri", List.of("united", "states", "of"), "ameri", "United States of America", 0, ImmutableList.of("United States of America"));
     }
 }


### PR DESCRIPTION
**Motivation**
To auto-complete phrases with stop words in them. Example: "united states of ameri" would need to match "United States of America" with "of" being indexed as a stopword

**Modification** 
Use Lucene parser when parsing the search input into query to preserve the positions of the stopwords and turn them into Lucene gaps for matching.
Plus, some more enhancement to matching when the phrase ends with a stopword

**Results**
The example mentioned works. 