### PR TITLE
Resolves #2493: PlanOrderingKey too strict when computing order for In union

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -31,6 +31,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** The Cascades planner can now plan against aggregate indexes with repeated grouping columns [(Issue #2472)](https://github.com/FoundationDB/fdb-record-layer/issues/2472)
 * **Feature** Online Indexing: add reverse order option [(Issue #2474)](https://github.com/FoundationDB/fdb-record-layer/issues/2474)
+* **Feature** The planner will now select in-union plans in cases when the index contains additional columns that are not specified in the requested ordering [(Issue #2493)](https://github.com/FoundationDB/fdb-record-layer/issues/2493)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -611,6 +611,7 @@ public class RecordQueryPlanner implements QueryPlanner {
         return planContext.rankComparisons.getPlanComparison(asEquals) != null;
     }
 
+    @Nullable
     private ScoredPlan planFilterWithInUnion(@Nonnull PlanContext planContext, @Nonnull InExtractor inExtractor) {
         final ScoredPlan scoredPlan = planFilterForInJoin(planContext, inExtractor.subFilter(), true);
         if (scoredPlan != null) {
@@ -618,8 +619,16 @@ public class RecordQueryPlanner implements QueryPlanner {
             if (scoredPlan.planOrderingKey == null) {
                 return null;
             }
-            final KeyExpression candidateKey = getKeyForMerge(planContext.query.getSort(), planContext.commonPrimaryKey);
-            final KeyExpression comparisonKey = PlanOrderingKey.mergedComparisonKey(Collections.singletonList(scoredPlan), candidateKey, true);
+            @Nullable final KeyExpression candidateKey;
+            boolean candidateOnly;
+            if (getConfiguration().shouldOmitPrimaryKeyInOrderingKeyForInUnion()) {
+                candidateKey = planContext.query.getSort();
+                candidateOnly = false;
+            } else {
+                candidateKey = getKeyForMerge(planContext.query.getSort(), planContext.commonPrimaryKey);
+                candidateOnly = true;
+            }
+            final KeyExpression comparisonKey = PlanOrderingKey.mergedComparisonKey(Collections.singletonList(scoredPlan), candidateKey, candidateOnly);
             if (comparisonKey == null) {
                 return null;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -265,6 +265,13 @@ public class RecordQueryPlanMatchers {
     }
 
     @Nonnull
+    public static BindingMatcher<RecordQueryPlan> isNotReverse() {
+        return typedWithDownstream(RecordQueryPlan.class,
+                Extractor.of(RecordQueryPlan::isReverse, name -> "isNotReversed(" + name + ")"),
+                PrimitiveMatchers.equalsObject(false));
+    }
+
+    @Nonnull
     public static BindingMatcher<RecordQueryPlanWithIndex> indexName(@Nonnull String indexName) {
         return typedWithDownstream(RecordQueryPlanWithIndex.class,
                 Extractor.of(RecordQueryPlanWithIndex::getIndexName, name -> "indexName(" + name + ")"),
@@ -577,6 +584,13 @@ public class RecordQueryPlanMatchers {
     @Nonnull
     public static BindingMatcher<RecordQueryInUnionOnValuesPlan> inUnionOnValuesPlan(@Nonnull final BindingMatcher<? extends RecordQueryPlan> downstream) {
         return childrenPlans(RecordQueryInUnionOnValuesPlan.class, all(downstream));
+    }
+
+    @Nonnull
+    public static BindingMatcher<RecordQueryInUnionOnValuesPlan> inUnionComparisonValues(@Nonnull CollectionMatcher<? extends Value> comparisonValuesMatcher) {
+        return typedWithDownstream(RecordQueryInUnionOnValuesPlan.class,
+                Extractor.of(RecordQueryInUnionOnValuesPlan::getComparisonKeyValues, name -> "comparisonValues(" + name + ")"),
+                comparisonValuesMatcher);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
@@ -123,9 +123,13 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.coveringIndexPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.fetchFromPartialRecordPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.filterPlan;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.inUnionComparisonKey;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.inUnionOnExpressionPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexName;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlanOf;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.isNotReverse;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.isReverse;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.queryComponents;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.scanComparisons;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.unionOnExpressionPlan;
@@ -136,6 +140,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -694,6 +699,160 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
                     }
                 }
             }
+        }
+    }
+
+    @ParameterizedTest(name = "inFilterOnKeyAndOrderByValue[reverse={0}]")
+    @BooleanSource
+    void inFilterOnKeyAndOrderByValue(boolean reverse) {
+        final Index unnestedOtherKeyValueIndex = new Index("unnestedOtherKeyValue",
+                concat(field(PARENT_CONSTITUENT).nest("other_id"), field("entry").nest(concatenateFields("key", "value"))));
+        final RecordMetaDataHook hook = addUnnestedType()
+                .andThen(metaData -> {
+                    final RecordTypeBuilder outerRecord = metaData.getRecordType("OuterRecord");
+                    outerRecord.setPrimaryKey(concatenateFields("other_id", "rec_id"));
+
+                    metaData.addIndex(OUTER_WITH_ENTRIES, unnestedOtherKeyValueIndex);
+                });
+        final List<TestRecordsNestedMapProto.OuterRecord> data = setUpData(hook);
+        final Set<Long> otherIds = data.stream().map(TestRecordsNestedMapProto.OuterRecord::getOtherId).collect(Collectors.toSet());
+        assertThat(otherIds, not(empty()));
+        final Set<String> keys = mapKeys(data);
+        assertThat(keys, not(empty()));
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenMapStore(context, hook);
+
+            final String otherParam = "otherParam";
+            final String keyListParam = "keyListParam";
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType(OUTER_WITH_ENTRIES)
+                    .setFilter(
+                            Query.and(
+                                    Query.field(PARENT_CONSTITUENT).matches(
+                                            Query.field("other_id").equalsParameter(otherParam)),
+                                    Query.field("entry").matches(Query.field("key").in(keyListParam))
+                            )
+                    )
+                    .setSort(field("entry").nest("value"), reverse)
+                    .build();
+
+            planner.setConfiguration(planner.getConfiguration().asBuilder()
+                    .setOmitPrimaryKeyInOrderingKeyForInUnion(true)
+                    .setAttemptFailedInJoinAsUnionMaxSize(100)
+                    .build());
+            final RecordQueryPlan plan = planQuery(query);
+            assertEquals(reverse, plan.isReverse());
+            final List<KeyExpression> comparisonKeyComponents = ImmutableList.<KeyExpression>builder()
+                    .add(field("entry").nest("value"))
+                    .addAll(recordStore.getRecordMetaData().getSyntheticRecordType(OUTER_WITH_ENTRIES).getPrimaryKey().normalizeKeyForPositions())
+                    .build();
+            assertThat(comparisonKeyComponents, hasSize(4));
+            assertEquals(5, comparisonKeyComponents.stream().mapToInt(KeyExpression::getColumnSize).sum());
+            assertMatchesExactly(plan, inUnionOnExpressionPlan(indexPlan()
+                    .where(indexName(unnestedOtherKeyValueIndex.getName()))
+                    .and(scanComparisons(range("[EQUALS $" + otherParam + ", EQUALS $__in_key__0]")))
+                    .and(reverse ? isReverse() : isNotReverse())
+            ).where(inUnionComparisonKey(list(comparisonKeyComponents))));
+            assertEquals(reverse ? -1181713337L : -1181714298L, plan.planHash(CURRENT_LEGACY));
+            assertEquals(reverse ? 1959162892L : 1959341638L, plan.planHash(CURRENT_FOR_CONTINUATION));
+
+            for (long otherId : otherIds) {
+                for (String key1 : keys) {
+                    for (String key2 : keys) {
+                        final List<Pair<TestRecordsNestedMapProto.OuterRecord, TestRecordsNestedMapProto.MapRecord.Entry>> expected = data.stream()
+                                .filter(rec -> rec.getOtherId() == otherId)
+                                .flatMap(rec -> rec.getMap().getEntryList().stream()
+                                        .filter(entry -> entry.getKey().equals(key1) || entry.getKey().equals(key2))
+                                        .map(entry -> Pair.of(rec, entry)))
+                                .sorted((p1, p2) -> {
+                                    int comparison = p1.getRight().getValue().compareTo(p2.getRight().getValue());
+                                    if (comparison != 0) {
+                                        return reverse ? (comparison * -1) : comparison;
+                                    }
+                                    comparison = Long.compare(p1.getLeft().getRecId(), p2.getLeft().getRecId());
+                                    if (comparison != 0) {
+                                        return reverse ? (comparison * -1) : comparison;
+                                    }
+                                    comparison = Integer.compare(p1.getLeft().getMap().getEntryList().indexOf(p1.getRight()), p2.getLeft().getMap().getEntryList().indexOf(p2.getRight()));
+                                    return reverse ? (comparison * -1) : comparison;
+                                })
+                                .collect(Collectors.toList());
+
+                        final Bindings bindings = Bindings.newBuilder()
+                                .set(otherParam, otherId)
+                                .set(keyListParam, List.of(key1, key2))
+                                .build();
+                        final EvaluationContext evaluationContext = EvaluationContext.forBindings(bindings);
+                        final List<Pair<TestRecordsNestedMapProto.OuterRecord, TestRecordsNestedMapProto.MapRecord.Entry>> queried = plan.execute(recordStore, evaluationContext)
+                                .map(FDBQueriedRecord::getSyntheticRecord)
+                                .map(synthetic -> {
+                                    TestRecordsNestedMapProto.OuterRecord outer = TestRecordsNestedMapProto.OuterRecord.newBuilder()
+                                            .mergeFrom(synthetic.getConstituent(PARENT_CONSTITUENT).getRecord())
+                                            .build();
+                                    TestRecordsNestedMapProto.MapRecord.Entry entry = TestRecordsNestedMapProto.MapRecord.Entry.newBuilder()
+                                            .mergeFrom(synthetic.getConstituent("entry").getRecord())
+                                            .build();
+                                    return Pair.of(outer, entry);
+                                })
+                                .asList()
+                                .join();
+                        assertEquals(expected, queried);
+                    }
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "inFilterOrderByValueAsOr[reverse={0}]")
+    @BooleanSource
+    void inFilterOrderByValueAsOr(boolean reverse) {
+        final Index unnestedOtherKeyValueIndex = new Index("unnestedOtherKeyValue",
+                concat(field(PARENT_CONSTITUENT).nest("other_id"), field("entry").nest(concatenateFields("key", "value"))));
+        final RecordMetaDataHook hook = addUnnestedType()
+                .andThen(metaData -> {
+                    final RecordTypeBuilder outerRecord = metaData.getRecordType("OuterRecord");
+                    outerRecord.setPrimaryKey(concatenateFields("other_id", "rec_id"));
+
+                    metaData.addIndex(OUTER_WITH_ENTRIES, unnestedOtherKeyValueIndex);
+                });
+        final List<TestRecordsNestedMapProto.OuterRecord> data = setUpData(hook);
+        final Set<Long> otherIds = data.stream().map(TestRecordsNestedMapProto.OuterRecord::getOtherId).collect(Collectors.toSet());
+        assertThat(otherIds, not(empty()));
+        final Set<String> keys = mapKeys(data);
+        assertThat(keys, not(empty()));
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenMapStore(context, hook);
+
+            final long otherId = 1L;
+            assertThat(otherId, in(otherIds));
+            final List<String> keyList = List.of("2", "4", "6");
+            keyList.forEach(key -> assertThat(key, in(keys)));
+
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType(OUTER_WITH_ENTRIES)
+                    .setFilter(
+                            Query.and(
+                                    Query.field(PARENT_CONSTITUENT).matches(
+                                            Query.field("other_id").equalsValue(otherId)),
+                                    Query.field("entry").matches(Query.field("key").in(keyList))
+                            )
+                    )
+                    .setSort(field("entry").nest("value"), reverse)
+                    .build();
+
+            planner.setConfiguration(planner.getConfiguration().asBuilder()
+                    .setAttemptFailedInJoinAsOr(true)
+                    .setOmitPrimaryKeyInUnionOrderingKey(true)
+                    .setNormalizeNestedFields(true)
+                    .build());
+            // The way the Boolean expression is normalized after replacing the IN with an OR results in an expression
+            // that is not matched, so query planning fails. This could be fixed by using the BooleanNormalizer
+            // after re-writing the query, but this code path is more-or-less deprecated in favor of planning as
+            // an in-union, so just assert that this fails until we start planning this as an ordinary union
+            final RecordCoreException rce = assertThrows(RecordCoreException.class, () -> planQuery(query));
+            assertThat(rce.getMessage(), containsString("Cannot sort without appropriate index"));
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSortQueryIndexSelectionTest.java
@@ -327,7 +327,7 @@ class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase {
                                             int expectedReturn,
                                             int maxDiscarded,
                                             @Nonnull Matcher<RecordQueryPlan> planMatcher,
-                                            @Nonnull TestHelpers.DangerousConsumer<TestRecords1Proto.MySimpleRecord.Builder> checkRecord) throws Exception {
+                                            @Nonnull TestHelpers.DangerousConsumer<TestRecords1Proto.MySimpleRecord> checkRecord) throws Exception {
         RecordQuery query = RecordQuery.newBuilder()
                 .setRecordType("MySimpleRecord")
                 .setFilter(filter)
@@ -338,14 +338,14 @@ class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase {
         assertEquals(planHash, plan.planHash(PlanHashable.CURRENT_LEGACY), "unexpected plan hash for filter: " + filter);
 
         AtomicLong lastId = new AtomicLong(reverse ? Long.MAX_VALUE : Long.MIN_VALUE);
-        int returned = querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty, builder -> {
-            checkRecord.accept(builder);
+        int returned = querySimpleRecordStore(NO_HOOK, plan, EvaluationContext::empty, rec -> {
+            checkRecord.accept(rec);
             if (reverse) {
-                assertThat(builder.getRecNo(), lessThan(lastId.get()));
+                assertThat(rec.getRecNo(), lessThan(lastId.get()));
             } else {
-                assertThat(builder.getRecNo(), greaterThan(lastId.get()));
+                assertThat(rec.getRecNo(), greaterThan(lastId.get()));
             }
-            lastId.set(builder.getRecNo());
+            lastId.set(rec.getRecNo());
         }, context -> assertDiscardedAtMost(maxDiscarded, context));
 
         assertEquals(expectedReturn, returned, "unexpected return count for filter: " + filter);
@@ -356,7 +356,7 @@ class FDBSortQueryIndexSelectionTest extends FDBRecordStoreQueryTestBase {
                                             boolean reverse,
                                             int planHash,
                                             int expectedReturn,
-                                            @Nonnull TestHelpers.DangerousConsumer<TestRecords1Proto.MySimpleRecord.Builder> checkRecord) throws Exception {
+                                            @Nonnull TestHelpers.DangerousConsumer<TestRecords1Proto.MySimpleRecord> checkRecord) throws Exception {
         sortByPrimaryKeyWithFilter(
                 filter,
                 reverse,


### PR DESCRIPTION
This takes basically the same approach that was taken for #2350, but this time applying it to `InUnion` plans rather than just regular union plans.

This change is guarded behind a planner configuration plan. This is necessary because the new algorithm can choose new ordering keys for the in-union, and so the user needs to be able to control its roll out. This is to mirror what we did with #2408.

This resolves #2493.