### PR TITLE
Resolves #2421: Add implementations for BaseIndexFileFormatTestCase 

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,6 +29,8 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add lucene partitioning metadata [(Issue #2390)](https://github.com/FoundationDB/fdb-record-layer/issues/2390)
+* **Feature** Add implementations of all sub-classes of `BaseIndexFileFormatTestCase` [(Issue #2421)](https://github.com/FoundationDB/fdb-record-layer/issues/2421)
+* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
@@ -174,7 +174,7 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
     }
 
     private Map<String, String> protoToLucene(final List<LuceneFieldInfosProto.Attribute> attributesList) {
-        return attributesList.stream().collect(Collectors.toMap(
+        return attributesList.stream().collect(Collectors.toUnmodifiableMap(
                 LuceneFieldInfosProto.Attribute::getKey,
                 LuceneFieldInfosProto.Attribute::getValue));
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormatTest.java
@@ -110,20 +110,20 @@ public class LuceneOptimizedCompoundFormatTest extends BaseCompoundFormatTestCas
         } else {
             dir = newMockFSDirectory(createTempDir("CFSManySubFiles"));
         }
+        // fileCount was originally FILE_COUNT, but that goes against checkStyle
+        final int fileCount = atLeast(500);
         // --END CUSTOM--
-
-        final int FILE_COUNT = atLeast(500);
 
         List<String> files = new ArrayList<>();
         SegmentInfo si = newSegmentInfo(dir, "_123");
-        for (int fileIdx = 0; fileIdx < FILE_COUNT; fileIdx++) {
-          String file = "_123." + fileIdx;
-          files.add(file);
-          try (IndexOutput out = dir.createOutput(file, newIOContext(random()))) {
-            CodecUtil.writeIndexHeader(out, "Foo", 0, si.getId(), "suffix");
-            out.writeByte((byte) fileIdx);
-            CodecUtil.writeFooter(out);
-          }
+        for (int fileIdx = 0; fileIdx < fileCount; fileIdx++) {
+            String file = "_123." + fileIdx;
+            files.add(file);
+            try (IndexOutput out = dir.createOutput(file, newIOContext(random()))) {
+                CodecUtil.writeIndexHeader(out, "Foo", 0, si.getId(), "suffix");
+                out.writeByte((byte)fileIdx);
+                CodecUtil.writeFooter(out);
+            }
         }
 
         assertEquals(0, dir.getFileHandleCount());
@@ -132,22 +132,22 @@ public class LuceneOptimizedCompoundFormatTest extends BaseCompoundFormatTestCas
         si.getCodec().compoundFormat().write(dir, si, IOContext.DEFAULT);
         Directory cfs = si.getCodec().compoundFormat().getCompoundReader(dir, si, IOContext.DEFAULT);
 
-        final IndexInput[] ins = new IndexInput[FILE_COUNT];
-        for (int fileIdx = 0; fileIdx < FILE_COUNT; fileIdx++) {
-          ins[fileIdx] = cfs.openInput("_123." + fileIdx, newIOContext(random()));
-          CodecUtil.checkIndexHeader(ins[fileIdx], "Foo", 0, 0, si.getId(), "suffix");
+        final IndexInput[] ins = new IndexInput[fileCount];
+        for (int fileIdx = 0; fileIdx < fileCount; fileIdx++) {
+            ins[fileIdx] = cfs.openInput("_123." + fileIdx, newIOContext(random()));
+            CodecUtil.checkIndexHeader(ins[fileIdx], "Foo", 0, 0, si.getId(), "suffix");
         }
 
         assertEquals(1, dir.getFileHandleCount());
 
-        for (int fileIdx = 0; fileIdx < FILE_COUNT; fileIdx++) {
-          assertEquals((byte) fileIdx, ins[fileIdx].readByte());
+        for (int fileIdx = 0; fileIdx < fileCount; fileIdx++) {
+            assertEquals((byte)fileIdx, ins[fileIdx].readByte());
         }
 
         assertEquals(1, dir.getFileHandleCount());
 
-        for(int fileIdx=0;fileIdx<FILE_COUNT;fileIdx++) {
-          ins[fileIdx].close();
+        for (int fileIdx = 0; fileIdx < fileCount; fileIdx++) {
+            ins[fileIdx].close();
         }
         cfs.close();
 
@@ -158,10 +158,10 @@ public class LuceneOptimizedCompoundFormatTest extends BaseCompoundFormatTestCas
      * This is a direct copy of the {@link BaseCompoundFormatTestCase#testLargeCFS()}, except in that version it
      * always creates a FSDirectory, whereas here, if testing against FDB we use the directory under test.
      * <p>
-     *     You can search for "--BEGIN CUSTOM--" and "--END CUSTOM--" in the code to see exactly which lines.
+     * You can search for "--BEGIN CUSTOM--" and "--END CUSTOM--" in the code to see exactly which lines.
      * </p>
      * <p>
-     *     Currently ignored because it takes 2 minutes trying to write 500MB to a single file.
+     * Currently ignored because it takes 2 minutes trying to write 500MB to a single file.
      * </p>
      *
      * @throws IOException if there's issues
@@ -170,7 +170,7 @@ public class LuceneOptimizedCompoundFormatTest extends BaseCompoundFormatTestCas
     @Ignore
     public void testLargeCFS() throws IOException {
         final String testfile = "_123.test";
-        IOContext context = new IOContext(new FlushInfo(0, 512*1024*1024));
+        IOContext context = new IOContext(new FlushInfo(0, 512 * 1024 * 1024));
 
         // --BEGIN CUSTOM--
         Directory dir;
@@ -184,12 +184,12 @@ public class LuceneOptimizedCompoundFormatTest extends BaseCompoundFormatTestCas
 
         SegmentInfo si = newSegmentInfo(dir, "_123");
         try (IndexOutput out = dir.createOutput(testfile, context)) {
-          CodecUtil.writeIndexHeader(out, "Foo", 0, si.getId(), "suffix");
-          byte[] bytes = new byte[512];
-          for(int i=0;i<1024*1024;i++) {
-            out.writeBytes(bytes, 0, bytes.length);
-          }
-          CodecUtil.writeFooter(out);
+            CodecUtil.writeIndexHeader(out, "Foo", 0, si.getId(), "suffix");
+            byte[] bytes = new byte[512];
+            for (int i = 0; i < 1024 * 1024; i++) {
+                out.writeBytes(bytes, 0, bytes.length);
+            }
+            CodecUtil.writeFooter(out);
         }
 
         si.setFiles(Collections.singleton(testfile));

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedCompoundFormatTest.java
@@ -1,0 +1,200 @@
+/*
+ * LuceneOptimizedCompoundFormatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.BaseCompoundFormatTestCase;
+import org.apache.lucene.index.BaseFieldInfoFormatTestCase;
+import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FlushInfo;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MockDirectoryWrapper;
+import org.apache.lucene.store.NRTCachingDirectory;
+import org.apache.lucene.util.TestRuleLimitSysouts;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test that gets the actual test cases from {@link BaseFieldInfoFormatTestCase}.
+ */
+// Tip: if you see a failure that has something like:
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C]:0)
+// or
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C:33261A5D888FEB6A]:0)
+// You can add
+// @Seed("C185081D42F0F43C")
+// to rerun the test class with the same seed. That will work even if you then only run one of the tests
+@Seed("C185081D42F0F43C")
+@ThreadLeakFilters(defaultFilters = true, filters = {
+        FDBThreadFilter.class
+})
+@TestRuleLimitSysouts.Limit(bytes = 50_000L) // 50k assuming debug logging
+// sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
+@SuppressWarnings("java:S2187")
+public class LuceneOptimizedCompoundFormatTest extends BaseCompoundFormatTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+        TestingCodec.allowRandomCompoundFiles();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void testMultiClose() throws IOException {
+        BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+
+    /**
+     * This is a direct copy of the {@link BaseCompoundFormatTestCase#testManySubFiles()}, except in that version it
+     * always creates a FSDirectory, whereas here, if testing against FDB we use the directory under test.
+     * <p>
+     * You can search for "--BEGIN CUSTOM--" and "--END CUSTOM--" in the code to see exactly which lines.
+     * </p>
+     *
+     * @throws IOException if there's issues
+     */
+    @Override
+    public void testManySubFiles() throws IOException {
+        // --BEGIN CUSTOM--
+        MockDirectoryWrapper dir;
+        if (BaseIndexFileFormatTestCaseUtils.isUsingFDBDirectory()) {
+            dir = newMockDirectory();
+        } else {
+            dir = newMockFSDirectory(createTempDir("CFSManySubFiles"));
+        }
+        // --END CUSTOM--
+
+        final int FILE_COUNT = atLeast(500);
+
+        List<String> files = new ArrayList<>();
+        SegmentInfo si = newSegmentInfo(dir, "_123");
+        for (int fileIdx = 0; fileIdx < FILE_COUNT; fileIdx++) {
+          String file = "_123." + fileIdx;
+          files.add(file);
+          try (IndexOutput out = dir.createOutput(file, newIOContext(random()))) {
+            CodecUtil.writeIndexHeader(out, "Foo", 0, si.getId(), "suffix");
+            out.writeByte((byte) fileIdx);
+            CodecUtil.writeFooter(out);
+          }
+        }
+
+        assertEquals(0, dir.getFileHandleCount());
+
+        si.setFiles(files);
+        si.getCodec().compoundFormat().write(dir, si, IOContext.DEFAULT);
+        Directory cfs = si.getCodec().compoundFormat().getCompoundReader(dir, si, IOContext.DEFAULT);
+
+        final IndexInput[] ins = new IndexInput[FILE_COUNT];
+        for (int fileIdx = 0; fileIdx < FILE_COUNT; fileIdx++) {
+          ins[fileIdx] = cfs.openInput("_123." + fileIdx, newIOContext(random()));
+          CodecUtil.checkIndexHeader(ins[fileIdx], "Foo", 0, 0, si.getId(), "suffix");
+        }
+
+        assertEquals(1, dir.getFileHandleCount());
+
+        for (int fileIdx = 0; fileIdx < FILE_COUNT; fileIdx++) {
+          assertEquals((byte) fileIdx, ins[fileIdx].readByte());
+        }
+
+        assertEquals(1, dir.getFileHandleCount());
+
+        for(int fileIdx=0;fileIdx<FILE_COUNT;fileIdx++) {
+          ins[fileIdx].close();
+        }
+        cfs.close();
+
+        dir.close();
+    }
+
+    /**
+     * This is a direct copy of the {@link BaseCompoundFormatTestCase#testLargeCFS()}, except in that version it
+     * always creates a FSDirectory, whereas here, if testing against FDB we use the directory under test.
+     * <p>
+     *     You can search for "--BEGIN CUSTOM--" and "--END CUSTOM--" in the code to see exactly which lines.
+     * </p>
+     * <p>
+     *     Currently ignored because it takes 2 minutes trying to write 500MB to a single file.
+     * </p>
+     *
+     * @throws IOException if there's issues
+     */
+    @Override
+    @Ignore
+    public void testLargeCFS() throws IOException {
+        final String testfile = "_123.test";
+        IOContext context = new IOContext(new FlushInfo(0, 512*1024*1024));
+
+        // --BEGIN CUSTOM--
+        Directory dir;
+        if (BaseIndexFileFormatTestCaseUtils.isUsingFDBDirectory()) {
+            dir = newDirectory();
+        } else {
+            // this is what the base code does
+            dir = new NRTCachingDirectory(newFSDirectory(createTempDir()), 2.0, 25.0);
+        }
+        // --END CUSTOM--
+
+        SegmentInfo si = newSegmentInfo(dir, "_123");
+        try (IndexOutput out = dir.createOutput(testfile, context)) {
+          CodecUtil.writeIndexHeader(out, "Foo", 0, si.getId(), "suffix");
+          byte[] bytes = new byte[512];
+          for(int i=0;i<1024*1024;i++) {
+            out.writeBytes(bytes, 0, bytes.length);
+          }
+          CodecUtil.writeFooter(out);
+        }
+
+        si.setFiles(Collections.singleton(testfile));
+        si.getCodec().compoundFormat().write(dir, si, context);
+
+        dir.close();
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedDocValuesFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedDocValuesFormatTest.java
@@ -1,0 +1,372 @@
+/*
+ * LuceneOptimizedDocValuesFormatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.BaseDocValuesFormatTestCase;
+import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.TestRuleLimitSysouts;
+import org.apache.lucene.util.TestUtil;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
+
+/**
+ * Test that gets the actual test cases from {@link BaseDocValuesFormatTestCase}.
+ */
+// Tip: if you see a failure that has something like:
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C]:0)
+// or
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C:33261A5D888FEB6A]:0)
+// You can add
+// @Seed("C185081D42F0F43C")
+// to rerun the test class with the same seed. That will work even if you then only run one of the tests
+@Seed("C185081D42F0F43C")
+@ThreadLeakFilters(defaultFilters = true, filters = {
+        FDBThreadFilter.class
+})
+@TestRuleLimitSysouts.Limit(bytes = 85_000L) // 85k assuming debug logging
+// sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
+@SuppressWarnings("java:S2187")
+public class LuceneOptimizedDocValuesFormatTest extends BaseDocValuesFormatTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void testMultiClose() throws IOException {
+        BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+
+    /**
+     * The seed at the top of this class (C185081D42F0F43C) causes this test to wrap the
+     * {@link com.apple.foundationdb.record.lucene.directory.FDBDirectory} in an
+     * {@link org.apache.lucene.store.NRTCachingDirectory}, which will interact with ram, rather than the underlying
+     * {@code FDBDirectory}, which doesn't necessarily call through. At the very least this breaks
+     * {@link LuceneOptimizedFieldInfosFormat}, which expects to have {@code directory.createOutput(filename).close()}
+     * to create the file reference.
+     * @throws IOException if an unexpected exception is thrown
+     */
+    @Seed("C185081D42F0F43D")
+    @Override
+    public void testMissingSortedBytes() throws IOException {
+        super.testMissingSortedBytes();
+    }
+
+    /**
+     * This is a direct copy of the
+     * {@link BaseDocValuesFormatTestCase#doTestSortedSetVsStoredFields(int, int, int, int, int)}, except in that
+     * version it always creates a FSDirectory, whereas here, if testing against FDB we use the directory under test.
+     * <p>
+     * You can search for "--BEGIN CUSTOM--" and "--END CUSTOM--" in the code to see exactly which lines.
+     * </p>
+     *
+     * @throws IOException if there's issues
+     */
+    @Override
+    protected void doTestSortedSetVsStoredFields(final int numDocs, final int minLength, final int maxLength,
+                                                 final int maxValuesPerDoc, final int maxUniqueValues) throws Exception {
+        // --BEGIN CUSTOM--
+        Directory dir;
+        if (BaseIndexFileFormatTestCaseUtils.isUsingFDBDirectory()) {
+            dir = newDirectory();
+        } else {
+            dir = newFSDirectory(createTempDir("dvduel"));
+        }
+        // --END CUSTOM--
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        RandomIndexWriter writer = new RandomIndexWriter(random(), dir, conf);
+
+        Set<String> valueSet = new HashSet<String>();
+        for (int i = 0; i < 10000 && valueSet.size() < maxUniqueValues; ++i) {
+          final int length = TestUtil.nextInt(random(), minLength, maxLength);
+          valueSet.add(TestUtil.randomSimpleString(random(), length));
+        }
+        String[] uniqueValues = valueSet.toArray(new String[0]);
+
+        // index some docs
+        if (VERBOSE) {
+          System.out.println("\nTEST: now add numDocs=" + numDocs);
+        }
+        for (int i = 0; i < numDocs; i++) {
+          Document doc = new Document();
+          Field idField = new StringField("id", Integer.toString(i), Field.Store.NO);
+          doc.add(idField);
+          int numValues = TestUtil.nextInt(random(), 0, maxValuesPerDoc);
+          // create a random set of strings
+          Set<String> values = new TreeSet<>();
+          for (int v = 0; v < numValues; v++) {
+            values.add(RandomPicks.randomFrom(random(), uniqueValues));
+          }
+
+          // add ordered to the stored field
+          for (String v : values) {
+            doc.add(new StoredField("stored", v));
+          }
+
+          // add in any order to the dv field
+          ArrayList<String> unordered = new ArrayList<>(values);
+          Collections.shuffle(unordered, random());
+          for (String v : unordered) {
+            doc.add(new SortedSetDocValuesField("dv", newBytesRef(v)));
+          }
+
+          writer.addDocument(doc);
+          if (random().nextInt(31) == 0) {
+            writer.commit();
+          }
+        }
+
+        // delete some docs
+        int numDeletions = random().nextInt(numDocs /10);
+        if (VERBOSE) {
+          System.out.println("\nTEST: now delete " + numDeletions + " docs");
+        }
+        for (int i = 0; i < numDeletions; i++) {
+          int id = random().nextInt(numDocs);
+          writer.deleteDocuments(new Term("id", Integer.toString(id)));
+        }
+
+        // compare
+        if (VERBOSE) {
+          System.out.println("\nTEST: now get reader");
+        }
+        DirectoryReader ir = writer.getReader();
+        TestUtil.checkReader(ir);
+        for (LeafReaderContext context : ir.leaves()) {
+          LeafReader r = context.reader();
+          SortedSetDocValues docValues = r.getSortedSetDocValues("dv");
+          for (int i = 0; i < r.maxDoc(); i++) {
+            String stringValues[] = r.document(i).getValues("stored");
+            if (docValues != null) {
+              if (docValues.docID() < i) {
+                docValues.nextDoc();
+              }
+            }
+            if (docValues != null && stringValues.length > 0) {
+              assertEquals(i, docValues.docID());
+              for (int j = 0; j < stringValues.length; j++) {
+                assert docValues != null;
+                long ord = docValues.nextOrd();
+                assert ord != NO_MORE_ORDS;
+                BytesRef scratch = docValues.lookupOrd(ord);
+                assertEquals(stringValues[j], scratch.utf8ToString());
+              }
+              assertEquals(NO_MORE_ORDS, docValues.nextOrd());
+            }
+          }
+        }
+        if (VERBOSE) {
+          System.out.println("\nTEST: now close reader");
+        }
+        ir.close();
+        if (VERBOSE) {
+          System.out.println("TEST: force merge");
+        }
+        writer.forceMerge(1);
+
+        // compare again
+        ir = writer.getReader();
+        TestUtil.checkReader(ir);
+        for (LeafReaderContext context : ir.leaves()) {
+          LeafReader r = context.reader();
+          SortedSetDocValues docValues = r.getSortedSetDocValues("dv");
+          for (int i = 0; i < r.maxDoc(); i++) {
+            String stringValues[] = r.document(i).getValues("stored");
+            if (docValues.docID() < i) {
+              docValues.nextDoc();
+            }
+            if (docValues != null && stringValues.length > 0) {
+              assertEquals(i, docValues.docID());
+              for (int j = 0; j < stringValues.length; j++) {
+                assert docValues != null;
+                long ord = docValues.nextOrd();
+                assert ord != NO_MORE_ORDS;
+                BytesRef scratch = docValues.lookupOrd(ord);
+                assertEquals(stringValues[j], scratch.utf8ToString());
+              }
+              assertEquals(NO_MORE_ORDS, docValues.nextOrd());
+            }
+          }
+        }
+        if (VERBOSE) {
+          System.out.println("TEST: close reader");
+        }
+        ir.close();
+        if (VERBOSE) {
+          System.out.println("TEST: close writer");
+        }
+        writer.close();
+        if (VERBOSE) {
+          System.out.println("TEST: close dir");
+        }
+        dir.close();
+    }
+
+    /**
+     * This is a direct copy of the {@link BaseDocValuesFormatTestCase#doTestSortedVsStoredFields(int, double, Supplier)},
+     * except in that version it always creates a FSDirectory, whereas here, if testing against FDB we use the directory
+     * under test.
+     * <p>
+     * You can search for "--BEGIN CUSTOM--" and "--END CUSTOM--" in the code to see exactly which lines.
+     * </p>
+     *
+     * @throws IOException if there's issues
+     */
+    @Override
+    protected void doTestSortedVsStoredFields(final int numDocs, final double density, final Supplier<byte[]> bytes) throws Exception {
+        // --BEGIN CUSTOM--
+        Directory dir;
+        if (BaseIndexFileFormatTestCaseUtils.isUsingFDBDirectory()) {
+            dir = newDirectory();
+        } else {
+            dir = newFSDirectory(createTempDir("dvduel"));
+        }
+        // --END CUSTOM--
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        RandomIndexWriter writer = new RandomIndexWriter(random(), dir, conf);
+        Document doc = new Document();
+        Field idField = new StringField("id", "", Field.Store.NO);
+        Field storedField = new StoredField("stored", new byte[0]);
+        Field dvField = new SortedDocValuesField("dv", newBytesRef());
+        doc.add(idField);
+        doc.add(storedField);
+        doc.add(dvField);
+
+        // index some docs
+        for (int i = 0; i < numDocs; i++) {
+          if (random().nextDouble() > density) {
+            writer.addDocument(new Document());
+            continue;
+          }
+          idField.setStringValue(Integer.toString(i));
+          byte[] buffer = bytes.get();
+          storedField.setBytesValue(buffer);
+          dvField.setBytesValue(buffer);
+          writer.addDocument(doc);
+          if (random().nextInt(31) == 0) {
+            writer.commit();
+          }
+        }
+
+        // delete some docs
+        int numDeletions = random().nextInt(numDocs /10);
+        for (int i = 0; i < numDeletions; i++) {
+          int id = random().nextInt(numDocs);
+          writer.deleteDocuments(new Term("id", Integer.toString(id)));
+        }
+
+        // compare
+        DirectoryReader ir = writer.getReader();
+        TestUtil.checkReader(ir);
+        for (LeafReaderContext context : ir.leaves()) {
+          LeafReader r = context.reader();
+          BinaryDocValues docValues = DocValues.getBinary(r, "dv");
+          docValues.nextDoc();
+          for (int i = 0; i < r.maxDoc(); i++) {
+            BytesRef binaryValue = r.document(i).getBinaryValue("stored");
+            if (binaryValue == null) {
+              assertTrue(docValues.docID() > i);
+            } else {
+              assertEquals(i, docValues.docID());
+              assertEquals(binaryValue, docValues.binaryValue());
+              docValues.nextDoc();
+            }
+          }
+          assertEquals(DocIdSetIterator.NO_MORE_DOCS, docValues.docID());
+        }
+        ir.close();
+        writer.forceMerge(1);
+
+        // compare again
+        ir = writer.getReader();
+        TestUtil.checkReader(ir);
+        for (LeafReaderContext context : ir.leaves()) {
+          LeafReader r = context.reader();
+          BinaryDocValues docValues = DocValues.getBinary(r, "dv");
+          docValues.nextDoc();
+          for (int i = 0; i < r.maxDoc(); i++) {
+            BytesRef binaryValue = r.document(i).getBinaryValue("stored");
+            if (binaryValue == null) {
+              assertTrue(docValues.docID() > i);
+            } else {
+              assertEquals(i, docValues.docID());
+              assertEquals(binaryValue, docValues.binaryValue());
+              docValues.nextDoc();
+            }
+          }
+          assertEquals(DocIdSetIterator.NO_MORE_DOCS, docValues.docID());
+        }
+        ir.close();
+        writer.close();
+        dir.close();
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfoFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfoFormatTest.java
@@ -1,0 +1,101 @@
+/*
+ * LuceneOptimizedFieldInfoFormatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BaseFieldInfoFormatTestCase;
+import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.TestRuleLimitSysouts;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+
+import java.io.IOException;
+
+/**
+ * Test that gets the actual test cases from {@link BaseFieldInfoFormatTestCase}.
+ */
+// Tip: if you see a failure that has something like:
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C]:0)
+// or
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C:33261A5D888FEB6A]:0)
+// You can add
+// @Seed("C185081D42F0F43C")
+// to rerun the test class with the same seed. That will work even if you then only run one of the tests
+@Seed("C185081D42F0F43C")
+@ThreadLeakFilters(defaultFilters = true, filters = {
+        FDBThreadFilter.class
+})
+@TestRuleLimitSysouts.Limit(bytes = 50_000L) // 50k assuming debug logging
+// sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
+@SuppressWarnings("java:S2187")
+public class LuceneOptimizedFieldInfoFormatTest extends BaseFieldInfoFormatTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void testMultiClose() throws IOException {
+        BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+
+    /**
+     * Ignored test because we don't call {@link Directory#openInput}.
+     * @throws Exception if an unexpected exception occurs
+     */
+    @Override
+    @Ignore
+    public void testExceptionOnCloseInput() throws Exception {
+        super.testExceptionOnCloseInput();
+    }
+
+    /**
+     * Ignored test because we don't call {@link Directory#openInput}.
+     * @throws Exception if an unexpected exception occurs
+     */
+    @Override
+    @Ignore
+    public void testExceptionOnOpenInput() throws Exception {
+        super.testExceptionOnOpenInput();
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfoFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfoFormatTest.java
@@ -80,7 +80,7 @@ public class LuceneOptimizedFieldInfoFormatTest extends BaseFieldInfoFormatTestC
     }
 
     /**
-     * Ignored test because we don't call {@link Directory#openInput}.
+     * Ignored test because we don't call {@link Directory#openInput} in {@link LuceneOptimizedFieldInfosFormat#read}.
      * @throws Exception if an unexpected exception occurs
      */
     @Override
@@ -90,7 +90,7 @@ public class LuceneOptimizedFieldInfoFormatTest extends BaseFieldInfoFormatTestC
     }
 
     /**
-     * Ignored test because we don't call {@link Directory#openInput}.
+     * Ignored test because we don't call {@link Directory#openInput} in {@link LuceneOptimizedFieldInfosFormat#read}.
      * @throws Exception if an unexpected exception occurs
      */
     @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedNormsFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedNormsFormatTest.java
@@ -1,0 +1,79 @@
+/*
+ * LuceneOptimizedNormsFormatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.index.BaseNormsFormatTestCase;
+import org.apache.lucene.util.TestRuleLimitSysouts;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+/**
+ * Test that gets the actual test cases from {@link BaseNormsFormatTestCase}.
+ */
+// Tip: if you see a failure that has something like:
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C]:0)
+// or
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C:33261A5D888FEB6A]:0)
+// You can add
+// @Seed("C185081D42F0F43C")
+// to rerun the test class with the same seed. That will work even if you then only run one of the tests
+@Seed("C185081D42F0F43C")
+@ThreadLeakFilters(defaultFilters = true, filters = {
+        FDBThreadFilter.class
+})
+@TestRuleLimitSysouts.Limit(bytes = 50_000L) // 50k assuming debug logging
+// sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
+@SuppressWarnings("java:S2187")
+public class LuceneOptimizedNormsFormatTest extends BaseNormsFormatTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void testMultiClose() throws IOException {
+        BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormatTest.java
@@ -1,0 +1,106 @@
+/*
+ * LuceneOptimizedPointsFormatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.index.BasePointsFormatTestCase;
+import org.apache.lucene.util.TestRuleLimitSysouts;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+
+import java.io.IOException;
+
+/**
+ * Test that gets the actual test cases from {@link BasePointsFormatTestCase}.
+ */
+// Tip: if you see a failure that has something like:
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C]:0)
+// or
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C:33261A5D888FEB6A]:0)
+// You can add
+// @Seed("C185081D42F0F43C")
+// to rerun the test class with the same seed. That will work even if you then only run one of the tests
+@Seed("C185081D42F0F43C")
+@ThreadLeakFilters(defaultFilters = true, filters = {
+        FDBThreadFilter.class
+})
+@TestRuleLimitSysouts.Limit(bytes = 50_000L) // 50k assuming debug logging
+// sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
+@SuppressWarnings("java:S2187")
+public class LuceneOptimizedPointsFormatTest extends BasePointsFormatTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void testMultiClose() throws IOException {
+        BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+
+    /**
+     * {@link BasePointsFormatTestCase#testWithExceptions()} creates a fsDirectory, and we only work with
+     * {@link com.apple.foundationdb.record.lucene.directory.FDBDirectory}.
+     * <p>
+     *     Inlining requires copying multiple helper private methods.
+     * </p>
+     * @throws Exception if an unexpected exception happens
+     */
+    @Override
+    @Ignore
+    public void testWithExceptions() throws Exception {
+        super.testWithExceptions();
+    }
+
+    @Override
+    public void testAddIndexes() throws IOException {
+        TestFDBDirectory.allowAddIndexes();
+        super.testAddIndexes();
+    }
+
+    @Override
+    public void testOneDimTwoValues() throws Exception {
+        TestFDBDirectory.allowAddIndexes();
+        super.testOneDimTwoValues();
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPostingsFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * LuceneOptimizedStoredFieldsFormatTest.java
+ * LuceneOptimizedPostingsFormatTest.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -20,20 +20,17 @@
 
 package com.apple.foundationdb.record.lucene.codec;
 
-import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
-import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
+
 import com.carrotsearch.randomizedtesting.annotations.Seed;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.compressing.CompressingCodec;
 import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.index.BasePostingsFormatTestCase;
 import org.apache.lucene.index.BaseStoredFieldsFormatTestCase;
 import org.apache.lucene.util.TestRuleLimitSysouts;
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
-import java.util.Random;
 
 /**
  * Test for {@link LuceneOptimizedStoredFieldsFormat} that gets the actual test cases from {@link BaseStoredFieldsFormatTestCase}.
@@ -52,74 +49,28 @@ import java.util.Random;
 @TestRuleLimitSysouts.Limit(bytes = 50_000L) // 50k assuming debug logging
 // sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
 @SuppressWarnings("java:S2187")
-public class LuceneOptimizedStoredFieldsFormatTest extends BaseStoredFieldsFormatTestCase {
-
-    public LuceneOptimizedStoredFieldsFormatTest() {
-        FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
-        factory.getDatabase();
-    }
+public class LuceneOptimizedPostingsFormatTest extends BasePostingsFormatTestCase {
 
     @BeforeClass
-    public static void beforeClass() throws Exception {
-        // We have to manually copy these from FDBTestBase because we are a junit4 test class, thanks to Lucene,
-        // but that class is JUnit4
-        FDBTestBase.initFDB();
-        FDBTestBase.setupBlockingInAsyncDetection();
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
     }
 
     @Override
     protected Codec getCodec() {
-        if (isUsingFDBDirectory()) {
-            return new TestingCodec();
-        } else {
-            return CompressingCodec.randomInstance(new Random());
-        }
-    }
-
-    private static boolean isUsingFDBDirectory() {
-        return System.getProperty("tests.directory", "random").equals(TestFDBDirectory.class.getName());
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
     }
 
     @Override
-    @Before
     public void setUp() throws Exception {
         super.setUp();
-        TestingCodec.reset();
-        TestFDBDirectory.reset();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        TestingCodec.reset();
-        TestFDBDirectory.reset();
-    }
-
-    @Override
-    public void testNumericField() throws Exception {
-        TestingCodec.disableLaziness();
-        super.testNumericField();
-    }
-
-    @Override
-    public void testRandomExceptions() throws Exception {
-        // Failed due to UncheckedIOException with @Seed("6EA33D597F925691")
-        TestingCodec.disableLazinessForLiveDocs();
-        super.testRandomExceptions();
-    }
-
-    @Override
-    @Nightly // copied from base implementation, it doesn't appear to be inherited
-    public void testRamBytesUsed() throws IOException {
-        TestingCodec.disableLaziness();
-        TestFDBDirectory.useFullBufferToSurviveDeletes();
-        super.testRamBytesUsed();
-    }
-
-    @Override
-    public void testMismatchedFields() throws Exception {
-        TestFDBDirectory.allowAddIndexes();
-        super.testMismatchedFields();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedSegmentInfoFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedSegmentInfoFormatTest.java
@@ -1,0 +1,86 @@
+/*
+ * LuceneOptimizedSegmentInfoFormatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BaseFieldInfoFormatTestCase;
+import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.index.BaseSegmentInfoFormatTestCase;
+import org.apache.lucene.util.TestRuleLimitSysouts;
+import org.apache.lucene.util.Version;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+/**
+ * Test that gets the actual test cases from {@link BaseFieldInfoFormatTestCase}.
+ */
+// Tip: if you see a failure that has something like:
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C]:0)
+// or
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C:33261A5D888FEB6A]:0)
+// You can add
+// @Seed("C185081D42F0F43C")
+// to rerun the test class with the same seed. That will work even if you then only run one of the tests
+@Seed("C185081D42F0F43C")
+@ThreadLeakFilters(defaultFilters = true, filters = {
+        FDBThreadFilter.class
+})
+@TestRuleLimitSysouts.Limit(bytes = 50_000L) // 50k assuming debug logging
+// sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
+@SuppressWarnings("java:S2187")
+public class LuceneOptimizedSegmentInfoFormatTest extends BaseSegmentInfoFormatTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void testMultiClose() throws IOException {
+        BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+
+    @Override
+    protected Version[] getVersions() {
+        return new Version[] {Version.LUCENE_8_11_1};
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedTermVectorsFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedTermVectorsFormatTest.java
@@ -1,0 +1,80 @@
+/*
+ * LuceneOptimizedTermVectorsFormatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.codec;
+
+
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BaseFieldInfoFormatTestCase;
+import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
+import org.apache.lucene.index.BaseTermVectorsFormatTestCase;
+import org.apache.lucene.util.TestRuleLimitSysouts;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+/**
+ * Test that gets the actual test cases from {@link BaseFieldInfoFormatTestCase}.
+ */
+// Tip: if you see a failure that has something like:
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C]:0)
+// or
+//  at __randomizedtesting.SeedInfo.seed([C185081D42F0F43C:33261A5D888FEB6A]:0)
+// You can add
+// @Seed("C185081D42F0F43C")
+// to rerun the test class with the same seed. That will work even if you then only run one of the tests
+@Seed("C185081D42F0F43C")
+@ThreadLeakFilters(defaultFilters = true, filters = {
+        FDBThreadFilter.class
+})
+@TestRuleLimitSysouts.Limit(bytes = 50_000L) // 50k assuming debug logging
+// sonarcloud doesn't seem to be able to detect the junit4 style of just having the method start with "test"
+@SuppressWarnings("java:S2187")
+public class LuceneOptimizedTermVectorsFormatTest extends BaseTermVectorsFormatTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BaseIndexFileFormatTestCaseUtils.beforeClass();
+    }
+
+    @Override
+    protected Codec getCodec() {
+        return BaseIndexFileFormatTestCaseUtils.getCodec();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        BaseIndexFileFormatTestCaseUtils.resetStaticConfigs();
+    }
+
+    @Override
+    public void testMultiClose() throws IOException {
+        BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestingCodec.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestingCodec.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.lucene.codec;
 
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
+import com.apple.foundationdb.record.lucene.directory.FDBLuceneFileReference;
 import com.google.auto.service.AutoService;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CompoundFormat;
@@ -37,6 +39,7 @@ import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.codecs.TermVectorsFormat;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
@@ -48,6 +51,8 @@ import org.apache.lucene.util.Bits;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Wrapper around {@link LuceneOptimizedCodec} to better support tests provided by lucene.
@@ -61,6 +66,7 @@ public class TestingCodec extends Codec {
     private LuceneOptimizedCodec underlying;
     private static boolean disableLaziness;
     private static boolean disableLazinessForLiveDocs;
+    private static boolean allowRandomCompoundFiles;
 
     public TestingCodec() {
         super("RLT");
@@ -81,6 +87,15 @@ public class TestingCodec extends Codec {
      */
     public static void disableLazinessForLiveDocs() {
         TestingCodec.disableLazinessForLiveDocs = true;
+    }
+
+    /**
+     * The tests for the compound format don't necessarily create segments in the way we expect them, so there might
+     * not be a FieldInfos, and the code needs to be updated to handle that; if this is set, we will create our own
+     * {@link LuceneOptimizedCompoundFormat} that doesn't treat the FieldInfos as special.
+     */
+    public static void allowRandomCompoundFiles() {
+        TestingCodec.allowRandomCompoundFiles = true;
     }
 
     /**
@@ -192,7 +207,28 @@ public class TestingCodec extends Codec {
 
     @Override
     public CompoundFormat compoundFormat() {
-        return underlying.compoundFormat();
+        if (allowRandomCompoundFiles) {
+            return new LuceneOptimizedCompoundFormat(((LuceneOptimizedCompoundFormat)underlying.compoundFormat()).compoundFormat) {
+                @Override
+                protected void copyFieldInfos(final SegmentInfo si, final Set<String> filesForAfter, final FDBDirectory directory) {
+                    // copy the id, only if it's present
+                    final Optional<String> fieldInfosName = filesForAfter.stream().filter(FDBDirectory::isFieldInfoFile).findFirst();
+                    if (fieldInfosName.isPresent()) {
+                        final String fieldInfosFileName = fieldInfosName.orElseThrow();
+                        final FDBLuceneFileReference fieldInfosReference = directory.getFDBLuceneFileReference(fieldInfosFileName);
+                        String entriesFile = IndexFileNames.segmentFileName(si.name, "", ENTRIES_EXTENSION);
+                        directory.setFieldInfoId(entriesFile, fieldInfosReference.getFieldInfosId(), fieldInfosReference.getFieldInfosBitSet());
+                    }
+                }
+
+                @Override
+                protected void validateFileCounts(final Set<String> files, final int fieldInfos, final int storedFields) {
+                    // assume a-ok
+                }
+            };
+        } else {
+            return underlying.compoundFormat();
+        }
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -126,6 +126,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     @Test
     public void testMissingSeek() {
         final CompletableFuture<byte[]> seekFuture = directory.readBlock(
+                new EmptyIndexInput("Test Empty"),
                 "testDescription",
                 directory.getFDBLuceneFileReferenceAsync("testReference"),
                 1
@@ -138,11 +139,13 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     @Test
     public void testWriteSeekData() throws Exception {
         directory.writeFDBLuceneFileReference("testReference1", new FDBLuceneFileReference(1, 1, 1, 1));
-        assertNull(directory.readBlock("testReference1", directory.getFDBLuceneFileReferenceAsync("testReference1"), 1).get());
+        final EmptyIndexInput emptyInput = new EmptyIndexInput("Empty Input");
+        assertNull(directory.readBlock(emptyInput,
+                "testReference1", directory.getFDBLuceneFileReferenceAsync("testReference1"), 1).get());
         directory.writeFDBLuceneFileReference("testReference2", new FDBLuceneFileReference(2, 1, 1, 200));
         byte[] data = "test string for write".getBytes();
         directory.writeData(2, 1, data);
-        assertNotNull(directory.readBlock("testReference2",
+        assertNotNull(directory.readBlock(emptyInput, "testReference2",
                 directory.getFDBLuceneFileReferenceAsync("testReference2"), 1).get(), "seek data should exist");
 
         directory.getCallerContext().commit();

--- a/fdb-record-layer-lucene/src/test/java/org/apache/lucene/index/BaseIndexFileFormatTestCaseUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/org/apache/lucene/index/BaseIndexFileFormatTestCaseUtils.java
@@ -1,0 +1,371 @@
+/*
+ * BaseIndexFileFormatTestCaseUtils.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.index;
+
+import com.apple.foundationdb.record.lucene.codec.TestFDBDirectory;
+import com.apple.foundationdb.record.lucene.codec.TestingCodec;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTestBase;
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsConsumer;
+import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.NormsConsumer;
+import org.apache.lucene.codecs.NormsProducer;
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.TermVectorsWriter;
+import org.apache.lucene.codecs.compressing.CompressingCodec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FlushInfo;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Random;
+import java.util.TreeSet;
+
+/**
+ * Utilities for classes extending from {@link BaseIndexFileFormatTestCase}.
+ */
+public final class BaseIndexFileFormatTestCaseUtils {
+
+    private BaseIndexFileFormatTestCaseUtils() {
+    }
+
+    public static boolean isUsingFDBDirectory() {
+        return System.getProperty("tests.directory", "random").equals(TestFDBDirectory.class.getName());
+    }
+
+    @Nonnull
+    public static Codec getCodec() {
+        if (isUsingFDBDirectory()) {
+            return new TestingCodec();
+        } else {
+            return CompressingCodec.randomInstance(new Random());
+        }
+    }
+
+    public static void beforeClass() {
+        // We have to manually copy these from FDBTestBase because we are a junit4 test class, thanks to Lucene,
+        // but that class is JUnit4
+        FDBTestBase.initFDB();
+        FDBTestBase.setupBlockingInAsyncDetection();
+        FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
+        factory.getDatabase();
+    }
+
+    public static void resetStaticConfigs() {
+        TestingCodec.reset();
+        TestFDBDirectory.reset();
+    }
+
+    /**
+     * This is a direct copy of the {@link BaseIndexFileFormatTestCase#testMultiClose()}, except in that version it
+     * always creates a {@link org.apache.lucene.store.FSDirectory}, whereas here, if testing against FDB we use the
+     * directory under test.
+     * <p>
+     *     You can search for "--BEGIN CUSTOM--" and "--END CUSTOM--" in the code to see exactly which lines.
+     * </p>
+     * <p>
+     *     Every extension of {@link BaseIndexFileFormatTestCase} needs to override this in the same way, so this has
+     *     been extracted into a utils method. In order to do this, methods have been changed to refer to the
+     *     {@code testCase} parameter, or to the relevant class if it's a static method
+     * </p>
+     *
+     * @throws IOException if there's issues
+     */
+    public static void testMultiClose(BaseIndexFileFormatTestCase testCase) throws IOException {
+        // first make a one doc index
+        final Directory oneDocIndex = testCase.applyCreatedVersionMajor(LuceneTestCase.newDirectory());
+        final IndexWriter iw = new IndexWriter(oneDocIndex, new IndexWriterConfig(new MockAnalyzer(LuceneTestCase.random())));
+        final Document oneDoc = new Document();
+        final FieldType customType = new FieldType(TextField.TYPE_STORED);
+        customType.setStoreTermVectors(true);
+        Field customField = new Field("field", "contents", customType);
+        oneDoc.add(customField);
+        oneDoc.add(new NumericDocValuesField("field", 5));
+        iw.addDocument(oneDoc);
+        LeafReader oneDocReader = LuceneTestCase.getOnlyLeafReader(DirectoryReader.open(iw));
+        iw.close();
+
+        // now feed to codec apis manually
+        // --BEGIN CUSTOM--
+        Directory dir;
+        if (isUsingFDBDirectory()) {
+            dir = LuceneTestCase.newDirectory();
+        } else {
+            // this is what the base code does
+            // we use FSDir, things like ramdir are not guaranteed to cause fails if you write to them after close(), etc
+            dir = LuceneTestCase.newFSDirectory(LuceneTestCase.createTempDir("justSoYouGetSomeChannelErrors"));
+        }
+        // --END CUSTOM--
+        Codec codec = testCase.getCodec();
+
+        SegmentInfo segmentInfo = new SegmentInfo(dir, Version.LATEST, Version.LATEST, "_0", 1, false, codec, Collections.emptyMap(), StringHelper.randomId(), Collections.emptyMap(), null);
+        FieldInfo proto = oneDocReader.getFieldInfos().fieldInfo("field");
+        FieldInfo field = new FieldInfo(proto.name, proto.number, proto.hasVectors(), proto.omitsNorms(), proto.hasPayloads(),
+                proto.getIndexOptions(), proto.getDocValuesType(), proto.getDocValuesGen(), new HashMap<>(),
+                proto.getPointDimensionCount(), proto.getPointIndexDimensionCount(), proto.getPointNumBytes(), proto.isSoftDeletesField());
+
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] {field});
+
+        SegmentWriteState writeState = new SegmentWriteState(null, dir,
+                segmentInfo, fieldInfos,
+                null, new IOContext(new FlushInfo(1, 20)));
+
+        SegmentReadState readState = new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.READ);
+
+        // PostingsFormat
+        NormsProducer fakeNorms = new NormsProducer() {
+
+            @Override
+            public void close() throws IOException {
+            }
+
+            @Override
+            public long ramBytesUsed() {
+                return 0;
+            }
+
+            @Override
+            public NumericDocValues getNorms(FieldInfo field) throws IOException {
+                if (field.hasNorms() == false) {
+                    return null;
+                }
+                return oneDocReader.getNormValues(field.name);
+            }
+
+            @Override
+            public void checkIntegrity() throws IOException {
+            }
+
+        };
+        try (FieldsConsumer consumer = codec.postingsFormat().fieldsConsumer(writeState)) {
+            final Fields fields = new Fields() {
+                TreeSet<String> indexedFields = new TreeSet<>(FieldInfos.getIndexedFields(oneDocReader));
+
+                @Override
+                public Iterator<String> iterator() {
+                    return indexedFields.iterator();
+                }
+
+                @Override
+                public Terms terms(String field) throws IOException {
+                    return oneDocReader.terms(field);
+                }
+
+                @Override
+                public int size() {
+                    return indexedFields.size();
+                }
+            };
+            consumer.write(fields, fakeNorms);
+            IOUtils.close(consumer);
+            IOUtils.close(consumer);
+        }
+        try (FieldsProducer producer = codec.postingsFormat().fieldsProducer(readState)) {
+            IOUtils.close(producer);
+            IOUtils.close(producer);
+        }
+
+        // DocValuesFormat
+        try (DocValuesConsumer consumer = codec.docValuesFormat().fieldsConsumer(writeState)) {
+            consumer.addNumericField(field,
+                    new EmptyDocValuesProducer() {
+                        @Override
+                        public NumericDocValues getNumeric(FieldInfo field) {
+                            return new NumericDocValues() {
+                                int docID = -1;
+
+                                @Override
+                                public int docID() {
+                                    return docID;
+                                }
+
+                                @Override
+                                public int nextDoc() {
+                                    docID++;
+                                    if (docID == 1) {
+                                        docID = NO_MORE_DOCS;
+                                    }
+                                    return docID;
+                                }
+
+                                @Override
+                                public int advance(int target) {
+                                    if (docID <= 0 && target == 0) {
+                                        docID = 0;
+                                    } else {
+                                        docID = NO_MORE_DOCS;
+                                    }
+                                    return docID;
+                                }
+
+                                @Override
+                                public boolean advanceExact(int target) throws IOException {
+                                    docID = target;
+                                    return target == 0;
+                                }
+
+                                @Override
+                                public long cost() {
+                                    return 1;
+                                }
+
+                                @Override
+                                public long longValue() {
+                                    return 5;
+                                }
+                            };
+                        }
+                    });
+            IOUtils.close(consumer);
+            IOUtils.close(consumer);
+        }
+        try (DocValuesProducer producer = codec.docValuesFormat().fieldsProducer(readState)) {
+            IOUtils.close(producer);
+            IOUtils.close(producer);
+        }
+
+        // NormsFormat
+        try (NormsConsumer consumer = codec.normsFormat().normsConsumer(writeState)) {
+            consumer.addNormsField(field,
+                    new NormsProducer() {
+                        @Override
+                        public NumericDocValues getNorms(FieldInfo field) {
+                            return new NumericDocValues() {
+                                int docID = -1;
+
+                                @Override
+                                public int docID() {
+                                    return docID;
+                                }
+
+                                @Override
+                                public int nextDoc() {
+                                    docID++;
+                                    if (docID == 1) {
+                                        docID = NO_MORE_DOCS;
+                                    }
+                                    return docID;
+                                }
+
+                                @Override
+                                public int advance(int target) {
+                                    if (docID <= 0 && target == 0) {
+                                        docID = 0;
+                                    } else {
+                                        docID = NO_MORE_DOCS;
+                                    }
+                                    return docID;
+                                }
+
+                                @Override
+                                public boolean advanceExact(int target) throws IOException {
+                                    docID = target;
+                                    return target == 0;
+                                }
+
+                                @Override
+                                public long cost() {
+                                    return 1;
+                                }
+
+                                @Override
+                                public long longValue() {
+                                    return 5;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public void checkIntegrity() {
+                        }
+
+                        @Override
+                        public void close() {
+                        }
+
+                        @Override
+                        public long ramBytesUsed() {
+                            return 0;
+                        }
+                    });
+            IOUtils.close(consumer);
+            IOUtils.close(consumer);
+        }
+        try (NormsProducer producer = codec.normsFormat().normsProducer(readState)) {
+            IOUtils.close(producer);
+            IOUtils.close(producer);
+        }
+
+        // TermVectorsFormat
+        try (TermVectorsWriter consumer = codec.termVectorsFormat().vectorsWriter(dir, segmentInfo, writeState.context)) {
+            consumer.startDocument(1);
+            consumer.startField(field, 1, false, false, false);
+            consumer.startTerm(new BytesRef("testing"), 2);
+            consumer.finishTerm();
+            consumer.finishField();
+            consumer.finishDocument();
+            consumer.finish(fieldInfos, 1);
+            IOUtils.close(consumer);
+            IOUtils.close(consumer);
+        }
+        try (TermVectorsReader producer = codec.termVectorsFormat().vectorsReader(dir, segmentInfo, fieldInfos, readState.context)) {
+            IOUtils.close(producer);
+            IOUtils.close(producer);
+        }
+
+        // StoredFieldsFormat
+        try (StoredFieldsWriter consumer = codec.storedFieldsFormat().fieldsWriter(dir, segmentInfo, writeState.context)) {
+            consumer.startDocument();
+            consumer.writeField(field, customField);
+            consumer.finishDocument();
+            consumer.finish(fieldInfos, 1);
+            IOUtils.close(consumer);
+            IOUtils.close(consumer);
+        }
+        try (StoredFieldsReader producer = codec.storedFieldsFormat().fieldsReader(dir, segmentInfo, fieldInfos, readState.context)) {
+            IOUtils.close(producer);
+            IOUtils.close(producer);
+        }
+
+        IOUtils.close(oneDocReader, oneDocIndex, dir);
+    }
+
+}


### PR DESCRIPTION
This includes the following commits:
1. Bring in the tests, with a bunch failing, and extract shared utilities
2. Bring in `LuceneOptimizedCompoundFormatTest ` and create an extension of `LuceneOptimizedCompoundFormat` that doesn't ensure that all `.cfs` contain a `.fip`, and use that in `LuceneOptimizedCompoundFormatTest`, since that test uses the format arbitrarily.
3. Throw an `EOFException` in `FDBIndexInput` when reading past the end of the file
4. Correctly set the `resource` when creating a `slice`. This also meant adding a proper `fileName` parameter/field to `FDBIndexInput`, and meant that the `readBlock` could be changed to take the `requestingInput` instead of `nestedResourceDescription`, since the `indexInput.toString()` now contains both the parent `cfs` and inner file.
5. Clarify the comments around which tests are ignored
6. Update release notes (I didn't really expect to be able to do this all at once
7. Reformat all the code so that it passes checkStyle (mostly done with intelliJ)