### PR TITLE
DO NOT MERGE - Measure performance of pre-order implementations

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/PlanHashable.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/PlanHashable.java
@@ -244,6 +244,9 @@ public interface PlanHashable {
         if (mode.getKind() != PlanHashKind.LEGACY && obj instanceof Map) {
             return mapsPlanHash(mode, (Map<?, ?>)obj);
         }
+        if (obj instanceof PlanHashable) {
+            return ((PlanHashable)obj).planHash(mode);
+        }
         if (obj instanceof Iterable<?>) {
             return iterablePlanHash(mode, (Iterable<?>)obj);
         }
@@ -252,9 +255,6 @@ public interface PlanHashable {
         }
         if (obj.getClass().isArray() && obj.getClass().getComponentType().isPrimitive()) {
             return primitiveArrayHash(obj);
-        }
-        if (obj instanceof PlanHashable) {
-            return ((PlanHashable)obj).planHash(mode);
         }
         return obj.hashCode();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NotValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NotValue.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.AbstractValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.BooleanValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.auto.service.AutoService;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -50,6 +51,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * A value that flips the output of its boolean child.
@@ -67,12 +69,16 @@ public class NotValue extends AbstractValue implements BooleanValue {
     @Nonnull
     private final Value child;
 
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier;
+
     /**
      * Constructs a new {@link NotValue} instance.
      * @param child The child expression.
      */
     public NotValue(@Nonnull final Value child) {
         this.child = child;
+        this.childrenSupplier = Suppliers.memoize(() -> List.of(this.child));
     }
 
     @Override
@@ -99,7 +105,7 @@ public class NotValue extends AbstractValue implements BooleanValue {
     @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        return ImmutableList.of(child);
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PreOrderIterator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PreOrderIterator.java
@@ -1,0 +1,108 @@
+/*
+ * PreOrderIterator.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.google.common.collect.Iterables;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Stack;
+
+/**
+ * An iterator that accesses all elements of a {@link TreeLike} object in pre-order fashion.
+ * It attempts to reduce the number of memory allocations as much as possible, and does so
+ * by implementing a mix of level-based traversal and pre-order traversal; a {@link Stack} is used
+ * to enable depth first search, however instead of maintaining individual {@link TreeLike} node in
+ * each stack frame the entire list of (amortized) children is stored along with an index pointing out
+ * to the current element that is returned to the user.
+ *
+ * @param <T> The type of the iterator element.
+ */
+@NotThreadSafe
+public final class PreOrderIterator<T extends TreeLike<T>> implements Iterator<T> {
+
+    @Nonnull
+    private final Stack<Pair<Iterable<? extends T>, Integer>> stack;
+
+    private static final int INITIAL_POSITION = -1;
+
+    private PreOrderIterator(@Nonnull final T traversable) {
+        stack = new Stack<>();
+        // this is the only list allocation done to put the root in the stack.
+        // all the remaining lists added to the stack are references to children
+        // lists (copy by reference).
+        stack.push(MutablePair.of(List.of(traversable.getThis()), INITIAL_POSITION));
+    }
+
+    @Override
+    public boolean hasNext() {
+        while (true) {
+            if (stack.empty()) {
+                return false;
+            }
+            final var currentLevelIndex = stack.peek().getRight();
+            final var currentLevelItemsCount = Iterables.size(stack.peek().getLeft());
+            if (currentLevelIndex + 1 < currentLevelItemsCount) {
+                return true;
+            } else {
+                // pop the stack, and continue doing so, until we either find a next element
+                // by looking into previous levels in reverse (stack) order, progressively
+                // do so until either an item is found, or the stack becomes empty, and no item
+                // is to be found meaning that the traversal is complete.
+                stack.pop();
+            }
+        }
+    }
+
+    @Override
+    public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("no more elements");
+        }
+        final var currentIndexPosition = stack.peek().getRight();
+        final var currentLevelItems = stack.peek().getLeft();
+        final var nextItemIndex = currentIndexPosition + 1;
+
+        // mark the next item as the current one in this stack frame, note that
+        // the position must be valid because hasNext() is called first, and hasNext()
+        // makes sure that, if there is a next element, it modifies the stack index such
+        // that incrementing it would lead to finding that next element correctly.
+        final var result = Iterables.get(currentLevelItems, nextItemIndex);
+        stack.peek().setValue(nextItemIndex);
+        final var resultChildren = result.getChildren();
+
+        // descend into the children (if any) to conform to pre-order FDF semantics.
+        if (!Iterables.isEmpty(resultChildren)) {
+            stack.push(MutablePair.of(resultChildren, INITIAL_POSITION));
+        }
+        return result;
+    }
+
+    @Nonnull
+    public static <T extends TreeLike<T>> PreOrderIterator<T> over(@Nonnull final T traversable) {
+        return new PreOrderIterator<>(traversable);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/TreeLike.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/TreeLike.java
@@ -41,7 +41,7 @@ import java.util.function.UnaryOperator;
  * {@link T}.
  * @param <T> type parameter of the node
  */
-public interface TreeLike<T extends TreeLike<T>> {
+public interface TreeLike<T extends TreeLike<T>> extends Iterable<T> {
 
     /**
      * Method to get a {@code T}-typed {@code this}. This is the equivalent of Scala's typed self. Java's type inference
@@ -250,6 +250,16 @@ public interface TreeLike<T extends TreeLike<T>> {
             }
             return t;
         });
+    }
+
+    /**
+     * Returns an iterator that traverse the nodes in pre-order.
+     * @return an iterator that traverse the nodes in pre-order.
+     */
+    @Override
+    @Nonnull
+    default Iterator<T> iterator() {
+        return PreOrderIterator.over(getThis());
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AndOrValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AndOrValue.java
@@ -44,6 +44,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
 import com.google.auto.service.AutoService;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -54,6 +55,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * A {@link Value} that applies conjunction/disjunction on its boolean children, and if possible, simplifies its boolean children.
@@ -67,6 +69,8 @@ public class AndOrValue extends AbstractValue implements BooleanValue {
     private final Value leftChild;
     @Nonnull
     private final Value rightChild;
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier = Suppliers.memoize(this::computeChildren);
     @Nonnull
     private final Operator operator;
 
@@ -139,9 +143,14 @@ public class AndOrValue extends AbstractValue implements BooleanValue {
     }
 
     @Nonnull
+    private Iterable<? extends Value> computeChildren() {
+        return ImmutableList.of(leftChild, rightChild);
+    }
+
+    @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        return ImmutableList.of(leftChild, rightChild);
+        return childrenSupplier.get();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -74,6 +74,8 @@ public class ArithmeticValue extends AbstractValue {
     private final Value leftChild;
     @Nonnull
     private final Value rightChild;
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier = Suppliers.memoize(this::computeChildren);
 
     @Nonnull
     private static final Supplier<Map<Triple<LogicalOperator, TypeCode, TypeCode>, PhysicalOperator>> operatorMapSupplier =
@@ -119,9 +121,14 @@ public class ArithmeticValue extends AbstractValue {
     }
 
     @Nonnull
+    private Iterable<? extends Value> computeChildren() {
+        return ImmutableList.of(leftChild, rightChild);
+    }
+
+    @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        return ImmutableList.of(leftChild, rightChild);
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CountValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CountValue.java
@@ -41,6 +41,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type.TypeCode;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
 import com.google.auto.service.AutoService;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -52,6 +53,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BinaryOperator;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 /**
@@ -65,6 +67,8 @@ public class CountValue extends AbstractValue implements AggregateValue, Streama
     protected final PhysicalOperator operator;
     @Nullable
     private final Value child;
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier = Suppliers.memoize(this::computeChildren);
 
     @Nonnull
     private final String indexTypeName;
@@ -135,13 +139,18 @@ public class CountValue extends AbstractValue implements AggregateValue, Streama
     }
 
     @Nonnull
-    @Override
-    public Iterable<? extends Value> getChildren() {
+    private Iterable<? extends Value> computeChildren() {
         if (child != null) {
             return ImmutableList.of(child);
         } else {
             return ImmutableList.of();
         }
+    }
+
+    @Nonnull
+    @Override
+    public Iterable<? extends Value> getChildren() {
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/InOpValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/InOpValue.java
@@ -44,6 +44,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -54,6 +55,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * A {@link Value} that checks if the left child is in the list of values.
@@ -67,6 +69,9 @@ public class InOpValue extends AbstractValue implements BooleanValue {
     @Nonnull
     private final Value inArrayValue;
 
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier = Suppliers.memoize(this::computeChildren);
+
     /**
      * Creates a new instance of {@link InOpValue}.
      * @param probeValue The left child in `IN` operator
@@ -79,12 +84,14 @@ public class InOpValue extends AbstractValue implements BooleanValue {
     }
 
     @Nonnull
+    private Iterable<? extends Value> computeChildren() {
+        return ImmutableList.of(probeValue, inArrayValue);
+    }
+
+    @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        final var builder = new ImmutableList.Builder<Value>();
-        builder.add(probeValue);
-        builder.add(inArrayValue);
-        return builder.build();
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LikeOperatorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LikeOperatorValue.java
@@ -43,6 +43,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type.TypeCode;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
 import com.google.auto.service.AutoService;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -53,6 +54,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 /**
@@ -66,6 +68,9 @@ public class LikeOperatorValue extends AbstractValue implements BooleanValue {
     private final Value srcChild;
     @Nonnull
     private final Value patternChild;
+
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier = Suppliers.memoize(this::computeChildren);
 
     /**
      * Constructs a new instance of {@link LikeOperatorValue}.
@@ -107,9 +112,14 @@ public class LikeOperatorValue extends AbstractValue implements BooleanValue {
     }
 
     @Nonnull
+    private Iterable<? extends Value> computeChildren() {
+        return ImmutableList.of(srcChild, patternChild);
+    }
+
+    @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        return ImmutableList.of(srcChild, patternChild);
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PatternForLikeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PatternForLikeValue.java
@@ -38,6 +38,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type.TypeCode;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
 import com.google.auto.service.AutoService;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -49,6 +50,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * A {@link Value} that applies a like operator on its child expressions.
@@ -63,6 +65,8 @@ public class PatternForLikeValue extends AbstractValue {
     private final Value patternChild;
     @Nonnull
     private final Value escapeChild;
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier;
 
     /**
      * Constructs a new instance of {@link PatternForLikeValue}.
@@ -72,6 +76,7 @@ public class PatternForLikeValue extends AbstractValue {
     public PatternForLikeValue(@Nonnull final Value patternChild, @Nonnull final Value escapeChild) {
         this.patternChild = patternChild;
         this.escapeChild = escapeChild;
+        this.childrenSupplier = Suppliers.memoize(() -> List.of(patternChild, escapeChild));
     }
 
     @Nullable
@@ -102,7 +107,7 @@ public class PatternForLikeValue extends AbstractValue {
     @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        return ImmutableList.of(patternChild, escapeChild);
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
@@ -84,7 +84,7 @@ public class VariadicFunctionValue extends AbstractValue {
     public VariadicFunctionValue(@Nonnull PhysicalOperator operator,
                                  @Nonnull List<Value> children) {
         this.operator = operator;
-        this.children = children;
+        this.children = ImmutableList.copyOf(children);
     }
 
     @Nullable
@@ -109,7 +109,7 @@ public class VariadicFunctionValue extends AbstractValue {
     @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        return ImmutableList.copyOf(children);
+        return children;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PWindowedValue;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
@@ -37,6 +38,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -51,6 +53,9 @@ public abstract class WindowedValue extends AbstractValue {
 
     @Nonnull
     private final List<Value> argumentValues;
+
+    @Nonnull
+    private final Supplier<Iterable<? extends Value>> childrenSupplier = Suppliers.memoize(this::computeChildren);
 
     protected WindowedValue(@Nonnull final PlanSerializationContext serializationContext,
                             @Nonnull final PWindowedValue windowedValueProto) {
@@ -82,9 +87,14 @@ public abstract class WindowedValue extends AbstractValue {
     }
 
     @Nonnull
+    private Iterable<? extends Value> computeChildren() {
+        return ImmutableList.<Value>builder().addAll(partitioningValues).addAll(argumentValues).build();
+    }
+
+    @Nonnull
     @Override
     public Iterable<? extends Value> getChildren() {
-        return ImmutableList.<Value>builder().addAll(partitioningValues).addAll(argumentValues).build();
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
@@ -21,6 +21,8 @@
 package com.apple.foundationdb.record.util;
 
 import com.apple.foundationdb.record.query.plan.cascades.TreeLike;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
@@ -30,6 +32,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -44,6 +47,8 @@ public abstract class TrieNode<D, T, N extends TrieNode<D, T, N>> implements Tre
     private final T value;
     @Nullable
     private final Map<D, N> childrenMap;
+    @Nonnull
+    private final Supplier<Iterable<N>> childrenSupplier = Suppliers.memoize(this::computeChildren);
 
     public TrieNode(@Nullable final T value, @Nullable final Map<D, N> childrenMap) {
         this.value = value;
@@ -61,9 +66,14 @@ public abstract class TrieNode<D, T, N extends TrieNode<D, T, N>> implements Tre
     }
 
     @Nonnull
+    private Iterable<N> computeChildren() {
+        return childrenMap == null ? ImmutableList.of() : childrenMap.values();
+    }
+
+    @Nonnull
     @Override
     public Iterable<N> getChildren() {
-        return childrenMap == null ? ImmutableList.of() : childrenMap.values();
+        return childrenSupplier.get();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/util/TrieNode.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.util;
 
 import com.apple.foundationdb.record.query.plan.cascades.TreeLike;
-import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/TreeLikeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/TreeLikeTest.java
@@ -48,6 +48,8 @@ public class TreeLikeTest {
         final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
         assertEquals(ImmutableList.of("a", "b", "c"),
                 traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+        assertEquals(ImmutableList.of("a", "b", "c"),
+                StreamSupport.stream(t.spliterator(), false).map(item -> item.contents).collect(Collectors.toList()));
     }
 
     @Test
@@ -62,6 +64,42 @@ public class TreeLikeTest {
         final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
         assertEquals(ImmutableList.of("a", "b", "c", "d", "e"),
                 traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+        assertEquals(ImmutableList.of("a", "b", "c", "d", "e"),
+                StreamSupport.stream(t.spliterator(), false).map(item -> item.contents).collect(Collectors.toList()));
+    }
+
+    @Test
+    void testPreOrder3() {
+        final TreeNode t =
+                node("a",
+                        node("b",
+                                node("c"),
+                                node("d")),
+                        node("e",
+                                node("f",
+                                    node("g"),
+                                    node("h")),
+                                node("i")));
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
+        assertEquals(ImmutableList.of("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+        assertEquals(ImmutableList.of("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+                StreamSupport.stream(t.spliterator(), false).map(item -> item.contents).collect(Collectors.toList()));
+    }
+
+    @Test
+    void testPreOrder4() {
+        final TreeNode t =
+                node("a",
+                        node("b",
+                                node("c")));
+
+        final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
+        assertEquals(ImmutableList.of("a", "b", "c"),
+                traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+        assertEquals(ImmutableList.of("a", "b", "c"),
+                StreamSupport.stream(t.spliterator(), false).map(item -> item.contents).collect(Collectors.toList()));
     }
 
     @Test
@@ -71,6 +109,8 @@ public class TreeLikeTest {
         final ImmutableList<? extends TreeNode> traversed = ImmutableList.copyOf(t.inPreOrder());
         assertEquals(ImmutableList.of("a"),
                 traversed.stream().map(TreeNode::getContents).collect(ImmutableList.toImmutableList()));
+        assertEquals(ImmutableList.of("a"),
+                StreamSupport.stream(t.spliterator(), false).map(item -> item.contents).collect(Collectors.toList()));
     }
 
     @Test

--- a/fdb-record-layer-jmh/fdb-record-layer-jmh.gradle
+++ b/fdb-record-layer-jmh/fdb-record-layer-jmh.gradle
@@ -40,6 +40,12 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     testRuntimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+    implementation "com.google.guava:guava:${guavaVersion}"
+    jmh 'org.openjdk.jmh:jmh-core:1.36'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.36'
+
+    // this is the line that solves the missing /META-INF/BenchmarkList error
+    jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.36'
 }
 
 jmh {

--- a/fdb-record-layer-jmh/src/jmh/java/com/apple/foundationdb/record/benchmark/PreOrderPerformance.java
+++ b/fdb-record-layer-jmh/src/jmh/java/com/apple/foundationdb/record/benchmark/PreOrderPerformance.java
@@ -1,0 +1,204 @@
+/*
+ * PreOrderPerformance.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.benchmark;
+
+import com.apple.foundationdb.record.query.plan.cascades.TreeLike;
+import com.google.common.base.Objects;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Test performance of preorder implementations.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 5000)
+@Measurement(iterations = 5, timeUnit = TimeUnit.MILLISECONDS, time = 5000)
+public class PreOrderPerformance {
+
+    @Nonnull
+    private static final Random random = new Random(42);
+
+    @Nonnull
+    private static TreeNode randomTree(int size, int maxLevelSize) {
+        assert maxLevelSize <= size;
+        assert size >= 1;
+
+        final var nodeNames = IntStream.rangeClosed(1, size).mapToObj(String::valueOf).collect(Collectors.toList());
+        TreeNode result = new TreeNode(nodeNames.get(0), List.of());
+        var nodeCount = 0;
+        Deque<Optional<TreeNode>> deque = new ArrayDeque<>();
+        deque.add(Optional.of(result));
+        deque.add(Optional.empty());
+        while (nodeCount < size) {
+            // read off all the nodes at this stage.
+            if (deque.isEmpty()) {
+                break;
+            }
+            final var item = deque.pop();
+            if (deque.isEmpty()) {
+                break;
+            }
+            if (item.isEmpty()) {
+                deque.addLast(Optional.empty());
+            } else {
+                // add random children to current item
+                final var finalNodeCount = nodeCount;
+                final var children = IntStream.rangeClosed(1, 1 + random.nextInt(maxLevelSize))
+                        .filter(i -> finalNodeCount + i < nodeNames.size())
+                        .mapToObj(i -> new TreeNode(nodeNames.get(finalNodeCount + i), List.of()))
+                        .collect(Collectors.toList());
+                item.get().withChildren(children);
+                deque.addAll(children.stream().map(Optional::of).collect(Collectors.toList()));
+                nodeCount += children.size();
+            }
+        }
+        return result;
+    }
+
+    private static final TreeNode tree = randomTree(100, 5);
+
+    @Benchmark
+    @BenchmarkMode(Mode.All)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void measureOld() {
+        final List<Iterable<? extends TreeNode>> result = new ArrayList<>(1000000);
+        for (int i = 0; i < 1000000; ++i) {
+            final var x = tree.inPreOrder();
+            result.add(x);
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.All)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void measureNew() {
+        final List<Iterable<? extends TreeNode>> result = new ArrayList<>(1000000);
+        for (int i = 0; i < 1000000; ++i) {
+            List<TreeNode> x = new ArrayList<>();
+            tree.iterator().forEachRemaining(x::add);
+            result.add(x);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(PreOrderPerformance.class.getSimpleName() )
+                .addProfiler("gc")
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    private static class TreeNode implements TreeLike<TreeNode> {
+        private final String contents;
+        private List<TreeNode> children;
+
+        private final Supplier<Integer> heightSupplier;
+
+        public TreeNode(@Nonnull final String contents, final Iterable<? extends TreeNode> children) {
+            this.contents = contents;
+            this.children = ImmutableList.copyOf(children);
+            this.heightSupplier = Suppliers.memoize(this::computeHeight);
+        }
+
+        @Nonnull
+        public String getContents() {
+            return contents;
+        }
+
+        @Nonnull
+        @Override
+        public TreeNode getThis() {
+            return this;
+        }
+
+        @Nonnull
+        @Override
+        public Iterable<? extends TreeNode> getChildren() {
+            return children;
+        }
+
+        @Nonnull
+        @Override
+        public TreeNode withChildren(@Nonnull final Iterable<? extends TreeNode> newChildren) {
+            children = ImmutableList.copyOf(newChildren);
+            return this;
+        }
+
+        private int computeHeight() {
+            return 1 + children.stream().mapToInt(TreeLike::height).max().orElse(0);
+        }
+
+        @Override
+        public int height() {
+            return heightSupplier.get();
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TreeNode)) {
+                return false;
+            }
+            final TreeNode treeNode = (TreeNode)o;
+            return Objects.equal(getContents(), treeNode.getContents()) && Objects.equal(getChildren(), treeNode.getChildren());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getContents(), getChildren());
+        }
+
+        @Override
+        public String toString() {
+            return "(" + contents + "; " + getChildren() + ")";
+        }
+    }
+}


### PR DESCRIPTION
This is on top of #2464 and should not be merged. It adds a JMH Benchmark that compares the performance of current pre-order implementations in `TreeLike`.

To run the benchmark, go to `PreOrderPerformance` and run `main` function. The benchmark generates a random `TreeLike` tree comprising 100 nodes with maximum of 20 nodes in a level, it then compares the two implementations of pre-order traversal:
1. The old implementation, which is done in `TreeLike<>#inPreOrder()`
2. The new implementation exposed through the `Iterable#iterator()` interface that `TreeLike<>` now extends from.

The benchmark creates 1 million pre-ordered lists once using the old implementation and another time using the new implementation, and compares, among other things the memory consumption.

Excerpt from the test results:
```
PreOrderPerformance.measureNew                        avgt    5      8961491,750 ±   52626,970   us/op
PreOrderPerformance.measureNew:·gc.alloc.rate         avgt    5          191,126 ±       1,123  MB/sec
PreOrderPerformance.measureNew:·gc.alloc.rate.norm    avgt    5   1796000454,400 ±      55,106    B/op
PreOrderPerformance.measureNew:·gc.count              avgt    5           13,000                counts
PreOrderPerformance.measureNew:·gc.time               avgt    5          482,000                    ms
PreOrderPerformance.measureOld                        avgt    5      4003585,517 ± 4011325,561   us/op
PreOrderPerformance.measureOld:·gc.alloc.rate         avgt    5         2780,581 ±    2541,968  MB/sec
PreOrderPerformance.measureOld:·gc.alloc.rate.norm    avgt    5  11100000332,000 ±     466,039    B/op
PreOrderPerformance.measureOld:·gc.count              avgt    5           87,000                counts
PreOrderPerformance.measureOld:·gc.time               avgt    5        17566,000                    ms
```

I think the important bit here is `gc.alloc.rate` which shows the rate in which the garbage collector is invoked. In the old implementation 2541,968  MB/sec compared to 1,123  MB/sec, meaning that the new implementation is reducing the allocation rate by ~99,96%.