### PR TITLE
Fixes #2512: Unnested indexes generate an additional element with for null

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,6 +11,8 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 Support for the Protobuf 2 runtime has been removed as of this version. All artifacts now use Protobuf version 3. Note that the choice of Protobuf runtime version is distinct from the choice of Protobuf message syntax, and that users wishing to retain Protobuf 2 behavior can still achieve the same semantics (including [optional field behavior]()) as long as they specify the syntax on their Protobuf file as `proto2`. Note that the Maven artifacts using Protobuf version 3 used to be suffixed with `-pb3`. Existing Protobuf 3 users must remove that suffix from their dependency declarations (e.g., `fdb-record-layer-core-pb3` should now be `fdb-record-layer-core`).
 
+Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType` were changed in response to [Issue #2512](https://github.com/FoundationDB/fdb-record-layer/issues/2512). It was identified that extraneous synthetic records were being produced when one of the children was empty. This did not match the semantics of `FanOut` expressions, and so the unnesting calculation was changed. This means that any index on an existing `UnnestedRecordType` requires rebuilding to clear out any such entries from older indexes.
+
 <!--
 // begin next release
 ### NEXT_RELEASE
@@ -32,7 +34,7 @@ Support for the Protobuf 2 runtime has been removed as of this version. All arti
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Unnested record types no longer produce synthetic records for empty repeated fields [(Issue #2512)](https://github.com/FoundationDB/fdb-record-layer/issues/2512)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 


### PR DESCRIPTION
This updates the unnesting plan so that we should not generate records if we don't match all of the constituents. The way that this works is that:

1. There is a tree representing the relationship between each constituent and its child constituents
1. Each node has some stored record value, and then each child is mapped to a list of values (computed by evaluating the nesting expression on the node's record)
1. To get the full set of synthetic records, we need to compute the cross-product of the set of unnested records coming from each node
1. This cross product is computed by keeping iteration state in each node, and then incrementing each child, rolling over to incrementing the next child once we've exhausted each one

This updates the algorithm by:

1. Instead of keeping a map of current constituent values that we update as we update iteration state, we now recalculate the mapping by traversing the tree. The previous design had the flaw that if we didn't properly invalidate data from the tree, we could associate incorrect values together. The new design makes it harder to have bugs where we put in the child for a different parent in cases where we have two nestings on top of each other.
1. When we collect the results from the tree, we only return the result if every constituent has a value. This means that if any of the nested constituents are empty, they will not set a value for the constituent, so the empty value will be skipped.

New test cases for empty records were added to the `UnnestedRecordTypeTest`. The tests in question already were able to catch that the cross-product calculation was not done correctly, we just needed to add cases where we operated on empty records. The test was also improved, in that we now validate that for each synthetic record that comes back, the primary key values (which contain the index in the repeated value of the constituent) match the values returned by unnesting.

This fixes #2512.