### PR TITLE
Fixes #2408: Add planner configuration property to control union ordering key behavior

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** To avoid breaking continuations during a deployment, the improvement to union key matching added in [3.3.348.0](#333480) is now guarded by a planner configuration flag [(Issue #2408)](https://github.com/FoundationDB/fdb-record-layer/issues/2408)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -53,6 +53,7 @@ public class RecordQueryPlannerConfiguration {
     private final boolean checkForDuplicateConditions;
     private final boolean deferFetchAfterUnionAndIntersection;
     private final boolean deferFetchAfterInJoinAndInUnion;
+    private final boolean omitPrimaryKeyInUnionOrderingKey;
     private final boolean optimizeForIndexFilters;
     private final boolean optimizeForRequiredResults;
     private final int maxTaskQueueSize;
@@ -75,48 +76,29 @@ public class RecordQueryPlannerConfiguration {
     private final int maxNumReplansForInToJoin;
     private final int orToUnionMaxNumConjuncts;
 
-    private RecordQueryPlannerConfiguration(@Nonnull QueryPlanner.IndexScanPreference indexScanPreference,
-                                            boolean attemptFailedInJoinAsOr,
-                                            int attemptFailedInJoinAsUnionMaxSize,
-                                            int complexityThreshold,
-                                            boolean checkForDuplicateConditions,
-                                            boolean deferFetchAfterUnionAndIntersection,
-                                            boolean deferFetchAfterInJoinAndInUnion,
-                                            boolean optimizeForIndexFilters,
-                                            boolean optimizeForRequiredResults,
-                                            int maxTaskQueueSize,
-                                            int maxTotalTaskCount,
-                                            boolean useFullKeyForValueIndex,
-                                            int maxNumMatchesPerRuleCall,
-                                            @Nullable RecordQueryPlannerSortConfiguration sortConfiguration,
-                                            @Nonnull final Set<Class<? extends CascadesRule<?>>> disabledTransformationRules,
-                                            final boolean deferCrossProducts,
-                                            @Nonnull final IndexFetchMethod indexFetchMethod,
-                                            @Nonnull final Set<String> valueIndexesOverScanNeeded,
-                                            final boolean planOtherAttemptWholeFilter,
-                                            final int maxNumReplansForInToJoin,
-                                            final int orToUnionMaxNumConjuncts) {
-        this.indexScanPreference = indexScanPreference;
-        this.attemptFailedInJoinAsOr = attemptFailedInJoinAsOr;
-        this.attemptFailedInJoinAsUnionMaxSize = attemptFailedInJoinAsUnionMaxSize;
-        this.complexityThreshold = complexityThreshold;
-        this.checkForDuplicateConditions = checkForDuplicateConditions;
-        this.deferFetchAfterUnionAndIntersection = deferFetchAfterUnionAndIntersection;
-        this.deferFetchAfterInJoinAndInUnion = deferFetchAfterInJoinAndInUnion;
-        this.optimizeForIndexFilters = optimizeForIndexFilters;
-        this.optimizeForRequiredResults = optimizeForRequiredResults;
-        this.maxTaskQueueSize = maxTaskQueueSize;
-        this.maxTotalTaskCount = maxTotalTaskCount;
-        this.useFullKeyForValueIndex = useFullKeyForValueIndex;
-        this.maxNumMatchesPerRuleCall = maxNumMatchesPerRuleCall;
-        this.sortConfiguration = sortConfiguration;
-        this.disabledTransformationRules = ImmutableSet.copyOf(disabledTransformationRules);
-        this.deferCrossProducts = deferCrossProducts;
-        this.indexFetchMethod = indexFetchMethod;
-        this.valueIndexesOverScanNeeded = valueIndexesOverScanNeeded;
-        this.planOtherAttemptWholeFilter = planOtherAttemptWholeFilter;
-        this.maxNumReplansForInToJoin = maxNumReplansForInToJoin;
-        this.orToUnionMaxNumConjuncts = orToUnionMaxNumConjuncts;
+    private RecordQueryPlannerConfiguration(@Nonnull RecordQueryPlannerConfiguration.Builder builder) {
+        this.indexScanPreference = builder.indexScanPreference;
+        this.attemptFailedInJoinAsOr = builder.attemptFailedInJoinAsOr;
+        this.attemptFailedInJoinAsUnionMaxSize = builder.attemptFailedInJoinAsUnionMaxSize;
+        this.complexityThreshold = builder.complexityThreshold;
+        this.checkForDuplicateConditions = builder.checkForDuplicateConditions;
+        this.deferFetchAfterUnionAndIntersection = builder.deferFetchAfterUnionAndIntersection;
+        this.deferFetchAfterInJoinAndInUnion = builder.deferFetchAfterInJoinAndInUnion;
+        this.omitPrimaryKeyInUnionOrderingKey = builder.omitPrimaryKeyInUnionOrderingKey;
+        this.optimizeForIndexFilters = builder.optimizeForIndexFilters;
+        this.optimizeForRequiredResults = builder.optimizeForRequiredResults;
+        this.maxTaskQueueSize = builder.maxTaskQueueSize;
+        this.maxTotalTaskCount = builder.maxTotalTaskCount;
+        this.useFullKeyForValueIndex = builder.useFullKeyForValueIndex;
+        this.maxNumMatchesPerRuleCall = builder.maxNumMatchesPerRuleCall;
+        this.sortConfiguration = builder.sortConfiguration;
+        this.disabledTransformationRules = ImmutableSet.copyOf(builder.disabledTransformationRules);
+        this.deferCrossProducts = builder.deferCrossProducts;
+        this.indexFetchMethod = builder.indexFetchMethod;
+        this.valueIndexesOverScanNeeded = builder.valueIndexesOverScanNeeded;
+        this.planOtherAttemptWholeFilter = builder.planOtherAttemptWholeFilter;
+        this.maxNumReplansForInToJoin = builder.maxNumReplansForInToJoin;
+        this.orToUnionMaxNumConjuncts = builder.orToUnionMaxNumConjuncts;
     }
 
     /**
@@ -201,6 +183,10 @@ public class RecordQueryPlannerConfiguration {
      */
     public boolean shouldDeferFetchAfterInJoinAndInUnion() {
         return deferFetchAfterInJoinAndInUnion;
+    }
+
+    public boolean shouldOmitPrimaryKeyInUnionOrderingKey() {
+        return omitPrimaryKeyInUnionOrderingKey;
     }
 
     /**
@@ -351,6 +337,7 @@ public class RecordQueryPlannerConfiguration {
         private boolean checkForDuplicateConditions = false;
         private boolean deferFetchAfterUnionAndIntersection = false;
         private boolean deferFetchAfterInJoinAndInUnion = false;
+        private boolean omitPrimaryKeyInUnionOrderingKey = false;
         private boolean optimizeForIndexFilters = false;
         private boolean optimizeForRequiredResults = false;
         private int maxTaskQueueSize = 0;
@@ -380,6 +367,7 @@ public class RecordQueryPlannerConfiguration {
             this.checkForDuplicateConditions = configuration.checkForDuplicateConditions;
             this.deferFetchAfterUnionAndIntersection = configuration.deferFetchAfterUnionAndIntersection;
             this.deferFetchAfterInJoinAndInUnion = configuration.deferFetchAfterInJoinAndInUnion;
+            this.omitPrimaryKeyInUnionOrderingKey = configuration.omitPrimaryKeyInUnionOrderingKey;
             this.optimizeForIndexFilters = configuration.optimizeForIndexFilters;
             this.optimizeForRequiredResults = configuration.optimizeForRequiredResults;
             this.maxTaskQueueSize = configuration.maxTaskQueueSize;
@@ -428,6 +416,11 @@ public class RecordQueryPlannerConfiguration {
 
         public Builder setDeferFetchAfterInJoinAndInUnion(boolean deferFetchAfterInJoinAndInUnion) {
             this.deferFetchAfterInJoinAndInUnion = deferFetchAfterInJoinAndInUnion;
+            return this;
+        }
+
+        public Builder setOmitPrimaryKeyInUnionOrderingKey(boolean omitPrimaryKeyInUnionOrderingKey) {
+            this.omitPrimaryKeyInUnionOrderingKey = omitPrimaryKeyInUnionOrderingKey;
             return this;
         }
 
@@ -627,27 +620,7 @@ public class RecordQueryPlannerConfiguration {
         }
 
         public RecordQueryPlannerConfiguration build() {
-            return new RecordQueryPlannerConfiguration(indexScanPreference,
-                    attemptFailedInJoinAsOr,
-                    attemptFailedInJoinAsUnionMaxSize,
-                    complexityThreshold,
-                    checkForDuplicateConditions,
-                    deferFetchAfterUnionAndIntersection,
-                    deferFetchAfterInJoinAndInUnion,
-                    optimizeForIndexFilters,
-                    optimizeForRequiredResults,
-                    maxTaskQueueSize,
-                    maxTotalTaskCount,
-                    useFullKeyForValueIndex,
-                    maxNumMatchesPerRuleCall,
-                    sortConfiguration,
-                    disabledTransformationRules,
-                    deferCrossProducts,
-                    indexFetchMethod,
-                    valueIndexesOverScanNeeded,
-                    planOtherAttemptWholeFilter,
-                    maxNumReplansForInToJoin,
-                    orToUnionMaxNumConjuncts);
+            return new RecordQueryPlannerConfiguration(this);
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -2345,11 +2345,19 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
                             Query.not(Query.field("tag").oneOfThem().equalsValue("3:2")),
                             1, 758136569));
 
+            planner.setConfiguration(planner.getConfiguration().asBuilder().setOmitPrimaryKeyInUnionOrderingKey(true).build());
             assertEquals(Arrays.asList(Tuple.from(0L, 0L), Tuple.from(0L, 6L)),
                     queryComplexDocumentsWithOr((OrComponent) Query.or(
                             Query.field("text").text().containsAll("unit named after"),
                             Query.field("text").text().containsPhrase("אן ארמיי און פלאט")
                     ), 0, -396375489));
+
+            planner.setConfiguration(planner.getConfiguration().asBuilder().setOmitPrimaryKeyInUnionOrderingKey(false).build());
+            assertEquals(Arrays.asList(Tuple.from(0L, 0L), Tuple.from(0L, 6L)),
+                    queryComplexDocumentsWithOr((OrComponent) Query.or(
+                            Query.field("text").text().containsAll("unit named after"),
+                            Query.field("text").text().containsPhrase("אן ארמיי און פלאט")
+                    ), 0, -1558384887));
 
             assertEquals(Collections.singletonList(Tuple.from(1L, 5L)),
                     queryComplexDocumentsWithIndex(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrQueryToUnionTest.java
@@ -22,14 +22,15 @@ package com.apple.foundationdb.record.provider.foundationdb.query;
 
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorIterator;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
@@ -51,14 +52,16 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Prim
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.QueryPredicateMatchers;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionOnKeyExpressionPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionOnValuesPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.foundationdb.record.query.plan.visitor.RecordQueryPlannerSubstitutionVisitor;
 import com.apple.foundationdb.tuple.Tuple;
-import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Message;
@@ -71,6 +74,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -85,6 +89,7 @@ import static com.apple.foundationdb.record.TestHelpers.assertDiscardedExactly;
 import static com.apple.foundationdb.record.TestHelpers.assertDiscardedNone;
 import static com.apple.foundationdb.record.TestHelpers.assertLoadRecord;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.unbounded;
@@ -107,9 +112,10 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicatesFilterPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.queryComponents;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.scanComparisons;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.unionOnExpressionPlan;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.unionOnValuesPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.unorderedPrimaryKeyDistinctPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.unorderedUnionPlan;
-import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.SetMatcher.exactlyInAnyOrder;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers.fieldValueWithFieldNames;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -125,59 +131,141 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests related to planning a query with an OR clause into a union plan.
  */
 @Tag(Tags.RequiresFDB)
 class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
+    private static Stream<Boolean> booleanArgs() {
+        return Stream.of(false, true);
+    }
+
+    static class OrQueryParams {
+        private final boolean deferFetch;
+        private final boolean omitPrimaryKeyInOrderingKey;
+        private final boolean sortReverse;
+        private final boolean removeDuplicates;
+
+        OrQueryParams(boolean deferFetch,
+                      boolean omitPrimaryKeyInOrderingKey,
+                      boolean sortReverse,
+                      boolean removeDuplicates) {
+            this.deferFetch = deferFetch;
+            this.omitPrimaryKeyInOrderingKey = omitPrimaryKeyInOrderingKey;
+            this.sortReverse = sortReverse;
+            this.removeDuplicates = removeDuplicates;
+        }
+
+        public boolean shouldDeferFetch() {
+            return deferFetch;
+        }
+
+        public boolean shouldOmitPrimaryKeyInOrderingKey() {
+            return omitPrimaryKeyInOrderingKey;
+        }
+
+        public boolean isRemoveDuplicates() {
+            return removeDuplicates;
+        }
+
+        public boolean isSortReverse() {
+            return sortReverse;
+        }
+
+        public RecordQuery.Builder queryBuilder(@Nullable KeyExpression sort) {
+            return RecordQuery.newBuilder()
+                    .setRemoveDuplicates(removeDuplicates)
+                    .setSort(sort, sortReverse);
+        }
+
+        public RecordQuery.Builder queryBuilder() {
+            return queryBuilder(null);
+        }
+
+        public void setPlannerConfiguration(FDBRecordStoreQueryTestBase testBase) {
+            testBase.setDeferFetchAfterUnionAndIntersection(deferFetch);
+            testBase.setOmitPrimaryKeyInUnionOrderingKey(omitPrimaryKeyInOrderingKey);
+        }
+
+        @Override
+        public String toString() {
+            return "OrQueryParams{" +
+                   "deferFetch=" + deferFetch +
+                   ", omitPrimaryKeyInOrderingKey=" + omitPrimaryKeyInOrderingKey +
+                   ", sortReverse=" + sortReverse +
+                   ", removeDuplicates=" + removeDuplicates +
+                   '}';
+        }
+
+        @Nonnull
+        public OrQueryParams withSortReverse(boolean newSort) {
+            if (newSort == sortReverse) {
+                return this;
+            }
+            return new OrQueryParams(deferFetch, omitPrimaryKeyInOrderingKey, newSort, removeDuplicates);
+        }
+
+        @Nonnull
+        public OrQueryParams withRemoveDuplicates(boolean newRemoveDuplicates) {
+            if (newRemoveDuplicates == removeDuplicates) {
+                return this;
+            }
+            return new OrQueryParams(deferFetch, omitPrimaryKeyInOrderingKey, sortReverse, newRemoveDuplicates);
+        }
+
+    }
+
+    static Stream<OrQueryParams> baseParams() {
+        return booleanArgs().flatMap(deferFetch ->
+                booleanArgs().map(omitPrimaryKeyInOrderingKey ->
+                        new OrQueryParams(deferFetch, omitPrimaryKeyInOrderingKey, false, true)));
+    }
+
+    static Stream<OrQueryParams> paramsWithAndWithoutRemovesDuplicates() {
+        return baseParams().flatMap(params ->
+                booleanArgs().map(params::withRemoveDuplicates));
+    }
+
+    static Stream<OrQueryParams> reverseParams() {
+        return baseParams().map(baseParam -> baseParam.withSortReverse(true));
+    }
+
     /**
      * Verify that an OR of compatibly-ordered (up to reversal) indexed fields can be implemented as a union.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testComplexQuery6[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testComplexQuery6(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testComplexQuery6[{0}]")
+    @MethodSource("reverseParams")
+    void testComplexQuery6(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("odd"),
                         Query.field("num_value_3_indexed").equalsValue(0)))
-                .setSort(null, true)
-                .setRemoveDuplicates(true)
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(MySimpleRecord$str_value_indexed [[odd],[odd]] REVERSE) ∪ Index(MySimpleRecord$num_value_3_indexed [[0],[0]] REVERSE)
         // Fetch(Covering(Index(MySimpleRecord$str_value_indexed [[odd],[odd]] REVERSE) -> [rec_no: KEY[1], str_value_indexed: KEY[0]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[0],[0]] REVERSE) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
         RecordQueryPlan plan = planner.plan(query);
 
-        if (shouldDeferFetch && !(planner instanceof CascadesPlanner)) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]")))))));
-            assertMatchesExactly(plan, planMatcher);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]")))
+        ), null);
+        assertMatchesExactly(plan, planMatcher);
 
+        if (orQueryParams.shouldDeferFetch() && !(planner instanceof CascadesPlanner)) {
             assertTrue(plan.getQueryPlanChildren().stream().allMatch(QueryPlan::isReverse));
             assertEquals(-1584186103, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-357068519, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else if (planner instanceof CascadesPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]")))))));
-            assertMatchesExactly(plan, planMatcher);
-
             // Cascades does not mark everything as reversed in this case, but validate that all of the children go the same way
             boolean planReverseness = plan.getQueryPlanChildren().get(0).isReverse();
             plan.getQueryPlanChildren().forEach(child ->
@@ -185,12 +273,6 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             assertEquals(725509027, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-1507585422, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                            indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))),
-                            indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]"))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertTrue(plan.getQueryPlanChildren().stream().allMatch(QueryPlan::isReverse));
             assertEquals(-2067012572, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1784357954, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
@@ -213,26 +295,25 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             }
             assertEquals(60, i);
             assertDiscardedAtMost(10, context);
-            if (shouldDeferFetch) {
+            if (orQueryParams.shouldDeferFetch()) {
                 assertLoadRecord(60, context);
             }
         }
     }
 
     @DualPlannerTest
-    @ParameterizedTest(name = "testComplexQuery6Continuations[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testComplexQuery6Continuations(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testComplexQuery6Continuations[{0}]")
+    @MethodSource("baseParams")
+    void testComplexQuery6Continuations(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("odd"),
                         Query.field("num_value_3_indexed").equalsValue(0)))
-                .setRemoveDuplicates(true)
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
         RecordQueryPlan plan = planner.plan(query);
 
         try (FDBRecordContext context = openContext()) {
@@ -260,7 +341,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                 } while (continuation != null);
                 assertEquals(60, i);
                 assertDiscardedExactly(10, context);
-                if (shouldDeferFetch) {
+                if (orQueryParams.shouldDeferFetch()) {
                     assertLoadRecord(60, context);
                 }
             }
@@ -271,51 +352,36 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * Verify that queries with an OR of equality predicates on the same field are implemented using a union of indexes.
      */
     @DualPlannerTest
-    void testOrQuery1() throws Exception {
+    @ParameterizedTest(name = "testOrQuery1[{0}]")
+    @MethodSource("baseParams")
+    void testOrQuery1(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("num_value_3_indexed").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(2),
                         Query.field("num_value_3_indexed").equalsValue(4)))
                 .build();
-        setDeferFetchAfterUnionAndIntersection(true);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Fetch(Covering(Index(MySimpleRecord$num_value_3_indexed [[1],[1]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[2],[2]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[4],[4]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
         RecordQueryPlan plan = planner.plan(query);
+        final KeyExpression comparisonKey = planner instanceof CascadesPlanner ? concat(primaryKey("MySimpleRecord"), field("num_value_3_indexed")) : primaryKey("MySimpleRecord");
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[2],[2]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[4],[4]]")))
+        ), comparisonKey);
+        assertMatchesExactly(plan, planMatcher);
 
         if (planner instanceof CascadesPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[2],[2]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[4],[4]]"))))))
-                                    .where(comparisonKeyValues(exactlyInAnyOrder(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-1974122514, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1183017387, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[2],[2]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[4],[4]]"))))))
-                                    .where(comparisonKey(primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(1912003491, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(-1070595610, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            assertEquals(orQueryParams.shouldDeferFetch() ? 1912003491 : 273143354, plan.planHash(PlanHashable.CURRENT_LEGACY));
+            assertEquals(orQueryParams.shouldDeferFetch() ? -1070595610 : 1002901843, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
 
         try (FDBRecordContext context = openContext()) {
@@ -342,19 +408,19 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * Verify that queries with an OR of equality predicates on the same field are implemented using a union of indexes.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testOrQueryPlanEquals[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testOrQueryPlanEquals(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testOrQueryPlanEquals[{0}]")
+    @MethodSource("baseParams")
+    void testOrQueryPlanEquals(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("num_value_3_indexed").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(2),
                         Query.field("num_value_3_indexed").equalsValue(4)))
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
         RecordQueryPlan plan = planner.plan(query);
 
         RecordQuery query2 = RecordQuery.newBuilder()
@@ -364,7 +430,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                         Query.field("num_value_3_indexed").equalsValue(2),
                         Query.field("num_value_3_indexed").equalsValue(1)))
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
         RecordQueryPlan plan2 = planner.plan(query2);
 
         // plan is physically different but returns the same result
@@ -378,63 +444,36 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * using a union of indexes.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testOrQuery2[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testOrQuery2(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testOrQuery2[{0}]")
+    @MethodSource("baseParams")
+    void testOrQuery2(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("num_value_3_indexed").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(2),
                         Query.field("num_value_3_indexed").greaterThan(3)))
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Fetch(Covering(Index(MySimpleRecord$num_value_3_indexed [[1],[1]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Covering(Index(MySimpleRecord$num_value_3_indexed [[2],[2]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Covering(Index(MySimpleRecord$num_value_3_indexed ([3],>) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
         RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[2],[2]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>")))
+        ), concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")));
+        assertMatchesExactly(plan, planMatcher);
 
-        if (shouldDeferFetch && !(planner instanceof CascadesPlanner)) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[2],[2]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>"))))))
-                                    .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")))));
-            assertMatchesExactly(plan, planMatcher);
-
+        if (orQueryParams.shouldDeferFetch() && !(planner instanceof CascadesPlanner)) {
             assertEquals(504228282, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1520996708, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else if (planner instanceof CascadesPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[2],[2]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>"))))))
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no")))));
-
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-948815552, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-2075944345, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[2],[2]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>"))))
-                            .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(1299166123, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-700473135, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -463,56 +502,35 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * of indexes.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testOrQuery3[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testOrQuery3(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testOrQuery3[{0}]")
+    @MethodSource("baseParams")
+    void testOrQuery3(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("num_value_3_indexed").lessThan(2),
                         Query.field("num_value_3_indexed").greaterThan(3)))
                 .build();
 
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Fetch(Covering(Index(MySimpleRecord$num_value_3_indexed ([null],[2])) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Covering(Index(MySimpleRecord$num_value_3_indexed ([3],>) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
         RecordQueryPlan plan = planner.plan(query);
-        if (shouldDeferFetch && !(planner instanceof CascadesPlanner)) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([null],[2])"))))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>"))))))
-                                    .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")))));
-            assertMatchesExactly(plan, planMatcher);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([null],[2])"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>")))
+        ), concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")));
+        assertMatchesExactly(plan, planMatcher);
 
+        if (orQueryParams.shouldDeferFetch() && !(planner instanceof CascadesPlanner)) {
             assertEquals(-627934247, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(502710007, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else if (planner instanceof CascadesPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([null],[2])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>"))))))
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-2080978081, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1200736250, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([null],[2])"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],>"))))
-                            .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-1930405164, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-1650830816, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -540,62 +558,36 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * if all fields are indexed.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testOrQuery4[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testOrQuery4(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testOrQuery4[{0}]")
+    @MethodSource("baseParams")
+    void testOrQuery4(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("even"),
                         Query.field("num_value_3_indexed").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(3)))
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Fetch(Covering(Index(MySimpleRecord$str_value_indexed [[even],[even]]) -> [rec_no: KEY[1], str_value_indexed: KEY[0]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[1],[1]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[3],[3]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
         RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[even],[even]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]")))
+        ), primaryKey("MySimpleRecord"));
+        assertMatchesExactly(plan, planMatcher);
 
-        if (shouldDeferFetch && !(planner instanceof CascadesPlanner)) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[even],[even]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))))
-                                    .where(comparisonKey(primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
+        if (orQueryParams.shouldDeferFetch() && !(planner instanceof CascadesPlanner)) {
             assertEquals(-417814093, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-1082480572, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else if (planner instanceof CascadesPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[even],[even]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))))
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(1891881268, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(2056249763, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[even],[even]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))
-                            .where(comparisonKey(primaryKey("MySimpleRecord")));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-673254486, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(991016881, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -616,43 +608,35 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             }
             assertEquals(50 + 10 + 10, i);
             assertDiscardedAtMost(20, context);
-            if (shouldDeferFetch) {
+            if (orQueryParams.shouldDeferFetch()) {
                 assertLoadRecord(50 + 10 + 10, context);
             }
         }
-    }
-
-    @SuppressWarnings("unused") // used as parameter shource for parameterized test
-    static Stream<Arguments> testOrQuery5() {
-        return Stream.of(false, true).flatMap(shouldDeferFetch ->
-                Stream.of(false, true).map(removesDuplicates ->
-                        Arguments.of(shouldDeferFetch, removesDuplicates)));
     }
 
     /**
      * Verify that an OR of inequalities on different fields uses an unordered union, since there is no compatible ordering.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testOrQuery5[shouldDeferFetch = {0}, removesDuplicates = {1}]")
-    @MethodSource
-    void testOrQuery5(boolean shouldDeferFetch, boolean removesDuplicates) throws Exception {
+    @ParameterizedTest(name = "testOrQuery5[{0}]")
+    @MethodSource("paramsWithAndWithoutRemovesDuplicates")
+    void testOrQuery5(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").lessThan("m"),
                         Query.field("num_value_3_indexed").greaterThan(3)))
-                .setRemoveDuplicates(removesDuplicates)
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Unordered(Index(MySimpleRecord$str_value_indexed ([null],[m])) ∪ Index(MySimpleRecord$num_value_3_indexed ([3],>))
         RecordQueryPlan plan = planner.plan(query);
 
         // Cascades planner always removes duplicates
-        boolean planRemovesDuplicates = removesDuplicates || planner instanceof CascadesPlanner;
-        if (shouldDeferFetch || planner instanceof CascadesPlanner) {
+        boolean planRemovesDuplicates = orQueryParams.isRemoveDuplicates() || planner instanceof CascadesPlanner;
+        if (orQueryParams.shouldDeferFetch() || planner instanceof CascadesPlanner) {
             BindingMatcher<? extends RecordQueryPlan> planMatcher =
                     unorderedUnionPlan(
                             coveringIndexPlan()
@@ -714,47 +698,63 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     @Nonnull
     @SuppressWarnings("unused") // used by reflection
     private static Stream<Arguments> query5WithLimitsArgs() {
-        return Stream.of(1, 2, 5, 7).flatMap(i -> Stream.of(Arguments.of(i, false), Arguments.of(i, true)));
+        return Stream.of(1, 2, 5, 7).flatMap(i ->
+                paramsWithAndWithoutRemovesDuplicates().map(params -> Arguments.of(i, params)));
     }
 
     @DualPlannerTest
+    @ParameterizedTest(name = "testOrQuery5WithLimits[limit = {0}, {1}]")
     @MethodSource("query5WithLimitsArgs")
-    @ParameterizedTest(name = "testOrQuery5WithLimits[limit = {0}, removesDuplicates = {1}]")
-    void testOrQuery5WithLimits(int limit, boolean removesDuplicates) throws Exception {
+    void testOrQuery5WithLimits(int limit, OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        setDeferFetchAfterUnionAndIntersection(true);
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").lessThan("m"),
                         Query.field("num_value_3_indexed").greaterThan(3)))
-                .setRemoveDuplicates(removesDuplicates)
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Unordered(Index(MySimpleRecord$str_value_indexed ([null],[m])) ∪ Index(MySimpleRecord$num_value_3_indexed ([3],>))
         RecordQueryPlan plan = planner.plan(query);
-        boolean planRemovesDuplicates = removesDuplicates || planner instanceof CascadesPlanner;
-
-        final BindingMatcher<RecordQueryUnorderedUnionPlan> unionPlanBindingMatcher = unorderedUnionPlan(
-                coveringIndexPlan()
-                        .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")))),
-                coveringIndexPlan()
-                        .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")))));
+        boolean planRemovesDuplicates = orQueryParams.isRemoveDuplicates() || planner instanceof CascadesPlanner;
 
         final BindingMatcher<? extends RecordQueryPlan> planMatcher;
-        if (planRemovesDuplicates) {
-            planMatcher = fetchFromPartialRecordPlan(unorderedPrimaryKeyDistinctPlan(unionPlanBindingMatcher));
+        if (orQueryParams.shouldDeferFetch() || planner instanceof CascadesPlanner) {
+            final BindingMatcher<RecordQueryUnorderedUnionPlan> unionPlanBindingMatcher = unorderedUnionPlan(
+                    coveringIndexPlan()
+                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")))),
+                    coveringIndexPlan()
+                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")))));
+
+            if (planRemovesDuplicates) {
+                planMatcher = fetchFromPartialRecordPlan(unorderedPrimaryKeyDistinctPlan(unionPlanBindingMatcher));
+            } else {
+                planMatcher = fetchFromPartialRecordPlan(unionPlanBindingMatcher);
+            }
         } else {
-            planMatcher = fetchFromPartialRecordPlan(unionPlanBindingMatcher);
+            final BindingMatcher<RecordQueryUnorderedUnionPlan> unionPlanBindingMatcher = unorderedUnionPlan(
+                            indexPlan().where(indexName("MySimpleRecord$str_value_indexed")),
+                            indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")));
+            if (planRemovesDuplicates) {
+                planMatcher = unorderedPrimaryKeyDistinctPlan(unionPlanBindingMatcher);
+            } else {
+                planMatcher = unionPlanBindingMatcher;
+            }
         }
 
         assertMatchesExactly(plan, planMatcher);
 
         if (planner instanceof RecordQueryPlanner) {
-            assertEquals(planRemovesDuplicates ? 1898767693 : 1898767686, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(planRemovesDuplicates ? -583062018 : 212117636, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(planRemovesDuplicates ? 1898767693 : 1898767686, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(planRemovesDuplicates ? -583062018 : 212117636, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(planRemovesDuplicates ? -1569447744 : -1569447745, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(planRemovesDuplicates ? 1558364455 : -1941423187, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
             assertEquals(planRemovesDuplicates ? 1898767693 : 1898767686, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(planRemovesDuplicates ? -583062018 : 212117636, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
@@ -780,7 +780,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                         assertTrue(myrec.getStrValueIndexed().compareTo("m") < 0 ||
                                    myrec.getNumValue3Indexed() > 3);
                         uniqueKeys.add(rec.getPrimaryKey());
-                        if (removesDuplicates) {
+                        if (planRemovesDuplicates) {
                             assertThat(keysThisIteration.add(rec.getPrimaryKey()), is(true));
                         }
                         i++;
@@ -804,14 +804,16 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * compatibility.
      */
     @DualPlannerTest
-    void testOrQuery6() throws Exception {
+    @ParameterizedTest(name = "testOrQuery6[{0}]")
+    @MethodSource("baseParams")
+    void testOrQuery6(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = metaData ->
                 metaData.addIndex("MySimpleRecord",
                         new Index("str_value_3_index",
                                 "str_value_indexed",
                                 "num_value_3_indexed"));
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.and(
@@ -819,31 +821,23 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                                 Query.field("num_value_3_indexed").greaterThan(3)),
                         Query.field("num_value_3_indexed").lessThan(1)))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(str_value_3_index ([even, 3],[even]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Index(MySimpleRecord$num_value_3_indexed ([null],[1]))
         RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("([even, 3],[even]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([null],[1])")))
+        ), concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")));
+        assertMatchesExactly(plan, planMatcher);
 
         if (planner instanceof CascadesPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("([even, 3],[even]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([null],[1])"))))))
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(2006798704, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1476903216, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+        } else if (orQueryParams.shouldDeferFetch()) {
+            assertEquals(-835124758, plan.planHash(PlanHashable.CURRENT_LEGACY));
+            assertEquals(778876973, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("([even, 3],[even]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([null],[1])"))))
-                            .where(comparisonKey(concat(Key.Expressions.field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(1721396731, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-1374663850, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -869,19 +863,18 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
 
     /**
      * Verify that a complex query with an OR of an AND produces a union plan if the appropriate indexes are defined.
-     * Unlike {@link #testOrQuery6()}, the legs of the union are not compatibly ordered, so this will revert to using
+     * Unlike {@link #testOrQuery6(OrQueryParams)}, the legs of the union are not compatibly ordered, so this will revert to using
      * an unordered union.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testUnorderableOrQueryWithAnd[removesDuplicates = {0}]")
-    @BooleanSource
-    void testUnorderableOrQueryWithAnd(boolean removesDuplicates) throws Exception {
+    @ParameterizedTest(name = "testUnorderableOrQueryWithAnd[{0}]")
+    @MethodSource("paramsWithAndWithoutRemovesDuplicates")
+    void testUnorderableOrQueryWithAnd(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook()
                 .andThen(metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", new Index("multi_index_2", "str_value_indexed", "num_value_3_indexed")));
         complexQuerySetup(hook);
-        setDeferFetchAfterUnionAndIntersection(true);
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(
                         Query.and(
@@ -889,30 +882,54 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                                 Query.or(Query.field("num_value_2").lessThanOrEquals(1), Query.field("num_value_3_indexed").greaterThanOrEquals(3))
                         )
                 )
-                .setRemoveDuplicates(removesDuplicates)
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Unordered(Index(multi_index ([even, null],[even, 1]]) ∪ Index(multi_index_2 [[even, 3],[even]]))
-        RecordQueryPlan plan = planner.plan(query);
+        final RecordQueryPlan plan = planner.plan(query);
 
-        BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                unorderedUnionPlan(
-                        coveringIndexPlan()
-                                .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("([even, null],[even, 1]]"))))),
-                        coveringIndexPlan()
-                                .where(indexPlanOf(indexPlan().where(indexName("multi_index_2")).and(scanComparisons(range("[[even, 3],[even]]"))))));
-
-        // The Cascades planner always removes duplicates, even when removesDuplicates is not specified on the query
-        boolean planRemovesDuplicates = removesDuplicates || (planner instanceof CascadesPlanner);
-        if (planRemovesDuplicates) {
-            planMatcher = fetchFromPartialRecordPlan(unorderedPrimaryKeyDistinctPlan(planMatcher));
+        // The Cascades planner always removes duplicates and defers fetches, even when not specified on the query
+        final boolean planRemovesDuplicates = orQueryParams.isRemoveDuplicates() || (planner instanceof CascadesPlanner);
+        final boolean planDefersFetches = orQueryParams.shouldDeferFetch() || (planner instanceof CascadesPlanner);
+        List<BindingMatcher<? extends RecordQueryIndexPlan>> indexScanMatchers = List.of(
+                indexPlan().where(indexName("multi_index")).and(scanComparisons(range("([even, null],[even, 1]]"))),
+                indexPlan().where(indexName("multi_index_2")).and(scanComparisons(range("[[even, 3],[even]]")))
+        );
+        final List<? extends BindingMatcher<? extends RecordQueryPlan>> childPlanMatchers;
+        if (planDefersFetches) {
+            childPlanMatchers = indexScanMatchers.stream()
+                    .map(indexScanMatcher -> coveringIndexPlan().where(indexPlanOf(indexScanMatcher)))
+                    .collect(Collectors.toList());
         } else {
+            childPlanMatchers = indexScanMatchers;
+        }
+        BindingMatcher<? extends RecordQueryPlan> planMatcher = unorderedUnionPlan(childPlanMatchers);
+
+        if (planRemovesDuplicates) {
+            planMatcher = unorderedPrimaryKeyDistinctPlan(planMatcher);
+        }
+        if (planDefersFetches) {
             planMatcher = fetchFromPartialRecordPlan(planMatcher);
         }
         assertMatchesExactly(plan, planMatcher);
 
-        assertEquals(planRemovesDuplicates ? -1216499257 : -1216499264, plan.planHash(PlanHashable.CURRENT_LEGACY));
-        assertEquals(planRemovesDuplicates ? 610131412 : 1405311066, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+        if (planRemovesDuplicates) {
+            if (planDefersFetches) {
+                assertEquals(-1216499257, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(610131412, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(-173785610, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1543409411, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
+        } else {
+            if (planDefersFetches) {
+                assertEquals(-1216499264, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(1405311066, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(-173785611, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-748229757, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
+        }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
@@ -943,12 +960,13 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * without repetition out of the index key and primary key (see note).
      */
     @DualPlannerTest
-    void testOrQuery7() throws Exception {
+    @ParameterizedTest(name = "testOrQuery7[{0}]")
+    @MethodSource("baseParams")
+    void testOrQuery7(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexPrimaryKeyHook(true);
         complexQuerySetup(hook);
-        setDeferFetchAfterUnionAndIntersection(true);
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.and(
                         Query.field("str_value_indexed").equalsValue("even"),
@@ -956,35 +974,38 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                                 Query.field("num_value_3_indexed").equalsValue(1),
                                 Query.field("num_value_3_indexed").greaterThan(3))))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(str_value_3_index [[even, 1],[even, 1]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'num_value_unique' None}] Index(str_value_3_index ([even, 3],[even]])
         RecordQueryPlan plan = planner.plan(query);
+        final KeyExpression comparisonKey = (orQueryParams.shouldOmitPrimaryKeyInOrderingKey() || planner instanceof CascadesPlanner)
+                ? concatenateFields("num_value_3_indexed", "num_value_unique")
+                : concatenateFields("str_value_indexed", "num_value_3_indexed", "num_value_unique");
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("[[even, 1],[even, 1]]"))),
+                indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("([even, 3],[even]]")))
+        ), comparisonKey);
+        assertMatchesExactly(plan, planMatcher);
 
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("[[even, 1],[even, 1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("([even, 3],[even]]"))))))
-                                    .where(comparisonKey(concat(field("num_value_3_indexed"), field("num_value_unique")))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(-60058062, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(-1391842890, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                if (orQueryParams.shouldOmitPrimaryKeyInOrderingKey()) {
+                    assertEquals(-60058062, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                    assertEquals(-1391842890, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+                } else {
+                    assertEquals(-664830657, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                    assertEquals(1572009327, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+                }
+            } else {
+                if (orQueryParams.shouldOmitPrimaryKeyInOrderingKey()) {
+                    assertEquals(-8579725, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                    assertEquals(749583583, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+                } else {
+                    assertEquals(-94975810, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                    assertEquals(-581531496, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+                }
+            }
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("[[even, 1],[even, 1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("str_value_3_index")).and(scanComparisons(range("([even, 3],[even]]"))))))
-                                    // note that the comparison key is only on (num_value_3_indexed, num_value_unique) as str_value_indexed is equality-bound
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("num_value_unique")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-3043538, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-142082973, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -1017,43 +1038,37 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * and does not need to partake in the ordering.
      */
     @DualPlannerTest
-    void testOrQueryOrdered() throws Exception {
+    @ParameterizedTest(name = "testOrQueryOrdered[{0}]")
+    @MethodSource("baseParams")
+    void testOrQueryOrdered(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexPrimaryKeyHook();
         complexQuerySetup(hook);
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder(field("num_value_3_indexed"))
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("num_value_3_indexed").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(3)))
-                .setSort(field("num_value_3_indexed"))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(MySimpleRecord$num_value_3_indexed [[1],[1]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'str_value_indexed' None}, Field { 'num_value_unique' None}] Index(MySimpleRecord$num_value_3_indexed [[3],[3]])
         RecordQueryPlan plan = planner.plan(query);
+        BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]")))
+        ), concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")));
+        assertMatchesExactly(plan, planMatcher);
 
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))
-                            .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(1412961915, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(258619931, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(1300798826, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1882806542, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(1412961915, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(258619931, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))))
-                                    // note that the comparison key is only on the primary key
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("str_value_indexed"), fieldValueWithFieldNames("num_value_unique")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(2142773918, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(21338461, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -1077,32 +1092,25 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
         }
 
         query = query.toBuilder()
-                .setSort(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")))
+                .setSort(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")), orQueryParams.isSortReverse())
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
         plan = planner.plan(query);
+        planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]")))
+        ), concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")));
+        assertMatchesExactly(plan, planMatcher);
 
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))
-                            .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(1412961915, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(258435419, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(1300798826, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1882991054, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(1412961915, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(258435419, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))))
-                                    // note that the comparison key is only on the primary key
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("str_value_indexed"), fieldValueWithFieldNames("num_value_unique")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(2142773918, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(21153949, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -1114,11 +1122,13 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * @throws Exception from test set up
      */
     @DualPlannerTest
-    void testOrderedOrQueryWithMultipleValuesForEarlierColumn() throws Exception {
+    @ParameterizedTest(name = "testOrderedOrQueryWithMultipleValuesForEarlierColumn[{0}]")
+    @MethodSource("baseParams")
+    void testOrderedOrQueryWithMultipleValuesForEarlierColumn(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
 
-        final RecordQuery query = RecordQuery.newBuilder()
+        final RecordQuery query = orQueryParams.queryBuilder(field("num_value_3_indexed"))
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.and(
                         Query.field("str_value_indexed").equalsValue("odd"),
@@ -1127,7 +1137,6 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                                 Query.field("num_value_2").equalsValue(2)
                         )
                 ))
-                .setSort(field("num_value_3_indexed"))
                 .build();
 
         // Collect all of the expected values into a list of matchers
@@ -1147,35 +1156,25 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             commit(context);
         }
 
-        // Initially, do not defer fetches. Note that this only affects the old planner
-        planner.setConfiguration(planner.getConfiguration().asBuilder()
-                .setDeferFetchAfterUnionAndIntersection(false)
-                .build());
-
         // Index(multi_index [[odd, 0],[odd, 0]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Index(multi_index [[odd, 2],[odd, 2]])
+        orQueryParams.setPlannerConfiguration(this);
         RecordQueryPlan plan = planner.plan(query);
+        final KeyExpression comparisonKey = planner instanceof CascadesPlanner ? concat(field("num_value_3_indexed"), field("num_value_2"), primaryKey("MySimpleRecord")) : concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"));
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 0],[odd, 0]]"))),
+                indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 2],[odd, 2]]")))
+        ), comparisonKey);
+        assertMatchesExactly(plan, planMatcher);
+
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                            indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 0],[odd, 0]]"))),
-                            indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 2],[odd, 2]]"))))
-                            .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(-1477800426, plan.planHash(CURRENT_LEGACY));
-            assertEquals(-521036388, plan.planHash(CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(-1754668377, plan.planHash(CURRENT_LEGACY));
+                assertEquals(1632504435, plan.planHash(CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(-1477800426, plan.planHash(CURRENT_LEGACY));
+                assertEquals(-521036388, plan.planHash(CURRENT_FOR_CONTINUATION));
+            }
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 0],[odd, 0]]"))))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 2],[odd, 2]]"))))))
-                                    // note that the comparison key is on num_value_3_indexed + the primary key
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("num_value_2"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-2004620414, plan.planHash(CURRENT_LEGACY));
             assertEquals(661700665, plan.planHash(CURRENT_FOR_CONTINUATION));
         }
@@ -1189,59 +1188,6 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                     .join();
 
             // Validate that the queried records contain all expected values
-            assertThat(queried, containsInAnyOrder(expected));
-
-            // Validate sort
-            Integer maxNumValue3 = null;
-            for (TestRecords1Proto.MySimpleRecord queriedRec : queried) {
-                if (maxNumValue3 != null) {
-                    assertThat(maxNumValue3, lessThanOrEqualTo(queriedRec.getNumValue3Indexed()));
-                }
-                maxNumValue3 = queriedRec.getNumValue3Indexed();
-            }
-        }
-
-        // Update the plan configuration to defer fetches. With the old planner, this moves the fetch to before the queries are executed.
-        // With the new planner, this is already the default behavior
-        setDeferFetchAfterUnionAndIntersection(true);
-        // Fetch(Covering(Index(multi_index [[odd, 0],[odd, 0]])) ∪[Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Covering(Index(multi_index [[odd, 2],[odd, 2]])))
-        plan = planner.plan(query);
-        if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher = fetchFromPartialRecordPlan(
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                            coveringIndexPlan().where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 0],[odd, 0]]"))))),
-                            coveringIndexPlan().where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 2],[odd, 2]]"))))))
-                            .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))))
-            );
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(-1754668377, plan.planHash(CURRENT_LEGACY));
-            assertEquals(1632504435, plan.planHash(CURRENT_FOR_CONTINUATION));
-        } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 0],[odd, 0]]"))))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd, 2],[odd, 2]]"))))))
-                                    // note that the comparison key is on num_value_3_indexed + the primary key
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("num_value_2"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(-2004620414, plan.planHash(CURRENT_LEGACY));
-            assertEquals(661700665, plan.planHash(CURRENT_FOR_CONTINUATION));
-        }
-
-        try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, hook);
-            final List<TestRecords1Proto.MySimpleRecord> queried = recordStore.executeQuery(plan)
-                    .map(FDBRecord::getRecord)
-                    .map(msg -> TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(msg).build())
-                    .asList()
-                    .join();
-
-            // Validate contents
             assertThat(queried, containsInAnyOrder(expected));
 
             // Validate sort
@@ -1276,43 +1222,46 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * @see <a href="https://github.com/FoundationDB/fdb-record-layer/issues/2336">Issue #2336</a>
      */
     @DualPlannerTest
-    void testOrderedOrQueryWithIntermediateUnorderedColumn() throws Exception {
+    @ParameterizedTest(name = "testOrderedOrQueryWithIntermediateUnorderedColumn[{0}]")
+    @MethodSource("baseParams")
+    void testOrderedOrQueryWithIntermediateUnorderedColumn(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
 
-        final RecordQuery query = RecordQuery.newBuilder()
+        final RecordQuery query = orQueryParams.queryBuilder(field("num_value_2"))
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("odd"),
                         Query.field("str_value_indexed").equalsValue("even")
                 ))
-                .setSort(field("num_value_2"))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(multi_index [[odd],[odd]]) ∪[Field { 'num_value_2' None}, Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Index(multi_index [[even],[even]])
-        final RecordQueryPlan plan = planner.plan(query);
-        if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                            indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd],[odd]]"))),
-                            indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even],[even]]"))))
-                            .where(comparisonKey(concat(field("num_value_2"), field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(-363390528, plan.planHash(CURRENT_LEGACY));
-            assertEquals(1294497974, plan.planHash(CURRENT_FOR_CONTINUATION));
+        final RecordQueryPlan plan;
+        if (planner instanceof RecordQueryPlanner && !orQueryParams.shouldOmitPrimaryKeyInOrderingKey()) {
+            RecordCoreException err = assertThrows(RecordCoreException.class, () -> planner.plan(query));
+            assertThat(err.getMessage(), Matchers.containsString("Cannot sort without appropriate index"));
+            return;
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd],[odd]]"))))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even],[even]]"))))))
-                                    // note that the comparison key is on num_value_2 + num_value_3_indexed + the primary key
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_2"), fieldValueWithFieldNames("str_value_indexed"), fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
+            plan = planner.plan(query);
+        }
 
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[odd],[odd]]"))),
+                indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even],[even]]")))
+        ), planner instanceof CascadesPlanner ? concat(field("num_value_2"), field("str_value_indexed"), field("num_value_3_indexed"), primaryKey("MySimpleRecord")) : concat(field("num_value_2"), field("num_value_3_indexed"), primaryKey("MySimpleRecord")));
+        assertMatchesExactly(plan, planMatcher);
+
+        if (planner instanceof RecordQueryPlanner) {
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(1751233613, plan.planHash(CURRENT_LEGACY));
+                assertEquals(-846928499, plan.planHash(CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(-363390528, plan.planHash(CURRENT_LEGACY));
+                assertEquals(1294497974, plan.planHash(CURRENT_FOR_CONTINUATION));
+            }
+        } else {
             assertEquals(471546238, plan.planHash(CURRENT_LEGACY));
             assertEquals(1167317451, plan.planHash(CURRENT_FOR_CONTINUATION));
         }
@@ -1353,13 +1302,15 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * @throws Exception from test set up
      */
     @DualPlannerTest
-    void testOrderedUnionDoesNotUseIndexWithExtraRepeatedColumn() throws Exception {
+    @ParameterizedTest(name = "testOrderedUnionDoesNotUseIndexWithExtraRepeatedColumn[{0}]")
+    @MethodSource("baseParams")
+    void testOrderedUnionDoesNotUseIndexWithExtraRepeatedColumn(OrQueryParams orQueryParams) throws Exception {
         final Index index = new Index("str_3_repeater", concat(field("str_value_indexed"), field("num_value_3_indexed"), field("repeater", KeyExpression.FanType.FanOut)));
         RecordMetaDataHook hook = complexQuerySetupHook()
                 .andThen(metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index));
         complexQuerySetup(hook);
 
-        final RecordQuery query = RecordQuery.newBuilder()
+        final RecordQuery query = orQueryParams.queryBuilder(field("num_value_3_indexed"))
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("even"),
@@ -1367,6 +1318,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                 ))
                 .setSort(field("num_value_3_indexed"))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(MySimpleRecord$num_value_3_indexed <,>) | Or([str_value_indexed EQUALS even, str_value_indexed EQUALS odd])
         RecordQueryPlan plan = planner.plan(query);
@@ -1423,9 +1375,9 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     }
 
     @DualPlannerTest
-    @ParameterizedTest(name = "testOrQueryChildReordering[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testOrQueryChildReordering(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testOrQueryChildReordering[{0}]")
+    @MethodSource("baseParams")
+    void testOrQueryChildReordering(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
         RecordQuery query1 = RecordQuery.newBuilder()
@@ -1436,7 +1388,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                 .setSort(null, true)
                 .setRemoveDuplicates(true)
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(MySimpleRecord$str_value_indexed [[odd],[odd]] REVERSE) ∪ Index(MySimpleRecord$num_value_3_indexed [[0],[0]] REVERSE)
         // Fetch(Covering(Index(MySimpleRecord$str_value_indexed [[odd],[odd]] REVERSE) -> [rec_no: KEY[1], str_value_indexed: KEY[0]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[0],[0]] REVERSE) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
@@ -1454,7 +1406,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
         assertNotEquals(plan1, plan2);
         assertEquals(plan1.semanticHashCode(), plan2.semanticHashCode());
         assertTrue(plan1.semanticEquals(plan2));
-        if (shouldDeferFetch && !(planner instanceof CascadesPlanner)) {
+        if (orQueryParams.shouldDeferFetch() && !(planner instanceof CascadesPlanner)) {
             assertEquals(-1584186103, plan1.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-357068519, plan1.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
             assertEquals(-91575587, plan2.planHash(PlanHashable.CURRENT_LEGACY));
@@ -1493,28 +1445,26 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             }
             assertEquals(60, i);
             assertDiscardedAtMost(20, context);
-            if (shouldDeferFetch) {
+            if (orQueryParams.shouldDeferFetch()) {
                 assertLoadRecord(120, context);
             }
         }
     }
 
     @DualPlannerTest
-    @ParameterizedTest(name = "testOrQueryChildReordering2[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testOrQueryChildReordering2(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testOrQueryChildReordering2[{0}]")
+    @MethodSource("reverseParams")
+    void testOrQueryChildReordering2(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query1 = RecordQuery.newBuilder()
+        RecordQuery query1 = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("odd"),
                         Query.field("num_value_3_indexed").equalsValue(0),
                         Query.field("num_value_3_indexed").equalsValue(3)))
-                .setSort(null, true)
-                .setRemoveDuplicates(true)
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(MySimpleRecord$str_value_indexed [[odd],[odd]] REVERSE) ∪ Index(MySimpleRecord$num_value_3_indexed [[0],[0]] REVERSE) ∪ Index(MySimpleRecord$num_value_3_indexed [[3],[3]] REVERSE)
         // Fetch(Covering(Index(MySimpleRecord$str_value_indexed [[odd],[odd]] REVERSE) -> [rec_no: KEY[1], str_value_indexed: KEY[0]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[0],[0]] REVERSE) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[3],[3]] REVERSE) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
@@ -1531,7 +1481,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
         assertEquals(plan1.semanticHashCode(), plan2.semanticHashCode());
         assertTrue(plan1.semanticEquals(plan2));
         
-        if (shouldDeferFetch && !(planner instanceof CascadesPlanner)) {
+        if (orQueryParams.shouldDeferFetch() && !(planner instanceof CascadesPlanner)) {
             assertEquals(770691035, plan1.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1890796442, plan1.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
             assertEquals(1289607451, plan2.planHash(PlanHashable.CURRENT_LEGACY));
@@ -1570,7 +1520,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             }
             assertEquals(70, i);
             assertDiscardedAtMost(40, context);
-            if (shouldDeferFetch) {
+            if (orQueryParams.shouldDeferFetch()) {
                 assertLoadRecord(140, context);
             }
         }
@@ -1580,7 +1530,9 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * Verify that a query with an OR of an AND can be implemented as a union of an index scan with an intersection of index scans.
      */
     @DualPlannerTest
-    void testOrderedOrQueryWithAnd() throws Exception {
+    @ParameterizedTest(name = "testOrderedOrQueryWithAnd[{0}]")
+    @MethodSource("baseParams")
+    void testOrderedOrQueryWithAnd(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = metaData -> {
             metaData.addIndex("MySimpleRecord", "str_2", concat(field("str_value_indexed"), field("num_value_2")));
             metaData.addIndex("MySimpleRecord", "nu_2", concat(field("num_value_unique"), field("num_value_2")));
@@ -1588,31 +1540,47 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
         };
         complexQuerySetup(hook);
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder(field("num_value_2"))
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("even"),
                         Query.and(
                                 Query.field("num_value_3_indexed").equalsValue(1),
                                 Query.field("num_value_unique").equalsValue(909))))
-                .setSort(field("num_value_2"))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(str_2 [[even],[even]]) ∪[Field { 'num_value_2' None}, Field { 'rec_no' None}] Index(nu_2 [[909],[909]]) ∩ Index(n3_2 [[1],[1]])
         RecordQueryPlan plan = planner.plan(query);
 
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("str_2")).and(scanComparisons(range("[[even],[even]]"))),
-                                    intersectionOnExpressionPlan(
-                                            indexPlan().where(indexName("nu_2")).and(scanComparisons(range("[[909],[909]]"))),
-                                            indexPlan().where(indexName("n3_2")).and(scanComparisons(range("[[1],[1]]")))))
-                            .where(comparisonKey(concat(field("num_value_2"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
+            if (orQueryParams.shouldDeferFetch()) {
+                final BindingMatcher<? extends RecordQueryPlan> planMatcher =
+                        unionOnExpressionPlan(
+                                indexPlan().where(indexName("str_2")).and(scanComparisons(range("[[even],[even]]"))),
+                                fetchFromPartialRecordPlan(
+                                        intersectionOnExpressionPlan(
+                                                coveringIndexPlan().where(indexPlanOf(indexPlan().where(indexName("nu_2")).and(scanComparisons(range("[[909],[909]]"))))),
+                                                coveringIndexPlan().where(indexPlanOf(indexPlan().where(indexName("n3_2")).and(scanComparisons(range("[[1],[1]]"))))))
+                                ))
+                                .where(comparisonKey(concat(field("num_value_2"), primaryKey("MySimpleRecord"))));
+                assertMatchesExactly(plan, planMatcher);
 
-            assertEquals(-1659601413, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(-1344221020, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+                assertEquals(-31022114, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1965726789, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                final BindingMatcher<? extends RecordQueryPlan> planMatcher =
+                        unionOnExpressionPlan(
+                                indexPlan().where(indexName("str_2")).and(scanComparisons(range("[[even],[even]]"))),
+                                intersectionOnExpressionPlan(
+                                        indexPlan().where(indexName("nu_2")).and(scanComparisons(range("[[909],[909]]"))),
+                                        indexPlan().where(indexName("n3_2")).and(scanComparisons(range("[[1],[1]]")))))
+                                .where(comparisonKey(concat(field("num_value_2"), primaryKey("MySimpleRecord"))));
+                assertMatchesExactly(plan, planMatcher);
+
+                assertEquals(-1659601413, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1344221020, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
             final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                     fetchFromPartialRecordPlan(
@@ -1649,56 +1617,34 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * union cursors works properly with a returned record limit.
      */
     @DualPlannerTest
-    @ParameterizedTest(name = "testComplexLimits5[shouldDeferFetch = {0}]")
-    @BooleanSource
-    void testComplexLimits5(boolean shouldDeferFetch) throws Exception {
+    @ParameterizedTest(name = "testComplexLimits5[{0}]")
+    @MethodSource("baseParams")
+    void testComplexLimits5(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("odd"),
                         Query.field("num_value_3_indexed").equalsValue(0)))
                 .build();
-        setDeferFetchAfterUnionAndIntersection(shouldDeferFetch);
+        orQueryParams.setPlannerConfiguration(this);
 
         // Fetch(Covering(Index(MySimpleRecord$str_value_indexed [[odd],[odd]]) -> [rec_no: KEY[1], str_value_indexed: KEY[0]]) ∪ Covering(Index(MySimpleRecord$num_value_3_indexed [[0],[0]]) -> [num_value_3_indexed: KEY[0], rec_no: KEY[1]]))
         RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]")))
+        ), primaryKey("MySimpleRecord"));
+        assertMatchesExactly(plan, planMatcher);
 
-        if (shouldDeferFetch && !(planner instanceof CascadesPlanner)) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]"))))))
-                                    .where(comparisonKey(primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-
+        if (orQueryParams.shouldDeferFetch() && !(planner instanceof CascadesPlanner)) {
             assertEquals(-1584186334, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-351348461, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else if (planner instanceof CascadesPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]"))))))
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(725509027, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-1507585422, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("[[odd],[odd]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[0],[0]]"))))
-                            .where(comparisonKey(primaryKey("MySimpleRecord")));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-2067012605, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1790078012, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -1720,7 +1666,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             }
             assertEquals(5, i);
             assertDiscardedAtMost(1, context);
-            if (shouldDeferFetch) {
+            if (orQueryParams.shouldDeferFetch()) {
                 assertLoadRecord(5, context);
             }
         }
@@ -1731,11 +1677,13 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * In particular, verify that an AND of OR still uses a union of index scans (an OR of AND).
      */
     @DualPlannerTest
-    void testOrQueryDenorm() throws Exception {
+    @ParameterizedTest(name = "testOrQueryDenorm[{0}]")
+    @MethodSource("baseParams")
+    void testOrQueryDenorm(OrQueryParams orQueryParams) throws Exception {
         // new Index("multi_index", "str_value_indexed", "num_value_2", "num_value_3_indexed")
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.and(
                         Query.field("str_value_indexed").equalsValue("even"),
@@ -1746,28 +1694,25 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                                         Query.field("num_value_3_indexed").greaterThanOrEquals(2),
                                         Query.field("num_value_3_indexed").lessThanOrEquals(3)))))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(multi_index [[even, 0, 0],[even, 0, 0]]) ∪[Field { 'num_value_3_indexed' None}, Field { 'rec_no' None}] Index(multi_index [[even, 0, 2],[even, 0, 3]])
         RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even, 0, 0],[even, 0, 0]]"))),
+                indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even, 0, 2],[even, 0, 3]]")))
+        ), concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord")));
+        assertMatchesExactly(plan, planMatcher);
+
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even, 0, 0],[even, 0, 0]]"))),
-                                    indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even, 0, 2],[even, 0, 3]]"))))
-                            .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
-            assertMatchesExactly(plan, planMatcher);
-            assertEquals(-2074065439, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(-1146901452, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(-1633556172, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(1006639371, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(-2074065439, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1146901452, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even, 0, 0],[even, 0, 0]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("multi_index")).and(scanComparisons(range("[[even, 0, 2],[even, 0, 3]]"))))))
-                                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
             assertEquals(1208367290, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(1704665614, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
@@ -1796,7 +1741,9 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * in how they exhaust the union sources.
      */
     @DualPlannerTest
-    void testOrQuerySplitContinuations() throws Exception {
+    @ParameterizedTest(name = "testOrQuerySplitContinuations[{0}]")
+    @MethodSource("baseParams")
+    void testOrQuerySplitContinuations(OrQueryParams orQueryParams) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
 
@@ -1809,43 +1756,37 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
             commit(context);
         }
         // Each substream completes before the next one starts.
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("num_value_3_indexed").equalsValue(1),
                         Query.field("num_value_3_indexed").equalsValue(3),
                         Query.field("num_value_3_indexed").equalsValue(5)))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(MySimpleRecord$num_value_3_indexed [[1],[1]]) ∪ Index(MySimpleRecord$num_value_3_indexed [[3],[3]]) ∪ Index(MySimpleRecord$num_value_3_indexed [[5],[5]])
         RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[5],[5]]")))
+        ), planner instanceof CascadesPlanner ? concat(primaryKey("MySimpleRecord"), field("num_value_3_indexed")) : primaryKey("MySimpleRecord"));
+        assertMatchesExactly(plan, planMatcher);
+
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))),
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[5],[5]]"))))
-                            .where(comparisonKey(primaryKey("MySimpleRecord")));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(273143386, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(1919034675, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(1912003715, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-154462778, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(273143386, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(1919034675, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[1],[1]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[3],[3]]"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("[[5],[5]]"))))))
-                                    .where(comparisonKeyValues(exactlyInAnyOrder(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no")))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(-1974122290, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(2099150219, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
+
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             for (int limit = 1; limit <= 5; limit++) {
@@ -1875,17 +1816,20 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      * Verify that queries with an OR of predicates with a common scan and different filters does not bother with a Union.
      */
     @DualPlannerTest
-    void testOrQueryNoIndex() throws Exception {
+    @ParameterizedTest(name = "testOrQueryNoIndex[{0}]")
+    @MethodSource("baseParams")
+    void testOrQueryNoIndex(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = metadata -> metadata.removeIndex("MySimpleRecord$num_value_3_indexed");
         complexQuerySetup(hook);
         QueryComponent orComponent = Query.or(
                 Query.field("num_value_3_indexed").equalsValue(1),
                 Query.field("num_value_3_indexed").equalsValue(2),
                 Query.field("num_value_3_indexed").equalsValue(4));
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.and(Query.field("str_value_indexed").equalsValue("even"), orComponent))
                 .build();
+        orQueryParams.setPlannerConfiguration(this);
 
         // Index(MySimpleRecord$str_value_indexed [[even],[even]]) | Or([num_value_3_indexed EQUALS 1, num_value_3_indexed EQUALS 2, num_value_3_indexed EQUALS 4])
         RecordQueryPlan plan = planner.plan(query);
@@ -1957,7 +1901,7 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
         RecordQueryPlan modifiedPlan1 = RecordQueryPlannerSubstitutionVisitor.applyRegularVisitors(RecordQueryPlannerConfiguration.defaultPlannerConfiguration(), originalPlan1, recordStore.getRecordMetaData(), PlannableIndexTypes.DEFAULT, primaryKey("MySimpleRecord"));
         final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                 fetchFromPartialRecordPlan(
-                        RecordQueryPlanMatchers.unionOnExpressionPlan(
+                        unionOnExpressionPlan(
                                 coveringIndexPlan()
                                         .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")))),
                                 coveringIndexPlan()
@@ -1975,14 +1919,16 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     }
 
     @DualPlannerTest
-    void deferFetchOnUnionWithInnerFilter() throws Exception {
+    @ParameterizedTest(name = "deferFetchOnUnionWithInnerFilter[{0}]")
+    @MethodSource("baseParams")
+    void deferFetchOnUnionWithInnerFilter(OrQueryParams orQueryParams) throws Exception {
         complexQuerySetup(metaData -> {
             // We don't prefer covering indexes over other indexes yet.
             metaData.removeIndex("MySimpleRecord$num_value_3_indexed");
             metaData.addIndex("MySimpleRecord", "coveringIndex", new KeyWithValueExpression(concat(field("num_value_2"), field("num_value_3_indexed")), 1));
         });
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").startsWith("foo"),
@@ -1994,27 +1940,45 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                                 Query.field("num_value_2").greaterThanOrEquals(26))
                 ))
                 .build();
-        setDeferFetchAfterUnionAndIntersection(true);
+        orQueryParams.setPlannerConfiguration(this);
         RecordQueryPlan plan = planner.plan(query);
 
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            unorderedPrimaryKeyDistinctPlan(
-                                    unorderedUnionPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("{[foo],[foo]}"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("coveringIndex")).and(scanComparisons(range("[[2],[4]]"))))),
-                                            filterPlan(
-                                                    coveringIndexPlan()
-                                                            .where(indexPlanOf(indexPlan().where(indexName("coveringIndex")).and(scanComparisons(range("[[26],>"))))))
-                                                    .where(queryComponents(exactly(equalsObject(Query.field("num_value_3_indexed").lessThanOrEquals(18)))))
-                                    )));
-            assertMatchesExactly(plan, planMatcher);
+            if (orQueryParams.shouldDeferFetch()) {
+                final BindingMatcher<? extends RecordQueryPlan> planMatcher =
+                        fetchFromPartialRecordPlan(
+                                unorderedPrimaryKeyDistinctPlan(
+                                        unorderedUnionPlan(
+                                                coveringIndexPlan()
+                                                        .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("{[foo],[foo]}"))))),
+                                                coveringIndexPlan()
+                                                        .where(indexPlanOf(indexPlan().where(indexName("coveringIndex")).and(scanComparisons(range("[[2],[4]]"))))),
+                                                filterPlan(
+                                                        coveringIndexPlan()
+                                                                .where(indexPlanOf(indexPlan().where(indexName("coveringIndex")).and(scanComparisons(range("[[26],>"))))))
+                                                        .where(queryComponents(exactly(equalsObject(Query.field("num_value_3_indexed").lessThanOrEquals(18)))))
+                                        )));
+                assertMatchesExactly(plan, planMatcher);
 
-            assertEquals(-1829743477, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(-1168128533, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+                assertEquals(-1829743477, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1168128533, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                final BindingMatcher<? extends RecordQueryPlan> planMatcher =
+                        unorderedPrimaryKeyDistinctPlan(
+                                unorderedUnionPlan(
+                                        indexPlan().where(indexName("MySimpleRecord$str_value_indexed")).and(scanComparisons(range("{[foo],[foo]}"))),
+                                        indexPlan().where(indexName("coveringIndex")).and(scanComparisons(range("[[2],[4]]"))),
+                                        fetchFromPartialRecordPlan(
+                                                filterPlan(
+                                                        coveringIndexPlan()
+                                                                .where(indexPlanOf(indexPlan().where(indexName("coveringIndex")).and(scanComparisons(range("[[26],>"))))))
+                                                        .where(queryComponents(exactly(equalsObject(Query.field("num_value_3_indexed").lessThanOrEquals(18)))))
+                                        )));
+                assertMatchesExactly(plan, planMatcher);
+
+                assertEquals(-1023404717, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(787297195, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
             final BindingMatcher<? extends RecordQueryPlan> planMatcher =
                     fetchFromPartialRecordPlan(
@@ -2037,67 +2001,61 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
     }
 
     @DualPlannerTest
-    void testOrQueryToDistinctUnion() throws Exception {
+    @ParameterizedTest(name = "testOrQueryToDistinctUnion[{0}]")
+    @MethodSource("baseParams")
+    void testOrQueryToDistinctUnion(OrQueryParams orQueryParams) throws Exception {
         RecordMetaDataHook hook = complexQuerySetupHook();
         complexQuerySetup(hook);
-        setDeferFetchAfterUnionAndIntersection(true);
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("m"),
                         Query.field("num_value_3_indexed").equalsValue(3)))
-                .setRemoveDuplicates(true)
                 .build();
 
+        orQueryParams.setPlannerConfiguration(this);
         final RecordQueryPlan plan = planner.plan(query);
+        final BindingMatcher<? extends RecordQueryPlan> planMatcher = queryPlanMatcher(orQueryParams, List.of(
+                indexPlan().where(indexName("MySimpleRecord$str_value_indexed")),
+                indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed"))
+        ), null);
+        assertMatchesExactly(plan, planMatcher);
 
         if (planner instanceof RecordQueryPlanner) {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed"))))));
-            assertMatchesExactly(plan, planMatcher);
-
-            assertEquals(-1608004667, plan.planHash(PlanHashable.CURRENT_LEGACY));
-            assertEquals(-291254354, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            if (orQueryParams.shouldDeferFetch()) {
+                assertEquals(-1608004667, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-291254354, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertEquals(-2070415224, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(1850172119, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
         } else {
-            final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnValuesPlan(
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")))),
-                                    coveringIndexPlan()
-                                            .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed"))))));
-            assertMatchesExactly(plan, planMatcher);
-
             assertEquals(701690694, plan.planHash(PlanHashable.CURRENT_LEGACY));
             assertEquals(-1447491315, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
         }
     }
 
     @DualPlannerTest
-    void testOrQueryToDistinctUnionWithPartialDefer() throws Exception {
+    @ParameterizedTest(name = "testOrQueryToDistinctUnionWithPartialDefer[{0}]")
+    @MethodSource("baseParams")
+    void testOrQueryToDistinctUnionWithPartialDefer(OrQueryParams orQueryParams) throws Exception {
         complexQuerySetup(null);
-        setDeferFetchAfterUnionAndIntersection(true);
 
-        RecordQuery query = RecordQuery.newBuilder()
+        RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.or(
                         Query.field("str_value_indexed").equalsValue("m"),
                         Query.field("num_value_3_indexed").equalsValue(3),
                         Query.and(Query.field("num_value_2").equalsValue(3), Query.field("num_value_3_indexed").equalsValue(4))))
-                .setRemoveDuplicates(true)
                 .build();
 
+        orQueryParams.setPlannerConfiguration(this);
         final RecordQueryPlan plan = planner.plan(query);
 
         if (planner instanceof RecordQueryPlanner) {
             final BindingMatcher<? extends RecordQueryPlan> planMatcher =
-                    RecordQueryPlanMatchers.unionOnExpressionPlan(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")),
+                    unionOnExpressionPlan(indexPlan().where(indexName("MySimpleRecord$str_value_indexed")),
                             indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")),
                             filterPlan(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed"))).where(queryComponents(exactly(equalsObject(Query.field("num_value_2").equalsValue(3))))));
 
@@ -2129,11 +2087,12 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
      *      (according to the current cost model which is probably correct).
      */
     @DualPlannerTest
-    void testComplexOrQueryToDistinctUnion() throws Exception {
+    @ParameterizedTest(name = "testComplexOrQueryToDistinctUnion[{0}]")
+    @MethodSource("baseParams")
+    void testComplexOrQueryToDistinctUnion(OrQueryParams orQueryParams) throws Exception {
         complexQuerySetup(null);
-        setDeferFetchAfterUnionAndIntersection(true);
 
-        final RecordQuery query = RecordQuery.newBuilder()
+        final RecordQuery query = orQueryParams.queryBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(Query.and(
                         Query.field("str_value_indexed").equalsValue("outer"),
@@ -2156,70 +2115,95 @@ class FDBOrQueryToUnionTest extends FDBRecordStoreQueryTestBase {
                                         Query.field("num_value_3_indexed").lessThan(16)),
                                 Query.and(Query.field("num_value_3_indexed").greaterThan(17),
                                         Query.field("num_value_3_indexed").lessThan(18)))))
-                .setRemoveDuplicates(true)
                 .build();
 
+        orQueryParams.setPlannerConfiguration(this);
         final RecordQueryPlan plan = planner.plan(query);
-        
+
+        final List<BindingMatcher<RecordQueryIndexPlan>> indexMatchers = List.of(
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([1],[2])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],[4])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([5],[6])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([7],[8])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([9],[10])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([11],[12])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([13],[14])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([15],[16])"))),
+                        indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([17],[18])")))
+        );
+
         final BindingMatcher<? extends RecordQueryPlan> planMatcher;
         if (planner instanceof RecordQueryPlanner) {
-            planMatcher = filterPlan(
-                    fetchFromPartialRecordPlan(
-                            RecordQueryPlanMatchers.unionOnExpressionPlan(
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([1],[2])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],[4])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([5],[6])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([7],[8])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([9],[10])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([11],[12])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([13],[14])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([15],[16])"))))),
-                                            coveringIndexPlan()
-                                                    .where(indexPlanOf(indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([17],[18])"))))))
-                                    .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))))
-                    ))
-                    .where(queryComponents(exactly(equalsObject(Query.field("str_value_indexed").equalsValue("outer")))));
-
+            if (orQueryParams.shouldDeferFetch()) {
+                planMatcher = filterPlan(
+                        fetchFromPartialRecordPlan(
+                                unionOnExpressionPlan(
+                                        indexMatchers.stream()
+                                                .map(indexPlanMatcher -> coveringIndexPlan().where(indexPlanOf(indexPlanMatcher)))
+                                                .collect(Collectors.toList()))
+                                        .where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))))
+                        ))
+                        .where(queryComponents(exactly(equalsObject(Query.field("str_value_indexed").equalsValue("outer")))));
+            } else {
+                planMatcher = unionOnExpressionPlan(
+                        indexMatchers
+                                .stream()
+                                .map(indexPlanMatcher -> filterPlan(indexPlanMatcher).where(queryComponents(exactly(equalsObject(Query.field("str_value_indexed").equalsValue("outer"))))))
+                                .collect(Collectors.toList())
+                ).where(comparisonKey(concat(field("num_value_3_indexed"), primaryKey("MySimpleRecord"))));
+            }
         } else {
             planMatcher = RecordQueryPlanMatchers.unionOnValuesPlan(
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([1],[2])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([3],[4])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([5],[6])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([7],[8])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([9],[10])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([11],[12])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([13],[14])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([15],[16])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))),
-                            predicatesFilterPlan(
-                                    indexPlan().where(indexName("MySimpleRecord$num_value_3_indexed")).and(scanComparisons(range("([17],[18])"))))
-                                    .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer"))))))
-                    .where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no"))));
-
+                    indexMatchers.stream().map(indexPlanMatcher -> predicatesFilterPlan(indexPlanMatcher)
+                            .where(predicates(only(valuePredicate(ValueMatchers.fieldValueWithFieldNames("str_value_indexed"), new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, "outer")))))
+                    ).collect(Collectors.toList())
+            ).where(comparisonKeyValues(exactly(fieldValueWithFieldNames("num_value_3_indexed"), fieldValueWithFieldNames("rec_no"))));
         }
         assertMatches(plan, planMatcher);
+    }
+
+    @Nonnull
+    private BindingMatcher<? extends RecordQueryPlan> queryPlanMatcher(@Nonnull OrQueryParams orQueryParams, @Nonnull List<BindingMatcher<RecordQueryIndexPlan>> indexPlanMatchers, @Nullable KeyExpression comparisonKey) {
+        BindingMatcher<? extends RecordQueryUnionPlan> unionPlanMatcher = unionPlanMatcher(orQueryParams, indexPlanMatchers, comparisonKey);
+        if (planner instanceof CascadesPlanner || orQueryParams.shouldDeferFetch()) {
+            return fetchFromPartialRecordPlan(unionPlanMatcher);
+        } else {
+            return unionPlanMatcher;
+        }
+    }
+
+    @Nonnull
+    private BindingMatcher<? extends RecordQueryUnionPlan> unionPlanMatcher(@Nonnull OrQueryParams orQueryParams, @Nonnull List<BindingMatcher<RecordQueryIndexPlan>> indexPlanMatchers, @Nullable KeyExpression comparisonKey) {
+        if (planner instanceof RecordQueryPlanner) {
+            BindingMatcher<RecordQueryUnionOnKeyExpressionPlan> unionPlanMatcher;
+            if (orQueryParams.shouldDeferFetch()) {
+                unionPlanMatcher = unionOnExpressionPlan(
+                        indexPlanMatchers.stream().map(indexPlanMatcher -> coveringIndexPlan().where(indexPlanOf(indexPlanMatcher))).collect(Collectors.toList())
+                );
+            } else {
+                unionPlanMatcher = unionOnExpressionPlan(indexPlanMatchers);
+            }
+            if (comparisonKey != null) {
+                unionPlanMatcher = unionPlanMatcher.where(comparisonKey(comparisonKey));
+            }
+            return unionPlanMatcher;
+        } else {
+            BindingMatcher<RecordQueryUnionOnValuesPlan> unionPlanMatcher = unionOnValuesPlan(
+                    indexPlanMatchers.stream().map(indexPlanMatcher -> coveringIndexPlan().where(indexPlanOf(indexPlanMatcher))).collect(Collectors.toList())
+            );
+            if (comparisonKey != null) {
+                List<BindingMatcher<? extends Value>> fieldValueMatchers = comparisonKey.normalizeKeyForPositions().stream()
+                        .map(childExpr -> {
+                            if (childExpr instanceof FieldKeyExpression) {
+                                return fieldValueWithFieldNames(((FieldKeyExpression)childExpr).getFieldName());
+                            } else {
+                                return fail("unexpected comparison key type: " + childExpr);
+                            }
+                        })
+                        .collect(Collectors.toList());
+                unionPlanMatcher = unionPlanMatcher.where(comparisonKeyValues(exactly(fieldValueMatchers)));
+            }
+            return unionPlanMatcher;
+        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -484,6 +484,16 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         }
     }
 
+    protected void setOmitPrimaryKeyInUnionOrderingKey(boolean shouldOmitPrimaryKeyInUnionOrderingKey) {
+        if (planner instanceof RecordQueryPlanner) {
+            RecordQueryPlanner recordQueryPlanner = (RecordQueryPlanner)planner;
+            recordQueryPlanner.setConfiguration(recordQueryPlanner.getConfiguration()
+                    .asBuilder()
+                    .setOmitPrimaryKeyInUnionOrderingKey(shouldOmitPrimaryKeyInUnionOrderingKey)
+                    .build());
+        }
+    }
+
     protected void setOptimizeForIndexFilters(boolean shouldOptimizeForIndexFilters) {
         assertTrue(planner instanceof RecordQueryPlanner);
         RecordQueryPlanner recordQueryPlanner = (RecordQueryPlanner)planner;


### PR DESCRIPTION
In order to avoid breaking continuations of plans affected by #2336, this adds a planner configuration flag that allows the user to effectively revert to the old behavior. This property is set to the old behavior by default, letting users to opt-in to the new behavior if they know it is safe for their deployment. This also includes a bit of a revamp of the or query tests to make sure all of the configurations get tested. There were two queries that had their plan hashes updated in #2350 (resolving #2336). The plan hashes in this PR for the legacy mode match the old plan hashes from before #2350 went in.

This fixes #2408.