### PR TITLE
Fix `Type.Enum` coercion logic

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Coercion logic does not handle `Enum` type correctly [(Issue #2517)](https://github.com/FoundationDB/fdb-record-layer/issues/2517)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
@@ -485,6 +485,21 @@ public interface Type extends Narrowable<Type>, PlanSerializable {
             return null;
         }
 
+        if (t1.isEnum() != t2.isEnum()) {
+            return null;
+        }
+
+        if (t1.isEnum()) {
+            final var t1Enum = (Enum)t1;
+            final var t2Enum = (Enum)t2;
+            final var t1EnumValues = t1Enum.enumValues;
+            final var t2EnumValues = t2Enum.enumValues;
+            if (t1EnumValues == null) {
+                return t2EnumValues == null ? t1Enum.withNullability(isResultNullable) : null;
+            }
+            return t1EnumValues.equals(t2EnumValues) ? t1Enum.withNullability(isResultNullable) : null;
+        }
+
         if (t1.getTypeCode() != t2.getTypeCode()) {
             return null;
         }
@@ -1525,7 +1540,7 @@ public interface Type extends Narrowable<Type>, PlanSerializable {
             return getTypeCode() + "<" +
                    Objects.requireNonNull(enumValues)
                            .stream()
-                           .map(Object::toString)
+                           .map(EnumValue::toString)
                            .collect(Collectors.joining(", ")) + ">";
         }
 
@@ -1630,6 +1645,11 @@ public interface Type extends Narrowable<Type>, PlanSerializable {
             @Override
             public int hashCode() {
                 return Objects.hash(name, number);
+            }
+
+            @Override
+            public String toString() {
+                return name + '(' + number + ')';
             }
 
             @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/TypeRepository.java
@@ -190,7 +190,6 @@ public class TypeRepository {
         return getMessageDescriptor(msgTypeName);
     }
 
-
     /**
      * Gets the enum value for the given enum type and name.
      *
@@ -236,6 +235,18 @@ public class TypeRepository {
             enumType = enumDescriptorMapFull.get(enumTypeName);
         }
         return enumType;
+    }
+
+    /**
+     * Gets the protobuf message descriptor for the given message type.
+     *
+     * @param type the type the caller wants to look up
+     * @return the message descriptor (null if not found)
+     */
+    @Nullable
+    public EnumDescriptor getEnumDescriptor(@Nonnull final Type type) {
+        String msgTypeName = getProtoTypeName(type);
+        return getEnumDescriptor(msgTypeName);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -89,7 +89,6 @@ public class MessageHelpers {
         return getFieldOnMessage(current, fieldNames.get(fieldNames.size() - 1));
     }
 
-    @SuppressWarnings("UnstableApiUsage") // caused by usage of Guava's ImmutableIntArray.
     @Nullable
     public static Object getFieldValueForFieldOrdinals(@Nonnull MessageOrBuilder message, @Nonnull ImmutableIntArray fieldOrdinals) {
         if (fieldOrdinals.isEmpty()) {
@@ -266,14 +265,13 @@ public class MessageHelpers {
                                                               @Nullable final TransformationTrieNode transformationsTrie,
                                                               @Nullable final CoercionTrieNode coercionsTrie,
                                                               @Nonnull final Type targetType,
-                                                              @Nullable Descriptors.Descriptor targetDescriptor,
+                                                              @Nonnull Descriptors.Descriptor targetDescriptor,
                                                               @Nonnull final Type currentType,
                                                               @Nonnull Descriptors.Descriptor currentDescriptor,
                                                               @Nullable final Object current) {
         final var value = transformationsTrie == null ? null : transformationsTrie.getValue();
         Verify.verify(value == null);
 
-        targetDescriptor = Verify.verifyNotNull(targetDescriptor);
         final var targetDescriptorFields = targetDescriptor.getFields();
         final var targetRecordType = (Type.Record)targetType;
         final var currentRecordType = (Type.Record)currentType;
@@ -287,13 +285,19 @@ public class MessageHelpers {
             final var index = messageFieldDescriptor.getIndex();
             final var transformationTrieForField = transformationsChildrenMap == null ? null : transformationsChildrenMap.get(index);
             final var targetFieldDescriptor = targetDescriptorFields.get(index);
-            final var targetDescriptorForField = targetFieldDescriptor.getJavaType() == Descriptors.FieldDescriptor.JavaType.MESSAGE ? targetFieldDescriptor.getMessageType() : null;
+            final var targetDescriptorForField = targetFieldDescriptor.getJavaType() == Descriptors.FieldDescriptor.JavaType.MESSAGE
+                                                 ? targetFieldDescriptor.getMessageType()
+                                                 : targetFieldDescriptor.getJavaType() == Descriptors.FieldDescriptor.JavaType.ENUM
+                                                   ? targetFieldDescriptor.getEnumType()
+                                                   : null;
             final var promotionTrieForField = coercionsChildrenMap == null ? null : coercionsChildrenMap.get(index);
             final var targetFieldType = targetRecordType.getField(index).getFieldType();
             if (transformationTrieForField != null) {
                 final var currentFieldType = currentRecordType.getField(index).getFieldType();
                 Object fieldResult;
                 if (transformationTrieForField.getValue() == null) {
+                    Verify.verify(targetDescriptorForField instanceof Descriptors.Descriptor);
+
                     //
                     // Note that this recursive call has to happen even if the field value is null,
                     // as the transformations have to be done exhaustively, which then can create non-null values
@@ -305,7 +309,7 @@ public class MessageHelpers {
                                     transformationTrieForField,
                                     promotionTrieForField,
                                     targetFieldType,
-                                    targetDescriptorForField,
+                                    (Descriptors.Descriptor)targetDescriptorForField,
                                     currentFieldType,
                                     Verify.verifyNotNull(messageFieldDescriptor.getMessageType()),
                                     currentMessage == null ? null : currentMessage.getField(messageFieldDescriptor));
@@ -348,7 +352,7 @@ public class MessageHelpers {
     @Nullable
     public static Object coerceObject(@Nullable final CoercionTrieNode coercionsTrie,
                                       @Nonnull final Type targetType,
-                                      @Nullable final Descriptors.Descriptor targetDescriptor,
+                                      @Nullable final Descriptors.GenericDescriptor targetDescriptor,
                                       @Nonnull final Type currentType,
                                       @Nullable final Object current) {
         SemanticException.check(current != null || targetType.isNullable(), SemanticException.ErrorCode.NULL_ASSIGNMENT);
@@ -360,7 +364,8 @@ public class MessageHelpers {
 
         if (coercionsTrie == null) {
             if (targetDescriptor != null && current instanceof Message) {
-                return deepCopyMessageIfNeeded(targetDescriptor, (Message)current);
+                Verify.verify(targetDescriptor instanceof Descriptors.Descriptor);
+                return deepCopyMessageIfNeeded((Descriptors.Descriptor)targetDescriptor, (Message)current);
             }
             return current;
         }
@@ -376,6 +381,14 @@ public class MessageHelpers {
         }
 
         //
+        // This is another leaf case: The target can be an Enum,
+        if (targetType.isEnum()) {
+            Verify.verify(targetDescriptor instanceof Descriptors.EnumDescriptor);
+            final var coercionFunction = Verify.verifyNotNull(coercionsTrie.getValue());
+            return Verify.verifyNotNull(coercionFunction.apply(targetDescriptor, current));
+        }
+
+        //
         // This juggles with a change in nullability for arrays. If we were nullable before, but now we are not or
         // vice versa, we need to change the wrapping in protobuf.
         //
@@ -386,7 +399,8 @@ public class MessageHelpers {
         }
 
         if (targetType.isRecord()) {
-            return coerceMessage(coercionsTrie, targetType, Verify.verifyNotNull(targetDescriptor), currentType, (Message)current);
+            Verify.verify(targetDescriptor instanceof Descriptors.Descriptor);
+            return coerceMessage(coercionsTrie, targetType, Verify.verifyNotNull((Descriptors.Descriptor)targetDescriptor), currentType, (Message)current);
         }
 
         throw new IllegalStateException("unsupported java type for record field");
@@ -407,7 +421,7 @@ public class MessageHelpers {
     @Nonnull
     public static Object coerceArray(@Nonnull final Type.Array targetArrayType,
                                      @Nonnull final Type.Array currentArrayType,
-                                     @Nullable Descriptors.Descriptor targetDescriptor,
+                                     @Nullable Descriptors.GenericDescriptor targetDescriptor,
                                      @Nullable final CoercionTrieNode elementsTrie,
                                      @Nonnull final Object current) {
         final var targetElementType = Verify.verifyNotNull(targetArrayType.getElementType());
@@ -415,7 +429,8 @@ public class MessageHelpers {
 
         final Descriptors.FieldDescriptor targetElementFieldDescriptor;
         if (targetArrayType.isNullable()) {
-            targetElementFieldDescriptor = Verify.verifyNotNull(targetDescriptor).findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName());
+            Verify.verify(targetDescriptor instanceof Descriptors.Descriptor);
+            targetElementFieldDescriptor = Verify.verifyNotNull((Descriptors.Descriptor)targetDescriptor).findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName());
         } else {
             targetElementFieldDescriptor = null;
         }
@@ -443,7 +458,7 @@ public class MessageHelpers {
 
         if (targetArrayType.isNullable()) {
             // the target descriptor is the wrapping holder
-            final var wrapperBuilder = DynamicMessage.newBuilder(Verify.verifyNotNull(targetDescriptor));
+            final var wrapperBuilder = DynamicMessage.newBuilder(Verify.verifyNotNull((Descriptors.Descriptor)targetDescriptor));
             wrapperBuilder.setField(Verify.verifyNotNull(targetElementFieldDescriptor), coercedArray);
             return wrapperBuilder.build();
         }
@@ -690,7 +705,7 @@ public class MessageHelpers {
     /**
      * Coercion (bi)-function which also is plan hashable.
      */
-    public interface CoercionBiFunction extends BiFunction<Descriptors.Descriptor, Object, Object>, PlanHashable, PlanSerializable {
+    public interface CoercionBiFunction extends BiFunction<Descriptors.GenericDescriptor, Object, Object>, PlanHashable, PlanSerializable {
         @Nonnull
         @SuppressWarnings("unused")
         PCoercionBiFunction toCoercionBiFunctionProto(@Nonnull PlanSerializationContext serializationContext);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
@@ -82,7 +82,9 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
         NULL_TO_STRING(Type.TypeCode.NULL, Type.TypeCode.STRING, (descriptor, in) -> (String) null),
         NULL_TO_ARRAY(Type.TypeCode.NULL, Type.TypeCode.ARRAY, (descriptor, in) -> null),
         NULL_TO_RECORD(Type.TypeCode.NULL, Type.TypeCode.RECORD, (descriptor, in) -> null),
-        NONE_TO_ARRAY(Type.TypeCode.NONE, Type.TypeCode.ARRAY, (descriptor, in) -> in);
+        NONE_TO_ARRAY(Type.TypeCode.NONE, Type.TypeCode.ARRAY, (descriptor, in) -> in),
+        NULL_TO_ENUM(Type.TypeCode.NULL, Type.TypeCode.ENUM, (descriptor, in) -> null),
+        STRING_TO_ENUM(Type.TypeCode.STRING, Type.TypeCode.ENUM, ((descriptor, in) -> ((Descriptors.EnumDescriptor)descriptor).findValueByName((String)in)));
 
         @Nonnull
         private static final Supplier<BiMap<PhysicalOperator, PPhysicalOperator>> protoEnumBiMapSupplier =
@@ -93,10 +95,10 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
         @Nonnull
         private final Type.TypeCode to;
         @Nonnull
-        private final BiFunction<Descriptors.Descriptor, Object, Object> promotionFunction;
+        private final BiFunction<Descriptors.GenericDescriptor, Object, Object> promotionFunction;
 
         PhysicalOperator(@Nonnull final Type.TypeCode from, @Nonnull final Type.TypeCode to,
-                         @Nonnull final BiFunction<Descriptors.Descriptor, Object, Object> promotionFunction) {
+                         @Nonnull final BiFunction<Descriptors.GenericDescriptor, Object, Object> promotionFunction) {
             this.from = from;
             this.to = to;
             this.promotionFunction = promotionFunction;
@@ -113,11 +115,11 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
         }
 
         @Nonnull
-        public BiFunction<Descriptors.Descriptor, Object, Object> getPromotionFunction() {
+        public BiFunction<Descriptors.GenericDescriptor, Object, Object> getPromotionFunction() {
             return promotionFunction;
         }
 
-        public Object apply(@Nullable final Descriptors.Descriptor descriptor, @Nullable Object in) {
+        public Object apply(@Nullable final Descriptors.GenericDescriptor descriptor, @Nullable Object in) {
             return promotionFunction.apply(descriptor, in);
         }
 
@@ -215,9 +217,20 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
             return result;
         }
 
+        final Descriptors.GenericDescriptor genericDescriptor;
+        if (isSimplePromotion) {
+            genericDescriptor = null;
+        } else {
+            if (promoteToType.isEnum()) {
+                genericDescriptor = context.getTypeRepository().getEnumDescriptor(promoteToType);
+            } else {
+                Verify.verify(promoteToType.isRecord());
+                genericDescriptor = context.getTypeRepository().getMessageDescriptor(promoteToType);
+            }
+        }
         return MessageHelpers.coerceObject(promotionTrie,
                 promoteToType,
-                isSimplePromotion ? null : context.getTypeRepository().getMessageDescriptor(promoteToType),
+                genericDescriptor,
                 inValue.getResultType(),
                 result);
     }
@@ -305,6 +318,10 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
     public static CoercionTrieNode computePromotionsTrie(@Nonnull final Type targetType,
                                                          @Nonnull Type currentType,
                                                          @Nullable final MessageHelpers.TransformationTrieNode transformationsTrie) {
+        if (targetType.getTypeCode() == Type.TypeCode.ANY) {
+            return null;
+        }
+
         if (transformationsTrie != null && transformationsTrie.getValue() != null) {
             currentType = transformationsTrie.getValue().getResultType();
         }
@@ -320,6 +337,12 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
         }
 
         Verify.verify(targetType.getTypeCode() == currentType.getTypeCode());
+
+        if (currentType.isEnum()) {
+            SemanticException.check(currentType.withNullability(false).equals(targetType.withNullability(false)),
+                    SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+            return null;
+        }
 
         if (currentType.isArray()) {
             final var targetArrayType = (Type.Array)targetType;
@@ -396,7 +419,8 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
             SemanticException.check(!inArray.isErased() && !promoteToArray.isErased(), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
             return isPromotionNeeded(Verify.verifyNotNull(inArray.getElementType()), Verify.verifyNotNull(promoteToArray.getElementType()));
         }
-        SemanticException.check(inType.isPrimitive() && promoteToType.isPrimitive(), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+        SemanticException.check(inType.isPrimitive() && promoteToType.isPrimitive() ||
+                inType.isPrimitive() && promoteToType.isEnum(), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
         return inType.getTypeCode() != promoteToType.getTypeCode();
     }
 
@@ -412,7 +436,7 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
         }
 
         @Override
-        public Object apply(final Descriptors.Descriptor targetDescriptor, final Object current) {
+        public Object apply(final Descriptors.GenericDescriptor targetDescriptor, final Object current) {
             return operator.apply(targetDescriptor, current);
         }
 
@@ -499,7 +523,7 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
         }
 
         @Override
-        public Object apply(final Descriptors.Descriptor targetDescriptor, final Object current) {
+        public Object apply(final Descriptors.GenericDescriptor targetDescriptor, final Object current) {
             return MessageHelpers.coerceArray(toArrayType, fromArrayType, targetDescriptor, elementsTrie, current);
         }
 

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -157,6 +157,8 @@ message PPrimitiveCoercionBiFunction {
     NULL_TO_ARRAY = 13;
     NULL_TO_RECORD = 14;
     NONE_TO_ARRAY = 15;
+    NULL_TO_ENUM = 16;
+    STRING_TO_ENUM = 17;
   }
   optional PPhysicalOperator operator = 1;
 }


### PR DESCRIPTION
The logic for handling coercion of `Type.Enum` is missing, this fix adds strict coercion rules for `Enum` type described as the following:
For a given `Enum` `E1`, we can perform the following coercions:
* nullable `E1` to nullable `E1` (enum to itself)
* not nullable `E1` to not nullable `E1` (enum to itself)
* not nullable `E1` to nullable `E1` (this is fine since the nullable `E1`'s domain can accommodate for all elements in `E1`.

It also adds a new promotion rule that accepts promoting `String` type to `Enum` type, this is useful for e.g. enabling the insertion of `Enum` values in an `INSERT` statement as a normal `String` literal.

This fixes #2517 .