### PR TITLE
RESOLVES #2494: Optimize insertion of older Lucene documents to avoid…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Feature** Allow running Lucene's tests with a random seed & multiple iterations [(Issue #2479)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Support rearranging documents between Lucene partitions [(Issue #2465)](https://github.com/FoundationDB/fdb-record-layer/issues/2465)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Optimize insertion of older Lucene documents to avoid unnecessary partition re-balancing [(Issue #2494)](https://github.com/FoundationDB/fdb-record-layer/issues/2494)
 * **Feature** The Cascades planner can now plan against aggregate indexes with repeated grouping columns [(Issue #2472)](https://github.com/FoundationDB/fdb-record-layer/issues/2472)
 * **Feature** Online Indexing: add reverse order option [(Issue #2474)](https://github.com/FoundationDB/fdb-record-layer/issues/2474)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -319,7 +319,21 @@ public class LucenePartitioner {
      */
     @Nonnull
     private CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getOrCreatePartitionInfo(@Nonnull Tuple groupKey, long timestamp) {
-        return assignPartitionInternal(groupKey, timestamp, true);
+        return assignPartitionInternal(groupKey, timestamp, true).thenCompose(assignedPartitionInfo -> {
+            // optimization: if assigned partition is full and doc to be added is older than the partition's `from` timestamp,
+            // we create a new partition for it, in order to avoid unnecessary re-balancing later.
+            if (assignedPartitionInfo.getCount() >= indexPartitionHighWatermark && timestamp < getFrom(assignedPartitionInfo)) {
+                return getAllPartitionMetaInfo(groupKey).thenApply(partitionInfos -> {
+                    int maxPartitionId = partitionInfos.stream()
+                            .map(LucenePartitionInfoProto.LucenePartitionInfo::getId)
+                            .max(Integer::compare)
+                            .orElse(0);
+                    return newPartitionMetadata(timestamp, maxPartitionId + 1);
+                });
+            }
+            // else
+            return CompletableFuture.completedFuture(assignedPartitionInfo);
+        });
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -843,12 +843,14 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             validateDocsInPartition(index, 0, groupingKey, totalDocCount, makeKeyTuples(docGroupFieldValue, 1000, 1009), "text:propose");
         }
 
-        // now add a document older than the oldest document in partition 0
-        // it should go into partition 1
+        // now add 5 documents older than the oldest document in partition 0
+        // they should go into partition 1
         try (FDBRecordContext context = openContext(contextProps)) {
             schemaSetup.accept(context);
-            recordStore.saveRecord(createComplexDocument(1000L + totalDocCount, ENGINEER_JOKE, docGroupFieldValue, start - 1));
-            validateDocsInPartition(index, 1, groupingKey, 1, makeKeyTuples(docGroupFieldValue, 1010, 1010), "text:propose");
+            for (int i = 0; i < 5; i++) {
+                recordStore.saveRecord(createComplexDocument(1000L + totalDocCount + i, ENGINEER_JOKE, docGroupFieldValue, start - i - 1));
+            }
+            validateDocsInPartition(index, 1, groupingKey, 5, makeKeyTuples(docGroupFieldValue, 1010, 1014), "text:propose");
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -647,12 +647,12 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         }
     }
 
-    static Stream<Pair<Index, Tuple>> repartitionGroupedTest() {
+    static Stream<Pair<Index, Tuple>> dualGroupModeIndexProvider() {
         return Stream.of(Pair.of(COMPLEX_PARTITIONED, Tuple.from(1L)), Pair.of(COMPLEX_PARTITIONED_NOGROUP, Tuple.from()));
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource(value = {"dualGroupModeIndexProvider"})
     void repartitionGroupedTest(Pair<Index, Tuple> indexAndGroupingKey) throws IOException {
         Index index = indexAndGroupingKey.getLeft();
         Tuple groupingKey = indexAndGroupingKey.getRight();
@@ -811,6 +811,44 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
                     totalDocCount - 6, Set.copyOf(ids.subList(6, totalDocCount)), "simple_text:propose");
             validateDocsInPartition(JOINED_INDEX, 1, groupingKey,
                     6, Set.copyOf(ids.subList(0, 6)), "simple_text:propose");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = {"dualGroupModeIndexProvider"})
+    void optimizedPartitionInsertionTest(Pair<Index, Tuple> indexAndGroupingKey) throws IOException {
+        Index index = indexAndGroupingKey.getLeft();
+        Tuple groupingKey = indexAndGroupingKey.getRight();
+        final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
+                .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 6)
+                .build();
+
+        final int totalDocCount = 10; // configured index's highwater mark
+        Consumer<FDBRecordContext> schemaSetup = context -> rebuildIndexMetaData(context, COMPLEX_DOC, index);
+        long docGroupFieldValue = groupingKey.isEmpty() ? 0L : groupingKey.getLong(0);
+
+        // create/save documents
+        long start = Instant.now().toEpochMilli();
+        try (FDBRecordContext context = openContext(contextProps)) {
+            schemaSetup.accept(context);
+            for (int i = 0; i < totalDocCount; i++) {
+                recordStore.saveRecord(createComplexDocument(1000L + i, ENGINEER_JOKE, docGroupFieldValue, start + i * 100));
+            }
+            commit(context);
+        }
+
+        // partition 0 should be at capacity now
+        try (FDBRecordContext context = openContext(contextProps)) {
+            schemaSetup.accept(context);
+            validateDocsInPartition(index, 0, groupingKey, totalDocCount, makeKeyTuples(docGroupFieldValue, 1000, 1009), "text:propose");
+        }
+
+        // now add a document older than the oldest document in partition 0
+        // it should go into partition 1
+        try (FDBRecordContext context = openContext(contextProps)) {
+            schemaSetup.accept(context);
+            recordStore.saveRecord(createComplexDocument(1000L + totalDocCount, ENGINEER_JOKE, docGroupFieldValue, start - 1));
+            validateDocsInPartition(index, 1, groupingKey, 1, makeKeyTuples(docGroupFieldValue, 1010, 1010), "text:propose");
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -843,14 +843,15 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             validateDocsInPartition(index, 0, groupingKey, totalDocCount, makeKeyTuples(docGroupFieldValue, 1000, 1009), "text:propose");
         }
 
-        // now add 5 documents older than the oldest document in partition 0
-        // they should go into partition 1
+        // now add 20 documents older than the oldest document in partition 0
+        // they should go into partitions 1 and 2
         try (FDBRecordContext context = openContext(contextProps)) {
             schemaSetup.accept(context);
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < 20; i++) {
                 recordStore.saveRecord(createComplexDocument(1000L + totalDocCount + i, ENGINEER_JOKE, docGroupFieldValue, start - i - 1));
             }
-            validateDocsInPartition(index, 1, groupingKey, 5, makeKeyTuples(docGroupFieldValue, 1010, 1014), "text:propose");
+            validateDocsInPartition(index, 1, groupingKey, 10, makeKeyTuples(docGroupFieldValue, 1010, 1019), "text:propose");
+            validateDocsInPartition(index, 2, groupingKey, 10, makeKeyTuples(docGroupFieldValue, 1020, 1029), "text:propose");
         }
     }
 


### PR DESCRIPTION
… partition re-balancing

- when a document being inserted is assigned to a partition that's at or higher than its high watermark, and the document's timestamp is older than all documents in the partition, create a new partition for the inserted document. This avoids re-balancing of the full partition later.