### PR TITLE
Set release option during Java builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,9 @@ subprojects {
 
                 //enable incremental compilation
                 options.incremental = true
+
+                //target byte-code compatibility with Java 11 (regardless of build JDK)
+                options.release = 11
             }
         }
     }


### PR DESCRIPTION
This configures the Java builds to set the release option to fix the byte code to JDK 11. This will allow us to move our build instance forward to JDK 17 without needing to worry about breaking compatibility with any JDK 11 consumers of the project. This gets us ready for #2360