### PR TITLE
Resolves #2509: Use metrics for rebalancing partitions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Use Locale.ROOT when parsing lucene queries [(Issue #2503)](https://github.com/FoundationDB/fdb-record-layer/issues/2503)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Use metrics instead of info log when rebalancing lucene partitions [(Issue #2509)](https://github.com/FoundationDB/fdb-record-layer/issues/2509)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -68,7 +68,14 @@ public class LuceneEvents {
         LUCENE_MERGE("Lucene merge"),
         /** Number of find merge calls (calculation of lucene's required merges). */
         LUCENE_FIND_MERGES("Lucene find merges"),
-        ;
+        /**
+         * Amount of time spent in a transaction doing partition rebalancing.
+         */
+        LUCENE_REBALANCE_PARTITION_TRANSACTION("Lucene rebalance partition transaction"),
+        /**
+         * Amount of time spent moving documents during partition rebalancing.
+         */
+        LUCENE_REBALANCE_PARTITION("Lucene rebalance partition");
 
         private final String title;
         private final String logKey;
@@ -229,7 +236,8 @@ public class LuceneEvents {
         LUCENE_AGILE_COMMITS_SIZE_QUOTA("lucene agile commits size quota", false),
         /** Number of agile context commits after exceeding time quota. */
         LUCENE_AGILE_COMMITS_TIME_QUOTA("lucene agile commits time quota", false),
-        ;
+        LUCENE_REBALANCE_PARTITION("lucene rebalance partition", false),
+        LUCENE_REBALANCE_PARTITION_DOC_COUNT("lucene rebalance partition count", true);
 
         private final String title;
         private final boolean isSize;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -619,15 +619,19 @@ public class LucenePartitioner {
                     final Integer repartitionDocumentCount = Math.min(
                             Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT)),
                             indexPartitionHighWatermark);
+                    long startTimeNanos = System.nanoTime();
                     LuceneRecordCursor luceneRecordCursor = getOldestNDocuments(
                             partitionInfo,
                             groupingKey,
                             repartitionDocumentCount + 1);
 
                     return moveDocsFromPartition(partitionInfo, groupingKey, maxPartitionId, luceneRecordCursor)
-                            .thenApply(movedCount -> Pair.of(
-                                    movedCount,
-                                    Math.max(partitionInfo.getCount() - movedCount - indexPartitionHighWatermark, 0)));
+                            .thenApply(movedCount -> {
+                                state.context.record(LuceneEvents.Events.LUCENE_REBALANCE_PARTITION, System.nanoTime() - startTimeNanos);
+                                return Pair.of(
+                                        movedCount,
+                                        Math.max(partitionInfo.getCount() - movedCount - indexPartitionHighWatermark, 0));
+                            });
                 }
             }
             // here: no partitions need re-balancing
@@ -739,13 +743,15 @@ public class LucenePartitioner {
                         .setCount(partitionInfo.getCount() - records.size())
                         .setFrom(ByteString.copyFrom(Tuple.from(newBoundaryTimestamp).pack()));
                 savePartitionMetadata(groupingKey, builder);
-                if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info(KeyValueLogMessage.of("Repartitioning Records",
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(KeyValueLogMessage.of("Repartitioning Records",
                             LuceneLogMessageKeys.GROUP, groupingKey,
                             LuceneLogMessageKeys.PARTITION, partitionInfo.getId(),
                             LuceneLogMessageKeys.TOTAL_COUNT, partitionInfo.getCount(),
                             LuceneLogMessageKeys.COUNT, records.size()));
                 }
+                state.context.increment(LuceneEvents.Counts.LUCENE_REBALANCE_PARTITION);
+                state.context.increment(LuceneEvents.Counts.LUCENE_REBALANCE_PARTITION_DOC_COUNT, records.size());
 
                 // value of the "destination" partition's `from` timestamp
                 final long overflowPartitionFromTimestamp = getPartitioningTimestampValue(records.get(0));


### PR DESCRIPTION
This downgrades the log to debug level, and adds metrics for timing, and document counts.