### PR TITLE
Fixes #2502: DeleteRecordsWhere should modify predicate for synthetic record types

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Indexes on synthetic types are now included in `deleteRecordsWhere` operations [(Issue #2502)](https://github.com/FoundationDB/fdb-record-layer/issues/2502)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
@@ -27,7 +27,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add map support for Maps in Lucene [(Issue #2488)](https://github.com/FoundationDB/fdb-record-layer/issues/2488)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Unnested record types now support range deletion via `deleteRecordsWhere` [(Issue #2502)](https://github.com/FoundationDB/fdb-record-layer/issues/2502)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Feature** Add map support for Maps in Lucene [(Issue #2488)](https://github.com/FoundationDB/fdb-record-layer/issues/2488)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Unnested record types now support range deletion via `deleteRecordsWhere` [(Issue #2502)](https://github.com/FoundationDB/fdb-record-layer/issues/2502)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Disabled indexes no longer participate in `deleteRecordsWhere` operations [(Issue #2505)](https://github.com/FoundationDB/fdb-record-layer/issues/2505)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1848,6 +1848,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 // record type key is different for the synthetic type and the requested type
                 return false;
             }
+            // Synthetic types nest stored records under named constituents. Find a constituent corresponding
+            // to the appropriate record type(s) under which the original predicate can be nested to find the
+            // set of index entries corresponding to the deleted stored records
             String constituentName = null;
             for (RecordType indexRecordType : recordTypesForIndex) {
                 final SyntheticRecordType<?> syntheticRecordType = (SyntheticRecordType<?>)indexRecordType;
@@ -1879,19 +1882,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             }
             if (constituentName == null) {
                 return false;
-            }
-            if (recordType != null) {
-                // In the first loop, we have validated that there is a single constituent that contains elements
-                // of the record type we're looking to delete. In this loop, make sure that there isn't a constituent
-                // with that name that is of a different type
-                for (RecordType indexRecordType : recordTypesForIndex) {
-                    final SyntheticRecordType<?> syntheticRecordType = (SyntheticRecordType<?>)indexRecordType;
-                    for (SyntheticRecordType.Constituent constituent : syntheticRecordType.getConstituents()) {
-                        if (constituentName.equals(constituent.getName()) && !recordType.equals(constituent.getRecordType())) {
-                            return false;
-                        }
-                    }
-                }
             }
             if (typelessComponent == null) {
                 // The only predicate was the one on type. If we get here, all records should be synthesized from the

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreDeleteWhereTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreDeleteWhereTest.java
@@ -367,6 +367,9 @@ public class FDBRecordStoreDeleteWhereTest extends FDBRecordStoreTestBase {
     @BooleanSource
     void testDeleteWherePermutedMinMax(boolean max) throws Exception {
         final Random random = new Random();
+        // Equivalent of to an index on:
+        //    path, min/max(rec_no), num
+        // That is, the aggregate is grouped by (path, num) but ordered first by path, then the aggregate, then num
         final Index extremumIndex = new Index("MyRecord$extremum_recno_by_num_by_path",
                 new GroupingKeyExpression(field("header").nest(concatenateFields("path", "num", "rec_no")), 1),
                 max ? IndexTypes.PERMUTED_MAX : IndexTypes.PERMUTED_MIN,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/UnnestedRecordTypeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/UnnestedRecordTypeTest.java
@@ -20,8 +20,10 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataProto;
@@ -32,14 +34,21 @@ import com.apple.foundationdb.record.TestRecordsImportedMapProto;
 import com.apple.foundationdb.record.TestRecordsNestedMapProto;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.SyntheticRecordType;
 import com.apple.foundationdb.record.metadata.UnnestedRecordType;
 import com.apple.foundationdb.record.metadata.UnnestedRecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression.FanType;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
+import com.apple.foundationdb.record.provider.foundationdb.query.FDBRecordStoreQueryTestBase;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.expressions.QueryComponent;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordFromStoredRecordPlan;
 import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordPlanner;
 import com.apple.foundationdb.tuple.Tuple;
@@ -54,24 +63,35 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
+import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlan;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.scanComparisons;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -80,7 +100,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests of the {@link UnnestedRecordType} class. Some of these tests may require access to an underlying FDB record store.
  */
 @Tag(Tags.RequiresFDB)
-class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
+class UnnestedRecordTypeTest extends FDBRecordStoreQueryTestBase {
     @Nonnull
     private static final String OUTER = "OuterRecord";
     @Nonnull
@@ -100,6 +120,10 @@ class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
     private static final String KEY_ONE_KEY_TWO_VALUE_ONE_VALUE_TWO_INDEX = "keyOneKeyTwoValueOneValueTwo";
     @Nonnull
     private static final String INNER_FOO_OUTER_BAR_INNER_BAR_INDEX = "innerFooOuterBarInnerBar";
+    @Nonnull
+    private static final String OTHER_KEY_ID_VALUE_INDEX = "otherKeyIdValue";
+    @Nonnull
+    private static final String MULTI_TYPE_DOUBLE_NESTED_INDEX = "multiTypeDoubleNested";
 
     @Nonnull
     private static RecordMetaData mapMetaData(@Nonnull RecordMetaDataHook hook) {
@@ -207,6 +231,51 @@ class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
     }
 
     @Nonnull
+    private static RecordMetaDataHook addOtherKeyIdValueIndex() {
+        return metaData -> {
+            final KeyExpression expr = concat(
+                    field(PARENT_CONSTITUENT).nest("other_id"),
+                    field("map_entry").nest("key"),
+                    field(PARENT_CONSTITUENT).nest("rec_id"),
+                    field("map_entry").nest("value")
+            );
+            metaData.addIndex(UNNESTED_MAP, new Index(OTHER_KEY_ID_VALUE_INDEX, expr));
+        };
+    }
+
+    @Nonnull
+    private static RecordMetaDataHook addMultiTypeDoubleUnnestedIndex() {
+        return addMultiTypeDoubleUnnestedIndex(concat(field(PARENT_CONSTITUENT).nest(field("middle").nest("other_int")), field("inner").nest("foo")));
+    }
+
+    @Nonnull
+    private static RecordMetaDataHook addMultiTypeDoubleUnnestedIndex(@Nonnull KeyExpression rootExpression) {
+        return addDoubleNestedType().andThen(metaDataBuilder -> {
+            UnnestedRecordTypeBuilder secondUnnested = metaDataBuilder.addUnnestedRecordType("MiddleUnnested");
+            secondUnnested.addParentConstituent(PARENT_CONSTITUENT, metaDataBuilder.getRecordType("MiddleRecord"));
+            secondUnnested.addNestedConstituent("inner", TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.InnerRecord.getDescriptor(), PARENT_CONSTITUENT,
+                    field("other_middle").nest(field("inner", FanType.FanOut)));
+
+            final Index index = new Index(MULTI_TYPE_DOUBLE_NESTED_INDEX, rootExpression);
+            metaDataBuilder.addMultiTypeIndex(List.of(metaDataBuilder.getIndexableRecordType(DOUBLE_NESTED), metaDataBuilder.getIndexableRecordType("MiddleUnnested")), index);
+        });
+    }
+
+    @Nonnull
+    private static RecordMetaDataHook setOuterPrimaryKey(@Nonnull KeyExpression primaryKey) {
+        return metaData -> {
+            RecordTypeBuilder typeBuilder = metaData.getRecordType(OUTER);
+            typeBuilder.setPrimaryKey(primaryKey);
+        };
+    }
+
+    @Nonnull
+    private static RecordMetaDataHook setOuterAndMiddlePrimaryKey(@Nonnull KeyExpression primaryKey) {
+        return setOuterPrimaryKey(primaryKey)
+                .andThen(metaDataBuilder -> metaDataBuilder.getRecordType("MiddleRecord").setPrimaryKey(primaryKey));
+    }
+
+    @Nonnull
     private static TestRecordsNestedMapProto.OuterRecord sampleMapRecord() {
         return TestRecordsNestedMapProto.OuterRecord.newBuilder()
                 .setRecId(1066)
@@ -218,6 +287,7 @@ class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
                 )
                 .build();
     }
+
 
     @Nonnull
     private static TestRecordsNestedMapProto.OuterRecord sampleMapRecordWithOnlyValueDifferent() {
@@ -264,6 +334,7 @@ class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
                         .setBar("two")
                 )
                 .addManyMiddle(TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.newBuilder()
+                        .setOtherInt(1L)
                         .addInner(TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.InnerRecord.newBuilder()
                                 .setFoo(3L)
                                 .setBar("three")
@@ -278,6 +349,7 @@ class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
                         )
                 )
                 .addManyMiddle(TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.newBuilder()
+                        .setOtherInt(2L)
                         .addInner(TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.InnerRecord.newBuilder()
                                 .setFoo(6L)
                                 .setBar("six")
@@ -292,6 +364,7 @@ class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
                         )
                 )
                 .addManyMiddle(TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.newBuilder()
+                        .setOtherInt(3L)
                         .addInner(TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.InnerRecord.newBuilder()
                                 .setFoo(9L)
                                 .setBar("nine")
@@ -837,5 +910,350 @@ class UnnestedRecordTypeTest extends FDBRecordStoreTestBase {
 
             commit(context);
         }
+    }
+
+    @Test
+    void deleteRecordsWhere() {
+        final RecordMetaDataHook hook = setOuterPrimaryKey(concatenateFields("other_id", "rec_id"))
+                .andThen(addMapType())
+                .andThen(addOtherKeyIdValueIndex());
+        final RecordMetaData metaData = mapMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+
+            final TestRecordsNestedMapProto.OuterRecord rec = sampleMapRecord();
+            final List<FDBStoredRecord<Message>> saved = saveRecordsForDeleteRecordsWhere(rec);
+
+            assertAllPresent(saved);
+            assertThat(queryOtherKeyIdValue(rec.getOtherId()), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() + 1), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() - 1), not(empty()));
+
+            recordStore.deleteRecordsWhere(Query.field("other_id").equalsValue(rec.getOtherId()));
+
+            assertAllAbsent(saved.subList(0, 2));
+            assertAllPresent(saved.subList(2, saved.size()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId()), empty());
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() + 1), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() - 1), not(empty()));
+
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereFailsIfNotAligned() {
+        final RecordMetaDataHook hook = setOuterPrimaryKey(concatenateFields("other_id", "rec_id"))
+                .andThen(addMapType())
+                .andThen(addKeyOtherIntValueIndex());
+        final RecordMetaData metaData = mapMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+            assertDeleteRecordsWhereFails(null, Query.field("other_id").equalsValue(42L), KEY_OTHER_INT_VALUE_INDEX);
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereWithTypeFilterFailsIfNotAligned() {
+        final RecordMetaDataHook hook = setOuterPrimaryKey(concat(recordType(), field("other_id"), field("rec_id")))
+                .andThen(addMapType())
+                .andThen(addKeyOtherIntValueIndex());
+        final RecordMetaData metaData = mapMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+            assertDeleteRecordsWhereFails(OUTER, Query.field("other_id").equalsValue(42L), KEY_OTHER_INT_VALUE_INDEX);
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereWithTypeFilter() {
+        // As types are specified, make sure the primary key of the outer record is prefixed by record type
+        final RecordMetaDataHook hook = setOuterPrimaryKey(concat(recordType(), field("other_id"), field("rec_id")))
+                .andThen(addMapType())
+                .andThen(addOtherKeyIdValueIndex());
+        final RecordMetaData metaData = mapMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+
+            final TestRecordsNestedMapProto.OuterRecord rec = sampleMapRecord();
+            final List<FDBStoredRecord<Message>> saved = saveRecordsForDeleteRecordsWhere(rec);
+
+            assertAllPresent(saved);
+            assertThat(queryOtherKeyIdValue(rec.getOtherId()), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() + 1), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() - 1), not(empty()));
+
+            recordStore.deleteRecordsWhere(OUTER, Query.field("other_id").equalsValue(rec.getOtherId()));
+
+            assertAllAbsent(saved.subList(0, 2));
+            assertAllPresent(saved.subList(2, saved.size()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId()), empty());
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() + 1), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() - 1), not(empty()));
+
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereWithOnlyTypeFilter() {
+        // As types are specified, make sure the primary key of the outer record is prefixed by record type
+        final RecordMetaDataHook hook = setOuterPrimaryKey(concat(recordType(), field("rec_id")))
+                .andThen(addMapType())
+                .andThen(addOtherKeyIdValueIndex());
+        final RecordMetaData metaData = mapMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+
+            final TestRecordsNestedMapProto.OuterRecord rec = sampleMapRecord();
+            final List<FDBStoredRecord<Message>> saved = saveRecordsForDeleteRecordsWhere(rec);
+
+            assertAllPresent(saved);
+            assertThat(queryOtherKeyIdValue(rec.getOtherId()), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() + 1), not(empty()));
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() - 1), not(empty()));
+
+            recordStore.deleteRecordsWhere(OUTER, null);
+
+            assertAllAbsent(saved);
+            assertThat(queryOtherKeyIdValue(rec.getOtherId()), empty());
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() + 1), empty());
+            assertThat(queryOtherKeyIdValue(rec.getOtherId() - 1), empty());
+
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereOnMultiTypeIndex() {
+        // Add two unnested record types to the index (on the same stored record type)
+        final RecordMetaDataHook hook = setOuterPrimaryKey(concat(recordType(), field("other_id"), field("rec_id")))
+                .andThen(addMapType())
+                .andThen(addTwoMapsType())
+                .andThen(metaDataBuilder -> {
+                    final Index syntheticOtherIndex = new Index("syntheticOther", concat(field(PARENT_CONSTITUENT).nest("other_id"), Key.Expressions.value(42L)));
+                    metaDataBuilder.addMultiTypeIndex(List.of(metaDataBuilder.getSyntheticRecordType(UNNESTED_MAP), metaDataBuilder.getSyntheticRecordType(TWO_UNNESTED_MAPS)), syntheticOtherIndex);
+                });
+        final RecordMetaData metaData = mapMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+
+            final TestRecordsNestedMapProto.OuterRecord rec = sampleMapRecord();
+            final FDBStoredRecord<Message> storedRecord = recordStore.saveRecord(rec);
+
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordTypes(List.of(UNNESTED_MAP, TWO_UNNESTED_MAPS))
+                    .setFilter(Query.field(PARENT_CONSTITUENT).matches(Query.field("other_id").equalsValue(rec.getOtherId())))
+                    .build();
+
+            assertNotNull(recordStore.loadRecord(storedRecord.getPrimaryKey()));
+            assertThat(recordStore.executeQuery(query).asList().join(), not(empty()));
+
+            recordStore.deleteRecordsWhere(OUTER, Query.field("other_id").equalsValue(rec.getOtherId()));
+
+            assertNull(recordStore.loadRecord(storedRecord.getPrimaryKey()));
+            assertThat(recordStore.executeQuery(query).asList().join(), empty());
+
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereFailsWhenParentTypesHaveDifferentNames() {
+        final String secondMapType = "secondMapType";
+        final RecordMetaDataHook hook = setOuterPrimaryKey(concat(recordType(), field("rec_id")))
+                .andThen(addMapType())
+                .andThen(metaDataBuilder -> {
+                    final UnnestedRecordTypeBuilder typeBuilder = metaDataBuilder.addUnnestedRecordType(secondMapType);
+                    typeBuilder.addParentConstituent("p", metaDataBuilder.getRecordType(OUTER));
+                    typeBuilder.addNestedConstituent("map_entry", TestRecordsNestedMapProto.MapRecord.Entry.getDescriptor(), "p", ENTRIES_FAN_OUT);
+                })
+                .andThen(metaDataBuilder -> {
+                    final Index syntheticOtherIndex = new Index("syntheticOther", field("map_entry").nest("key"));
+                    metaDataBuilder.addMultiTypeIndex(List.of(metaDataBuilder.getSyntheticRecordType(UNNESTED_MAP), metaDataBuilder.getSyntheticRecordType(secondMapType)), syntheticOtherIndex);
+                });
+        final RecordMetaData metaData = mapMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+            assertDeleteRecordsWhereFails(OUTER, null, "syntheticOther");
+        }
+    }
+
+    @Test
+    void deleteWhereWithDifferentTypedParents() {
+        // Create a multi-type index on two different unnested types. Each one has a parent constituent named and an inner constituent, so the index is well-defined.
+        // The first column in the index is middle.rec_no, which we also set as the first column in the combined primary key. This means that it should be legal to
+        // perform a delete where with a middle.rec_no predicate
+        final RecordMetaDataHook hook = addMultiTypeDoubleUnnestedIndex()
+                .andThen(setOuterAndMiddlePrimaryKey(concat(field("middle").nest("other_int"), field("rec_no"))));
+        final RecordMetaData metaData = doubleNestedMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+
+            final Set<Long> otherIds = Set.of(1L, 2L, 3L);
+            final TestRecordsDoubleNestedProto.OuterRecord outer = sampleDoubleNestedRecord();
+            final Map<Long, List<FDBStoredRecord<Message>>> recordsByMiddleOther = new HashMap<>();
+            for (long otherId : otherIds) {
+                List<FDBStoredRecord<Message>> saved = new ArrayList<>();
+                saved.add(recordStore.saveRecord(outer.toBuilder().setMiddle(TestRecordsDoubleNestedProto.OuterRecord.MiddleRecord.newBuilder().setOtherInt(otherId)).build()));
+                for (int i = 0; i < 5; i++) {
+                    final TestRecordsDoubleNestedProto.MiddleRecord middle = TestRecordsDoubleNestedProto.MiddleRecord.newBuilder()
+                            .setRecNo(i)
+                            .setMiddle(TestRecordsDoubleNestedProto.MiddleRecord.newBuilder().setOtherInt(otherId))
+                            .setOtherMiddle(outer.getManyMiddle(0))
+                            .build();
+                    saved.add(recordStore.saveRecord(middle));
+                }
+                recordsByMiddleOther.put(otherId, saved);
+            }
+            otherIds.forEach(otherId -> assertAllPresent(recordsByMiddleOther.get(otherId)));
+
+            final String otherParam = "o";
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordTypes(List.of(DOUBLE_NESTED, "MiddleUnnested"))
+                    .setFilter(Query.field(PARENT_CONSTITUENT).matches(Query.field("middle").matches(Query.field("other_int").equalsParameter(otherParam))))
+                    .setSort(field("inner").nest("foo"))
+                    .build();
+            final RecordQueryPlan plan = planQuery(query);
+            assertMatchesExactly(plan, indexPlan()
+                    .where(indexName(MULTI_TYPE_DOUBLE_NESTED_INDEX))
+                    .and(scanComparisons(range("[EQUALS $" + otherParam + "]")))
+            );
+
+            final Map<Long, List<IndexEntry>> entriesByOtherId = new HashMap<>();
+            otherIds.forEach(otherId -> {
+                EvaluationContext evaluationContext = EvaluationContext.forBinding(otherParam, otherId);
+                try (RecordCursor<FDBQueriedRecord<Message>> cursor = plan.execute(recordStore, evaluationContext)) {
+                    List<IndexEntry> entries = cursor.map(FDBQueriedRecord::getIndexEntry).asList().join();
+                    assertThat(entries, not(empty()));
+                    entriesByOtherId.put(otherId, entries);
+                }
+            });
+
+            recordStore.deleteRecordsWhere(Query.field("middle").matches(Query.field("other_int").equalsValue(1L)));
+
+            otherIds.forEach(otherId -> {
+                // Assert the appropriate records have been deleted
+                final List<FDBStoredRecord<Message>> saved = recordsByMiddleOther.get(otherId);
+                if (otherId == 1L) {
+                    assertAllAbsent(saved);
+                } else {
+                    assertAllPresent(saved);
+                }
+
+                // Assert the appropriate entries have been deleted and the rest are unaffected
+                EvaluationContext evaluationContext = EvaluationContext.forBinding(otherParam, otherId);
+                try (RecordCursor<FDBQueriedRecord<Message>> cursor = plan.execute(recordStore, evaluationContext)) {
+                    List<IndexEntry> entries = cursor.map(FDBQueriedRecord::getIndexEntry).asList().join();
+                    if (otherId == 1L) {
+                        assertThat(entries, empty());
+                    } else {
+                        assertEquals(entriesByOtherId.get(otherId), entries);
+                    }
+                }
+            });
+
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereOnMultiTypeFailsWithAmbiguousParent() {
+        // Create a multi-type index on two different unnested types. Each one has a parent constituent named and an inner constituent, so the index is well-defined.
+        // The primary keys have record type prefixes, so we can delete records of a given type, but the index does not have unique prefixes for each type, so it
+        // must block the delete records where.
+        final RecordMetaDataHook hook = addMultiTypeDoubleUnnestedIndex()
+                .andThen(setOuterAndMiddlePrimaryKey(concat(recordType(), field("middle").nest("other_int"), field("rec_no"))));
+        final RecordMetaData metaData = doubleNestedMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+
+            assertDeleteRecordsWhereFails(OUTER, null, MULTI_TYPE_DOUBLE_NESTED_INDEX);
+            assertDeleteRecordsWhereFails("MiddleRecord", null, MULTI_TYPE_DOUBLE_NESTED_INDEX);
+
+            assertDeleteRecordsWhereFails(OUTER, Query.field("middle").matches(Query.field("other_int").equalsValue(2L)), MULTI_TYPE_DOUBLE_NESTED_INDEX);
+            assertDeleteRecordsWhereFails("MiddleRecord", Query.field("middle").matches(Query.field("other_int").equalsValue(2L)), MULTI_TYPE_DOUBLE_NESTED_INDEX);
+
+            commit(context);
+        }
+    }
+
+    @Test
+    void deleteWhereOnMultiTypeFailsWithRecordTypePrefix() {
+        // Create a multi-type index on two different unnested types. Each one has a parent constituent named and an inner constituent, so the index is well-defined.
+        // The multi-type index in this case has a record type prefix. In theory, we actually could perform the delete records where, but the record type key in the
+        // index matches the synthetic type's record type key, not the base type. This means we'd need to translate the record type key before deleting data from the
+        // index. Until we get that working, just assert that this fails.
+        final RecordMetaDataHook hook = addMultiTypeDoubleUnnestedIndex(concat(recordType(), field(PARENT_CONSTITUENT).nest(field("middle").nest("other_int")), field("inner").nest("foo")))
+                .andThen(setOuterAndMiddlePrimaryKey(concat(recordType(), field("middle").nest("other_int"), field("rec_no"))));
+        final RecordMetaData metaData = doubleNestedMetaData(hook);
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenRecordStore(context, metaData);
+
+            assertDeleteRecordsWhereFails(OUTER, null, MULTI_TYPE_DOUBLE_NESTED_INDEX);
+            assertDeleteRecordsWhereFails("MiddleRecord", null, MULTI_TYPE_DOUBLE_NESTED_INDEX);
+
+            assertDeleteRecordsWhereFails(OUTER, Query.field("middle").matches(Query.field("other_int").equalsValue(2L)), MULTI_TYPE_DOUBLE_NESTED_INDEX);
+            assertDeleteRecordsWhereFails("MiddleRecord", Query.field("middle").matches(Query.field("other_int").equalsValue(2L)), MULTI_TYPE_DOUBLE_NESTED_INDEX);
+
+            commit(context);
+        }
+    }
+
+    @Nonnull
+    private List<FDBSyntheticRecord> queryOtherKeyIdValue(long otherId) {
+        final RecordQuery query = RecordQuery.newBuilder()
+                .setRecordType(UNNESTED_MAP)
+                .setFilter(Query.field(PARENT_CONSTITUENT).matches(Query.field("other_id").equalsValue(otherId)))
+                .setSort(concat(field("map_entry").nest("key"), field(PARENT_CONSTITUENT).nest("rec_id")))
+                .build();
+        try (RecordCursor<FDBSyntheticRecord> cursor = recordStore.executeQuery(query).map(FDBQueriedRecord::getSyntheticRecord)) {
+            return cursor.asList().join();
+        }
+    }
+
+    @Nonnull
+    private List<FDBStoredRecord<Message>> saveRecordsForDeleteRecordsWhere(TestRecordsNestedMapProto.OuterRecord baseRec) {
+        final List<FDBStoredRecord<Message>> saved = new ArrayList<>();
+        saved.add(recordStore.saveRecord(baseRec));
+        saved.add(recordStore.saveRecord(baseRec.toBuilder().setRecId(baseRec.getRecId() + 1).build()));
+        saved.add(recordStore.saveRecord(baseRec.toBuilder().setRecId(baseRec.getRecId() + 2).setOtherId(baseRec.getOtherId() + 1).build()));
+        saved.add(recordStore.saveRecord(baseRec.toBuilder().setRecId(baseRec.getRecId() + 3).setOtherId(baseRec.getOtherId() + 1).build()));
+        saved.add(recordStore.saveRecord(baseRec.toBuilder().setRecId(baseRec.getRecId() + 4).setOtherId(baseRec.getOtherId() - 1).build()));
+        saved.add(recordStore.saveRecord(baseRec.toBuilder().setRecId(baseRec.getRecId() + 5).setOtherId(baseRec.getOtherId() - 1).build()));
+        return saved;
+    }
+
+    private void assertAllPresent(final List<FDBStoredRecord<Message>> records) {
+        records.forEach(rec ->
+                assertNotNull(recordStore.loadRecord(rec.getPrimaryKey()), () -> ("record with primary key " + rec.getPrimaryKey() + " should be present")));
+    }
+
+    private void assertAllAbsent(final List<FDBStoredRecord<Message>> records) {
+        records.forEach(rec ->
+                assertNull(recordStore.loadRecord(rec.getPrimaryKey()), () -> ("record with primary key " + rec.getPrimaryKey() + " should be absent")));
+    }
+
+    private void assertDeleteRecordsWhereFails(@Nullable String typeName, @Nullable QueryComponent component, @Nonnull String indexName) {
+        Query.InvalidExpressionException err = assertThrows(Query.InvalidExpressionException.class, () -> {
+            if (typeName == null) {
+                recordStore.deleteRecordsWhere(component);
+            } else {
+                recordStore.deleteRecordsWhere(typeName, component);
+            }
+        });
+        assertThat(err.getMessage(), containsString("deleteRecordsWhere not supported by index " + indexName));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/UnnestedRecordTypeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/UnnestedRecordTypeTest.java
@@ -89,7 +89,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/fdb-record-layer-core/src/test/proto/test_records_double_nested.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_double_nested.proto
@@ -36,6 +36,7 @@ message OuterRecord {
         }
         repeated OuterRecord.MiddleRecord.InnerRecord inner = 1;
         optional OtherRecord other = 2;
+        optional int64 other_int = 3;
     }
     optional int64 rec_no = 1 [(field).primary_key = true];
     optional MiddleRecord middle = 2;
@@ -52,6 +53,7 @@ message MiddleRecord {
     optional int64 rec_no = 1 [(field).primary_key = true];
     optional MiddleRecord middle = 2;
     optional OuterRecord.MiddleRecord other_middle = 3;
+    optional int64 other_int = 4;
 }
 
 message RecordTypeUnion {

--- a/fdb-record-layer-core/src/test/proto/test_records_double_nested.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_double_nested.proto
@@ -43,6 +43,7 @@ message OuterRecord {
     repeated MiddleRecord.InnerRecord inner = 3;
     optional OtherRecord other = 4;
     repeated MiddleRecord many_middle = 5;
+    optional int64 other_int = 6;
 }
 
 message OtherRecord {


### PR DESCRIPTION
When we delete all elements of a type, we need to modify the check so that it will remove all synthetic recorsd that reference the deleted base elements. This means modifying the predicate slightly. In particular, if there's a delete predicate like:

```java
Query.field("foo").equalsValue("bar")
```

And there's an unnested record type where the parent constituent is named `p`, then the correct predicate on the unnested record is:

```java
Query.field("p").matches(Query.field("foo").equalsValue("bar"))
```

This PR makes a few changes:

1. It makes sure that we gather up the indexes on synthetic types to check whether they are valid. This used to not work for cases where we were indexing only a single record type.
1. It validates that it can modify the predicate. For instance, if the index is on a single unnested record type, it can rewrite the predicate to be on the parent constituent. This check attempts to be a little conservative, completely skipping `JoinedRecordTypes`, which have more complicted semantics here

This fixes https://github.com/FoundationDB/fdb-record-layer/issues/2502.