### PR TITLE
Resolves #2491: Use multiple partitions to perform rebalancing

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -30,6 +30,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Feature** Support rearranging documents between Lucene partitions [(Issue #2465)](https://github.com/FoundationDB/fdb-record-layer/issues/2465)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** The Cascades planner can now plan against aggregate indexes with repeated grouping columns [(Issue #2472)](https://github.com/FoundationDB/fdb-record-layer/issues/2472)
+* **Feature** Use multiple partitions to perform rebalancing & merge all partitions [(Issue #2491)](https://github.com/FoundationDB/fdb-record-layer/issues/2491)
 * **Feature** Online Indexing: add reverse order option [(Issue #2474)](https://github.com/FoundationDB/fdb-record-layer/issues/2474)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/test/java/com/apple/test/RandomizedTestUtils.java
+++ b/fdb-extensions/src/test/java/com/apple/test/RandomizedTestUtils.java
@@ -1,0 +1,63 @@
+/*
+ * RandomizedTestUtils.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.test;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * A Utility class for adding randomness to tests.
+ */
+public final class RandomizedTestUtils {
+    private RandomizedTestUtils() {
+    }
+
+    /**
+     * Return a stream of randomly generated arguments based on the gradle properties.
+     * <p>
+     *     Tip: Use {@code Stream.concat(streamOfFixedArguments, RandomizedTestUtils.randomArguments(random -> { ... }} to have some fixed
+     *     arguments, and also add randomized arguments when including random tests.
+     * </p>
+     * @param randomArguments A mapper from a {@link Random} to the arguments to be provided to
+     * @return a stream of {@link Arguments} for a {@link org.junit.jupiter.params.ParameterizedTest}
+     */
+    public static Stream<Arguments> randomArguments(Function<Random, Arguments> randomArguments) {
+        if (includeRandomTests()) {
+            Random random = ThreadLocalRandom.current();
+            return IntStream.range(0, getIterations()).mapToObj(i -> randomArguments.apply(random));
+        } else {
+            return Stream.of();
+        }
+    }
+
+    private static int getIterations() {
+        return Integer.parseInt(System.getProperty("tests.iterations", "0"));
+    }
+
+    private static boolean includeRandomTests() {
+        return Boolean.parseBoolean(System.getProperty("tests.includeRandom", "false"));
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
@@ -76,9 +76,12 @@ public enum LuceneLogMessageKeys {
 
     //Lucene component
     COMPONENT,
-    NAME, GROUP,
+    NAME,
+    GROUP,
     PARTITION,
-    RECORD_TIMESTAMP;
+    RECORD_TIMESTAMP,
+    COUNT,
+    TOTAL_COUNT;
 
     private final String logKey;
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -607,7 +607,7 @@ public class LucenePartitioner {
                 LOGGER.trace(partitionInfos.stream()
                         .sorted(Comparator.comparing(pi -> Tuple.fromBytes(pi.getFrom().toByteArray())))
                         .map(pi -> "pi[" + pi.getId() + "]@" + pi.getCount() + Tuple.fromBytes(pi.getFrom().toByteArray()) + "->" + Tuple.fromBytes(pi.getTo().toByteArray()))
-                        .collect(Collectors.joining(", ", "Rebalancing partitions: ", "")));
+                        .collect(Collectors.joining(", ", "Rebalancing partitions (group=" + groupingKey + "): ", "")));
             }
 
             for (LucenePartitionInfoProto.LucenePartitionInfo partitionInfo : partitionInfos) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -531,7 +531,7 @@ public class LucenePartitioner {
      *
      * @param start The continuation at which to resume rebalancing, as returned from a previous call to
      * {@code rebalancePartitions}.
-     * @return a tuple of the next group that needs repartitioning
+     * @return a continuation at which to resume rebalancing in another call to {@code rebalancePartitions}
      */
     @Nonnull
     public CompletableFuture<RecordCursorContinuation> rebalancePartitions(RecordCursorContinuation start) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -316,12 +316,8 @@ public class LucenePartitioner {
     void savePartitionMetadata(@Nonnull Tuple groupKey, @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo.Builder builder) {
         LucenePartitionInfoProto.LucenePartitionInfo updatedPartition = builder.build();
         state.context.ensureActive().set(
-                partitionMetadataKeyFromTimestamp(groupKey, getTimestampFromPartitionInfo(builder)),
+                partitionMetadataKeyFromTimestamp(groupKey, getFrom(builder)),
                 updatedPartition.toByteArray());
-    }
-
-    private static long getTimestampFromPartitionInfo(@Nonnull final LucenePartitionInfoProto.LucenePartitionInfoOrBuilder builder) {
-        return Tuple.fromBytes(builder.getFrom().toByteArray()).getLong(0);
     }
 
     @Nonnull
@@ -501,7 +497,7 @@ public class LucenePartitioner {
      * @param partitionInfo partition metadata instance
      * @return long
      */
-    public static long getFrom(@Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static long getFrom(@Nonnull LucenePartitionInfoProto.LucenePartitionInfoOrBuilder partitionInfo) {
         return Tuple.fromBytes(partitionInfo.getFrom().toByteArray()).getLong(0);
     }
 
@@ -675,7 +671,7 @@ public class LucenePartitioner {
      * @param groupingKey grouping key
      * @param maxPartitionId current max partition id
      * @param cursor documents to move
-     * @return void future
+     * @return A future containing the amount of documents that were moved
      */
     @Nonnull
     private CompletableFuture<Integer> moveDocsFromPartition(@Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo,
@@ -775,7 +771,7 @@ public class LucenePartitioner {
         if (previous == null) {
             return getNewestPartition(groupingKey, context, indexSubspace);
         } else {
-            final Range range = new TupleRange(groupingKey.add(PARTITION_META_SUBSPACE), partitionMetadataKeyTuple(groupingKey, getTimestampFromPartitionInfo(previous)),
+            final Range range = new TupleRange(groupingKey.add(PARTITION_META_SUBSPACE), partitionMetadataKeyTuple(groupingKey, getFrom(previous)),
                     EndpointType.TREE_START, EndpointType.RANGE_EXCLUSIVE)
                     .toRange(indexSubspace);
             final AsyncIterable<KeyValue> rangeIterable = context.ensureActive().getRange(range, Integer.MAX_VALUE, true, StreamingMode.WANT_ALL);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -566,7 +566,7 @@ public class FDBDirectory extends Directory  {
             });
             return null;
         }).thenAccept(ignore -> {
-            if (LOGGER.isTraceEnabled()) {
+            if (LOGGER.isDebugEnabled()) {
                 List<String> displayList = new ArrayList<>(outMap.size());
                 long totalSize = 0L;
                 long actualTotalSize = 0L;
@@ -575,7 +575,7 @@ public class FDBDirectory extends Directory  {
                     totalSize += entry.getValue().getSize();
                     actualTotalSize += entry.getValue().getActualSize();
                 }
-                LOGGER.trace(getLogMessage("listAllFiles",
+                LOGGER.debug(getLogMessage("listAllFiles",
                         LuceneLogMessageKeys.FILE_COUNT, displayList.size(),
                         LuceneLogMessageKeys.FILE_LIST, displayList,
                         LuceneLogMessageKeys.FILE_TOTAL_SIZE, totalSize,
@@ -877,8 +877,8 @@ public class FDBDirectory extends Directory  {
     @Override
     public void close() {
         agilityContext.flush();
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace(getLogMessage("close called",
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(getLogMessage("close called",
                     LuceneLogMessageKeys.BLOCK_CACHE_STATS, blockCache.stats()));
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -566,7 +566,7 @@ public class FDBDirectory extends Directory  {
             });
             return null;
         }).thenAccept(ignore -> {
-            if (LOGGER.isDebugEnabled()) {
+            if (LOGGER.isTraceEnabled()) {
                 List<String> displayList = new ArrayList<>(outMap.size());
                 long totalSize = 0L;
                 long actualTotalSize = 0L;
@@ -575,7 +575,7 @@ public class FDBDirectory extends Directory  {
                     totalSize += entry.getValue().getSize();
                     actualTotalSize += entry.getValue().getActualSize();
                 }
-                LOGGER.debug(getLogMessage("listAllFiles",
+                LOGGER.trace(getLogMessage("listAllFiles",
                         LuceneLogMessageKeys.FILE_COUNT, displayList.size(),
                         LuceneLogMessageKeys.FILE_LIST, displayList,
                         LuceneLogMessageKeys.FILE_TOTAL_SIZE, totalSize,
@@ -877,8 +877,8 @@ public class FDBDirectory extends Directory  {
     @Override
     public void close() {
         agilityContext.flush();
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(getLogMessage("close called",
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace(getLogMessage("close called",
                     LuceneLogMessageKeys.BLOCK_CACHE_STATS, blockCache.stats()));
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -146,15 +146,14 @@ public class FDBDirectoryManager implements AutoCloseable {
         } else {
             AtomicReference<LucenePartitionInfoProto.LucenePartitionInfo> lastPartitionInfo = new AtomicReference<>();
             return AsyncUtil.whileTrue(() -> getNextPartitionInfo(groupingKey, agileContext, lastPartitionInfo)
-                    .thenApply(partitionId -> mergePartition(analyzerWrapper, groupingKey, agileContext, partitionId, lastPartitionInfo)));
+                    .thenApply(partitionId -> mergePartition(analyzerWrapper, groupingKey, agileContext, partitionId)));
         }
     }
 
     @Nonnull
-    private Boolean mergePartition(final LuceneAnalyzerWrapper analyzerWrapper, final Tuple groupingKey,
-                                   final AgilityContext agileContext, final Integer partitionId,
-                                   final AtomicReference<LucenePartitionInfoProto.LucenePartitionInfo> lastPartitionInfo) {
-        if (lastPartitionInfo.get() == null) {
+    private Boolean mergePartition(@Nonnull final LuceneAnalyzerWrapper analyzerWrapper, @Nonnull final Tuple groupingKey,
+                                   @Nonnull final AgilityContext agileContext, @Nullable final Integer partitionId) {
+        if (partitionId == null) {
             return false;
         } else {
             try {
@@ -173,7 +172,8 @@ public class FDBDirectoryManager implements AutoCloseable {
         }
     }
 
-    private CompletableFuture<Integer> getNextPartitionInfo(final Tuple groupingKey, final AgilityContext agileContext, final AtomicReference<LucenePartitionInfoProto.LucenePartitionInfo> lastPartitionInfo) {
+    private CompletableFuture<Integer> getNextPartitionInfo(final Tuple groupingKey, final AgilityContext agileContext,
+                                                            final AtomicReference<LucenePartitionInfoProto.LucenePartitionInfo> lastPartitionInfo) {
         return agileContext.apply(context -> LucenePartitioner.getNextPartitionInfo(
                         context, groupingKey, lastPartitionInfo.get(), state.indexSubspace)
                 .thenApply(partitionInfo -> {
@@ -247,7 +247,6 @@ public class FDBDirectoryManager implements AutoCloseable {
         }
         return createdDirectories.computeIfAbsent(mapKey, key -> new FDBDirectoryWrapper(state, key, mergeDirectoryCount, agilityContext));
     }
-
 
     private AgilityContext getAgilityContext(boolean useAgilityContext) {
         final IndexDeferredMaintenanceControl deferredControl = state.store.getIndexDeferredMaintenanceControl();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -98,7 +98,7 @@ public class FDBDirectoryManager implements AutoCloseable {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    public CompletableFuture<Void> mergeIndex(LucenePartitioner partitioner, LuceneAnalyzerWrapper analyzerWrapper) {
+    public CompletableFuture<Void> mergeIndex(@Nonnull LucenePartitioner partitioner, LuceneAnalyzerWrapper analyzerWrapper) {
         // This function will iterate the grouping keys and explicitly merge each
 
         final ScanProperties scanProperties = ScanProperties.FORWARD_SCAN.with(
@@ -133,8 +133,9 @@ public class FDBDirectoryManager implements AutoCloseable {
                         2);
     }
 
-    private CompletableFuture<Void> mergeIndex(LuceneAnalyzerWrapper analyzerWrapper, Tuple groupingKey, @Nullable LucenePartitioner partitioner, final AgilityContext agileContext) {
-        if (partitioner == null) {
+    private CompletableFuture<Void> mergeIndex(LuceneAnalyzerWrapper analyzerWrapper, Tuple groupingKey,
+                                               @Nonnull LucenePartitioner partitioner, final AgilityContext agileContext) {
+        if (!partitioner.isPartitioningEnabled()) {
             try {
                 getDirectoryWrapper(groupingKey, null, agileContext).mergeIndex(analyzerWrapper);
                 return AsyncUtil.DONE;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -159,7 +159,7 @@ class FDBDirectoryWrapper implements AutoCloseable {
 
     @Nonnull
     @SuppressWarnings("PMD.CloseResource")
-    public IndexWriter getWriter(LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
+    public IndexWriter getWriter(@Nonnull LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
         if (writer == null || !writerAnalyzerId.equals(analyzerWrapper.getUniqueIdentifier())) {
             synchronized (this) {
                 if (writer == null || !writerAnalyzerId.equals(analyzerWrapper.getUniqueIdentifier())) {
@@ -209,7 +209,7 @@ class FDBDirectoryWrapper implements AutoCloseable {
         directory.close();
     }
 
-    public void mergeIndex(LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
+    public void mergeIndex(@Nonnull LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
         getWriter(analyzerWrapper).maybeMerge();
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -850,7 +850,9 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                 Stream.of(
                         Arguments.of(13L),
                         Arguments.of(-644766138635622644L),
-                        Arguments.of(-1089113174774589435L)),
+                        Arguments.of(-1089113174774589435L),
+                        Arguments.of(6223372946177329440L),
+                        Arguments.of(-4003151658223916927L)),
                 RandomizedTestUtils.randomArguments(random -> Arguments.of(random.nextLong())));
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -1049,7 +1049,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         // partition 0 should be at capacity now
         try (FDBRecordContext context = openContext(contextProps)) {
             schemaSetup.accept(context);
-            validateDocsInPartition(index, 0, groupingKey, totalDocCount, makeKeyTuples(docGroupFieldValue, 1000, 1009), "text:propose");
+            validateDocsInPartition(index, 0, groupingKey, makeKeyTuples(docGroupFieldValue, 1000, 1009), "text:propose");
         }
 
         // now add 20 documents older than the oldest document in partition 0
@@ -1059,8 +1059,8 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             for (int i = 0; i < 20; i++) {
                 recordStore.saveRecord(createComplexDocument(1000L + totalDocCount + i, ENGINEER_JOKE, docGroupFieldValue, start - i - 1));
             }
-            validateDocsInPartition(index, 1, groupingKey, 10, makeKeyTuples(docGroupFieldValue, 1010, 1019), "text:propose");
-            validateDocsInPartition(index, 2, groupingKey, 10, makeKeyTuples(docGroupFieldValue, 1020, 1029), "text:propose");
+            validateDocsInPartition(index, 1, groupingKey, makeKeyTuples(docGroupFieldValue, 1010, 1019), "text:propose");
+            validateDocsInPartition(index, 2, groupingKey, makeKeyTuples(docGroupFieldValue, 1020, 1029), "text:propose");
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -825,7 +825,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         final Map<Integer, Integer> segmentCounts = getSegmentCounts(index, groupingKey, contextProps, schemaSetup);
         assertThat(segmentCounts, Matchers.aMapWithSize(allIds.size() / 10));
         assertEquals(IntStream.range(0, allIds.size() / 10).boxed()
-                        .collect(Collectors.toMap(Function.identity(), partitionId -> 1)),
+                        .collect(Collectors.toMap(Function.identity(), partitionId -> 2)),
                 segmentCounts);
 //
 //        try (FDBRecordContext context = openContext(contextProps)) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -729,8 +729,8 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
     }
 
     private void validateDocsInPartition(Index index, int partitionId, Tuple groupingKey,
-                                         Set<Tuple> expectedIds, final String universalSearch) throws IOException {
-        LuceneIndexTestValidator.validateDocsInPartition(recordStore, index, partitionId, groupingKey, expectedIds, universalSearch);
+                                         Set<Tuple> expectedPrimaryKeys, final String universalSearch) throws IOException {
+        LuceneIndexTestValidator.validateDocsInPartition(recordStore, index, partitionId, groupingKey, expectedPrimaryKeys, universalSearch);
     }
 
     private Map<Integer, Integer> getSegmentCounts(Index index,

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
@@ -1,0 +1,241 @@
+/*
+ * LuceneIndexValidator.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager;
+import com.apple.foundationdb.record.lucene.search.LuceneOptimizedIndexSearcher;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.base.Verify;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocs;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A utility for validating the consistency and contents of a lucene index.
+ */
+public class LuceneIndexTestValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LuceneIndexTestValidator.class);
+    private final Supplier<FDBRecordContext> contextProvider;
+    private final Function<FDBRecordContext, FDBRecordStore> schemaSetup;
+
+    public LuceneIndexTestValidator(Supplier<FDBRecordContext> contextProvider, Function<FDBRecordContext, FDBRecordStore> schemaSetup) {
+        this.contextProvider = contextProvider;
+        this.schemaSetup = schemaSetup;
+    }
+
+    /**
+     * A broad validation of the lucene index, asserting consistency, and that various operations did what they were
+     * supposed to do.
+     * <p>
+     *     This has a lot of validation that could be added, and it would be good to be able to control whether it's
+     *     expected that `mergeIndex` had been run or not; right now it assumes it has been run.
+     * </p>
+     * @param index the index to validate
+     * @param expectedIds a map from group to primaryKey to timestamp
+     * @param repartitionCount the configured repartition count
+     * @param universalSearch a search that will return all the documents
+     * @throws IOException if there is any issue interacting with lucene
+     */
+    void validate(Index index, final Map<Integer, Map<Tuple, Long>> expectedIds,
+                  final int repartitionCount, final String universalSearch) throws IOException {
+        boolean isGrouped = index.getRootExpression() instanceof GroupingKeyExpression;
+        final int partitionHighWatermark = Integer.parseInt(index.getOption(LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK));
+        // If there is less than repartitionCount of free space in the older partition, we'll create a new partition
+        // rather than moving fewer than repartitionCount
+        int maxPerPartition = partitionHighWatermark;
+        int minPerPartition = partitionHighWatermark <= repartitionCount ?
+                               partitionHighWatermark :
+                               partitionHighWatermark - repartitionCount;
+
+        for (final Map.Entry<Integer, Map<Tuple, Long>> entry : expectedIds.entrySet()) {
+            final Integer group = entry.getKey();
+            LOGGER.debug(KeyValueLogMessage.of("Validating group",
+                    "group", group,
+                    "expectedCount", entry.getValue().size()));
+
+            final List<Tuple> records = entry.getValue().entrySet().stream()
+                    .sorted(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+            final Tuple groupingKey = isGrouped ? Tuple.from(group) : Tuple.from();
+            List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos = getPartitionMeta(index, groupingKey);
+            partitionInfos.sort(Comparator.comparing(info -> Tuple.fromBytes(info.getFrom().toByteArray())));
+            Set<Integer> usedIds = new HashSet<>();
+            Tuple lastToTuple = null;
+            int visitedCount = 0;
+            String allCounts = partitionInfos.stream()
+                    .map(info -> String.valueOf(info.getCount()))
+                    .collect(Collectors.joining(",", "[", "]"));
+
+            try (FDBRecordContext context = contextProvider.get()) {
+                final FDBRecordStore recordStore = schemaSetup.apply(context);
+
+                for (int i = 0; i < partitionInfos.size(); i++) {
+                    final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = partitionInfos.get(i);
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace("Group: " + group + " PartitionInfo[" + partitionInfo.getId() +
+                                "]: count:" + partitionInfo.getCount() + " " +
+                                Tuple.fromBytes(partitionInfo.getFrom().toByteArray()) + "-> " +
+                                Tuple.fromBytes(partitionInfo.getTo().toByteArray()));
+                    }
+
+                    assertThat(allCounts, partitionInfo.getCount(),
+                            Matchers.allOf(lessThanOrEqualTo(maxPerPartition), greaterThan(0)));
+                    // Depending on the relationship between repartitionCount and partitionHighWatermark
+                    // it's possible that either of the last element or the second to last element could be less than
+                    // the minPerPartition. I don't know the abstract logic, but an example would be that if the most
+                    // recent partition has 15, the high-watermark is 10, and the repartition is 10, it will move 10 out,
+                    // Resulting in the most recent having 5, and the one before having 10.
+                    // This seems reasonable in actual production situations where we would expect high-watermark to be
+                    // multiple orders of magnitude larger than the repartition count. (i.e. if the high watermark is
+                    // 500,000 it shouldn't matter if the actual document count is 499,990 or 499,995).
+                    // Avoiding this might also mean that you end up with excessive transactions if you are usually adding
+                    // to the most-recent partition, namely, it would keep rebalancing by moving 1 record at a time to
+                    // get it below the high watermark.
+
+                    // If there is only one partition, it's totally fine for it to be any value less than maxPerPartition
+                    if (i < partitionInfos.size() - 2) {
+                        assertThat(allCounts, partitionInfo.getCount(),
+                                Matchers.allOf(
+                                        greaterThanOrEqualTo(minPerPartition),
+                                        lessThanOrEqualTo(maxPerPartition)));
+                    }
+                    assertTrue(usedIds.add(partitionInfo.getId()), () -> "Duplicate id: " + partitionInfo);
+                    final Tuple fromTuple = Tuple.fromBytes(partitionInfo.getFrom().toByteArray());
+                    if (i > 0) {
+                        assertThat(fromTuple, greaterThan(lastToTuple));
+                    }
+                    lastToTuple = Tuple.fromBytes(partitionInfo.getTo().toByteArray());
+                    assertThat(fromTuple, lessThanOrEqualTo(lastToTuple));
+
+                    LOGGER.debug(KeyValueLogMessage.of("Visited partition",
+                            "group", group,
+                            "documentsSoFar", visitedCount,
+                            "documentsInGroup", records.size(),
+                            "partitionInfo.count", partitionInfo.getCount()));
+                    validateDocsInPartition(recordStore, index, partitionInfo.getId(), groupingKey,
+                            Set.copyOf(records.subList(visitedCount, visitedCount + partitionInfo.getCount())),
+                            universalSearch);
+                    visitedCount += partitionInfo.getCount();
+                }
+            }
+
+        }
+    }
+
+    private List<LucenePartitionInfoProto.LucenePartitionInfo> getPartitionMeta(Index index,
+                                                                                Tuple groupingKey) {
+        try (FDBRecordContext context = contextProvider.get()) {
+            final FDBRecordStore recordStore = schemaSetup.apply(context);
+            LuceneIndexMaintainer indexMaintainer = (LuceneIndexMaintainer) recordStore.getIndexMaintainer(index);
+            return indexMaintainer.getPartitioner().getAllPartitionMetaInfo(groupingKey).join();
+        }
+    }
+
+
+    private void validateDocsInPartition(final FDBRecordStore recordStore, Index index, int partitionId, Tuple groupingKey,
+                                         Set<Tuple> expectedIds, final String universalSearch) throws IOException {
+        LuceneScanQuery scanQuery;
+        if (groupingKey.isEmpty()) {
+            scanQuery = (LuceneScanQuery) LuceneIndexTestUtils.fullSortTextSearch(recordStore, index, universalSearch, null);
+        } else {
+            scanQuery = (LuceneScanQuery) groupedSortedTextSearch(recordStore, index,
+                    universalSearch,
+                    null,
+                    groupingKey.getLong(0));
+        }
+        final IndexReader indexReader = getIndexReader(recordStore, index, partitionId, groupingKey);
+        LuceneOptimizedIndexSearcher searcher = new LuceneOptimizedIndexSearcher(indexReader);
+        TopDocs newTopDocs = searcher.search(scanQuery.getQuery(), Integer.MAX_VALUE);
+
+        assertNotNull(newTopDocs);
+        assertNotNull(newTopDocs.scoreDocs);
+        assertEquals(expectedIds.size(), newTopDocs.scoreDocs.length);
+
+        Set<String> fields = Set.of(LuceneIndexMaintainer.PRIMARY_KEY_FIELD_NAME);
+        Assertions.assertEquals(expectedIds.stream().sorted().collect(Collectors.toList()), Arrays.stream(newTopDocs.scoreDocs)
+                        .map(scoreDoc -> {
+                            try {
+                                Document document = searcher.doc(scoreDoc.doc, fields);
+                                IndexableField primaryKey = document.getField(LuceneIndexMaintainer.PRIMARY_KEY_FIELD_NAME);
+                                return Tuple.fromBytes(primaryKey.binaryValue().bytes);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .sorted()
+                        .collect(Collectors.toList()),
+                () -> index.getRootExpression() + " " + groupingKey + ":" + partitionId);
+    }
+
+    private IndexReader getIndexReader(final FDBRecordStore recordStore, final Index index, final int partitionId, final Tuple groupingKey) throws IOException {
+        IndexMaintainerState state = new IndexMaintainerState(recordStore, index, recordStore.getIndexMaintenanceFilter());
+        return FDBDirectoryManager.getManager(state).getIndexReader(groupingKey, partitionId);
+    }
+
+    private LuceneScanBounds groupedSortedTextSearch(final FDBRecordStoreBase<?> recordStore, Index index, String search, Sort sort, Object group) {
+        LuceneScanParameters scan = new LuceneScanQueryParameters(
+                Verify.verifyNotNull(ScanComparisons.from(new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, group))),
+                new LuceneQuerySearchClause(LuceneQueryType.QUERY, search, false),
+                sort,
+                null,
+                null,
+                null);
+
+        return scan.bind(recordStore, index, EvaluationContext.EMPTY);
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
@@ -187,8 +187,8 @@ public class LuceneIndexTestValidator {
     }
 
 
-    private void validateDocsInPartition(final FDBRecordStore recordStore, Index index, int partitionId, Tuple groupingKey,
-                                         Set<Tuple> expectedIds, final String universalSearch) throws IOException {
+    public static void validateDocsInPartition(final FDBRecordStore recordStore, Index index, int partitionId, Tuple groupingKey,
+                                               Set<Tuple> expectedIds, final String universalSearch) throws IOException {
         LuceneScanQuery scanQuery;
         if (groupingKey.isEmpty()) {
             scanQuery = (LuceneScanQuery) LuceneIndexTestUtils.fullSortTextSearch(recordStore, index, universalSearch, null);
@@ -222,12 +222,12 @@ public class LuceneIndexTestValidator {
                 () -> index.getRootExpression() + " " + groupingKey + ":" + partitionId);
     }
 
-    private IndexReader getIndexReader(final FDBRecordStore recordStore, final Index index, final int partitionId, final Tuple groupingKey) throws IOException {
+    public static IndexReader getIndexReader(final FDBRecordStore recordStore, final Index index, final int partitionId, final Tuple groupingKey) throws IOException {
         IndexMaintainerState state = new IndexMaintainerState(recordStore, index, recordStore.getIndexMaintenanceFilter());
         return FDBDirectoryManager.getManager(state).getIndexReader(groupingKey, partitionId);
     }
 
-    private LuceneScanBounds groupedSortedTextSearch(final FDBRecordStoreBase<?> recordStore, Index index, String search, Sort sort, Object group) {
+    public static LuceneScanBounds groupedSortedTextSearch(final FDBRecordStoreBase<?> recordStore, Index index, String search, Sort sort, Object group) {
         LuceneScanParameters scan = new LuceneScanQueryParameters(
                 Verify.verifyNotNull(ScanComparisons.from(new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, group))),
                 new LuceneQuerySearchClause(LuceneQueryType.QUERY, search, false),

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -167,6 +167,11 @@ tasks.withType(Test).configureEach { task ->
         }
         if (!project.hasProperty('tests.includeRandom')) {
             task.testFramework.options.excludeTags.add('Random')
+        } else {
+            systemProperties['tests.includeRandom'] = 'true'
+        }
+        if (project.hasProperty('tests.iterations')) {
+            systemProperties['tests.iterations'] = project.getProperty('tests.iterations')
         }
         task.testFramework.options.excludeTags.add('Performance')
     }


### PR DESCRIPTION
The main change here is that this uses multiple transactions to move documents between partitions. It also ensures that merge happens on all partitions.
This is a rather simplistic implementation, with a fixed property for how many to move per transaction.
In order to test all the permutations this adds some randomized tests that create a bunch of random data, in a single, most-recent partition and then runs the mergeIndex to move them between partitions.

It also does a few other things:
1. The search used in getOldestNDocuments was not right, and wasn't sorting properly
2. The JOINED index used in tests has the sort added
3. It changes the tuple at the beginnig by doing `groupKey.add()` rather than using a nested tuple.