### PR TITLE
Test improvements

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -43,7 +43,6 @@
       <option name="FOR_BRACE_FORCE" value="3" />
     </codeStyleSettings>
     <codeStyleSettings language="JAVA">
-      <option name="INDENT_CASE_FROM_SWITCH" value="false" />
       <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
       <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
       <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenOnlineIndexingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenOnlineIndexingTest.java
@@ -176,7 +176,7 @@ class LucenOnlineIndexingTest extends FDBRecordStoreTestBase {
 
     @Test
     void luceneOnlineIndexingTest6() {
-        luceneOnlineIndexingTestAny(COMPLEX_MULTIPLE_GROUPED, COMPLEX_DOC, 77, 20, 0, 17);
+        luceneOnlineIndexingTestAny(COMPLEX_MULTIPLE_GROUPED, COMPLEX_DOC, 77, 20, 0, 20);
     }
 
     private String randomText(Random rn) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -342,6 +342,13 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
         }
     }
 
+    @Override
+    public FDBRecordContext openContext() {
+        final RecordLayerPropertyStorage.Builder props = RecordLayerPropertyStorage.newBuilder()
+                .addProp(LuceneRecordContextProperties.LUCENE_MERGE_MAX_SIZE, Config.LUCENE_MERGE_MAX_SIZE);
+        return super.openContext(props);
+    }
+
     private void mergeIndexes(final Set<Index> indexesRequireMerge, @Nullable final PrintStream mergeCsv,
                               final long testStartMillis, final DataModel dataModel) {
         if (indexesRequireMerge == null) {
@@ -350,12 +357,10 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
         if (ThreadLocalRandom.current().nextInt(1000) < (1000 - Config.MERGE_PROBABLITY_OF_1000)) {
             return;
         }
-        final RecordLayerPropertyStorage.Builder insertProps = RecordLayerPropertyStorage.newBuilder()
-                .addProp(LuceneRecordContextProperties.LUCENE_MERGE_MAX_SIZE, Config.LUCENE_MERGE_MAX_SIZE);
 
         long startMillis;
         FDBStoreTimer mergeTimer = new FDBStoreTimer();
-        try (FDBRecordContext context = openContext(insertProps)) {
+        try (FDBRecordContext context = openContext()) {
             createOrOpenRecordStore(context, recordStore.getRecordMetaData());
             startMillis = System.currentTimeMillis();
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -492,18 +492,18 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
 
         void prep() {
             switch (Config.INDEX_MAINTENANCE) {
-            case Disable:
-                disableIndex();
-                break;
-            case Rebuild:
-                disableIndex();
-                buildIndex();
-                break;
-            case Build:
-                buildIndex();
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown enum: " + Config.INDEX_MAINTENANCE);
+                case Disable:
+                    disableIndex();
+                    break;
+                case Rebuild:
+                    disableIndex();
+                    buildIndex();
+                    break;
+                case Build:
+                    buildIndex();
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown enum: " + Config.INDEX_MAINTENANCE);
             }
             if (maxDocId > 0) {
                 updateSearchWords();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -300,6 +300,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
                 var mergeCsv = createCsv("merges", dataModel.continuing)) {
 
             for (int i = 0; i < Config.LOOP_COUNT; i++) {
+                logger.info("Running loop " + i + " with " + dataModel.maxDocId + " records so far");
                 long startMillis;
                 if (Config.COMMANDS_TO_RUN.contains(Command.IncreaseCount)) {
                     for (int i1 = 0; i1 < 90; i1++) {
@@ -419,9 +420,8 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
             printJsonPair(out, RECORD_COUNT_COLUMN, dataModel.maxDocId);
             printJsonPair(out, OPERATION_MILLIS, System.currentTimeMillis() - startMillis);
             printJsonPair(out, INDEX_MAINTENANCE, Config.INDEX_MAINTENANCE.name());
-            extraKeysAndValues.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> {
-                printJsonPair(out, entry.getKey(), entry.getValue());
-            });
+            extraKeysAndValues.entrySet().stream().sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> printJsonPair(out, entry.getKey(), entry.getValue()));
             final Comparator<Map.Entry<String, Number>> sortByMetricType = Comparator.comparing(e -> {
                 final String[] split = e.getKey().split("_");
                 return split[split.length - 1];
@@ -430,9 +430,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
             final Comparator<Map.Entry<String, Number>> sortByName = Map.Entry.comparingByKey();
             timer.getKeysAndValues().entrySet().stream()
                     .sorted(sortByName)
-                    .forEach(entry -> {
-                        printJsonPair(out, entry.getKey(), entry.getValue());
-                    });
+                    .forEach(entry -> printJsonPair(out, entry.getKey(), entry.getValue()));
             out.println("\"foo\": 0"); // to not add the last comma
             out.println("}");
         }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -68,6 +68,7 @@ import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -450,11 +451,12 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
     @Nonnull
     private static PrintStream createCsv(final String name, final boolean append) throws FileNotFoundException {
         final String filename = ".out/LuceneScaleTest." + Config.ISOLATION_ID + "." + name + ".csv";
+        boolean writeHeader = !append || !new File(filename).exists();
         final PrintStream printStream = new PrintStream(new FileOutputStream(filename, append), true);
 
         boolean success = false;
         try {
-            if (!append) {
+            if (writeHeader) {
                 printStream.println(String.join(",", CSV_COLUMNS));
             }
             success = true;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -531,8 +531,8 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
                 continuing = maxDocId > 0;
                 if (!store.isIndexReadable(INDEX.getName())) {
                     indexBuilder = OnlineIndexer.newBuilder()
-                            .setRecordStoreBuilder(store.asBuilder())
-                            .setTargetIndexesByName(List.of(INDEX.getName()))
+                            .setRecordStore(store)
+                            .addTargetIndex(INDEX.getName())
                             .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                                     .setDeferMergeDuringIndexing(true)
                                     .build());


### PR DESCRIPTION
A few improvements to LuceneScaleTest, and a change to make `LucenOnlineIndexingTest.luceneOnlineIndexingTest6` less flaky (saw a failure https://github.com/FoundationDB/fdb-record-layer/pull/2430)