### PR TITLE
Resolves #2455 and Resolves #2457: fixes some random Lucene test failures

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,8 +15,8 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Sync files referencing FieldInfosId [(Issue #2455)](https://github.com/FoundationDB/fdb-record-layer/issues/2455)
+* **Bug fix** Support closing FDBIndexOutput [(Issue #2457)](https://github.com/FoundationDB/fdb-record-layer/issues/2457)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
@@ -121,6 +121,7 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
         write(directory, infos, fileName);
     }
 
+    @SuppressWarnings("java:S3776") // more complicated than sonarcloud wants, but not by enough to warrant creating new classes
     @VisibleForTesting
     public void write(final Directory directory, final FieldInfos infos, final String fileName) throws IOException {
         // Bitset to track what fields in the global info we are using

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
@@ -170,7 +170,7 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
                 fieldInfosStorage.updateGlobalFieldInfos(globalFieldInfos);
             }
         }
-        fieldInfosStorage.setFieldInfoId(fileName, id, bitSet);
+        fieldInfosStorage.setFieldInfoId(directory, fileName, id, bitSet);
     }
 
     private Map<String, String> protoToLucene(final List<LuceneFieldInfosProto.Attribute> attributesList) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
@@ -102,9 +102,11 @@ public final class FDBIndexOutput extends IndexOutput {
             LOGGER.trace(getLogMessage("close()",
                     LuceneLogMessageKeys.RESOURCE, resourceDescription));
         }
-        flush();
-        buffer = null; // prevent writing after close
-        fdbDirectory.writeFDBLuceneFileReference(resourceDescription, new FDBLuceneFileReference(id, currentSize, actualSize, blockSize));
+        if (buffer != null) {
+            flush();
+            buffer = null; // prevent writing after close
+            fdbDirectory.writeFDBLuceneFileReference(resourceDescription, new FDBLuceneFileReference(id, currentSize, actualSize, blockSize));
+        }
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedPointsFormatTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.lucene.codec;
 
 
 import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.Seeds;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.BaseIndexFileFormatTestCaseUtils;
@@ -94,5 +95,11 @@ public class LuceneOptimizedPointsFormatTest extends BasePointsFormatTestCase {
     public void testOneDimTwoValues() throws Exception {
         TestFDBDirectory.allowAddIndexes();
         super.testOneDimTwoValues();
+    }
+
+    @Seeds({@Seed(), @Seed("FA63D2AE2DE7C6B0")})
+    @Override
+    public void testMultiValued() throws Exception {
+        super.testMultiValued();
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedTermVectorsFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedTermVectorsFormatTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.lucene.codec;
 
 
 import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.Seeds;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.BaseFieldInfoFormatTestCase;
@@ -76,5 +77,11 @@ public class LuceneOptimizedTermVectorsFormatTest extends BaseTermVectorsFormatT
     @Override
     public void testMultiClose() throws IOException {
         BaseIndexFileFormatTestCaseUtils.testMultiClose(this);
+    }
+
+    @Seeds({@Seed(), @Seed("F007433804DC4123")})
+    @Override
+    public void testRandomExceptions() throws Exception {
+        super.testRandomExceptions();
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestingCodec.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestingCodec.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.lucene.codec;
 
 import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
-import com.apple.foundationdb.record.lucene.directory.FDBLuceneFileReference;
 import com.google.auto.service.AutoService;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CompoundFormat;
@@ -39,7 +38,6 @@ import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.codecs.TermVectorsFormat;
 import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
@@ -211,14 +209,11 @@ public class TestingCodec extends Codec {
         if (allowRandomCompoundFiles) {
             return new LuceneOptimizedCompoundFormat(((LuceneOptimizedCompoundFormat)underlying.compoundFormat()).underlying) {
                 @Override
-                protected void copyFieldInfos(final SegmentInfo si, final Set<String> filesForAfter, final FDBDirectory directory) {
+                protected void copyFieldInfosId(final Directory dir, final Set<String> filesForAfter, final String entriesFile) throws IOException {
                     // copy the id, only if it's present
                     final Optional<String> fieldInfosName = filesForAfter.stream().filter(FDBDirectory::isFieldInfoFile).findFirst();
                     if (fieldInfosName.isPresent()) {
-                        final String fieldInfosFileName = fieldInfosName.orElseThrow();
-                        final FDBLuceneFileReference fieldInfosReference = directory.getFDBLuceneFileReference(fieldInfosFileName);
-                        String entriesFile = IndexFileNames.segmentFileName(si.name, "", ENTRIES_EXTENSION);
-                        directory.setFieldInfoId(entriesFile, fieldInfosReference.getFieldInfosId(), fieldInfosReference.getFieldInfosBitSet());
+                        super.copyFieldInfosId(dir, filesForAfter, entriesFile);
                     }
                 }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -199,4 +200,10 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
 
     }
 
+    @Test
+    void testCloseTwice() {
+        FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
+        output.close();
+        assertDoesNotThrow(output::close);
+    }
 }


### PR DESCRIPTION
This resolves three issues:
1. #2455 - If the `FDBDirectory` is wrapped in a `NRTCachingDirectory`, we may end up only writing the output to `NRTCachingDirectory`, and not syncing it to the underlying `FDBDirectory`. This may only be a test issue, but the resolution is to call `sync`, which is a no-op in `FDBDirectory`, so this seems worthwhile.
2. Similar to #2455 there is an issue with not syncing while copying the field infos id to the `.cfe` when creating a compound file. This includes a fix, and adds a seed that reproduces it.
3. #2457 - If Lucene closes an FDBIndexOutput twice it will result in an NPE. We now make sure that doesn't happen. This is brought into this PR, because without this fix, the seed originally noted in #2455 cannot be included, as the test still fails.