### PR TITLE
Resolve #2415: Lucene: cross transactional merges - extra cleanup

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add lucene partitioning metadata [(Issue #2390)](https://github.com/FoundationDB/fdb-record-layer/issues/2390)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Lucene: cross transactional merges - extra cleanup [(Issue #2415)](https://github.com/FoundationDB/fdb-record-layer/issues/2415)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add lucene partitioning metadata [(Issue #2390)](https://github.com/FoundationDB/fdb-record-layer/issues/2390)
-* **Feature** Lucene: cross transactional merges - extra cleanup [(Issue #2415)](https://github.com/FoundationDB/fdb-record-layer/issues/2415)
+* **Feature** Lucene: cross transactional merge path - extra cleanup [(Issue #2415)](https://github.com/FoundationDB/fdb-record-layer/issues/2415)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
@@ -61,7 +61,7 @@ public enum LuceneLogMessageKeys {
     LENGTH,
     LOCK_NAME,
     LOCK_EXISTING_TIMESTAMP,
-    LOCK_TIMESTAMP,
+    LOCK_DIRECTORY,
     MERGE_SOURCE,
     MERGE_TRIGGER,
     OFFSET,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.MutationType;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.StreamingMode;
-import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
@@ -53,7 +52,6 @@ import com.google.common.base.Verify;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.ByteString;
-import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.ByteBuffersDataInput;
@@ -76,7 +74,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -997,77 +994,10 @@ public class FDBDirectory extends Directory  {
         return ref.getId();
     }
 
-    private byte[] fileLockKey(String lockName) {
+    byte[] fileLockKey(String lockName) {
         return fileLockSubspace.pack(Tuple.from(lockName));
     }
 
-    private static byte[] fileLockValue(long timeStampMillis) {
-        return Tuple.from(timeStampMillis).pack();
-    }
-
-    private static long fileLockValueToTimestamp(byte[] value) {
-        return value == null || value.length < 2 ? 0 :
-               Tuple.fromBytes(value).getLong(0);
-    }
-
-    public void fileLockSet(String lockName, long timeStampMillis) {
-        byte[] key = fileLockKey(lockName);
-        byte[] value = fileLockValue(timeStampMillis);
-        asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK,
-                agilityContext.apply(aContext ->
-                        aContext.ensureActive().get(key)
-                                .thenAccept(val -> {
-                                    if (val != null) {
-                                        long existingTimeStamp =  fileLockValueToTimestamp(val);
-                                        if (existingTimeStamp > (timeStampMillis - DateUtils.MILLIS_PER_HOUR) &&
-                                                existingTimeStamp < (timeStampMillis + DateUtils.MILLIS_PER_HOUR)) {
-                                            // Here: this lock is valid
-                                            throw new RecordCoreException("FileLock: Set: found old lock")
-                                                    .addLogInfo(LuceneLogMessageKeys.LOCK_EXISTING_TIMESTAMP, existingTimeStamp,
-                                                            LuceneLogMessageKeys.LOCK_TIMESTAMP, timeStampMillis);
-                                        }
-                                        // Here: this lock is either too old, or in the future. Steal it
-                                        if (LOGGER.isWarnEnabled()) {
-                                            LOGGER.warn(getLogMessage("FileLock: Set: found old lock, discard it",
-                                                    LuceneLogMessageKeys.LOCK_EXISTING_TIMESTAMP, existingTimeStamp,
-                                                    LuceneLogMessageKeys.LOCK_TIMESTAMP, timeStampMillis));
-                                        }
-                                    }
-                                    final Transaction tr = aContext.ensureActive();
-                                    tr.addWriteConflictKey(key);
-                                    tr.set(key, value);
-                                })
-                ));
-        agilityContext.flush();
-    }
-
-    public long fileLockGet(String lockName) {
-        // return time stamp if exists, 0 if not
-        byte[] key = fileLockKey(lockName);
-        byte[] val = asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK, agilityContext.get(key));
-        return fileLockValueToTimestamp(val);
-    }
-
-    public void fileLockClear(String lockName, long timeStampMillis) {
-        byte[] key = fileLockKey(lockName);
-        byte[] value = fileLockValue(timeStampMillis);
-        asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK,
-                agilityContext.apply(aContext ->
-                        aContext.ensureActive().get(key)
-                                .thenAccept(val -> {
-                                    if (!Arrays.equals(value, val)) {
-                                        throw new RecordCoreException("FileLock: Clear: found unexpected lock")
-                                                .addLogInfo(LogMessageKeys.ACTUAL, val,
-                                                        LuceneLogMessageKeys.LOCK_EXISTING_TIMESTAMP, fileLockValueToTimestamp(val),
-                                                        LuceneLogMessageKeys.LOCK_TIMESTAMP, timeStampMillis);
-                                    }
-                                    final Transaction tr = aContext.ensureActive();
-                                    tr.addWriteConflictKey(key);
-                                    tr.clear(key);
-                                })
-                ));
-        agilityContext.flush();
-    }
 
     // Map stored segment id back to segment name.
     @Nullable

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -20,12 +20,21 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.lucene.LuceneEvents;
+import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
+import com.apple.foundationdb.tuple.Tuple;
+import org.apache.commons.lang3.time.DateUtils;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Produce a lock over {@link FDBDirectory}.
@@ -38,37 +47,40 @@ public final class FDBDirectoryLockFactory extends LockFactory {
     }
 
     @Override
-    public Lock obtainLock(final Directory dir, final String lockName) throws IOException {
+    public Lock obtainLock(final Directory dir, final String lockName) {
         // dir is ignored
-        return new FDBDirectoryLock(directory, lockName);
+        return new FDBDirectoryLock(directory.getAgilityContext(), lockName, directory.fileLockKey(lockName));
     }
 
     private static class FDBDirectoryLock extends Lock {
 
-        final FDBDirectory directory;
+        final AgilityContext agilityContext;
         final String lockName;
         final long timeStampMillis;
+        final byte[] fileLockKey;
         boolean closed;
+        private static final Logger LOGGER = LoggerFactory.getLogger(FDBDirectoryLock.class);
 
-        public FDBDirectoryLock(final FDBDirectory directory, final String lockName) {
-            this.directory = directory;
-            this.lockName = lockName;
+        public FDBDirectoryLock(final AgilityContext agilityContext, final String lockName, byte[] fileLockKey) {
+            this.agilityContext = agilityContext;
+            this.lockName = lockName; // for log messages
+            this.fileLockKey = fileLockKey;
             this.timeStampMillis = System.currentTimeMillis();
-            directory.fileLockSet(lockName, timeStampMillis);
+            fileLockSet( timeStampMillis);
         }
 
         @Override
         public void close() {
-            directory.fileLockClear(lockName, timeStampMillis);
+            fileLockClear(timeStampMillis);
             closed = true;
         }
 
         @Override
-        public void ensureValid() throws IOException {
+        public void ensureValid() {
             if (closed) {
                 throw new AlreadyClosedException("Lock instance already released: " + this);
             }
-            long existingValue = directory.fileLockGet(lockName);
+            long existingValue = fileLockGet();
             if (existingValue == 0) {
                 throw new AlreadyClosedException("Lock file was deleted (lock=" + this + ")");
             }
@@ -77,9 +89,73 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             }
         }
 
+
+        private static byte[] fileLockValue(long timeStampMillis) {
+            return Tuple.from(timeStampMillis).pack();
+        }
+
+        private static long fileLockValueToTimestamp(byte[] value) {
+            return value == null || value.length < 2 ? 0 :
+                   Tuple.fromBytes(value).getLong(0);
+        }
+
+        public void fileLockSet(long timeStampMillis) {
+            byte[] value = fileLockValue(timeStampMillis);
+            agilityContext.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK,
+                    agilityContext.apply(aContext ->
+                            aContext.ensureActive().get(fileLockKey)
+                                    .thenAccept(val -> {
+                                        if (val != null) {
+                                            long existingTimeStamp =  fileLockValueToTimestamp(val);
+                                            if (existingTimeStamp > (timeStampMillis - DateUtils.MILLIS_PER_HOUR) &&
+                                                    existingTimeStamp < (timeStampMillis + DateUtils.MILLIS_PER_HOUR)) {
+                                                // Here: this lock is valid
+                                                throw new RecordCoreException("FileLock: Set: found old lock")
+                                                        .addLogInfo(LuceneLogMessageKeys.LOCK_EXISTING_TIMESTAMP, existingTimeStamp,
+                                                                LuceneLogMessageKeys.LOCK_DIRECTORY, this);
+                                            }
+                                            // Here: this lock is either too old, or in the future. Steal it
+                                            if (LOGGER.isWarnEnabled()) {
+                                                LOGGER.warn(KeyValueLogMessage.of("FileLock: Set: found old lock, discard it",
+                                                        LuceneLogMessageKeys.LOCK_EXISTING_TIMESTAMP, existingTimeStamp,
+                                                        LuceneLogMessageKeys.LOCK_DIRECTORY, this));
+                                            }
+                                        }
+                                        aContext.ensureActive().set(fileLockKey, value);
+                                    })
+                    ));
+            agilityContext.flush();
+        }
+
+        public long fileLockGet() {
+            // return time stamp if exists, 0 if not
+            byte[] val = agilityContext.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK, agilityContext.get(fileLockKey));
+            return fileLockValueToTimestamp(val);
+        }
+
+        public void fileLockClear(long timeStampMillis) {
+            byte[] value = fileLockValue(timeStampMillis);
+            agilityContext.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK,
+                    agilityContext.apply(aContext ->
+                            aContext.ensureActive().get(fileLockKey)
+                                    .thenAccept(val -> {
+                                        if (!Arrays.equals(value, val)) {
+                                            throw new RecordCoreException("FileLock: Clear: found unexpected lock")
+                                                    .addLogInfo(LogMessageKeys.ACTUAL, val,
+                                                            LuceneLogMessageKeys.LOCK_EXISTING_TIMESTAMP, fileLockValueToTimestamp(val),
+                                                            LuceneLogMessageKeys.LOCK_DIRECTORY, this);
+                                        }
+                                        aContext.ensureActive().clear(fileLockKey);
+                                    })
+                    ));
+            agilityContext.flush();
+        }
+
+
+
         @Override
         public String toString() {
-            return "FDBDirectory: name=" + lockName + " timeMillis=" + timeStampMillis;
+            return "FDBDirectoryLock: name=" + lockName + " timeMillis=" + timeStampMillis;
         }
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
@@ -191,7 +191,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                     for (int i = 1700; i < 1900; i += 17) {
                         final long iFinal = i;
                         // occasionally, we wish to have multiple writers
-                        int numWriters = 1 + Integer.numberOfLeadingZeros(i) / 2;
+                        int numWriters = 1 + Integer.numberOfTrailingZeros(i) / 2;
                         if (threadNum < numWriters) {
                             agilityContext.accept(aContext -> {
                                 final Transaction tr = aContext.ensureActive();
@@ -217,7 +217,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                             });
                         }
                     }
-                    context.commit();
+                    agilityContext.flush();
                 }
             });
         }
@@ -232,7 +232,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
             for (int i = 1700; i < 1900; i += 17) {
                 final long iFinal = i;
                 // occasionally, we wish to have multiple writers
-                int numWriters = 1 + Integer.numberOfLeadingZeros(i) / 2;
+                int numWriters = 1; // in this test, two writes may conflict each other
                 if (threadNum < numWriters) {
                     try (FDBRecordContext context = openContext()) {
                         final AgilityContext agilityContext = AgilityContext.factory(context, useAgile);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Tag(Tags.RequiresFDB)
 class AgilityContextTest extends FDBRecordStoreTestBase {
     int loopCount = 20;
-    int threadCount = 8; // if exceed 8, may cause an execution pool deadlock
+    int threadCount = 5; // if exceeds a certain size, may cause an execution pool deadlock
 
     void testAgilityContextConcurrentSingleObject(final AgilityContext agilityContext, boolean doFlush) throws ExecutionException, InterruptedException {
         agilityContextTestSingleThread(0, agilityContext, doFlush);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
@@ -1,0 +1,217 @@
+/*
+ * AgilityContextTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for AgilityContext.
+ */
+@Tag(Tags.RequiresFDB)
+class AgilityContextTest extends FDBRecordStoreTestBase {
+    int loopCount = 20;
+    int threadCount = 8; // if exceed 8, may cause an execution pool deadlock
+
+    void testAgilityContextConcurrentSingleObject(final AgilityContext agilityContext, boolean doFlush) throws ExecutionException, InterruptedException {
+        agilityContextTestSingleThread(0, agilityContext, doFlush);
+        agilityContextTestSingleThread(1, agilityContext, doFlush);
+        agilityContextTestSingleThread(1, agilityContext, doFlush);
+
+        for (int loop = 0; loop < loopCount; loop++) {
+            final int loopIndex = loop;
+            IntStream.rangeClosed(0, threadCount).parallel().forEach(i -> {
+                try {
+                    agilityContextTestSingleThread(loopIndex * i, agilityContext, doFlush);
+                } catch (ExecutionException | InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+
+    private void agilityContextTestSingleThread(int i, AgilityContext agilityContext, boolean explicityFlush) throws ExecutionException, InterruptedException {
+        byte[] key = Tuple.from(500, i).pack();
+        byte[] val = Tuple.from(i).pack();
+        try {
+            agilityContext.set(key, val);
+            if (explicityFlush && i % 3 == 0) { // keep some un-flushed values
+                final byte[] bytes = agilityContext.get(key).get();
+                long readVal = Tuple.fromBytes(bytes).getLong(0); // maybe flushed, probably not
+                assertEquals(readVal, i);
+                agilityContext.flush();
+                readVal = Tuple.fromBytes(bytes).getLong(0); // surely flushed
+                assertEquals(readVal, i);
+            }
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertLoopThreadsValues() {
+        try (FDBRecordContext context = fdb.openContext()) {
+            for (int loop = 0; loop < loopCount; loop++) {
+                final AgilityContext agilityContext = AgilityContext.factory(context, false);
+                for (int thread = 0; thread < threadCount; thread++) {
+                    int i = loop * thread;
+                    byte[] key = Tuple.from(500, i).pack();
+                    byte[] val = Tuple.from(i).pack();
+                    agilityContext.get(key).thenApply(bytes -> {
+                        assertEquals(val, bytes);
+                        final long existingVal = Tuple.fromBytes(bytes).getLong(0);
+                        assertEquals(i, existingVal);
+                        return null;
+                    });
+                }
+            }
+            context.commit();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testAgilityContextConcurrent(boolean useAgile)  throws ExecutionException, InterruptedException {
+        try (FDBRecordContext context = fdb.openContext()) {
+            final AgilityContext agilityContext = AgilityContext.factory(context, useAgile);
+            testAgilityContextConcurrentSingleObject(agilityContext, true);
+            context.commit();
+        }
+        assertLoopThreadsValues();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testAgilityContextConcurrentNonExplicitCommits(boolean useAgile) throws ExecutionException, InterruptedException {
+        for (int sizeQuota : new int[] {1, 2, 7, 21, 100, 10000}) {
+            final RecordLayerPropertyStorage.Builder insertProps = RecordLayerPropertyStorage.newBuilder()
+                    .addProp(LuceneRecordContextProperties.LUCENE_AGILE_COMMIT_SIZE_QUOTA, sizeQuota);
+
+            try (FDBRecordContext context = openContext(insertProps)) {
+                final AgilityContext agilityContext = AgilityContext.factory(context, useAgile);
+                testAgilityContextConcurrentSingleObject(agilityContext, false);
+                context.commit();
+            }
+        }
+        assertLoopThreadsValues();
+    }
+
+    void testAgilityContextOneLongWrite(int loopCount, int sizeLimit, int timeLimit) {
+        final RecordLayerPropertyStorage.Builder insertProps = RecordLayerPropertyStorage.newBuilder()
+                .addProp(LuceneRecordContextProperties.LUCENE_AGILE_COMMIT_SIZE_QUOTA, sizeLimit)
+                .addProp(LuceneRecordContextProperties.LUCENE_AGILE_COMMIT_TIME_QUOTA, timeLimit);
+
+        String ShelSilverstein =
+                "Oh, if you’re a bird, be an early bird\n" +
+                "And catch the worm for your breakfast plate.\n" +
+                "If you’re a bird, be an early early bird--\n" +
+                "But if you’re a worm, sleep late.";
+        try (FDBRecordContext context = openContext(insertProps)) {
+            final AgilityContext agilityContext = AgilityContext.factory(context, true);
+            for (int i = 0; i < loopCount; i++) {
+                byte[] key = Tuple.from(2023, i).pack();
+                byte[] val = Tuple.from(i, ShelSilverstein).pack();
+                agilityContext.set(key, val);
+            }
+            context.commit();
+        }
+        try (FDBRecordContext context = openContext(insertProps)) {
+            final AgilityContext agilityContext = AgilityContext.factory(context, false);
+            for (int i = 0; i < loopCount; i++) {
+                byte[] key = Tuple.from(2023, i).pack();
+                byte[] val = Tuple.from(i, ShelSilverstein).pack();
+                agilityContext.get(key).thenApply(bytes -> {
+                    assertEquals(val, bytes);
+                    return null;
+                });
+            }
+        }
+    }
+
+    @Test
+    void testAgilityContextSizeLimit() {
+        testAgilityContextOneLongWrite(73, 100, 100000);
+    }
+
+    @Test
+    void testAgilityContextTimeLimit() {
+        testAgilityContextOneLongWrite(77, 100000, 10);
+    }
+
+    void napTime(int napTimeMilliseconds) {
+        try {
+            Thread.sleep(napTimeMilliseconds);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testAgilityContextAtomicAttribute(boolean useAgile) {
+        final long prefix = 0x1abc1356; // avoid other tests' data
+        IntStream.rangeClosed(0, threadCount).parallel().forEach(threadNum -> {
+            try (FDBRecordContext context = openContext()) {
+                final AgilityContext agilityContext = AgilityContext.factory(context, useAgile);
+                for (long i = 1700; i < 1900; i += 17) {
+                    final long iFinal = i;
+                    if (threadNum == 0) {
+                        agilityContext.accept(aContext -> {
+                            final Transaction tr = aContext.ensureActive();
+                            for (int j = 0; j < 5; j++) {
+                                tr.set(Tuple.from(prefix, iFinal, j).pack(),
+                                        Tuple.from(iFinal).pack());
+                            }
+                        });
+                        napTime(3); // give a chance to other threads to run
+                    } else {
+                        napTime(3);
+                        agilityContext.accept(aContext -> {
+                            long[] values = new long[5];
+                            final Transaction tr = aContext.ensureActive();
+                            for (int j = 4; j >= 0; j--) {
+                                byte[] val = tr.get(Tuple.from(prefix, iFinal, j).pack()).join();
+                                values[j] = val == null ? 0 : Tuple.fromBytes(val).getLong(0);
+                            }
+                            for (int j = 1; j < 5; j++) {
+                                assertEquals(values[0], values[j]);
+                            }
+                        });
+                    }
+                }
+                context.commit();
+            }
+        });
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
@@ -1,0 +1,61 @@
+/*
+ * FDBDirectoryLockTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.test.Tags;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.Lock;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag(Tags.RequiresFDB)
+class FDBDirectoryLockTest extends FDBDirectoryBaseTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testFileLock(boolean useAgile) throws IOException {
+        try (FDBRecordContext context = fdb.openContext()) {
+            directory = new FDBDirectory(subspace, context, null, null, null, true, useAgile);
+            String lockName = "file.lock";
+            final Lock lock1 = directory.obtainLock(lockName);
+            lock1.ensureValid();
+            RecordCoreException e = assertThrows(RecordCoreException.class, () -> directory.obtainLock(lockName));
+            assertTrue(e.getMessage().contains("found old lock"));
+            lock1.ensureValid();
+            lock1.close();
+            assertThrows(AlreadyClosedException.class, lock1::ensureValid);
+            final Lock lock2 = directory.obtainLock(lockName);
+            lock2.ensureValid();
+            e = assertThrows(RecordCoreException.class, () -> directory.obtainLock(lockName));
+            assertTrue(e.getMessage().contains("found old lock"));
+            lock2.ensureValid();
+            lock2.close();
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -22,15 +22,11 @@ package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.lucene.LuceneEvents;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
-import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
-import org.apache.lucene.store.AlreadyClosedException;
-import org.apache.lucene.store.Lock;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -38,14 +34,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
@@ -57,7 +50,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for FDBDirectory validating it can function as a backing store
@@ -241,62 +233,4 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         assertThat(String.format("Metric %s should be called at most %d times", metric, maximumValue),
                 timer.getCount(metric), lessThanOrEqualTo(maximumValue));
     }
-
-
-    @Test
-    void testFileLock() throws IOException {
-        String lockName = "file.lock";
-        final Lock lock1 = directory.obtainLock(lockName);
-        lock1.ensureValid();
-        RecordCoreException e = assertThrows(RecordCoreException.class, () -> directory.obtainLock(lockName));
-        assertTrue(e.getMessage().contains("found old lock"));
-        lock1.ensureValid();
-        lock1.close();
-        assertThrows(AlreadyClosedException.class, lock1::ensureValid);
-        final Lock lock2 = directory.obtainLock(lockName);
-        lock2.ensureValid();
-        e = assertThrows(RecordCoreException.class, () -> directory.obtainLock(lockName));
-        assertTrue(e.getMessage().contains("found old lock"));
-        lock2.ensureValid();
-        lock2.close();
-    }
-
-    @Test
-    void testAgilityContext() throws ExecutionException, InterruptedException {
-        try (FDBRecordContext context = fdb.openContext()) {
-            final AgilityContext agilityContext = AgilityContext.factory(context, true);
-            agilityContextTestSingleThread(0, agilityContext);
-            agilityContextTestSingleThread(1, agilityContext);
-            agilityContextTestSingleThread(1, agilityContext);
-
-            for (int loop = 0; loop < 20; loop++) {
-                IntStream.rangeClosed(0, 17).parallel().forEach(i -> {
-                    try {
-                        agilityContextTestSingleThread(i, agilityContext);
-                    } catch (ExecutionException | InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-            }
-        }
-    }
-
-    private void agilityContextTestSingleThread(int i, AgilityContext agilityContext) throws ExecutionException, InterruptedException {
-        byte[] key = Tuple.from(500, i).pack();
-        byte[] val = Tuple.from(i).pack();
-        try {
-            agilityContext.set(key, val);
-            if (random.nextInt(10) > 7) { // keep some un-flushed values
-                final byte[] bytes = agilityContext.get(key).get();
-                long readVal = Tuple.fromBytes(bytes).getLong(0); // maybe flushed, probably not
-                assertEquals(readVal, i);
-                agilityContext.flush();
-                readVal = Tuple.fromBytes(bytes).getLong(0); // surely flushed
-                assertEquals(readVal, i);
-            }
-        } catch (ExecutionException | InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }


### PR DESCRIPTION
  * Move FIleLock code to FDBDirectoryLock
  * FDBDirectoryLock: add test
  * AgilityContext: add test