### PR TITLE
Remove references of caller context to avoid future misuse

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** FDBDirecotry: remove references to caller context to avoid future mis-usage [(Issue #2412)](https://github.com/FoundationDB/fdb-record-layer/issues/2412)
 * **Feature** LuceneScaleTest: Add merge options to test configuration [(Issue #2410)](https://github.com/FoundationDB/fdb-record-layer/issues/2410)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
+import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.record.lucene.LuceneEvents;
 import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
@@ -30,6 +31,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfi
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.StampedLock;
@@ -66,6 +68,10 @@ public interface AgilityContext {
 
     default void clear(Range range) {
         accept(context -> context.ensureActive().clear(range));
+    }
+
+    default CompletableFuture<List<KeyValue>> getRange(byte[] begin, byte[] end) {
+        return apply(context -> context.ensureActive().getRange(begin, end).asList());
     }
 
     @Nonnull

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -23,10 +23,13 @@ package com.apple.foundationdb.record.lucene.directory;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.record.lucene.LuceneEvents;
 import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.StampedLock;
@@ -65,6 +68,38 @@ public interface AgilityContext {
         accept(context -> context.ensureActive().clear(range));
     }
 
+    @Nonnull
+    FDBRecordContext getCallerContext();
+
+    default <T> CompletableFuture<T> instrument(StoreTimer.Event event,
+                                                CompletableFuture<T> future ) {
+        return getCallerContext().instrument(event, future);
+    }
+
+    default <T> CompletableFuture<T> instrument(StoreTimer.Event event,
+                                                CompletableFuture<T> future,
+                                                long start) {
+        return getCallerContext().instrument(event, future, start);
+    }
+
+    default void increment(@Nonnull StoreTimer.Count count) {
+        getCallerContext().increment(count);
+    }
+
+    default void increment(@Nonnull StoreTimer.Count count, int size) {
+        getCallerContext().increment(count, size);
+    }
+
+    default void recordEvent(@Nonnull StoreTimer.Event event, long timeDelta ) {
+        getCallerContext().record(event, timeDelta);
+    }
+
+    @Nullable
+    default <T> T asyncToSync(StoreTimer.Wait event,
+                              @Nonnull CompletableFuture<T> async) {
+        return getCallerContext().asyncToSync(event, async);
+    }
+
 
     /**
      * A floating window (agile) context - create sub contexts and commit them as they reach their time/size quota.
@@ -101,6 +136,12 @@ public interface AgilityContext {
             this.sizeQuotaBytes = Objects.requireNonNullElse(callerContext.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_AGILE_COMMIT_SIZE_QUOTA), 900_000);
 
             callerContext.getOrCreateCommitCheck("AgilityContext.Agile:", name -> () -> CompletableFuture.runAsync(this::flush));
+        }
+
+        @Override
+        @Nonnull
+        public FDBRecordContext getCallerContext() {
+            return callerContext;
         }
 
         private long now() {
@@ -232,6 +273,12 @@ public interface AgilityContext {
         @Override
         public void flush() {
             // This is a no-op as the caller context should be committed by the caller.
+        }
+
+        @Override
+        @Nonnull
+        public FDBRecordContext getCallerContext() {
+            return callerContext;
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -136,7 +136,7 @@ public interface AgilityContext {
         Agile(FDBRecordContext callerContext) {
             this.callerContext = callerContext;
             contextConfigBuilder = callerContext.getConfig().toBuilder();
-            contextConfigBuilder.setWeakReadSemantics(null); // Since this context may be used for retries, do not allow weak read semantic
+            contextConfigBuilder.setWeakReadSemantics(null); // We don't want all the transactions to use the same read-version
             database = callerContext.getDatabase();
             this.timeQuotaMillis = Objects.requireNonNullElse(callerContext.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_AGILE_COMMIT_TIME_QUOTA), 4000);
             this.sizeQuotaBytes = Objects.requireNonNullElse(callerContext.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_AGILE_COMMIT_SIZE_QUOTA), 900_000);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -96,7 +96,7 @@ public interface AgilityContext {
         getCallerContext().increment(count, size);
     }
 
-    default void recordEvent(@Nonnull StoreTimer.Event event, long timeDelta ) {
+    default void recordEvent(@Nonnull StoreTimer.Event event, long timeDelta) {
         getCallerContext().record(event, timeDelta);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -74,6 +74,10 @@ public interface AgilityContext {
         return apply(context -> context.ensureActive().getRange(begin, end).asList());
     }
 
+    /**
+     * This function returns the caller's context. If called by external entities, it should only be used for testing.
+     * @return caller's context
+     */
     @Nonnull
     FDBRecordContext getCallerContext();
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -145,7 +145,7 @@ public class FDBIndexInput extends IndexInput {
     @Nonnull
     private FDBLuceneFileReference getFileReference() {
         if (actualReference == null) {
-            actualReference = fdbDirectory.getContext().asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_FILE_REFERENCE, reference);
+            actualReference = fdbDirectory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_FILE_REFERENCE, reference);
             if (actualReference == null) {
                 throw new RecordCoreException("File Reference missing for open IndexInput")
                         .addLogInfo(LuceneLogMessageKeys.RESOURCE, resourceDescription);
@@ -156,7 +156,7 @@ public class FDBIndexInput extends IndexInput {
 
     private byte[] getCurrentData() {
         if (actualCurrentData == null) {
-            actualCurrentData = fdbDirectory.getContext().asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_DATA_BLOCK, currentData);
+            actualCurrentData = fdbDirectory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_DATA_BLOCK, currentData);
         }
         return actualCurrentData;
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestFDBDirectory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestFDBDirectory.java
@@ -153,9 +153,9 @@ public class TestFDBDirectory extends FDBDirectory {
                         name.endsWith("." + LuceneOptimizedStoredFieldsFormat.STORED_FIELDS_EXTENSION)) {
                     final String segmentName = IndexFileNames.parseSegmentName(name);
                     final byte[] key = storedFieldsSubspace.pack(Tuple.from(segmentName));
-                    final List<KeyValue> rawStoredFields = context.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS,
-                            context.instrument(LuceneEvents.Events.LUCENE_READ_STORED_FIELDS,
-                                    context.ensureActive().getRange(key, ByteArrayUtil.strinc(key)).asList()));
+                    final List<KeyValue> rawStoredFields = asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS,
+                            getAgilityContext().instrument(LuceneEvents.Events.LUCENE_READ_STORED_FIELDS,
+                                    getAgilityContext().getRange(key, ByteArrayUtil.strinc(key))));
                     final Map<Long, byte[]> storedFields = rawStoredFields.stream().collect(Collectors.toMap(
                             keyValue -> storedFieldsSubspace.unpack(keyValue.getKey()).getLong(1),
                             keyValue -> keyValue.getValue()


### PR DESCRIPTION
The purpose of this PR is to prevent developers for accidentally misusing the caller context of FDBDirectory. 