### PR TITLE
Fixes #2388: IndexAggregateFunctionCall.isGroupingPermutable is now too …

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `IndexAggregateFunctionCall.isGroupingPermutable` is now too liberal [(Issue #2388)](https://github.com/FoundationDB/fdb-record-layer/issues/2388)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexAggregateFunctionCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexAggregateFunctionCall.java
@@ -152,7 +152,8 @@ public class IndexAggregateFunctionCall {
                                    ? ImmutableSet.of()
                                    : ImmutableSet.copyOf(groupingExpressions);
         this.groupedExpression = groupedExpression;
-        this.isGroupingPermutable = groupingKeyExpression.getGroupingSubKey().hasLosslessNormalization();
+        this.isGroupingPermutable = groupingKeyExpression.getGroupingSubKey().equals(EmptyKeyExpression.EMPTY) ||
+                                    groupingKeyExpression.hasLosslessNormalization();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -963,7 +963,8 @@ public class KeyExpressionTest {
                 Arguments.of(concat(field("foo"), field("bar")), true),
                 Arguments.of(field("foo").groupBy(field("bar")), true),
                 Arguments.of(field("parent").nest(field("foo"), field("bar")), true),
-                Arguments.of(field("parent").nest(field("child", FanType.FanOut).nest(field("foo"), field("bar"))), false)
+                Arguments.of(field("parent").nest(field("child", FanType.FanOut).nest(field("foo"), field("bar"))), false),
+                Arguments.of(new GroupingKeyExpression(field("parent", FanType.FanOut).nest(field("foo"), field("bar")), 1), false)
         );
     }
 


### PR DESCRIPTION
… liberal

Use the whole key so that correlations between the grouping and a grouped value are taken into account.

That is, how the predicate is called back to the way it was in f018461aa8e719fa16253922d9f082ab64973764 and only change how the predicate is computed.