### PR TITLE
Fixes #2462: PlanOrderingKey tripped up if the same expression appears multiple times

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Bug fix** Sync files referencing FieldInfosId [(Issue #2455)](https://github.com/FoundationDB/fdb-record-layer/issues/2455)
 * **Bug fix** Support closing FDBIndexOutput [(Issue #2457)](https://github.com/FoundationDB/fdb-record-layer/issues/2457)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `PlanOrderingKey` can now handle multiple instances of the same expression appearing within the same key [(Issue #2452)](https://github.com/FoundationDB/fdb-record-layer/issues/2462)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Bug fix** Support closing FDBIndexOutput [(Issue #2457)](https://github.com/FoundationDB/fdb-record-layer/issues/2457)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** The `PlanOrderingKey` can now handle multiple instances of the same expression appearing within the same key [(Issue #2452)](https://github.com/FoundationDB/fdb-record-layer/issues/2462)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The value portion of a `KeyWithValueExpression` no longer contributes to the `PlanOrderingKey` [(Issue #2469)](https://github.com/FoundationDB/fdb-record-layer/issues/2469)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.metadata.expressions.ListKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFilterPlan;
@@ -152,6 +153,12 @@ public class PlanOrderingKey {
             final RecordQueryPlanWithIndex indexPlan = (RecordQueryPlanWithIndex)queryPlan;
             final Index index = metaData.getIndex(indexPlan.getIndexName());
             final List<KeyExpression> keys = new ArrayList<>(index.getRootExpression().normalizeKeyForPositions());
+            if (index.getRootExpression() instanceof KeyWithValueExpression) {
+                int splitPoint = ((KeyWithValueExpression)index.getRootExpression()).getSplitPoint();
+                while (keys.size() > splitPoint) {
+                    keys.remove(keys.size() - 1);
+                }
+            }
             int pkeyStart = keys.size();
             int pKeyTail = pkeyStart;
             // Primary keys come after index value keys, unless they were already part of it.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.record.metadata.IndexAggregateFunctionCall;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
+import com.apple.foundationdb.record.metadata.UnnestedRecordType;
 import com.apple.foundationdb.record.metadata.UnnestedRecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
@@ -90,6 +91,7 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.list;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
 import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.only;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.comparisonKey;
@@ -108,7 +110,9 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.unorderedPrimaryKeyDistinctPlan;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -638,6 +642,76 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
                                 .join();
                         assertEquals(expected, queried);
                     }
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "orQueryWithIdInOrdering[reverse={0}]")
+    @BooleanSource
+    void orQueryWithIdInOrdering(boolean reverse) {
+        final Index keyIdValueIndex = new Index("synthetic$keyIdValue",
+                concat(field("entry").nest("key"), field(PARENT_CONSTITUENT).nest("rec_id"), field("entry").nest("value")));
+        final RecordMetaDataHook hook = addUnnestedType()
+                .andThen(metaData -> metaData.addIndex(OUTER_WITH_ENTRIES, keyIdValueIndex));
+        final List<TestRecordsNestedMapProto.OuterRecord> data = setUpData(hook);
+        final Set<String> keys = mapKeys(data);
+        assertThat(keys, not(empty()));
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenMapStore(context, hook);
+
+            final String key1Param = "key1Param";
+            final String key2Param = "key2Param";
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType(OUTER_WITH_ENTRIES)
+                    .setFilter(Query.field("entry").matches(
+                            Query.or(Query.field("key").equalsParameter(key1Param), Query.field("key").equalsParameter(key2Param))
+                    ))
+                    .setSort(field(PARENT_CONSTITUENT).nest("rec_id"), reverse)
+                    .build();
+            setNormalizeNestedFields(true);
+            setOmitPrimaryKeyInUnionOrderingKey(true);
+
+            final RecordQueryPlan plan = planQuery(query);
+            assertMatchesExactly(plan, unionOnExpressionPlan(
+                    indexPlan().where(indexName(keyIdValueIndex.getName())).and(scanComparisons(range("[EQUALS $" + key1Param + "]"))),
+                    indexPlan().where(indexName(keyIdValueIndex.getName())).and(scanComparisons(range("[EQUALS $" + key2Param + "]")))
+            ).where(comparisonKey(concat(field(PARENT_CONSTITUENT).nest("rec_id"), field("entry").nest("value"), recordType(), field(UnnestedRecordType.POSITIONS_FIELD).nest("entry")))));
+            assertEquals(reverse ? 1518478779L : 1518478746L, plan.planHash(CURRENT_LEGACY));
+            assertEquals(reverse ? 1391408828L : 1397128886L, plan.planHash(CURRENT_FOR_CONTINUATION));
+
+            for (String key1 : keys) {
+                for (String key2 : keys) {
+                    final Bindings bindings = Bindings.newBuilder()
+                            .set(key1Param, key1)
+                            .set(key2Param, key2)
+                            .build();
+                    final EvaluationContext evaluationContext = EvaluationContext.forBindings(bindings);
+
+                    final List<Pair<Long, String>> expected = data.stream()
+                            .flatMap(outerRecord -> outerRecord.getMap().getEntryList().stream()
+                                    .filter(entry -> entry.getKey().equals(key1) || entry.getKey().equals(key2))
+                                    .map(entry -> Pair.of(outerRecord.getRecId(), entry.getValue()))
+                            )
+                            .sorted(reverse ? Comparator.reverseOrder() : Comparator.naturalOrder())
+                            .collect(Collectors.toList());
+                    final List<Pair<Long, String>> actual = plan.execute(recordStore, evaluationContext)
+                            .map(FDBQueriedRecord::getSyntheticRecord)
+                            .map(synthetic -> {
+                                TestRecordsNestedMapProto.OuterRecord outerRecord = TestRecordsNestedMapProto.OuterRecord.newBuilder()
+                                        .mergeFrom(synthetic.getConstituent(PARENT_CONSTITUENT).getRecord())
+                                        .build();
+                                TestRecordsNestedMapProto.MapRecord.Entry entry = TestRecordsNestedMapProto.MapRecord.Entry.newBuilder()
+                                        .mergeFrom(synthetic.getConstituent("entry").getRecord())
+                                        .build();
+                                assertThat(entry.getKey(), either(equalTo(key1)).or(equalTo(key2)));
+                                assertTrue(outerRecord.getMap().getEntryList().contains(entry), () -> "outer record should contain entry.\n  Outer record:\n" + outerRecord + "\n  Entry:\n" + entry);
+                                return Pair.of(outerRecord.getRecId(), entry.getValue());
+                            })
+                            .asList()
+                            .join();
+                    assertEquals(expected, actual);
                 }
             }
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.query;
 
+import com.apple.foundationdb.record.Bindings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.PlanHashable;
@@ -573,9 +574,14 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
 
     @Nonnull
     protected RecordCursorIterator<FDBQueriedRecord<Message>> executeQuery(@Nonnull final RecordQueryPlan plan) {
+        return executeQuery(plan, Bindings.EMPTY_BINDINGS);
+    }
+
+    @Nonnull
+    protected RecordCursorIterator<FDBQueriedRecord<Message>> executeQuery(@Nonnull final RecordQueryPlan plan, @Nonnull Bindings bindings) {
         final var usedTypes = UsedTypesProperty.evaluate(plan);
         final var typeRepository = TypeRepository.newBuilder().addAllTypes(usedTypes).build();
-        return plan.execute(recordStore, EvaluationContext.forTypeRepository(typeRepository)).asIterator();
+        return plan.execute(recordStore, EvaluationContext.forBindingsAndTypeRepository(bindings, typeRepository)).asIterator();
     }
 
     protected static class Holder<T> {


### PR DESCRIPTION
This updates the handling for key expressions in `PlanOrderingKey` so that if the same expression appears multiple times, we only match it once.

This fixes #2462. That work was started in #2453, but it still had some edge cases where if none of the key expressions were in the equality prefix, the logic wasn't quite right.

I also added (in a separate commit) logic that fixes #2469. This is here mainly to avoid too many conflicts from updating the same bit of code, though it's conceptually separate. 