### PR TITLE
Fixes #2485: FDBExceptions::wrapException incorrectly wraps InterruptedExceptions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Bug fix** Sync files referencing FieldInfosId [(Issue #2455)](https://github.com/FoundationDB/fdb-record-layer/issues/2455)
 * **Bug fix** Support closing FDBIndexOutput [(Issue #2457)](https://github.com/FoundationDB/fdb-record-layer/issues/2457)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `FDBExceptions` now correctly wraps `InterruptedExceptions` instead of throwing an `IllegalArgumentException` [(Issue #2485)](https://github.com/FoundationDB/fdb-record-layer/issues/2485)
 * **Bug fix** Fix topological sort instability [(Issue #2476)](https://github.com/FoundationDB/fdb-record-layer/pull/2476)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
@@ -195,7 +195,7 @@ public class FDBExceptions {
         }
 
         if (ex instanceof InterruptedException) {
-            return new RecordCoreInterruptedException(ex.getMessage(), ex).addLogInfo(logInfo);
+            return new RecordCoreInterruptedException(ex.getMessage(), (InterruptedException)ex).addLogInfo(logInfo);
         }
         return new RecordCoreException(ex.getMessage(), ex).addLogInfo(logInfo);
     }


### PR DESCRIPTION
This updates the logic in `FDBExceptions::wrapException` to avoid an error with the message "Unbalanced key/value logging info". This was ultimately caused by a problem where the wrong constructor was being selected when creating the `RecordCoreInterruptedException`, so this adds a cast so that the signature now aligns with the correct constructor.

This fixes #2485.