### PR TITLE
RESOLVES #2465: Support rearranging documents between Lucene partitions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Support rearranging documents between Lucene partitions [(Issue #2465)](https://github.com/FoundationDB/fdb-record-layer/issues/2465)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -273,7 +273,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @SuppressWarnings({"PMD.CloseResource", "java:S2095"})
-    private void deleteDocument(Tuple groupingKey, Integer partitionId, Tuple primaryKey) throws IOException {
+    void deleteDocument(Tuple groupingKey, Integer partitionId, Tuple primaryKey) throws IOException {
         final long startTime = System.nanoTime();
         final IndexWriter indexWriter = directoryManager.getIndexWriter(groupingKey, partitionId, indexAnalyzerSelector.provideIndexAnalyzer(""));
         @Nullable final LucenePrimaryKeySegmentIndex segmentIndex = directoryManager.getDirectory(groupingKey, partitionId).getPrimaryKeySegmentIndex();
@@ -311,7 +311,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
 
     @Override
     public CompletableFuture<Void> mergeIndex() {
-        return directoryManager.mergeIndex(partitioner, indexAnalyzerSelector.provideIndexAnalyzer(""));
+        return partitioner.rebalancePartitions()
+                .thenCompose(ignored -> directoryManager.mergeIndex(partitioner, indexAnalyzerSelector.provideIndexAnalyzer("")));
     }
 
     @Nonnull

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
@@ -76,7 +76,9 @@ public enum LuceneLogMessageKeys {
 
     //Lucene component
     COMPONENT,
-    NAME;
+    NAME, GROUP,
+    PARTITION,
+    RECORD_TIMESTAMP;
 
     private final String logKey;
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -50,7 +50,6 @@ import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
-import com.google.common.base.Verify;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -566,8 +565,11 @@ public class LucenePartitioner {
                                                   @Nonnull final Tuple groupingKey,
                                                   int count) {
         final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(state.index, state.store.getRecordMetaData());
+        ScanComparisons comparisons = groupingKey.isEmpty() ?
+                                      ScanComparisons.EMPTY :
+                                      Objects.requireNonNull(ScanComparisons.from(new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, groupingKey.get(0))));
         LuceneScanParameters scan = new LuceneScanQueryParameters(
-                Verify.verifyNotNull(ScanComparisons.from(new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, groupingKey.get(0)))),
+                comparisons,
                 new LuceneQuerySearchClause(LuceneQueryType.QUERY, "*:*", false),
                 new Sort(new SortField(partitionTimestampFieldName, SortField.Type.LONG, false)),
                 null,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -94,4 +94,12 @@ public final class LuceneRecordContextProperties {
      * If set to true, disable the agility context feature and force every merge to be performed in a single transaction.
      */
     public static final RecordLayerPropertyKey<Boolean> LUCENE_AGILE_DISABLE_AGILITY_CONTEXT = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.agile.disabled", false);
+    /**
+     * Number of documents to move from a partition when its size exceeds {@see com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK}.
+     */
+    public static final RecordLayerPropertyKey<Integer> LUCENE_REPARTITION_DOCUMENT_COUNT = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.repartition.document.count", 10);
+    /**
+     * Fallback value of high watermark document count in a partition. This is used when {@see com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK} isn't defined for an index.
+     */
+    public static final RecordLayerPropertyKey<Integer> LUCENE_PARTITION_HIGH_WATERMARK = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.partition.high.watermark", 400_000);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -98,8 +98,4 @@ public final class LuceneRecordContextProperties {
      * Number of documents to move from a partition when its size exceeds {@link com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK}.
      */
     public static final RecordLayerPropertyKey<Integer> LUCENE_REPARTITION_DOCUMENT_COUNT = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.repartition.document.count", 10);
-    /**
-     * Fallback value of high watermark document count in a partition. This is used when {@link com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK} isn't defined for an index.
-     */
-    public static final RecordLayerPropertyKey<Integer> LUCENE_PARTITION_HIGH_WATERMARK = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.partition.high.watermark", 400_000);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -95,11 +95,11 @@ public final class LuceneRecordContextProperties {
      */
     public static final RecordLayerPropertyKey<Boolean> LUCENE_AGILE_DISABLE_AGILITY_CONTEXT = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.agile.disabled", false);
     /**
-     * Number of documents to move from a partition when its size exceeds {@see com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK}.
+     * Number of documents to move from a partition when its size exceeds {@link com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK}.
      */
     public static final RecordLayerPropertyKey<Integer> LUCENE_REPARTITION_DOCUMENT_COUNT = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.repartition.document.count", 10);
     /**
-     * Fallback value of high watermark document count in a partition. This is used when {@see com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK} isn't defined for an index.
+     * Fallback value of high watermark document count in a partition. This is used when {@link com.apple.foundationdb.record.lucene.LuceneIndexOptions#INDEX_PARTITION_HIGH_WATERMARK} isn't defined for an index.
      */
     public static final RecordLayerPropertyKey<Integer> LUCENE_PARTITION_HIGH_WATERMARK = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.partition.high.watermark", 400_000);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -134,12 +134,12 @@ public class FDBDirectoryManager implements AutoCloseable {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    private static CompletableFuture<Optional<Tuple>> nextTuple(@Nonnull FDBRecordContext context,
-                                                                @Nonnull Subspace subspace,
-                                                                @Nonnull KeyRange range,
-                                                                @Nonnull Optional<Tuple> lastTuple,
-                                                                @Nonnull ScanProperties scanProperties,
-                                                                int groupingCount) {
+    public static CompletableFuture<Optional<Tuple>> nextTuple(@Nonnull FDBRecordContext context,
+                                                               @Nonnull Subspace subspace,
+                                                               @Nonnull KeyRange range,
+                                                               @Nonnull Optional<Tuple> lastTuple,
+                                                               @Nonnull ScanProperties scanProperties,
+                                                               int groupingCount) {
         KeyValueCursor.Builder cursorBuilder =
                 KeyValueCursor.Builder.withSubspace(subspace)
                         .setContext(context)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
@@ -46,10 +46,10 @@ import com.apple.foundationdb.record.query.plan.debug.DebuggerWithSymbolTables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.lucene.search.Sort;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.Collections;
 import java.util.Random;
 
@@ -177,6 +177,15 @@ public class LuceneIndexTestUtils {
             planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
         }
         return planner;
+    }
+
+    public static LuceneScanBounds fullSortTextSearch(FDBRecordStore recordStore, Index index, String search, Sort sort) {
+        LuceneScanParameters scan = new LuceneScanQueryParameters(
+                ScanComparisons.EMPTY,
+                new LuceneQueryMultiFieldSearchClause(LuceneQueryType.QUERY, search, false),
+                sort, null, null,
+                null);
+        return scan.bind(recordStore, index, EvaluationContext.EMPTY);
     }
 
     public static LuceneScanBounds fullTextSearch(FDBRecordStore recordStore, Index index, String search, boolean highlight) {


### PR DESCRIPTION
- before index merge, partitions are examined for the count of documents they contain. If above a high watermark, the oldest N documents will be moved to an older partition. If no older partition exists, or if the N documents would make the older partition go over the high watermark, a new partition will be create and docs moved there.
- N is configurable via a property. It should be small enough so that the entire move can be performed in a single transaction. It is currently set to 10.