### PR TITLE
Fix: Phrase auto-completion with leading stop words does not find expected match 

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteQueryClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteQueryClause.java
@@ -286,7 +286,8 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
                     spanQuery.addGap(1);
                 }
             } else {
-                spanQuery.addClause(new SpanTermQuery(((TermQuery)phraseQuery).getTerm()));
+                // if NONSTOPWORD is the only term, then the rest of the phrase must be stop words
+                spanQuery.addGap(1);
             }
 
             if (!useGapForPrefix && prefix != null) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -2385,6 +2385,34 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    void autoCompletePhraseSearchWithLeadingStopWords() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            final Index index = SIMPLE_TEXT_WITH_AUTO_COMPLETE;
+            final List<KeyExpression> storedFields = ImmutableList.of(SIMPLE_TEXT_WITH_AUTO_COMPLETE_STORED_FIELD);
+
+            addIndexAndSaveRecordsForAutoCompleteOfPhrase(context, index);
+
+            queryAndAssertAutoCompleteSuggestionsReturned(index,
+                    storedFields,
+                    "text",
+                    "\"of ameri\"",
+                    ImmutableList.of("united states of america",
+                            "welcome to the united states of america",
+                            "united states is a country in the continent of america"));
+
+            queryAndAssertAutoCompleteSuggestionsReturned(index,
+                    storedFields,
+                    "text",
+                    "\"and of ameri\"",
+                    ImmutableList.of("united states of america",
+                            "welcome to the united states of america",
+                            "united states is a country in the continent of america"));
+
+            commit(context);
+        }
+    }
+
+    @Test
     void testAutoCompleteSearchMultipleResultsSingleDocument() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, metaDataBuilder -> {


### PR DESCRIPTION
Issue: https://github.com/FoundationDB/fdb-record-layer/issues/2450