### PR TITLE
Resolves #2503: Use Locale.ROOT when parsing lucene queries

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Use Locale.ROOT when parsing lucene queries [(Issue #2503)](https://github.com/FoundationDB/fdb-record-layer/issues/2503)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -158,14 +159,14 @@ public class LuceneIndexExpressions {
         public PointsConfig getPointsConfig() {
             switch (type) {
                 case INT:
-                    return new PointsConfig(NumberFormat.getInstance(), Integer.class);
+                    return new PointsConfig(NumberFormat.getInstance(Locale.ROOT), Integer.class);
                 case LONG:
-                    return new PointsConfig(NumberFormat.getInstance(), Long.class);
+                    return new PointsConfig(NumberFormat.getInstance(Locale.ROOT), Long.class);
                 case DOUBLE:
-                    return new PointsConfig(NumberFormat.getInstance(), Double.class);
+                    return new PointsConfig(NumberFormat.getInstance(Locale.ROOT), Double.class);
                 case BOOLEAN:
                     //booleans are weird, they are put in here to allow us to catch boolean fields in the parser
-                    return new BooleanPointsConfig(NumberFormat.getInstance());
+                    return new BooleanPointsConfig(NumberFormat.getInstance(Locale.ROOT));
                 case STRING:
                 case TEXT:
                 default:

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
@@ -1,0 +1,135 @@
+/*
+ * FDBLuceneHighlightingTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.highlight;
+
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.lucene.LuceneIndexTestUtils;
+import com.apple.foundationdb.record.lucene.synonym.EnglishSynonymMapConfig;
+import com.apple.foundationdb.record.lucene.synonym.SynonymMapRegistryImpl;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.FDBIndexedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOrphanBehavior;
+import com.apple.foundationdb.record.query.plan.QueryPlanner;
+import com.google.protobuf.Message;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static com.apple.foundationdb.record.lucene.LuceneIndexTestUtils.TEXT_AND_STORED_COMPLEX;
+import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.COMPLEX_DOC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests to make sure Lucene isn't using the default system locale.
+ * <p>
+ *     At some point, we may want to make the locale used for query parsing into an index option, or
+ *     {@link com.apple.foundationdb.record.lucene.LuceneRecordContextProperties}, but for now it is just set to
+ *     {@link Locale#ROOT}.
+ * </p>
+ */
+public class LuceneLocaleTest extends FDBRecordStoreTestBase {
+
+    @BeforeAll
+    public static void setup() {
+        //set up the English Synonym Map so that we don't spend forever setting it up for every test, because this takes a long time
+        SynonymMapRegistryImpl.instance().getSynonymMap(EnglishSynonymMapConfig.ExpandedEnglishSynonymMapConfig.CONFIG_NAME);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"default", "en_US", "de", "de_DE", "fr"})
+    void highlightedNumberRangeQuery(Locale locale) {
+        final Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(locale);
+            try (FDBRecordContext context = openContext()) {
+                rebuildIndexMetaData(context, COMPLEX_DOC, TEXT_AND_STORED_COMPLEX);
+                recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(1623L, "Hello record layer", "Hello record layer 2", 5, 1_234_097, false, 8.123));
+
+                Assertions.assertAll(
+                        () -> assertHighlightMatches("text: record AND group: [-12,340,984 TO 42,938]"),
+                        () -> assertHighlightMatches("text: record AND score: [1,000,000 TO 1,500,000]"),
+                        () -> assertHighlightMatches("text: record AND time: [4.913442 TO 8.14234]"),
+                        () -> assertSearchMatches("text: record AND group: [-12,340,984 TO 42,938]"),
+                        () -> assertSearchMatches("text: record AND score: [1,000,000 TO 1,500,000]"),
+                        () -> assertSearchMatches("text: record AND time: [4.913442 TO 8.14234]"));
+            }
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
+    private void assertSearchMatches(String search) {
+        Assertions.assertEquals(List.of(1623L),
+                recordStore.fetchIndexRecords(
+                        recordStore.scanIndex(TEXT_AND_STORED_COMPLEX, LuceneIndexTestUtils.fullTextSearch(recordStore, TEXT_AND_STORED_COMPLEX, search, false), null, ScanProperties.FORWARD_SCAN),
+                        IndexOrphanBehavior.ERROR)
+                        .map(r -> r.getPrimaryKey().get(1))
+                        .asList().join());
+    }
+
+    private void assertHighlightMatches(final String search) {
+        assertRecordHighlights(List.of("Hello {record} layer"),
+                recordStore.fetchIndexRecords(
+                        recordStore.scanIndex(TEXT_AND_STORED_COMPLEX, LuceneIndexTestUtils.fullTextSearch(recordStore, TEXT_AND_STORED_COMPLEX, search, true), null, ScanProperties.FORWARD_SCAN),
+                        IndexOrphanBehavior.ERROR));
+    }
+    /* ***************************************************************************************************/
+    /*private helper methods*/
+
+
+    @SuppressWarnings("SameParameterValue") //deliberately placed here to make it easier to add new tests
+    private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useCascadesPlanner);
+        this.recordStore = pair.getLeft();
+        this.planner = pair.getRight();
+    }
+
+    private void assertRecordHighlights(List<String> texts, RecordCursor<FDBIndexedRecord<Message>> cursor) {
+        List<String> highlighted = new ArrayList<>();
+        cursor.forEach(rec -> {
+            for (HighlightedTerm highlightedTerm : LuceneHighlighting.highlightedTermsForMessage(FDBQueriedRecord.indexed(rec), null)) {
+                final StringBuilder str = new StringBuilder(highlightedTerm.getSummarizedText());
+                int offset = 0;
+                for (int p = 0; p < highlightedTerm.getNumHighlights(); p++) {
+                    int start = highlightedTerm.getHighlightStart(p);
+                    int end = highlightedTerm.getHighlightEnd(p);
+                    str.insert(offset + start, "{");
+                    offset++;
+                    str.insert(offset + end, "}");
+                    offset++;
+                }
+                highlighted.add(str.toString());
+            }
+        }).join();
+        assertEquals(texts, highlighted);
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
@@ -73,6 +73,8 @@ public class LuceneLocaleTest extends FDBRecordStoreTestBase {
             try (FDBRecordContext context = openContext()) {
                 rebuildIndexMetaData(context, COMPLEX_DOC, TEXT_AND_STORED_COMPLEX);
                 recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(1623L, "Hello record layer", "Hello record layer 2", 5, 1_234_097, false, 8.123));
+                recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(1623L, "Hello record layer", "Hello record layer 2", -110_000_000, 999_999, false, 4.134059823));
+                recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(1623L, "Hello record layer", "Hello record layer 2", 51_000, 2_000_000, false, 9.2));
 
                 Assertions.assertAll(
                         () -> assertHighlightMatches("text: record AND group: [-12,340,984 TO 42,938]"),

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -168,6 +168,14 @@ tasks.withType(Test).configureEach { task ->
         if (!project.hasProperty('tests.includeRandom')) {
             task.testFramework.options.excludeTags.add('Random')
         } else {
+            if (!project.hasProperty('randomTestsLocale')) {
+                def random = new Random()
+                def availableLocales = Locale.getAvailableLocales()
+                rootProject.ext.randomTestsLocale = availableLocales[random.nextInt(availableLocales.size())]
+                logger.warn("Running tests with locale: ${rootProject.ext.randomTestsLocale}")
+            }
+            task.systemProperty('user.language', rootProject.ext.randomTestsLocale.language)
+            task.systemProperty('user.country', rootProject.ext.randomTestsLocale.country)
             systemProperties['tests.includeRandom'] = 'true'
         }
         if (project.hasProperty('tests.iterations')) {


### PR DESCRIPTION
To help protect us in the future, I also changed it so that if you run with tests.includeRandom it will run with a random locale.