### PR TITLE
`ConstantObjectValue` replace semantic check with verification in case of `null` value

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
@@ -122,11 +122,11 @@ public class ConstantObjectValue extends AbstractValue implements LeafValue, Val
     public <M extends Message> Object eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context) {
         final var obj = context.dereferenceConstant(alias, ordinal);
         if (obj == null) {
-            SemanticException.check(resultType.isNullable(), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+            Verify.verify(getResultType().isNullable());
             return obj;
         }
         if (obj instanceof DynamicMessage) {
-            SemanticException.check(resultType.isRecord(), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+            // TODO: run coercion for proper promotion, and if that fails then bailout.
             return obj;
         }
         final var objType = Type.fromObject(obj);


### PR DESCRIPTION
The semantic check is not necessary considering the `ConstantObjectValue` can be created with a `Any` type in scenarios where the Java object value can correspond to any binding given by the user. The check for typing is guaranteed to be done anyway in a `OfTypeValue` on top. Therefore, this check is not necessary.