### PR TITLE
Resolves #2418: Integrate the PERMUTED_MIN/_MAX index types into the query planners

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Permuted min and max indexes are now available during planning and aggregate function execution [(Issue #2418)](https://github.com/FoundationDB/fdb-record-layer/issues/2418)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add implementations of all sub-classes of `BaseIndexFileFormatTestCase` [(Issue #2421)](https://github.com/FoundationDB/fdb-record-layer/issues/2421)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
@@ -67,8 +67,6 @@ public class PermutedMinMaxIndexMaintainerFactory implements IndexMaintainerFact
                 int permutedSize = PermutedMinMaxIndexMaintainer.getPermutedSize(index);
                 if (permutedSize < 0) {
                     throw new MetaDataException("permuted size cannot be negative", LogMessageKeys.INDEX_NAME, index.getName());
-                } else if (permutedSize == 0) {
-                    throw new MetaDataException("no permutation does not need a special index type for MIN and MAX", LogMessageKeys.INDEX_NAME, index.getName());
                 } else if (permutedSize > groupingCount) {
                     throw new MetaDataException("permuted size cannot be larger than grouping size", LogMessageKeys.INDEX_NAME, index.getName());
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
@@ -259,7 +259,6 @@ public class AggregateIndexExpansionVisitor extends KeyExpressionExpansionVisito
         final List<Value> groupingValues = groupingValueReference == null ? Collections.emptyList() : Values.deconstructRecord(groupingValueReference);
         if (groupingValueReference != null) {
             int i = 0;
-            // final int lastGroupingPrefix = groupingValues.size() - columnPermutations;
             for (final var groupingValue : groupingValues) {
                 final var field = (FieldValue)groupingValue;
                 final var placeholder = groupingValue.asPlaceholder(selectWherePlaceholders.get(i++).getParameterAlias());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -24,6 +24,8 @@ import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
@@ -48,6 +50,7 @@ import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Iterables;
 import com.google.common.primitives.ImmutableIntArray;
 import com.google.protobuf.Descriptors;
 
@@ -167,6 +170,15 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
         return index.isUnique();
     }
 
+    public boolean isPermuted() {
+        return IndexTypes.PERMUTED_MAX.equals(index.getType()) || IndexTypes.PERMUTED_MIN.equals(index.getType());
+    }
+
+    private int getPermutedCount() {
+        @Nullable String permutedSizeOption = index.getOption(IndexOptions.PERMUTED_SIZE_OPTION);
+        return permutedSizeOption == null ? 0 : Integer.parseInt(permutedSizeOption);
+    }
+
     @Nonnull
     @Override
     public List<MatchedOrderingPart> computeMatchedOrderingParts(@Nonnull final MatchInfo matchInfo, @Nonnull final List<CorrelationIdentifier> sortParameterIds, final boolean isReverse) {
@@ -177,11 +189,14 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
 
         final var builder = ImmutableList.<MatchedOrderingPart>builder();
         final var candidateParameterIds = getOrderingAliases();
+        final List<Value> deconstructedValue = Values.deconstructRecord(selectHavingResultValue);
+        final AliasMap aliasMap = AliasMap.of(Iterables.getOnlyElement(selectHavingResultValue.getCorrelatedTo()), Quantifier.current());
 
         for (final var parameterId : sortParameterIds) {
             final var ordinalInCandidate = candidateParameterIds.indexOf(parameterId);
             Verify.verify(ordinalInCandidate >= 0);
-            final var normalizedKeyExpression = normalizedKeys.get(ordinalInCandidate);
+            int permutedIndex = indexWithPermutation(ordinalInCandidate);
+            final var normalizedKeyExpression = normalizedKeys.get(permutedIndex);
 
             Objects.requireNonNull(parameterId);
             Objects.requireNonNull(normalizedKeyExpression);
@@ -202,9 +217,12 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
             //
             // Compute a Value for this normalized key.
             //
+            final var value = deconstructedValue.get(permutedIndex).rebase(aliasMap);
+            /*
             final var value =
                     new ScalarTranslationVisitor(normalizedKeyExpression).toResultValue(Quantifier.current(),
                             baseType);
+             */
 
             builder.add(
                     MatchedOrderingPart.of(value,
@@ -213,6 +231,23 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
         }
 
         return builder.build();
+    }
+
+    private int indexWithPermutation(int i) {
+        if (isPermuted()) {
+            int permutedCount = getPermutedCount();
+            final GroupingKeyExpression groupingKeyExpression = (GroupingKeyExpression)index.getRootExpression();
+            int groupingCount = groupingKeyExpression.getGroupingCount();
+            if ( i < groupingCount - permutedCount) {
+                return i;
+            } else if (i >= groupingCount - permutedCount && i < groupingCount - permutedCount + groupingKeyExpression.getGroupedCount()) {
+                return i + permutedCount;
+            } else {
+                return i - permutedCount;
+            }
+        } else {
+            return i;
+        }
     }
 
     @Nonnull
@@ -226,30 +261,36 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
             return Ordering.emptyOrder();
         }
 
+        final List<Value> deconstructedValue = Values.deconstructRecord(selectHavingResultValue);
+        final AliasMap aliasMap = AliasMap.of(Iterables.getOnlyElement(selectHavingResultValue.getCorrelatedTo()), Quantifier.current());
+
         // TODO include the aggregate Value itself in the ordering.
         final var normalizedKeyExpressions = groupingKey.normalizeKeyForPositions();
         final var equalityComparisons = scanComparisons.getEqualityComparisons();
 
         for (var i = 0; i < equalityComparisons.size(); i++) {
-            final var normalizedKeyExpression = normalizedKeyExpressions.get(i);
-            final var comparison = equalityComparisons.get(i);
+            int permutedIndex = indexWithPermutation(i);
+            if (permutedIndex < normalizedKeyExpressions.size()) {
+                final var normalizedKeyExpression = normalizedKeyExpressions.get(permutedIndex);
 
-            if (normalizedKeyExpression.createsDuplicates()) {
-                continue;
+                if (normalizedKeyExpression.createsDuplicates()) {
+                    continue;
+                }
             }
 
-            final var normalizedValue =
-                    new ScalarTranslationVisitor(normalizedKeyExpression).toResultValue(Quantifier.current(),
-                            baseType);
-            equalityBoundValueMapBuilder.put(normalizedValue, comparison);
+            final var comparison = equalityComparisons.get(i);
+            equalityBoundValueMapBuilder.put(deconstructedValue.get(permutedIndex).rebase(aliasMap), comparison);
         }
 
         final var result = ImmutableList.<OrderingPart>builder();
         for (var i = scanComparisons.getEqualitySize(); i < normalizedKeyExpressions.size(); i++) {
-            final var normalizedKeyExpression = normalizedKeyExpressions.get(i);
+            int permutedIndex = indexWithPermutation(i);
+            if (permutedIndex < normalizedKeyExpressions.size()) {
+                final var normalizedKeyExpression = normalizedKeyExpressions.get(permutedIndex);
 
-            if (normalizedKeyExpression.createsDuplicates()) {
-                break;
+                if (normalizedKeyExpression.createsDuplicates()) {
+                    break;
+                }
             }
 
             //
@@ -259,8 +300,11 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
             // I think that restriction can be relaxed.
             //
             final var normalizedValue =
+                    /*
                     new ScalarTranslationVisitor(normalizedKeyExpression).toResultValue(Quantifier.current(),
                             baseType);
+                     */
+                    deconstructedValue.get(permutedIndex).rebase(aliasMap);
 
             result.add(OrderingPart.of(normalizedValue, isReverse));
         }
@@ -316,11 +360,47 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
         final var groupingCount = ((GroupingKeyExpression)index.getRootExpression()).getGroupingCount();
         Verify.verify(selectHavingFields.size() >= groupingCount);
 
+        final IndexKeyValueToPartialRecord.Builder builder = IndexKeyValueToPartialRecord.newBuilder(messageDescriptor);
+        if (isPermuted()) {
+            addFieldsForPermutedIndexEntry(selectHavingFields, groupingCount, builder);
+        } else {
+            addFieldsForNonPermutedIndexEntry(selectHavingFields, groupingCount, builder);
+        }
+
+        if (!builder.isValid()) {
+            throw new RecordCoreException(String.format("could not generate a covering index scan operator for '%s'; Invalid mapping between index entries to partial record", index.getName()));
+        }
+        return builder.build();
+    }
+
+    private void addFieldsForPermutedIndexEntry(@Nonnull List<Value> selectHavingFields, int groupingCount, @Nonnull IndexKeyValueToPartialRecord.Builder builder) {
+        // select-having value structure: (groupingCol1, groupingCol2, ... groupingColn, agg(coln+1))
+        // key structure                : KEY(groupingCol1, groupingCol2, ... groupingColn-permuted, agg(coln+1), groupingColn-permuted+1, ..., groupingColn) VALUE()
+        // groupingCount                : n+1
+        int permutedCount = getPermutedCount();
+
+        for (int i = 0; i < selectHavingFields.size(); i++) {
+            final Value keyValue = selectHavingFields.get(i);
+            if (keyValue instanceof FieldValue) {
+                int havingIndex;
+                if (i >= groupingCount - permutedCount && i < groupingCount) {
+                    havingIndex = i + permutedCount;
+                } else if (i >= groupingCount) {
+                    havingIndex = i - permutedCount;
+                } else {
+                    havingIndex = i;
+                }
+                final AvailableFields.FieldData fieldData = AvailableFields.FieldData.ofUnconditional(IndexKeyValueToPartialRecord.TupleSource.KEY, ImmutableIntArray.of(havingIndex));
+                addCoveringField(builder, (FieldValue)keyValue, fieldData);
+            }
+        }
+    }
+
+    private void addFieldsForNonPermutedIndexEntry(@Nonnull List<Value> selectHavingFields, int groupingCount, @Nonnull IndexKeyValueToPartialRecord.Builder builder) {
         // key structure                : KEY(groupingCol1, groupingCol2, ... groupingColn), VALUE(agg(coln+1))
         // groupingCount                : n+1
         // select-having value structure: (groupingCol1, groupingCol2, ... groupingColn, agg(coln+1))
 
-        final IndexKeyValueToPartialRecord.Builder builder = IndexKeyValueToPartialRecord.newBuilder(messageDescriptor);
         for (int i = 0; i < groupingCount; i++) {
             final Value keyValue = selectHavingFields.get(i);
             if (keyValue instanceof FieldValue) {
@@ -335,11 +415,6 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
                 addCoveringField(builder, (FieldValue)keyValue, fieldData);
             }
         }
-
-        if (!builder.isValid()) {
-            throw new RecordCoreException(String.format("could not generate a covering index scan operator for '%s'; Invalid mapping between index entries to partial record", index.getName()));
-        }
-        return builder.build();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -299,12 +299,7 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
             // expression. We used to refuse to compute the sort order in the presence of repeats, however,
             // I think that restriction can be relaxed.
             //
-            final var normalizedValue =
-                    /*
-                    new ScalarTranslationVisitor(normalizedKeyExpression).toResultValue(Quantifier.current(),
-                            baseType);
-                     */
-                    deconstructedValue.get(permutedIndex).rebase(aliasMap);
+            final var normalizedValue = deconstructedValue.get(permutedIndex).rebase(aliasMap);
 
             result.add(OrderingPart.of(normalizedValue, isReverse));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -261,7 +261,6 @@ public interface MatchCandidate {
     }
 
     @Nonnull
-    @SuppressWarnings("fallthrough")
     static Iterable<MatchCandidate> fromIndexDefinition(@Nonnull final RecordMetaData metaData,
                                                         @Nonnull final Index index,
                                                         final boolean isReverse) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -261,6 +261,7 @@ public interface MatchCandidate {
     }
 
     @Nonnull
+    @SuppressWarnings("fallthrough")
     static Iterable<MatchCandidate> fromIndexDefinition(@Nonnull final RecordMetaData metaData,
                                                         @Nonnull final Index index,
                                                         final boolean isReverse) {
@@ -283,55 +284,114 @@ public interface MatchCandidate {
         switch (indexType) {
             case IndexTypes.VALUE:
             case IndexTypes.VERSION:
-                expandIndexMatchCandidate(index,
-                    availableRecordTypeNames,
-                    availableRecordTypes,
-                    queriedRecordTypeNames,
-                    queriedRecordTypes,
-                    isReverse,
-                    commonPrimaryKeyForIndex,
-                    new ValueIndexExpansionVisitor(index, queriedRecordTypes)).ifPresent(resultBuilder::add);
+                expandValueIndexMatchCandidate(
+                        index,
+                        availableRecordTypeNames,
+                        availableRecordTypes,
+                        queriedRecordTypeNames,
+                        queriedRecordTypes,
+                        isReverse,
+                        commonPrimaryKeyForIndex
+                ).ifPresent(resultBuilder::add);
                 break;
             case IndexTypes.RANK:
                 // For rank() we need to create at least two candidates. One for BY_RANK scans and one for BY_VALUE scans.
-                expandIndexMatchCandidate(index,
+                expandValueIndexMatchCandidate(
+                        index,
                         availableRecordTypeNames,
                         availableRecordTypes,
                         queriedRecordTypeNames,
                         queriedRecordTypes,
                         isReverse,
-                        commonPrimaryKeyForIndex,
-                        new ValueIndexExpansionVisitor(index, queriedRecordTypes)).ifPresent(resultBuilder::add);
+                        commonPrimaryKeyForIndex
+                ).ifPresent(resultBuilder::add);
 
-                expandIndexMatchCandidate(index,
+                expandIndexMatchCandidate(
+                        index,
                         availableRecordTypeNames,
                         availableRecordTypes,
                         queriedRecordTypeNames,
                         queriedRecordTypes,
                         isReverse,
                         commonPrimaryKeyForIndex,
-                        new WindowedIndexExpansionVisitor(index, queriedRecordTypes))
-                        .ifPresent(resultBuilder::add);
+                        new WindowedIndexExpansionVisitor(index, queriedRecordTypes)
+                ).ifPresent(resultBuilder::add);
                 break;
             case IndexTypes.MAX_EVER_LONG: // fallthrough
             case IndexTypes.MIN_EVER_LONG: // fallthrough
             case IndexTypes.SUM: // fallthrough
             case IndexTypes.COUNT: // fallthrough
             case IndexTypes.COUNT_NOT_NULL:
-                expandIndexMatchCandidate(index,
-                            availableRecordTypeNames,
-                            availableRecordTypes,
-                            queriedRecordTypeNames,
-                            queriedRecordTypes,
-                            isReverse,
-                            null,
-                            new AggregateIndexExpansionVisitor(index, queriedRecordTypes))
-                            .ifPresent(resultBuilder::add);
+                expandAggregateIndexMatchCandidate(
+                        index,
+                        availableRecordTypeNames,
+                        availableRecordTypes,
+                        queriedRecordTypeNames,
+                        queriedRecordTypes,
+                        isReverse
+                ).ifPresent(resultBuilder::add);
+                break;
+            case IndexTypes.PERMUTED_MAX: // fallthrough
+            case IndexTypes.PERMUTED_MIN:
+                // For permuted min and max, we use the value index expansion for BY_VALUE scans and we use
+                // the aggregate index expansion for BY_GROUP scans
+                expandValueIndexMatchCandidate(
+                        index,
+                        availableRecordTypeNames,
+                        availableRecordTypes,
+                        queriedRecordTypeNames,
+                        queriedRecordTypes,
+                        isReverse,
+                        commonPrimaryKeyForIndex
+                ).ifPresent(resultBuilder::add);
+                expandAggregateIndexMatchCandidate(
+                        index,
+                        availableRecordTypeNames,
+                        availableRecordTypes,
+                        queriedRecordTypeNames,
+                        queriedRecordTypes,
+                        isReverse
+                ).ifPresent(resultBuilder::add);
                 break;
             default:
                 break;
         }
         return resultBuilder.build();
+    }
+
+    private static Optional<MatchCandidate> expandValueIndexMatchCandidate(@Nonnull final Index index,
+                                                                           @Nonnull final Set<String> availableRecordTypeNames,
+                                                                           @Nonnull final Collection<RecordType> availableRecordTypes,
+                                                                           @Nonnull final Set<String> queriedRecordTypeNames,
+                                                                           @Nonnull final Collection<RecordType> queriedRecordTypes,
+                                                                           final boolean isReverse,
+                                                                           @Nullable final KeyExpression commonPrimaryKeyForIndex) {
+        return expandIndexMatchCandidate(index,
+                availableRecordTypeNames,
+                availableRecordTypes,
+                queriedRecordTypeNames,
+                queriedRecordTypes,
+                isReverse,
+                commonPrimaryKeyForIndex,
+                new ValueIndexExpansionVisitor(index, queriedRecordTypes)
+        );
+    }
+
+    private static Optional<MatchCandidate> expandAggregateIndexMatchCandidate(@Nonnull final Index index,
+                                                                               @Nonnull final Set<String> availableRecordTypeNames,
+                                                                               @Nonnull final Collection<RecordType> availableRecordTypes,
+                                                                               @Nonnull final Set<String> queriedRecordTypeNames,
+                                                                               @Nonnull final Collection<RecordType> queriedRecordTypes,
+                                                                               final boolean isReverse) {
+        return expandIndexMatchCandidate(index,
+                availableRecordTypeNames,
+                availableRecordTypes,
+                queriedRecordTypeNames,
+                queriedRecordTypes,
+                isReverse,
+                null,
+                new AggregateIndexExpansionVisitor(index, queriedRecordTypes)
+        );
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
@@ -310,7 +310,7 @@ public class FieldValue extends AbstractValue implements ValueWithChild {
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
     @Nonnull
     public static Optional<FieldPath> stripFieldPrefixMaybe(@Nonnull FieldPath fieldPath,
-                                                              @Nonnull FieldPath potentialPrefixPath) {
+                                                            @Nonnull FieldPath potentialPrefixPath) {
         if (fieldPath.size() < potentialPrefixPath.size()) {
             return Optional.empty();
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
@@ -43,14 +43,18 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -320,11 +324,55 @@ public class FieldValue extends AbstractValue implements ValueWithChild {
         final var potentialPrefixFieldOrdinals = potentialPrefixPath.getFieldOrdinals();
         final var potentialPrefixFieldTypes = potentialPrefixPath.getFieldTypes();
         for (int i = 0; i < potentialPrefixPath.size(); i++) {
-            if (fieldPathOrdinals.get(i) != potentialPrefixFieldOrdinals.get(i) || !fieldPathTypes.get(i).equals(potentialPrefixFieldTypes.get(i))) {
+            if (fieldPathOrdinals.get(i) != potentialPrefixFieldOrdinals.get(i) || !equalIgnoringFieldNames(fieldPathTypes.get(i), potentialPrefixFieldTypes.get(i), new HashSet<>())) {
                 return Optional.empty();
             }
         }
         return Optional.of(fieldPath.subList(potentialPrefixPath.size(), fieldPath.size()));
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals") // Deliberate use of reference equality
+    private static boolean equalIgnoringFieldNames(@Nonnull Type t1, @Nonnull Type t2, @Nonnull Set<Pair<Type, Type>> explored) {
+        if (t1 == t2) {
+            // Short circuit for reference equality
+            return true;
+        }
+        if (t1.isNullable() != t2.isNullable()) {
+            return false;
+        }
+        if (t1.isArray()) {
+            if (!t2.isArray()) {
+                return false;
+            }
+            @Nullable Type t1Element = ((Type.Array)t1).getElementType();
+            @Nullable Type t2Element = ((Type.Array)t2).getElementType();
+            return t1Element != null && t2Element != null && equalIgnoringFieldNames(t1Element, t2Element, explored);
+        }
+        if (t1.isRecord()) {
+            if (!t2.isRecord()) {
+                return false;
+            }
+            // Use the explored set to avoid infinite recursion.
+            Pair<Type, Type> typePair = Pair.of(t1, t2);
+            if (explored.add(typePair)) {
+                List<Field> t1Fields = ((Type.Record)t1).getFields();
+                List<Field> t2Fields = ((Type.Record)t2).getFields();
+                if (t1Fields.size() != t2Fields.size()) {
+                    return false;
+                }
+                Iterator<Field> t1FieldIterator = t1Fields.iterator();
+                Iterator<Field> t2FieldIterator = t2Fields.iterator();
+                while (t1FieldIterator.hasNext() && t2FieldIterator.hasNext()) {
+                    Field t1Field = t1FieldIterator.next();
+                    Field t2Field = t2FieldIterator.next();
+                    if (!equalIgnoringFieldNames(t1Field.getFieldType(), t2Field.getFieldType(), explored)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+        return t1.equals(t2);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NumericAggregationValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NumericAggregationValue.java
@@ -141,10 +141,16 @@ public abstract class NumericAggregationValue extends AbstractValue implements V
     /**
      * Min aggregation {@code Value}.
      */
-    public static class Min extends NumericAggregationValue implements StreamableAggregateValue {
+    public static class Min extends NumericAggregationValue implements StreamableAggregateValue, IndexableAggregateValue {
 
         public Min(@Nonnull final PhysicalOperator operator, @Nonnull final Value child) {
             super(operator, child);
+        }
+
+        @Nonnull
+        @Override
+        public String getIndexName() {
+            return IndexTypes.PERMUTED_MIN;
         }
 
         @Nonnull
@@ -164,10 +170,16 @@ public abstract class NumericAggregationValue extends AbstractValue implements V
     /**
      * Max aggregation {@code Value}.
      */
-    public static class Max extends NumericAggregationValue implements StreamableAggregateValue {
+    public static class Max extends NumericAggregationValue implements StreamableAggregateValue, IndexableAggregateValue {
 
         public Max(@Nonnull final PhysicalOperator operator, @Nonnull final Value child) {
             super(operator, child);
+        }
+
+        @Nonnull
+        @Override
+        public String getIndexName() {
+            return IndexTypes.PERMUTED_MAX;
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexTest.java
@@ -20,30 +20,49 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.FunctionNames;
 import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -180,6 +199,135 @@ public class PermutedMinMaxIndexTest extends FDBRecordStoreTestBase {
                     ),
                     scanGroup(Tuple.from("yes"), true));
         }
+    }
+
+    @ParameterizedTest(name = "evaluateAggregateFunction[min={0}]")
+    @BooleanSource
+    void evaluateAggregateFunction(boolean min) {
+        final String functionName = min ? FunctionNames.MIN : FunctionNames.MAX;
+        final List<String> recordTypeNames = List.of("MySimpleRecord");
+        final RecordMetaDataHook hook = hook(min);
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            saveRecord(1, "yes", 1, 1);
+            saveRecord(2, "yes", 1, 2);
+            saveRecord(3, "yes", 1, 3);
+            saveRecord(4, "yes", 2, 4);
+            saveRecord(5, "yes", 2, 5);
+            saveRecord(6, "yes", 2, 6);
+            saveRecord(7, "no", 3, 7);
+            saveRecord(8, "no", 3, 8);
+            saveRecord(9, "no", 3, 9);
+            saveRecord(10, "no", 4, 10);
+            saveRecord(11, "no", 4, 11);
+            saveRecord(12, "no", 4, 12);
+
+            // Evaluate across the complete index
+            final IndexAggregateFunction ungrouped = new IndexAggregateFunction(
+                    functionName,
+                    Key.Expressions.field("num_value_3_indexed").ungrouped(),
+                    INDEX_NAME);
+            Tuple ungroupedExtremum = recordStore.evaluateAggregateFunction(recordTypeNames, ungrouped, Key.Evaluated.EMPTY, IsolationLevel.SERIALIZABLE).join();
+            assertEquals(min ? Tuple.from(1L) : Tuple.from(12L), ungroupedExtremum);
+
+            // Evaluate across the first column of the grouping key. This requires rolling up values across the different groups
+            IndexAggregateFunction stringValueGrouped = new IndexAggregateFunction(
+                    functionName,
+                    Key.Expressions.field("num_value_3_indexed").groupBy(Key.Expressions.field("str_value_indexed")),
+                    INDEX_NAME);
+            Tuple yesExtremum = recordStore.evaluateAggregateFunction(recordTypeNames, stringValueGrouped, Key.Evaluated.scalar("yes"), IsolationLevel.SERIALIZABLE).join();
+            assertEquals(min ? Tuple.from(1L) : Tuple.from(6L), yesExtremum);
+            Tuple noExtremum = recordStore.evaluateAggregateFunction(recordTypeNames, stringValueGrouped, Key.Evaluated.scalar("no"), IsolationLevel.SERIALIZABLE).join();
+            assertEquals(min ? Tuple.from(7L) : Tuple.from(12L), noExtremum);
+            Tuple maybeExtremum = recordStore.evaluateAggregateFunction(recordTypeNames, stringValueGrouped, Key.Evaluated.scalar("maybe"), IsolationLevel.SERIALIZABLE).join();
+            assertNull(maybeExtremum);
+
+            // Evaluate when limited to a single group. This requires scanning through the keys of the larger group and filtering out unrelated groups
+            IndexAggregateFunction mostSpecificallyGrouped = new IndexAggregateFunction(
+                    functionName,
+                    Key.Expressions.field("num_value_3_indexed").groupBy(Key.Expressions.concatenateFields("str_value_indexed", "num_value_2")),
+                    INDEX_NAME);
+            Tuple yes0Extremum = recordStore.evaluateAggregateFunction(recordTypeNames, mostSpecificallyGrouped, Key.Evaluated.concatenate("yes", 0L), IsolationLevel.SERIALIZABLE).join();
+            assertNull(yes0Extremum);
+            Tuple yes1Extremum = recordStore.evaluateAggregateFunction(recordTypeNames, mostSpecificallyGrouped, Key.Evaluated.concatenate("yes", 1L), IsolationLevel.SERIALIZABLE).join();
+            assertEquals(min ? Tuple.from(1L) : Tuple.from(3L), yes1Extremum);
+            Tuple yes2Extremum = recordStore.evaluateAggregateFunction(recordTypeNames, mostSpecificallyGrouped, Key.Evaluated.concatenate("yes", 2L), IsolationLevel.SERIALIZABLE).join();
+            assertEquals(min ? Tuple.from(4L) : Tuple.from(6L), yes2Extremum);
+            Tuple no3Extremum = recordStore.evaluateAggregateFunction(recordTypeNames, mostSpecificallyGrouped, Key.Evaluated.concatenate("no", 3L), IsolationLevel.SERIALIZABLE).join();
+            assertEquals(min ? Tuple.from(7L) : Tuple.from(9L), no3Extremum);
+            Tuple no4Extremum = recordStore.evaluateAggregateFunction(recordTypeNames, mostSpecificallyGrouped, Key.Evaluated.concatenate("no", 4L), IsolationLevel.SERIALIZABLE).join();
+            assertEquals(min ? Tuple.from(10L) : Tuple.from(12L), no4Extremum);
+            Tuple no5Extremum = recordStore.evaluateAggregateFunction(recordTypeNames, mostSpecificallyGrouped, Key.Evaluated.concatenate("no", 5L), IsolationLevel.SERIALIZABLE).join();
+            assertNull(no5Extremum);
+
+            commit(context);
+        }
+    }
+
+    @ParameterizedTest(name = "coveringIndexScan[min={0}]")
+    @BooleanSource
+    void coveringIndexScan(boolean min) {
+        final String functionName = min ? FunctionNames.MIN : FunctionNames.MAX;
+        final RecordMetaDataHook hook = hook(min);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            final String strValueParam = "str_value";
+            RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.field("str_value_indexed").equalsParameter(strValueParam))
+                    .setRequiredResults(List.of(Key.Expressions.field("num_value_2")))
+                    .build();
+            RecordQueryPlan plan = ((RecordQueryPlanner)planner).planCoveringAggregateIndex(query, INDEX_NAME);
+            assertNotNull(plan);
+            assertTrue(plan.hasIndexScan(INDEX_NAME));
+
+            saveRecord(1, "yes", 1, 1);
+            saveRecord(2, "yes", 1, 2);
+            saveRecord(3, "yes", 1, 3);
+            saveRecord(4, "yes", 2, 4);
+            saveRecord(5, "yes", 2, 5);
+            saveRecord(6, "yes", 2, 6);
+            saveRecord(7, "no", 3, 7);
+            saveRecord(8, "no", 3, 8);
+            saveRecord(9, "no", 3, 9);
+            saveRecord(10, "no", 4, 10);
+            saveRecord(11, "no", 4, 11);
+            saveRecord(12, "no", 4, 12);
+
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            List<Pair<Long, Long>> results = executePermutedIndexScan(plan, index, EvaluationContext.forBinding(strValueParam, "yes"));
+            assertThat(results, hasSize(2));
+            assertThat(results, containsInAnyOrder(Pair.of(1L, min ? 1L : 3L), Pair.of(2L, min ? 4L : 6L)));
+
+            results = executePermutedIndexScan(plan, index, EvaluationContext.forBinding(strValueParam, "no"));
+            assertThat(results, hasSize(2));
+            assertThat(results, containsInAnyOrder(Pair.of(3L, min ? 7L : 9L), Pair.of(4L, min ? 10L : 12L)));
+
+            results = executePermutedIndexScan(plan, index, EvaluationContext.forBinding(strValueParam, "maybe"));
+            assertThat(results, empty());
+
+            commit(context);
+        }
+    }
+
+    @Nonnull
+    private List<Pair<Long, Long>> executePermutedIndexScan(@Nonnull RecordQueryPlan plan, @Nonnull Index index, @Nullable EvaluationContext evaluationContext) {
+        return plan.execute(recordStore, evaluationContext == null ? EvaluationContext.EMPTY : evaluationContext)
+                .map(rec -> {
+                    assertEquals(index, rec.getIndex());
+                    TestRecords1Proto.MySimpleRecord simple = TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(rec.getRecord()).build();
+                    assertTrue(simple.hasNumValue2());
+                    long numValue2 = simple.getNumValue2();
+                    Tuple indexKey = rec.getIndexEntry().getKey();
+                    assertNotNull(indexKey);
+                    assertEquals(numValue2, indexKey.getLong(2));
+                    return Pair.of(numValue2, indexKey.getLong(1));
+                })
+                .asList()
+                .join();
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBPermutedMinMaxQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBPermutedMinMaxQueryTest.java
@@ -43,6 +43,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSort
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
@@ -110,8 +111,12 @@ class FDBPermutedMinMaxQueryTest extends FDBRecordStoreQueryTestBase {
         }
         final var num2Value = FieldValue.ofFieldName(baseQun.getFlowedObjectValue(), "num_value_2");
         final var num3Value = FieldValue.ofFieldName(baseQun.getFlowedObjectValue(), "num_value_3_indexed");
+        final List<Column<? extends Value>> groupingColumns = List.of(
+                Column.of(Type.Record.Field.of(num2Value.getResultType(), Optional.of("num_value_2")), num2Value),
+                Column.of(Type.Record.Field.of(num3Value.getResultType(), Optional.of("num_value_3_indexed")), num3Value)
+        );
         selectWhereBuilder
-                .addResultValue(RecordConstructorValue.ofColumns(List.of(Column.unnamedOf(num2Value), Column.unnamedOf(num3Value))))
+                .addResultValue(RecordConstructorValue.ofColumns(groupingColumns))
                 .addResultValue(baseQun.getFlowedObjectValue());
         return Quantifier.forEach(GroupExpressionRef.of(selectWhereBuilder.build().buildSelect()));
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBPermutedMinMaxQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBPermutedMinMaxQueryTest.java
@@ -1,0 +1,475 @@
+/*
+ * FDBPermutedMinMaxQueryTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.query;
+
+import com.apple.foundationdb.record.Bindings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.QueryPlanResult;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
+import com.apple.foundationdb.record.query.plan.cascades.Column;
+import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
+import com.apple.foundationdb.record.query.plan.cascades.GroupExpressionRef;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.GroupByExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
+import com.apple.test.BooleanSource;
+import com.apple.test.Tags;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for queries that use the {@link IndexTypes#PERMUTED_MIN} and {@link IndexTypes#PERMUTED_MAX} index types.
+ * There are additional tests for those tests in {@link com.apple.foundationdb.record.provider.foundationdb.indexes.PermutedMinMaxIndexTest}.
+ * These tests focus more on executing queries with a min- and max-function within it.
+ */
+@Tag(Tags.RequiresFDB)
+class FDBPermutedMinMaxQueryTest extends FDBRecordStoreQueryTestBase {
+    @Nonnull
+    private static final String MAX_UNIQUE_BY_2_3 = "maxNumValueUniqueBy2And3";
+    @Nonnull
+    private static final GroupingKeyExpression UNIQUE_BY_2_3 = field("num_value_unique")
+            .groupBy(concatenateFields("num_value_2", "num_value_3_indexed"));
+
+    private static Index maxUniqueBy2And3() {
+        return new Index(MAX_UNIQUE_BY_2_3, UNIQUE_BY_2_3, IndexTypes.PERMUTED_MAX, Map.of(IndexOptions.PERMUTED_SIZE_OPTION, "1"));
+    }
+
+    @Nonnull
+    private static Quantifier selectWhereQun(@Nonnull Quantifier baseQun, @Nullable QueryPredicate predicate) {
+        final var selectWhereBuilder = GraphExpansion.builder();
+        selectWhereBuilder.addQuantifier(baseQun);
+        if (predicate != null) {
+            selectWhereBuilder.addPredicate(predicate);
+        }
+        final var num2Value = FieldValue.ofFieldName(baseQun.getFlowedObjectValue(), "num_value_2");
+        final var num3Value = FieldValue.ofFieldName(baseQun.getFlowedObjectValue(), "num_value_3_indexed");
+        selectWhereBuilder
+                .addResultValue(RecordConstructorValue.ofColumns(List.of(Column.unnamedOf(num2Value), Column.unnamedOf(num3Value))))
+                .addResultValue(baseQun.getFlowedObjectValue());
+        return Quantifier.forEach(GroupExpressionRef.of(selectWhereBuilder.build().buildSelect()));
+    }
+
+    @Nonnull
+    private static Quantifier maxUniqueByGroupQun(@Nonnull Quantifier selectWhere) {
+        var baseReference = FieldValue.ofOrdinalNumber(selectWhere.getFlowedObjectValue(), 1);
+        final FieldValue groupedValue = FieldValue.ofFieldName(baseReference, "num_value_unique");
+        var aggregatedFieldRef = FieldValue.ofFields(selectWhere.getFlowedObjectValue(), baseReference.getFieldPath().withSuffix(groupedValue.getFieldPath()));
+        final Value maxUniqueValue = (Value) new NumericAggregationValue.MaxFn().encapsulate(List.of(aggregatedFieldRef));
+        final FieldValue groupingValue = FieldValue.ofOrdinalNumber(selectWhere.getFlowedObjectValue(), 0);
+        final GroupByExpression groupByExpression = new GroupByExpression(RecordConstructorValue.ofUnnamed(List.of(maxUniqueValue)), groupingValue, selectWhere);
+        return Quantifier.forEach(GroupExpressionRef.of(groupByExpression));
+    }
+
+    @Nonnull
+    private static Quantifier selectHaving(@Nonnull Quantifier groupedByQun, @Nullable QueryPredicate predicate, @Nonnull List<String> resultColumns) {
+        final var selectHavingBuilder = GraphExpansion.builder().addQuantifier(groupedByQun);
+        final var groupingValueReference = FieldValue.ofOrdinalNumber(groupedByQun.getFlowedObjectValue(), 0);
+        final var aggregateValueReference = FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupedByQun.getFlowedObjectValue(), 1), 0);
+        if (predicate != null) {
+            selectHavingBuilder.addPredicate(predicate);
+        }
+        for (String resultColumn : resultColumns) {
+            Value value;
+            switch (resultColumn) {
+                case "m":
+                    value = aggregateValueReference;
+                    break;
+                case "num_value_2":
+                    value = FieldValue.ofOrdinalNumber(groupingValueReference, 0);
+                    break;
+                case "num_value_3_indexed":
+                    value = FieldValue.ofOrdinalNumber(groupingValueReference, 1);
+                    break;
+                default:
+                    value = fail("Unknown result column name " + resultColumn);
+            }
+            selectHavingBuilder.addResultColumn(FDBSimpleQueryGraphTest.resultColumn(value, resultColumn));
+        }
+        return Quantifier.forEach(GroupExpressionRef.of(selectHavingBuilder.build().buildSelect()));
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    @ParameterizedTest
+    @BooleanSource
+    void selectMaxOrderByFirstGroup(boolean reverse) throws Exception {
+        Assumptions.assumeTrue(useCascadesPlanner);
+        final RecordMetaDataHook hook = metaData -> metaData.addIndex(metaData.getRecordType("MySimpleRecord"), maxUniqueBy2And3());
+        complexQuerySetup(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(planner, instanceOf(CascadesPlanner.class));
+            CascadesPlanner cascadesPlanner = (CascadesPlanner)planner;
+
+            // Issue a query equivalent to:
+            //   SELECT num_value_2, num_value_3_indexed, max(num_value_unique) as m FROM MySimpleRecord GROUP BY num_value_2, num_value_3_indexed ORDER BY num_value_2
+            QueryPlanResult result = cascadesPlanner.planGraph(() -> {
+                final var base = FDBSimpleQueryGraphTest.fullTypeScan(cascadesPlanner.getRecordMetaData(), "MySimpleRecord");
+
+                final var selectWhere = selectWhereQun(base, null);
+                final var groupedByQun = maxUniqueByGroupQun(selectWhere);
+
+                final var qun = selectHaving(groupedByQun, null, List.of("num_value_2", "num_value_3_indexed", "m"));
+                final AliasMap aliasMap = AliasMap.of(qun.getAlias(), Quantifier.current());
+                return GroupExpressionRef.of(new LogicalSortExpression(List.of(FieldValue.ofOrdinalNumber(qun.getFlowedObjectValue(), 0).rebase(aliasMap)), reverse, qun));
+            }, Optional.of(Set.of(MAX_UNIQUE_BY_2_3)), IndexQueryabilityFilter.DEFAULT, EvaluationContext.EMPTY);
+
+            assertNotNull(result);
+            RecordQueryPlan plan = result.getPlan();
+            assertMatchesExactly(plan, RecordQueryPlanMatchers.mapPlan(
+                    RecordQueryPlanMatchers.aggregateIndexPlan()
+                            .where(RecordQueryPlanMatchers.scanComparisons(ScanComparisons.unbounded()))
+                    )
+            );
+
+            final List<Tuple> tupleResults = executeAndGetTuples(plan, Bindings.EMPTY_BINDINGS, List.of("num_value_2", "num_value_3_indexed", "m"));
+            final Map<Integer, List<Tuple>> byNumValue2 = new HashMap<>();
+            int lastNumValue2 = reverse ? Integer.MAX_VALUE : Integer.MIN_VALUE;
+            for (Tuple tupleResult : tupleResults) {
+                int numValue2 = (int) tupleResult.getLong(0);
+                assertTrue(reverse ? numValue2 <= lastNumValue2 : numValue2 >= lastNumValue2, String.format("tuple %s should have num_value_2 that is %s than or equal to %d", tupleResult, reverse ? "less" : "greater", numValue2));
+                lastNumValue2 = numValue2;
+
+                List<Tuple> grouped = byNumValue2.computeIfAbsent(numValue2, ignore -> new ArrayList<>());
+                grouped.add(TupleHelpers.subTuple(tupleResult, 1, 3));
+            }
+            assertEquals(Set.of(0, 1, 2), byNumValue2.keySet());
+
+            for (Map.Entry<Integer, List<Tuple>> groupedResult : byNumValue2.entrySet()) {
+                int numValue2 = groupedResult.getKey();
+                final List<Tuple> groupedTuples = groupedResult.getValue();
+                final Map<Integer, Integer> expectedMaxes = expectedMaxesByNumValue3(val -> val == numValue2);
+                assertThat(groupedTuples, hasSize(expectedMaxes.size()));
+                final List<Matcher<? super Tuple>> expectedTuples = expectedTuples(expectedMaxes, reverse);
+                assertThat(groupedTuples, contains(expectedTuples));
+            }
+
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    void selectMaxByGroupWithFilter() throws Exception {
+        final RecordMetaDataHook hook = metaData -> metaData.addIndex(metaData.getRecordType("MySimpleRecord"), maxUniqueBy2And3());
+        complexQuerySetup(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(planner, instanceOf(CascadesPlanner.class));
+            CascadesPlanner cascadesPlanner = (CascadesPlanner) planner;
+
+            // Issue a query equivalent to:
+            //   SELECT num_value_3_indexed, max(num_value_unique) as m FROM MySimpleRecord WHERE num_value_2 = ?numValue2 GROUP BY num_value_3_indexed
+            final String numValue2Param = "numValue2";
+            QueryPlanResult result = cascadesPlanner.planGraph(() -> {
+                final var base = FDBSimpleQueryGraphTest.fullTypeScan(cascadesPlanner.getRecordMetaData(), "MySimpleRecord");
+
+                final var num2Value = FieldValue.ofFieldName(base.getFlowedObjectValue(), "num_value_2");
+                final var selectWhere = selectWhereQun(base, new ValuePredicate(num2Value, new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, numValue2Param)));
+                final var groupedByQun = maxUniqueByGroupQun(selectWhere);
+
+                final var qun = selectHaving(groupedByQun, null, List.of("num_value_3_indexed", "m"));
+                return GroupExpressionRef.of(new LogicalSortExpression(List.of(), false, qun));
+            }, Optional.of(Set.of(MAX_UNIQUE_BY_2_3)), IndexQueryabilityFilter.DEFAULT, EvaluationContext.EMPTY);
+
+            assertNotNull(result);
+            RecordQueryPlan plan = result.getPlan();
+            assertMatchesExactly(plan, RecordQueryPlanMatchers.mapPlan(
+                    RecordQueryPlanMatchers.aggregateIndexPlan()
+                        .where(RecordQueryPlanMatchers.scanComparisons(ScanComparisons.range("[EQUALS $" + numValue2Param + "]")))
+                    )
+            );
+
+            for (int numValue2 = -1; numValue2 <= 4; numValue2++) {
+                final List<Tuple> tupleResults = executeAndGetTuples(plan, Bindings.newBuilder().set(numValue2Param, numValue2).build(), List.of("num_value_3_indexed", "m"));
+
+                final int numValue2Value = numValue2;
+                final Map<Integer, Integer> expectedMaxes = expectedMaxesByNumValue3(val -> val == numValue2Value);
+                assertThat(tupleResults, hasSize(expectedMaxes.size()));
+                if (!expectedMaxes.isEmpty()) {
+                    final List<Matcher<? super Tuple>> expectedTuples = expectedTuples(expectedMaxes, false);
+                    assertThat(tupleResults, contains(expectedTuples));
+                }
+            }
+
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    @ParameterizedTest
+    @BooleanSource
+    void selectMaxByGroupWithOrder(boolean reverse) throws Exception {
+        Assumptions.assumeTrue(useCascadesPlanner);
+        final RecordMetaDataHook hook = metaData -> metaData.addIndex(metaData.getRecordType("MySimpleRecord"), maxUniqueBy2And3());
+        complexQuerySetup(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(planner, instanceOf(CascadesPlanner.class));
+            CascadesPlanner cascadesPlanner = (CascadesPlanner) planner;
+
+            // Issue a query equivalent to:
+            //   SELECT num_value_3_indexed, max(num_value_unique) as m FROM MySimpleRecord WHERE num_value_2 = ?numValue2 GROUP BY num_value_3_indexed ORDER BY max(num_value_unique)
+            final String numValue2Param = "numValue2";
+            QueryPlanResult result = cascadesPlanner.planGraph(() -> {
+                final var base = FDBSimpleQueryGraphTest.fullTypeScan(cascadesPlanner.getRecordMetaData(), "MySimpleRecord");
+
+                final var num2Value = FieldValue.ofFieldName(base.getFlowedObjectValue(), "num_value_2");
+                final var selectWhere = selectWhereQun(base, new ValuePredicate(num2Value, new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, numValue2Param)));
+                final var groupedByQun = maxUniqueByGroupQun(selectWhere);
+
+                final var qun = selectHaving(groupedByQun, null, List.of("m", "num_value_3_indexed"));
+                final AliasMap aliasMap = AliasMap.of(qun.getAlias(), Quantifier.current());
+                return GroupExpressionRef.of(new LogicalSortExpression(List.of(FieldValue.ofOrdinalNumber(qun.getFlowedObjectValue(), 0).rebase(aliasMap)), reverse, qun));
+            }, Optional.of(Set.of(MAX_UNIQUE_BY_2_3)), IndexQueryabilityFilter.DEFAULT, EvaluationContext.EMPTY);
+
+            assertNotNull(result);
+            RecordQueryPlan plan = result.getPlan();
+            assertMatchesExactly(plan, RecordQueryPlanMatchers.mapPlan(
+                    RecordQueryPlanMatchers.aggregateIndexPlan()
+                            .where(RecordQueryPlanMatchers.scanComparisons(ScanComparisons.range("[EQUALS $" + numValue2Param + "]")))
+                    )
+            );
+            assertEquals(reverse, plan.isReverse());
+
+            for (int numValue2 = -1; numValue2 <= 4; numValue2++) {
+                final List<Tuple> tupleResults = executeAndGetTuples(plan, Bindings.newBuilder().set(numValue2Param, numValue2).build(), List.of("num_value_3_indexed", "m"));
+
+                final int numValue2Value = numValue2;
+                final Map<Integer, Integer> expectedMaxes = expectedMaxesByNumValue3(val -> val == numValue2Value);
+                assertThat(tupleResults, hasSize(expectedMaxes.size()));
+                if (!expectedMaxes.isEmpty()) {
+                    final List<Matcher<? super Tuple>> expectedTuples = expectedTuples(expectedMaxes, reverse);
+                    assertThat(tupleResults, contains(expectedTuples));
+                }
+            }
+
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    void selectMaxGroupByWithPredicateOnMax() throws Exception {
+        final RecordMetaDataHook hook = metaData -> metaData.addIndex(metaData.getRecordType("MySimpleRecord"), maxUniqueBy2And3());
+        complexQuerySetup(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(planner, instanceOf(CascadesPlanner.class));
+            CascadesPlanner cascadesPlanner = (CascadesPlanner) planner;
+
+            // Issue a query equivalent to:
+            //   SELECT num_value_3_indexed, max(num_value_unique) as m FROM MySimpleRecord WHERE num_value_2 = ?numValue2 GROUP BY num_value_3_indexed HAVING max(num_value_unique) < ?maxValue
+            final String numValue2Param = "numValue2";
+            final String maxValueParam = "maxValue";
+            QueryPlanResult result = cascadesPlanner.planGraph(() -> {
+                final var base = FDBSimpleQueryGraphTest.fullTypeScan(cascadesPlanner.getRecordMetaData(), "MySimpleRecord");
+
+                final var num2Value = FieldValue.ofFieldName(base.getFlowedObjectValue(), "num_value_2");
+                final var selectWhere = selectWhereQun(base, new ValuePredicate(num2Value, new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, numValue2Param)));
+                final var groupedByQun = maxUniqueByGroupQun(selectWhere);
+
+                final var aggregateValueReference = FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupedByQun.getFlowedObjectValue(), 1), 0);
+                final var qun = selectHaving(groupedByQun, new ValuePredicate(aggregateValueReference, new Comparisons.ParameterComparison(Comparisons.Type.LESS_THAN, maxValueParam)), List.of("num_value_3_indexed", "m"));
+                return GroupExpressionRef.of(new LogicalSortExpression(List.of(), false, qun));
+            }, Optional.of(Set.of(MAX_UNIQUE_BY_2_3)), IndexQueryabilityFilter.DEFAULT, EvaluationContext.EMPTY);
+
+            assertNotNull(result);
+            RecordQueryPlan plan = result.getPlan();
+            assertMatchesExactly(plan, RecordQueryPlanMatchers.mapPlan(
+                    RecordQueryPlanMatchers.aggregateIndexPlan()
+                            .where(RecordQueryPlanMatchers.scanComparisons(ScanComparisons.range("[EQUALS $" + numValue2Param + ", [LESS_THAN $" + maxValueParam + "]]")))
+                    )
+            );
+
+            for (int numValue2 = -1; numValue2 <= 4; numValue2++) {
+                final int numValue2Value = numValue2;
+                final Map<Integer, Integer> baseMaxes = expectedMaxesByNumValue3(val -> val == numValue2Value);
+                int maxValue = (int) baseMaxes.values().stream().mapToInt(i -> i).average().orElse(0.0);
+
+                final List<Tuple> tupleResults = executeAndGetTuples(plan, Bindings.newBuilder().set(numValue2Param, numValue2).set(maxValueParam, maxValue).build(), List.of("num_value_3_indexed", "m"));
+                final Map<Integer, Integer> expectedMaxes = baseMaxes.entrySet().stream()
+                        .filter(entry -> entry.getValue() < maxValue)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                assertThat(tupleResults, hasSize(expectedMaxes.size()));
+                if (!baseMaxes.isEmpty()) {
+                    final List<Matcher<? super Tuple>> expectedTuples = expectedTuples(expectedMaxes, false);
+                    assertThat(tupleResults, contains(expectedTuples));
+                }
+            }
+
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    @ParameterizedTest
+    @BooleanSource
+    void selectMaxGroupByWithPredicateAndOrderByOnMax(boolean reverse) throws Exception {
+        Assumptions.assumeTrue(useCascadesPlanner);
+        final RecordMetaDataHook hook = metaData -> metaData.addIndex(metaData.getRecordType("MySimpleRecord"), maxUniqueBy2And3());
+        complexQuerySetup(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(planner, instanceOf(CascadesPlanner.class));
+            CascadesPlanner cascadesPlanner = (CascadesPlanner) planner;
+
+            // Issue a query equivalent to:
+            //   SELECT num_value_3_indexed, max(num_value_unique) as m FROM MySimpleRecord WHERE num_value_2 = ?numValue2 GROUP BY num_value_3_indexed HAVING max(num_value_unique) < ?maxValue ORDER BY max(num_value_unique)
+            final String numValue2Param = "numValue2";
+            final String maxValueParam = "maxValue";
+            QueryPlanResult result = cascadesPlanner.planGraph(() -> {
+                final var base = FDBSimpleQueryGraphTest.fullTypeScan(cascadesPlanner.getRecordMetaData(), "MySimpleRecord");
+
+                final var num2Value = FieldValue.ofFieldName(base.getFlowedObjectValue(), "num_value_2");
+                final var selectWhere = selectWhereQun(base, new ValuePredicate(num2Value, new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, numValue2Param)));
+                final var groupedByQun = maxUniqueByGroupQun(selectWhere);
+
+                final var aggregateValueReference = FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupedByQun.getFlowedObjectValue(), 1), 0);
+                final var qun = selectHaving(groupedByQun, new ValuePredicate(aggregateValueReference, new Comparisons.ParameterComparison(Comparisons.Type.GREATER_THAN, maxValueParam)), List.of("num_value_3_indexed", "m"));
+                final AliasMap aliasMap = AliasMap.of(qun.getAlias(), Quantifier.current());
+                return GroupExpressionRef.of(new LogicalSortExpression(List.of(FieldValue.ofOrdinalNumber(qun.getFlowedObjectValue(), 1).rebase(aliasMap)), reverse, qun));
+            }, Optional.of(Set.of(MAX_UNIQUE_BY_2_3)), IndexQueryabilityFilter.DEFAULT, EvaluationContext.EMPTY);
+
+            assertNotNull(result);
+            RecordQueryPlan plan = result.getPlan();
+            assertMatchesExactly(plan, RecordQueryPlanMatchers.mapPlan(
+                    RecordQueryPlanMatchers.aggregateIndexPlan()
+                            .where(RecordQueryPlanMatchers.scanComparisons(ScanComparisons.range("[EQUALS $" + numValue2Param + ", [GREATER_THAN $" + maxValueParam + "]]")))
+                    )
+            );
+
+            for (int numValue2 = -1; numValue2 <= 4; numValue2++) {
+                final int numValue2Value = numValue2;
+                final Map<Integer, Integer> baseMaxes = expectedMaxesByNumValue3(val -> val == numValue2Value);
+                int maxValue = (int) baseMaxes.values().stream().mapToInt(i -> i).average().orElse(0.0);
+
+                final List<Tuple> tupleResults = executeAndGetTuples(plan, Bindings.newBuilder().set(numValue2Param, numValue2).set(maxValueParam, maxValue).build(), List.of("num_value_3_indexed", "m"));
+                final Map<Integer, Integer> expectedMaxes = baseMaxes.entrySet().stream()
+                        .filter(entry -> entry.getValue() > maxValue)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                assertThat(tupleResults, hasSize(expectedMaxes.size()));
+                if (!baseMaxes.isEmpty()) {
+                    final List<Matcher<? super Tuple>> expectedTuples = expectedTuples(expectedMaxes, reverse);
+                    assertThat(tupleResults, contains(expectedTuples));
+                }
+            }
+
+            commit(context);
+        }
+    }
+
+    @Nonnull
+    private List<Tuple> executeAndGetTuples(@Nonnull RecordQueryPlan plan, @Nonnull Bindings bindings, @Nonnull List<String> fieldNames)  {
+        try (RecordCursor<QueryResult> cursor = FDBSimpleQueryGraphTest.executeCascades(recordStore, plan, bindings)) {
+            return cursor
+                    .map(rec -> {
+                        final Message msg = rec.getMessage();
+                        final Descriptors.Descriptor desc = msg.getDescriptorForType();
+                        List<Object> values = new ArrayList<>(fieldNames.size());
+                        for (String fieldName : fieldNames) {
+                            final Descriptors.FieldDescriptor fieldDescriptor = desc.findFieldByName(fieldName);
+                            values.add(msg.getField(fieldDescriptor));
+                        }
+                        return Tuple.fromItems(values);
+                    })
+                    .asList()
+                    .join();
+        }
+    }
+
+    @Nonnull
+    private static Map<Integer, Integer> expectedMaxesByNumValue3(Predicate<Integer> numValue2Filter) {
+        final Map<Integer, Integer> expectedMaxes = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            int numValue2 = i % 3;
+            if (!numValue2Filter.test(numValue2)) {
+                continue;
+            }
+            int numValue3 = i % 5;
+            int numValueUnique = 1000 - i;
+            expectedMaxes.compute(numValue3, (k, existing) -> existing == null ? numValueUnique : Math.max(numValueUnique, existing));
+        }
+        return expectedMaxes;
+    }
+
+    @Nonnull
+    private static List<Matcher<? super Tuple>> expectedTuples(@Nonnull Map<Integer, Integer> expectedMaxes, boolean reverse) {
+        return expectedMaxes.entrySet().stream()
+                .map(entry -> Tuple.from(entry.getKey(), entry.getValue()))
+                .sorted(Comparator.comparingLong(t -> (reverse ? -1L : 1L) * t.getLong(1)))
+                .map(Matchers::equalTo)
+                .collect(Collectors.toList());
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
+import com.apple.foundationdb.record.Bindings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.RecordCoreException;
@@ -138,11 +139,15 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
     }
 
     static RecordCursor<QueryResult> executeCascades(FDBRecordStore store, RecordQueryPlan plan) {
+        return executeCascades(store, plan, Bindings.EMPTY_BINDINGS);
+    }
+
+    static RecordCursor<QueryResult> executeCascades(FDBRecordStore store, RecordQueryPlan plan, Bindings bindings) {
         Set<Type> usedTypes = UsedTypesProperty.evaluate(plan);
         TypeRepository typeRepository = TypeRepository.newBuilder()
                 .addAllTypes(usedTypes)
                 .build();
-        EvaluationContext evaluationContext = EvaluationContext.forTypeRepository(typeRepository);
+        EvaluationContext evaluationContext = EvaluationContext.forBindingsAndTypeRepository(bindings, typeRepository);
         return plan.executePlan(store, evaluationContext, null, ExecuteProperties.SERIAL_EXECUTE);
     }
 


### PR DESCRIPTION
This does a few things:

1. It defines what index aggregate functions the `PERMUTED_MIN` and `PERMUTED_MAX` functions can evaluate. Effectively, this communicates with consumers that those indexes can be used to satisfy the `min` and `max` function. It also provides corresponding implementations of those functions using the index.
1. The `planCoveringIndex` method in the maintainer is updated to allow for scans over the index that cover the unpermuted grouping columns.
1. Match candidates for the index with the appropriate contents and the appropriate ordering are now generated for consumption by Cascades.
1. Ordering logic is updated so that the ordering keys are matchable for aggregate indexes. For most indexes, this follows the order of the key expression, though the `PERMUTED_MIN` and `PERMUTED_MAX` indexes have special handling for the permuted size.

This resolves #2418.