### PR TITLE
Resolve #2401: Make test less flaky

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,7 +16,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 ### NEXT_RELEASE
 
 * **Bug fix** Fixe Unbalanced log info exception [(Issue #2392)](https://github.com/FoundationDB/fdb-record-layer/issues/2392)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Make stored fields test less flaky [(Issue #2401)](https://github.com/FoundationDB/fdb-record-layer/issues/2401)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fixe Unbalanced log info exception [(Issue #2392)](https://github.com/FoundationDB/fdb-record-layer/issues/2392)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.provider.common.text.AllSuffixesTextTokeniz
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.query.plan.PlannableIndexTypes;
@@ -257,5 +258,20 @@ public class LuceneIndexTestUtils {
                         .setThirdValue("thirdValue" + docId)
                         .build())
                 .build();
+    }
+
+    /**
+     * Try to force a segment merge on the provided store using the given index. The merge will be triggered if there are
+     * sufficient conditions for one.
+     * @param recordStore the store where the index is stored
+     * @param index the Lucene indes to merge
+     */
+    public static void mergeSegments(final FDBRecordStore recordStore, final Index index) {
+        try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
+                .setRecordStore(recordStore)
+                .setIndex(index)
+                .build()) {
+            indexBuilder.mergeIndex();
+        }
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
@@ -408,3 +408,4 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
         return useOptimizedStoredFieldFormat ? TEXT_AND_STORED_COMPLEX : TEXT_AND_STORED_COMPLEX_WITHOUT_OPT_STORED_FIELDS;
     }
 }
+

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
@@ -161,6 +161,9 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
     @BooleanSource
     void testInsertDeleteDocuments(boolean useOptimizedStoredFieldsFormat) throws Exception {
         Index index = getSimpleTextIndex(useOptimizedStoredFieldsFormat);
+        final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
+                .addProp(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER, 2.0)
+                .build();
 
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
@@ -176,8 +179,21 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
         }
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
+            recordStore.deleteRecord(Tuple.from(1547L));
+            context.commit();
+        }
+        try (FDBRecordContext context = openContext(contextProps)) {
+            rebuildIndexMetaData(context, SIMPLE_DOC, index);
             final RecordQuery query = buildQuery("Document", Collections.emptyList(), SIMPLE_DOC);
             queryAndAssertFields(query, "text", Map.of(1624L, "Document 2"));
+            LuceneIndexTestUtils.mergeSegments(recordStore, index);
+            if (useOptimizedStoredFieldsFormat) {
+                try (FDBDirectory directory = new FDBDirectory(recordStore.indexSubspace(index), context, index.getOptions())) {
+                    // After a merge, all tombstones are removed and one document remains
+                    assertDocCountPerSegment(directory, List.of("_0", "_1", "_2"), List.of(0, 0, 1));
+                }
+                assertTrue(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS).getCount() > 0);
+            }
         }
     }
 
@@ -206,6 +222,9 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
     @BooleanSource
     void testInsertUpdateDocuments(boolean useOptimizedStoredFieldsFormat) throws Exception {
         Index index = getSimpleTextIndex(useOptimizedStoredFieldsFormat);
+        final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
+                .addProp(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER, 2.0)
+                .build();
 
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
@@ -221,10 +240,22 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
         }
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
+            recordStore.updateRecord(createSimpleDocument(1624L, "Document 4 modified", 2));
+            context.commit();
+        }
+        try (FDBRecordContext context = openContext(contextProps)) {
+            rebuildIndexMetaData(context, SIMPLE_DOC, index);
             final RecordQuery query = buildQuery("Document", Collections.emptyList(), SIMPLE_DOC);
             queryAndAssertFields(query, "text", Map.of(
                     1623L, "Document 3 modified",
-                    1624L, "Document 2"));
+                    1624L, "Document 4 modified"));
+            LuceneIndexTestUtils.mergeSegments(recordStore, index);
+            if (useOptimizedStoredFieldsFormat) {
+                try (FDBDirectory directory = new FDBDirectory(recordStore.indexSubspace(index), context, index.getOptions())) {
+                    // All 3 segments are going to merge to one with all documents
+                    assertDocCountPerSegment(directory, List.of("_0", "_1", "_2", "_3"), List.of(0, 0, 0, 3));
+                }
+            }
         }
     }
 
@@ -232,6 +263,9 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
     @BooleanSource
     void testDeleteAllDocuments(boolean useOptimizedStoredFieldsFormat) throws Exception {
         Index index = getSimpleTextIndex(useOptimizedStoredFieldsFormat);
+        final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
+                .addProp(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER, 2.0)
+                .build();
 
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
@@ -247,13 +281,14 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
             recordStore.deleteRecord(Tuple.from(1547L));
             context.commit();
         }
-        try (FDBRecordContext context = openContext()) {
+        try (FDBRecordContext context = openContext(contextProps)) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
             final RecordQuery query = buildQuery("Document", Collections.emptyList(), SIMPLE_DOC);
             queryAndAssertFields(query, "text", Map.of());
+            LuceneIndexTestUtils.mergeSegments(recordStore, index);
             if (useOptimizedStoredFieldsFormat) {
                 try (FDBDirectory directory = new FDBDirectory(recordStore.indexSubspace(index), context, index.getOptions())) {
-                    // When deleting all docs from the index, the last segment (_1) gets removed, leaving the _0 segment with the 3 tombstones
+                    // When deleting all docs from the index, the first segment (_0) was merged away and the last segment (_1) gets removed
                     assertDocCountPerSegment(directory, List.of("_0", "_1"), List.of(0, 0));
                 }
                 assertTrue(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS).getCount() > 0);


### PR DESCRIPTION
Lucene stored fields test was flaky when it was expecting documents in segments that were the results of a merge.
Added forced merge and `LUCENE_MERGE_SEGMENTS_PER_TIER` as well as additional fragmentation to the segments such that a merge is forced and the result is predictable.
