### PR TITLE
RESOLVES #2432: Add support for cross partition Lucene queries

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Feature 2 [(Issue #2432)](https://github.com/FoundationDB/fdb-record-layer/issues/2432)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ The Guava dependency version has been updated to 31.1. Projects may need to chec
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 2 [(Issue #2432)](https://github.com/FoundationDB/fdb-record-layer/issues/2432)
+* **Feature** Support for Cross-Partition Queries [(Issue #2432)](https://github.com/FoundationDB/fdb-record-layer/issues/2432)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneCursorContinuation.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneCursorContinuation.java
@@ -72,11 +72,18 @@ class LuceneCursorContinuation implements RecordCursorContinuation {
         return false;
     }
 
-    public static LuceneCursorContinuation fromScoreDoc(ScoreDoc scoreDoc) {
+    public static LuceneCursorContinuation fromScoreDoc(ScoreDoc scoreDoc, @Nullable Integer partitionId, @Nullable Long partitionTimestamp) {
         LuceneContinuationProto.LuceneIndexContinuation.Builder builder = LuceneContinuationProto.LuceneIndexContinuation.newBuilder()
                 .setDoc(scoreDoc.doc)
                 .setShard(scoreDoc.shardIndex)
                 .setScore(scoreDoc.score);
+
+        if (partitionId != null) {
+            builder.setPartitionId(partitionId);
+        }
+        if (partitionTimestamp != null) {
+            builder.setPartitionTimestamp(partitionTimestamp);
+        }
         if (scoreDoc instanceof FieldDoc) {
             for (Object field : ((FieldDoc)scoreDoc).fields) {
                 final LuceneContinuationProto.LuceneIndexContinuation.Field.Builder value = builder.addFieldsBuilder();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -144,12 +144,15 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         final IndexScanType scanType = scanBounds.getScanType();
         LOG.trace("scan scanType={}", scanType);
 
+
         if (scanType.equals(LuceneScanTypes.BY_LUCENE)) {
             LuceneScanQuery scanQuery = (LuceneScanQuery)scanBounds;
+            // if partitioning is enabled, a non-null continuation will include the current partition info
+            LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = continuation == null ? partitioner.selectQueryPartition(scanQuery.getGroupKey()) : null;
             return new LuceneRecordCursor(executor, state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_EXECUTOR_SERVICE),
                     state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_CURSOR_PAGE_SIZE),
                     scanProperties, state, scanQuery.getQuery(), scanQuery.getSort(), continuation,
-                    scanQuery.getGroupKey(), partitioner.selectQueryPartitionId(scanQuery.getGroupKey()), scanQuery.getLuceneQueryHighlightParameters(), scanQuery.getTermMap(),
+                    scanQuery.getGroupKey(), partitionInfo, scanQuery.getLuceneQueryHighlightParameters(), scanQuery.getTermMap(),
                     scanQuery.getStoredFields(), scanQuery.getStoredFieldTypes(), indexAnalyzerSelector, autoCompleteAnalyzerSelector);
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -114,15 +114,28 @@ public class LucenePartitioner {
      */
     @Nullable
     public Integer selectQueryPartitionId(@Nonnull Tuple groupKey) {
-        Integer partitionId = null;
         if (isPartitioningEnabled()) {
-            partitionId = 0;
-            LucenePartitionInfoProto.LucenePartitionInfo partition = state.context.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, getNewestPartition(groupKey));
-            if (partition != null) {
-                partitionId = partition.getId();
+            LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = selectQueryPartition(groupKey);
+            if (partitionInfo != null) {
+                return partitionInfo.getId();
             }
         }
-        return partitionId;
+        return null;
+    }
+
+    /**
+     * return the partition ID on which to run a query, given a grouping key.
+     * For now, the most recent partition is returned.
+     *
+     * @param groupKey group key
+     * @return partition, or <code>null</code> if partitioning isn't enabled or no partitioning metadata exist
+     */
+    @Nullable
+    public LucenePartitionInfoProto.LucenePartitionInfo selectQueryPartition(@Nonnull Tuple groupKey) {
+        return isPartitioningEnabled() ?
+               state.context.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, getNewestPartition(groupKey))
+               :
+               null;
     }
 
     /**
@@ -244,7 +257,7 @@ public class LucenePartitioner {
      * @return partition metadata key
      */
     @Nonnull
-    private byte[] partitionMetadataKeyFromTimestamp(@Nonnull Tuple groupKey, long timestamp) {
+    byte[] partitionMetadataKeyFromTimestamp(@Nonnull Tuple groupKey, long timestamp) {
         return state.indexSubspace.pack(Tuple.from(groupKey, PARTITION_META_SUBSPACE, timestamp));
     }
 
@@ -254,11 +267,24 @@ public class LucenePartitioner {
      * @param groupKey group key
      * @param builder builder instance
      */
-    private void savePartitionMetadata(@Nonnull Tuple groupKey, @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo.Builder builder) {
+    void savePartitionMetadata(@Nonnull Tuple groupKey, @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo.Builder builder) {
         LucenePartitionInfoProto.LucenePartitionInfo updatedPartition = builder.build();
         state.context.ensureActive().set(
                 partitionMetadataKeyFromTimestamp(groupKey, Tuple.fromBytes(builder.getFrom().toByteArray()).getLong(0)),
                 updatedPartition.toByteArray());
+    }
+
+    @Nullable
+    LucenePartitionInfoProto.LucenePartitionInfo findPartitionInfo(@Nonnull Tuple groupKey, long timestamp) {
+        Range range = new Range(state.indexSubspace.subspace(Tuple.from(groupKey, PARTITION_META_SUBSPACE)).pack(),
+                state.indexSubspace.subspace(Tuple.from(groupKey, PARTITION_META_SUBSPACE, timestamp)).pack());
+
+        final AsyncIterable<KeyValue> rangeIterable = state.context.ensureActive().getRange(range, 1, true, StreamingMode.WANT_ALL);
+
+        CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfoFuture = AsyncUtil.collect(rangeIterable)
+                .thenApply(targetPartition -> targetPartition.isEmpty() ? null : partitionInfoFromKV(targetPartition.get(0)));
+
+        return state.context.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, partitionInfoFuture);
     }
 
     /**
@@ -420,7 +446,7 @@ public class LucenePartitioner {
      * @param partitionInfo partition metadata instance
      * @return long
      */
-    private long getFrom(@Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static long getFrom(@Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
         return Tuple.fromBytes(partitionInfo.getFrom().toByteArray()).getLong(0);
     }
 
@@ -431,7 +457,7 @@ public class LucenePartitioner {
      * @param partitionInfo partition metadata instance
      * @return long
      */
-    private long getTo(@Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static long getTo(@Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
         return Tuple.fromBytes(partitionInfo.getTo().toByteArray()).getLong(0);
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -92,7 +92,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     /**
      * The records to skip.
      */
-    private final int skip;
+    private int skip;
     /**
      * To track the count of records left to skip.
      */
@@ -112,7 +112,12 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     private boolean exhausted = false;
     @Nullable
     private final Tuple groupingKey;
-    @Nullable final Integer partitionId;
+    @Nullable
+    Integer partitionId;
+    @Nullable
+    Long partitionTimestamp;
+    @Nonnull
+    LucenePartitioner partitioner;
     @Nullable
     private final List<String> storedFields;
     @Nonnull
@@ -142,7 +147,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                        @Nullable Sort sort,
                        byte[] continuation,
                        @Nullable Tuple groupingKey,
-                       @Nullable Integer partitionId,
+                       @Nullable LucenePartitionInfoProto.LucenePartitionInfo partitionInfo,
                        @Nullable LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters,
                        @Nullable Map<String, Set<String>> termMap,
                        @Nullable final List<String> storedFields,
@@ -162,21 +167,36 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         this.limitManager = new CursorLimitManager(state.context, scanProperties);
         this.limitRemaining = scanProperties.getExecuteProperties().getReturnedRowLimitOrMax();
         this.skip = scanProperties.getExecuteProperties().getSkip();
-        this.leftToSkip = scanProperties.getExecuteProperties().getSkip();
+        this.leftToSkip = this.skip;
         this.timer = state.context.getTimer();
         this.query = query;
         this.sort = sort;
+        if (partitionInfo != null) {
+            this.partitionTimestamp = LucenePartitioner.getFrom(partitionInfo);
+            this.partitionId = partitionInfo.getId();
+        }
         if (continuation != null) {
             try {
                 LuceneContinuationProto.LuceneIndexContinuation parsed = LuceneContinuationProto.LuceneIndexContinuation.parseFrom(continuation);
                 searchAfter = LuceneCursorContinuation.toScoreDoc(parsed);
+                // continuation partitionInfo "overrides" the defaults passed in
+                // from the index maintainer
+
+                // both must be either present or absent
+                if (parsed.hasPartitionId() != parsed.hasPartitionTimestamp()) {
+                    throw new RecordCoreException("Invalid continuation for Lucene index", "hasPartitionId", parsed.hasPartitionId(), "hasPartitionTimestamp", parsed.hasPartitionTimestamp());
+                }
+                if (parsed.hasPartitionId()) {
+                    this.partitionId = parsed.getPartitionId();
+                    this.partitionTimestamp = parsed.getPartitionTimestamp();
+                }
             } catch (Exception e) {
                 throw new RecordCoreException("Invalid continuation for Lucene index", "ContinuationValues", continuation, e);
             }
         }
+        partitioner = new LucenePartitioner(state);
         this.fields = state.index.getRootExpression().normalizeKeyForPositions();
         this.groupingKey = groupingKey;
-        this.partitionId = partitionId;
         this.luceneQueryHighlightParameters = luceneQueryHighlightParameters;
         this.termMap = termMap;
         this.analyzerSelector = analyzerSelector;
@@ -199,7 +219,8 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                 return CompletableFuture.completedFuture(false);
             }
             try {
-                searchForTopDocs(pageSize);
+                TopDocs topDocs = searchForTopDocs(pageSize);
+                leftToSkip -= topDocs.scoreDocs.length;
             } catch (IndexNotFoundException indexNotFoundException) {
                 // Trying to open an empty directory results in an IndexNotFoundException,
                 // but this should be interpreted as there not being any data to read
@@ -208,7 +229,6 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                 throw new RecordCoreException("Exception to lookup the auto complete suggestions", ioException)
                         .addLogInfo(LogMessageKeys.QUERY, query);
             }
-            leftToSkip -= pageSize;
             return CompletableFuture.completedFuture(leftToSkip >= pageSize);
         }, executor);
 
@@ -226,11 +246,47 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                         throw new RecordCoreException("Exception to lookup the auto complete suggestions", ioException)
                                 .addLogInfo(LogMessageKeys.QUERY, query);
                     }
-                    return lookupResults.onNext();
+                    return lookupResults.onNext().thenCompose(this::switchToNextOlderPartitionAndContinue);
                 }).thenCompose(Function.identity());
             }
-            return lookupResults.onNext();
+            return lookupResults.onNext().thenCompose(this::switchToNextOlderPartitionAndContinue);
         });
+    }
+
+    private CompletableFuture<RecordCursorResult<IndexEntry>> switchToNextOlderPartitionAndContinue(RecordCursorResult<IndexEntry> recordCursorResult) {
+        if (
+                recordCursorResult.hasNext() ||
+                partitionTimestamp == null ||
+                (nextResult != null && (nextResult.getNoNextReason().isOutOfBand() || nextResult.getNoNextReason().isLimitReached()))
+        ) {
+            return CompletableFuture.completedFuture(recordCursorResult);
+        }
+
+        // see if there's a next older partition by looking for the partition covering the timestamp equal to the `from` value of the
+        // current partition minus a millisecond (lowest resolution of timestamp)
+        LucenePartitionInfoProto.LucenePartitionInfo previousPartition =
+                partitioner.findPartitionInfo(Objects.requireNonNull(groupingKey), partitionTimestamp - 1);
+
+        if (previousPartition != null) {
+            // reset scan params/state
+            exhausted = false;
+            this.partitionTimestamp = LucenePartitioner.getFrom(previousPartition);
+            this.partitionId = previousPartition.getId();
+            searchAfter = null;
+            currentPosition = 0;
+            if (skip > 0) {
+                skip = leftToSkip;
+            }
+            try {
+                maybePerformScan();
+                return lookupResults.onNext();
+            } catch (IOException ioException) {
+                throw new RecordCoreException(ioException)
+                        .addLogInfo(LogMessageKeys.QUERY, query);
+            }
+        } else {
+            return CompletableFuture.completedFuture(nextResult);
+        }
     }
 
     @Override
@@ -238,6 +294,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         if (indexReader != null) {
             IOUtils.closeWhileHandlingException(indexReader);
         }
+        indexReader = null;
         closed = true;
     }
 
@@ -274,7 +331,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                 .mapPipelined(this::buildIndexEntryFromScoreDocAsync, state.store.getPipelineSize(PipelineOperation.KEY_TO_RECORD))
                 .mapResult(result -> {
                     if (result.hasNext() && limitManager.tryRecordScan()) {
-                        RecordCursorContinuation continuationFromDoc = LuceneCursorContinuation.fromScoreDoc(result.get().scoreDoc);
+                        RecordCursorContinuation continuationFromDoc = LuceneCursorContinuation.fromScoreDoc(result.get().scoreDoc, partitionId, partitionTimestamp);
                         currentPosition++;
                         if (limitRemaining != Integer.MAX_VALUE) {
                             limitRemaining--;
@@ -283,19 +340,19 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                     } else if (exhausted) {
                         nextResult = RecordCursorResult.exhausted();
                     } else if (limitRemaining <= 0) {
-                        RecordCursorContinuation continuationFromDoc = LuceneCursorContinuation.fromScoreDoc(searchAfter);
+                        RecordCursorContinuation continuationFromDoc = LuceneCursorContinuation.fromScoreDoc(searchAfter, partitionId, partitionTimestamp);
                         nextResult = RecordCursorResult.withoutNextValue(continuationFromDoc, NoNextReason.RETURN_LIMIT_REACHED);
                     } else {
                         final Optional<NoNextReason> stoppedReason = limitManager.getStoppedReason();
-                        if (!stoppedReason.isPresent()) {
+                        if (stoppedReason.isEmpty()) {
                             throw new RecordCoreException("limit manager stopped LuceneRecordCursor but did not report a reason");
                         } else {
-                            nextResult = RecordCursorResult.withoutNextValue(LuceneCursorContinuation.fromScoreDoc(searchAfter), stoppedReason.get());
+                            nextResult = RecordCursorResult.withoutNextValue(LuceneCursorContinuation.fromScoreDoc(searchAfter, partitionId, partitionTimestamp), stoppedReason.get());
                         }
                     }
                     return nextResult;
                 });
-        leftToSkip = 0;
+        leftToSkip = Math.max(0, leftToSkip - newTopDocs.scoreDocs.length);
     }
 
     private TopDocs searchForTopDocs(int limit) throws IOException {

--- a/fdb-record-layer-lucene/src/main/proto/lucene_continuation.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_continuation.proto
@@ -38,15 +38,21 @@ message LuceneIndexContinuation {
         }
     }
     repeated Field fields = 4;
+    optional int64 partitionTimestamp = 5;
+    optional int32 partitionId = 6;
 }
 
 message LuceneAutoCompleteIndexContinuation {
     required string key = 1;
     required uint64 value = 2;
     optional bytes payload = 3;
+    optional int64 partitionTimestamp = 4;
+    optional int32 partitionId = 5;
 }
 
 message LuceneSpellCheckIndexContinuation {
     required uint64 location = 1;
     required bytes value = 2;
+    optional int64 partitionTimestamp = 3;
+    optional int32 partitionId = 4;
 }


### PR DESCRIPTION
This update adds support for seamless cross partition Lucene queries with continuation.