### PR TITLE
Fixes #2513: Extra errors being reported by the scrubber for indexes on Unnested Record Types

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The index scrubbers now can handle value indexes on synthetic record types [(Issue #2513)](https://github.com/FoundationDB/fdb-record-layer/issues/2513)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.metadata.UnnestedRecordType;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.LiteralKeyExpression;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordPlanner;
 import com.apple.foundationdb.record.util.MapUtils;
 import com.google.common.base.Verify;
 import com.google.common.collect.Iterables;
@@ -415,7 +416,8 @@ public class RecordMetaData implements RecordMetaDataProvider {
         for (SyntheticRecordType<?> recordType : syntheticRecordTypes.values()) {
             for (Index index : recordType.getIndexes()) {
                 if (index.getLastModifiedVersion() > version) {
-                    result.put(index, Collections.singletonList(recordType));
+                    List<RecordType> storedTypes = List.copyOf(SyntheticRecordPlanner.storedRecordTypesForIndex(this, index, List.of(recordType)));
+                    result.put(index, storedTypes);
                 }
             }
             for (Index index : recordType.getMultiTypeIndexes()) {
@@ -423,7 +425,7 @@ public class RecordMetaData implements RecordMetaDataProvider {
                     if (!result.containsKey(index)) {
                         result.put(index, new ArrayList<>());
                     }
-                    result.get(index).add(recordType);
+                    result.get(index).addAll(SyntheticRecordPlanner.storedRecordTypesForIndex(this, index, List.of(recordType)));
                 }
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/UnnestedRecordType.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/UnnestedRecordType.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.metadata.expressions.LiteralKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBSyntheticRecord;
+import com.apple.foundationdb.record.provider.foundationdb.RecordDoesNotExistException;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -264,6 +265,10 @@ public class UnnestedRecordType extends SyntheticRecordType<UnnestedRecordType.N
     public CompletableFuture<FDBSyntheticRecord> loadByPrimaryKeyAsync(@Nonnull final FDBRecordStore store, @Nonnull final Tuple primaryKey) {
         Tuple parentPrimaryKey = primaryKey.getNestedTuple(1);
         return store.loadRecordAsync(parentPrimaryKey).thenApply(storedRecord -> {
+            if (storedRecord == null) {
+                throw new RecordDoesNotExistException("constituent record not found: " + parentConstituent.getName())
+                        .addLogInfo(LogMessageKeys.PRIMARY_KEY, parentPrimaryKey);
+            }
             Map<String, FDBStoredRecord<?>> constituentValues = new HashMap<>();
             constituentValues.put(getParentConstituent().getName(), storedRecord);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -47,6 +47,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.common.StoreTimerSnapshot;
 import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
 import com.apple.foundationdb.record.provider.foundationdb.synchronizedsession.SynchronizedSessionRunner;
+import com.apple.foundationdb.record.query.plan.RecordQueryPlanner;
 import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordFromStoredRecordPlan;
 import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordPlanner;
 import com.apple.foundationdb.subspace.Subspace;
@@ -956,9 +957,10 @@ public abstract class IndexingBase {
     @Nonnull
     SyntheticRecordFromStoredRecordPlan syntheticPlanForIndex(@Nonnull FDBRecordStore store, @Nonnull IndexingCommon.IndexContext indexContext) {
         if (!indexContext.isSynthetic) {
-            throw new RecordCoreException("unable create synethetic plan for non-synthetic index");
+            throw new RecordCoreException("unable to create synthetic plan for non-synthetic index");
         }
-        final SyntheticRecordPlanner syntheticPlanner = new SyntheticRecordPlanner(store.getRecordMetaData(), store.getRecordStoreState().withWriteOnlyIndexes(Collections.singletonList(indexContext.index.getName())), store.getTimer());
+        final RecordQueryPlanner queryPlanner = new RecordQueryPlanner(store.getRecordMetaData(), store.getRecordStoreState().withWriteOnlyIndexes(Collections.singletonList(indexContext.index.getName())));
+        final SyntheticRecordPlanner syntheticPlanner = new SyntheticRecordPlanner(store, queryPlanner);
         return syntheticPlanner.forIndex(indexContext.index);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
@@ -248,6 +248,7 @@ public class IndexingByIndex extends IndexingBase {
 
         validateOrThrowEx(common.getAllRecordTypes().size() == 1, "target index has multiple types");
         validateOrThrowEx(srcRecordTypes.size() == 1, "source index has multiple types");
+        validateOrThrowEx(srcRecordTypes.stream().noneMatch(RecordType::isSynthetic), "source index is on synthetic record types");
         validateOrThrowEx(!srcIndex.getRootExpression().createsDuplicates(), "source index creates duplicates");
         validateOrThrowEx(IndexTypes.VALUE.equals(srcIndex.getType()), "source index is not a VALUE index");
         validateOrThrowEx(common.getAllRecordTypes().containsAll(srcRecordTypes), "source index's type is not equal to target index's");

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaData;
-import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
@@ -136,8 +135,7 @@ public class IndexingCommon {
             }
             boolean isSynthetic = false;
             if (types.stream().anyMatch(RecordType::isSynthetic)) {
-                types = new SyntheticRecordPlanner(metaData, new RecordStoreState(null, null), getRunner().getTimer())
-                        .storedRecordTypesForIndex(targetIndex, types);
+                types = SyntheticRecordPlanner.storedRecordTypesForIndex(metaData, targetIndex, types);
                 isSynthetic = true;
             }
             targetIndexContexts.add(new IndexContext(targetIndex, types, isSynthetic));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -192,13 +192,18 @@ public class IndexingCommon {
     }
 
     @Nonnull
-    public Index getIndex() {
+    IndexContext getIndexContext() {
         if (isMultiTarget()) {
             // backward compatibility safeguard - modules that do not support multi targets (yet) will continue calling
             // this function, which verifies a very lonely target index
             throw new IndexingBase.ValidationException("Multi target index exist, but an operation that assumes a single index was called");
         }
-        return targetIndexContexts.get(0).index;
+        return targetIndexContexts.get(0);
+    }
+
+    @Nonnull
+    public Index getIndex() {
+        return getIndexContext().index;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -25,12 +25,10 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
-import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
-import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordPlanner;
 import com.apple.foundationdb.subspace.Subspace;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
@@ -938,19 +936,12 @@ public class OnlineIndexScrubber implements AutoCloseable {
             if (!metaData.hasIndex(index.getName()) || index != metaData.getIndex(index.getName())) {
                 throw new MetaDataException("Index " + index.getName() + " not contained within specified metadata");
             }
-            if (recordTypes == null) {
-                recordTypes = metaData.recordTypesForIndex(index);
-            } else {
+            if (recordTypes != null) {
                 for (RecordType recordType : recordTypes) {
                     if (recordType != metaData.getIndexableRecordType(recordType.getName())) {
                         throw new MetaDataException("Record type " + recordType.getName() + " not contained within specified metadata");
                     }
                 }
-            }
-            if (recordTypes.stream().anyMatch(RecordType::isSynthetic)) {
-                // The (stored) types to scan, not the (synthetic) types that are indexed.
-                recordTypes = new SyntheticRecordPlanner(metaData, new RecordStoreState(null, null), getTimer())
-                        .storedRecordTypesForIndex(index, recordTypes);
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
@@ -236,11 +236,12 @@ public class SyntheticRecordPlanner {
      * From those scans, queries will be executed to load other record types to complete the synthesis.
      * <p>
      * In cases such as full outer join, there is no single record type from which all joins can be produced.
+     * @param recordMetaData meta-data containing the synthetic record type
      * @param index the index that needs to be built
      * @param recordTypes a subset of the index's record types or {@code null} for all
      * @return a set of stored record types that are sufficient to generate the synthesized records for the index
      */
-    public Set<RecordType> storedRecordTypesForIndex(@Nonnull Index index, @Nullable Collection<RecordType> recordTypes) {
+    public static Set<RecordType> storedRecordTypesForIndex(@Nonnull RecordMetaData recordMetaData, @Nonnull Index index, @Nullable Collection<RecordType> recordTypes) {
         if (recordTypes == null) {
             recordTypes = recordMetaData.recordTypesForIndex(index);
         }
@@ -266,6 +267,21 @@ public class SyntheticRecordPlanner {
         }
         return result;
     }
+
+    /**
+     * Determine what stored record types would be need to scanned in order to rebuild a given index.
+     *
+     * From those scans, queries will be executed to load other record types to complete the synthesis.
+     * <p>
+     * In cases such as full outer join, there is no single record type from which all joins can be produced.
+     * @param index the index that needs to be built
+     * @param recordTypes a subset of the index's record types or {@code null} for all
+     * @return a set of stored record types that are sufficient to generate the synthesized records for the index
+     */
+    public Set<RecordType> storedRecordTypesForIndex(@Nonnull Index index, @Nullable Collection<RecordType> recordTypes) {
+        return storedRecordTypesForIndex(recordMetaData, index, recordTypes);
+    }
+
 
     /**
      * Construct a plan for generating synthetic records for a given index.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecordsJoinIndexProto;
 import com.apple.foundationdb.record.TestRecordsNestedMapProto;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
@@ -353,34 +354,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
                 .andThen(metaDataBuilder -> metaDataBuilder.addIndex(OnlineIndexerBuildUnnestedIndexTest.UNNESTED, targetIndex));
         openMetaData(recordHandler.getFileDescriptor(), hook);
 
-        final int numRecords = 20;
-        try (FDBRecordContext context = openContext()) {
-            for (int i = 0; i < numRecords; i++) {
-                recordStore.saveRecord(TestRecordsNestedMapProto.OuterRecord.newBuilder()
-                        .setRecId(2 * i)
-                        .setOtherId(i % 2)
-                        .setMap(TestRecordsNestedMapProto.MapRecord.newBuilder()
-                                .addEntry(TestRecordsNestedMapProto.MapRecord.Entry.newBuilder()
-                                        .setKey("a")
-                                        .setIntValue(i))
-                                .addEntry(TestRecordsNestedMapProto.MapRecord.Entry.newBuilder()
-                                        .setKey("b")
-                                        .setIntValue(i))
-                                .addEntry(TestRecordsNestedMapProto.MapRecord.Entry.newBuilder()
-                                        .setKey("c")
-                                        .setIntValue(i))
-                        )
-                        .build()
-                );
-                recordStore.saveRecord(TestRecordsNestedMapProto.OtherRecord.newBuilder()
-                        .setRecId(2 * i + 1)
-                        .setOtherId(i % 2)
-                        .build()
-                );
-            }
-
-            context.commit();
-        }
+        final long numRecords = 20;
+        populateNestedMapData(numRecords);
 
         final FDBStoreTimer timer = new FDBStoreTimer();
         try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
@@ -392,7 +367,7 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
             indexScrubber.scrubMissingIndexEntries();
         }
 
-        // Scanned 5 * numRecords. There are numRecords :
+        // Scanned 5 * numRecords. This is from:
         //  1. When looking for missing entries, we scan every record in the database. There are numRecords of type
         //     OuterRecord and numRecords of type OtherRecord (so that's 2 * numRecords)
         //  2. When scanning dangling entries, we look up one for every entry in the index. There are 3 map entries
@@ -401,5 +376,277 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
         assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(0, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
         assertEquals(0, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+    }
+
+    @Test
+    void testDetectDanglingUnnestedIndex() {
+        final Index targetIndex = new Index("unnestedIndex", concat(field("entry").nest("key"), field("parent").nest("other_id"), field("entry").nest("int_value")));
+        final OnlineIndexerBuildUnnestedIndexTest.OnlineIndexerTestUnnestedRecordHandler recordHandler = OnlineIndexerBuildUnnestedIndexTest.OnlineIndexerTestUnnestedRecordHandler.instance();
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = recordHandler.baseHook(true, null)
+                .andThen(metaDataBuilder -> metaDataBuilder.addIndex(OnlineIndexerBuildUnnestedIndexTest.UNNESTED, targetIndex));
+        openMetaData(recordHandler.getFileDescriptor(), hook);
+
+        final long numRecords = 30;
+        final List<Message> data = populateNestedMapData(numRecords);
+        int doDelete = 0;
+        try (FDBRecordContext context = openContext()) {
+            for (Message datum : data) {
+                if (!(datum instanceof TestRecordsNestedMapProto.OuterRecord)) {
+                    continue;
+                }
+                // Clear out the record data for 1/3 records
+                if (doDelete == 0) {
+                    Tuple primaryKey = recordHandler.getPrimaryKey(datum);
+                    context.ensureActive().clear(recordStore.recordsSubspace().subspace(primaryKey).range());
+                }
+                doDelete = (doDelete + 1) % 3;
+            }
+            context.commit();
+        }
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(false)
+                        .build())
+                .build()) {
+            assertThrows(RecordDoesNotExistException.class, indexScrubber::scrubDanglingIndexEntries);
+            indexScrubber.scrubMissingIndexEntries();
+        }
+    }
+
+    @Test
+    void testDetectMissingUnnestedIndex() {
+        final Index targetIndex = new Index("unnestedIndex", concat(field("entry").nest("key"), field("parent").nest("other_id"), field("entry").nest("int_value")));
+        final OnlineIndexerBuildUnnestedIndexTest.OnlineIndexerTestUnnestedRecordHandler recordHandler = OnlineIndexerBuildUnnestedIndexTest.OnlineIndexerTestUnnestedRecordHandler.instance();
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = recordHandler.baseHook(true, null)
+                .andThen(metaDataBuilder -> metaDataBuilder.addIndex(OnlineIndexerBuildUnnestedIndexTest.UNNESTED, targetIndex));
+        openMetaData(recordHandler.getFileDescriptor(), hook);
+
+        final long numRecords = 30;
+        final List<Message> data = populateNestedMapData(numRecords);
+        int doDelete = 0;
+        int deleteCount = 0;
+        try (FDBRecordContext context = openContext()) {
+            for (Message datum : data) {
+                if (!(datum instanceof TestRecordsNestedMapProto.OuterRecord)) {
+                    continue;
+                }
+                if (doDelete == 0) {
+                    // Clear out one of the entries for this record
+                    TestRecordsNestedMapProto.OuterRecord outerRecord = (TestRecordsNestedMapProto.OuterRecord)datum;
+                    if (!outerRecord.getMap().getEntryList().isEmpty()) {
+                        int entryToDeleteIndex = deleteCount % outerRecord.getMap().getEntryCount();
+                        TestRecordsNestedMapProto.MapRecord.Entry entryToDelete = outerRecord.getMap().getEntry(entryToDeleteIndex);
+                        final Tuple indexKey = Tuple.from(entryToDelete.getKey(), outerRecord.getOtherId(), entryToDelete.getIntValue(),
+                                metaData.getSyntheticRecordType(OnlineIndexerBuildUnnestedIndexTest.UNNESTED).getRecordTypeKey(), Tuple.from(outerRecord.getRecId()), Tuple.from(entryToDeleteIndex));
+                        context.ensureActive().clear(recordStore.indexSubspace(targetIndex).pack(indexKey));
+                        deleteCount++;
+                    }
+                }
+                doDelete = (doDelete + 1) % 3;
+            }
+            context.commit();
+        }
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(false)
+                        .build())
+                .build()) {
+            indexScrubber.scrubDanglingIndexEntries();
+            indexScrubber.scrubMissingIndexEntries();
+        }
+
+        // numRecords/3 records have been deleted. Each one created 3 entries, so the total number of
+        // dangling entries should equal numRecords
+        assertEquals(numRecords / 3, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
+
+        timer.reset();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(true)
+                        .build())
+                .build()) {
+            indexScrubber.scrubDanglingIndexEntries();
+            indexScrubber.scrubMissingIndexEntries();
+        }
+
+        assertEquals(numRecords / 3, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+        assertEquals(numRecords / 3, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
+
+        timer.reset();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(true)
+                        .build())
+                .build()) {
+            indexScrubber.scrubDanglingIndexEntries();
+            indexScrubber.scrubMissingIndexEntries();
+        }
+
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
+    }
+
+    @Test
+    void testScrubJoinedIndex() {
+        final Index targetIndex = new Index("joinedIndex", concat(field("simple").nest("num_value"), field("other").nest("num_value_3"), field("simple").nest("num_value_2")));
+        final OnlineIndexerBuildJoinedIndexTest.OnlineIndexerJoinedRecordHandler recordHandler = OnlineIndexerBuildJoinedIndexTest.OnlineIndexerJoinedRecordHandler.instance();
+        final FDBRecordStoreTestBase.RecordMetaDataHook hook = recordHandler.baseHook(true, null)
+                .andThen(recordHandler.addIndexHook(targetIndex));
+        openMetaData(recordHandler.getFileDescriptor(), hook);
+
+        final long numRecords = 30;
+        populateJoinedData(numRecords);
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .build())
+                .build()) {
+            indexScrubber.scrubDanglingIndexEntries();
+            indexScrubber.scrubMissingIndexEntries();
+        }
+
+        // Scanned 3 * numRecords. This is from:
+        //  1. When looking for missing entries, we scan every record in the database. There are numRecords of type
+        //     MySimpleRecord and numRecords of type MyOtherRecord (so that's 2 * numRecords)
+        //  2. When scanning dangling entries, we look up one for every entry in the index. There are is one entry
+        //     for each pair of simple and other records, so that's another numRecords scanned
+        assertEquals(numRecords * 3, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+        assertEquals(0, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(0, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
+        assertEquals(0, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+    }
+
+    @Test
+    void testDetectDanglingFromJoinedIndex() {
+        final Index targetIndex = new Index("joinedIndex", concat(field("simple").nest("num_value"), field("other").nest("num_value_3"), field("simple").nest("num_value_2")));
+        final OnlineIndexerBuildJoinedIndexTest.OnlineIndexerJoinedRecordHandler recordHandler = OnlineIndexerBuildJoinedIndexTest.OnlineIndexerJoinedRecordHandler.instance();
+        final FDBRecordStoreTestBase.RecordMetaDataHook hook = recordHandler.baseHook(true, null)
+                .andThen(recordHandler.addIndexHook(targetIndex));
+        openMetaData(recordHandler.getFileDescriptor(), hook);
+
+        final long numRecords = 100;
+        final List<Message> data = populateJoinedData(numRecords);
+        try (FDBRecordContext context = openContext()) {
+            int doDelete = 0;
+            for (Message datum : data) {
+                if (!(datum instanceof TestRecordsJoinIndexProto.MySimpleRecord)) {
+                    continue;
+                }
+                if (doDelete == 0) {
+                    TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = (TestRecordsJoinIndexProto.MySimpleRecord)datum;
+                    TestRecordsJoinIndexProto.MyOtherRecord otherRecord = recordStore.loadRecordAsync(Tuple.from(simpleRecord.getOtherRecNo()))
+                            .thenApply(storedRec -> TestRecordsJoinIndexProto.MyOtherRecord.newBuilder().mergeFrom(storedRec.getRecord()).build())
+                            .join();
+
+                    // Clear out both records that are a part of this join pair
+                    context.ensureActive().clear(recordStore.recordsSubspace().subspace(recordHandler.getPrimaryKey(simpleRecord)).range());
+                    context.ensureActive().clear(recordStore.recordsSubspace().subspace(recordHandler.getPrimaryKey(otherRecord)).range());
+                }
+                doDelete = (doDelete + 1) % 4;
+            }
+            context.commit();
+        }
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(false)
+                        .build())
+                .build()) {
+            assertThrows(RecordDoesNotExistException.class, indexScrubber::scrubDanglingIndexEntries);
+            indexScrubber.scrubMissingIndexEntries();
+        }
+    }
+
+    @Test
+    void testDetectMissingFromJoinedIndex() {
+        final Index targetIndex = new Index("joinedIndex", concat(field("simple").nest("num_value"), field("other").nest("num_value_3"), field("simple").nest("num_value_2")));
+        final OnlineIndexerBuildJoinedIndexTest.OnlineIndexerJoinedRecordHandler recordHandler = OnlineIndexerBuildJoinedIndexTest.OnlineIndexerJoinedRecordHandler.instance();
+        final FDBRecordStoreTestBase.RecordMetaDataHook hook = recordHandler.baseHook(true, null)
+                .andThen(recordHandler.addIndexHook(targetIndex));
+        openMetaData(recordHandler.getFileDescriptor(), hook);
+
+        final long numRecords = 100;
+        final List<Message> data = populateJoinedData(numRecords);
+        try (FDBRecordContext context = openContext()) {
+            int doDelete = 0;
+            for (Message datum : data) {
+                if (!(datum instanceof TestRecordsJoinIndexProto.MySimpleRecord)) {
+                    continue;
+                }
+                if (doDelete == 0) {
+                    TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = (TestRecordsJoinIndexProto.MySimpleRecord)datum;
+                    TestRecordsJoinIndexProto.MyOtherRecord otherRecord = recordStore.loadRecordAsync(Tuple.from(simpleRecord.getOtherRecNo()))
+                            .thenApply(storedRec -> TestRecordsJoinIndexProto.MyOtherRecord.newBuilder().mergeFrom(storedRec.getRecord()).build())
+                            .join();
+                    // Clear out the index key for this join pair
+                    final Tuple indexKey = Tuple.from(simpleRecord.getNumValue(), otherRecord.getNumValue3(), simpleRecord.getNumValue2(),
+                            metaData.getSyntheticRecordType("SimpleOtherJoin").getRecordTypeKey(), recordHandler.getPrimaryKey(simpleRecord), recordHandler.getPrimaryKey(otherRecord));
+                    context.ensureActive().clear(recordStore.indexSubspace(targetIndex).pack(indexKey));
+                }
+                doDelete = (doDelete + 1) % 4;
+            }
+            context.commit();
+        }
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(false)
+                        .build())
+                .build()) {
+            indexScrubber.scrubDanglingIndexEntries();
+            indexScrubber.scrubMissingIndexEntries();
+        }
+
+        assertEquals(numRecords / 4, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
+
+        timer.reset();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(true)
+                        .build())
+                .build()) {
+            indexScrubber.scrubDanglingIndexEntries();
+            indexScrubber.scrubMissingIndexEntries();
+        }
+
+        assertEquals(numRecords / 4, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+        assertEquals(numRecords / 4, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
+
+        timer.reset();
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(targetIndex, timer)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setLogWarningsLimit(Integer.MAX_VALUE)
+                        .setAllowRepair(true)
+                        .build())
+                .build()) {
+            indexScrubber.scrubDanglingIndexEntries();
+            indexScrubber.scrubMissingIndexEntries();
+        }
+
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(0L, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -255,6 +256,8 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                     List<M> thisBatch = recordsWhileBuilding.subList(i, Math.min(i + 30, recordsWhileBuilding.size()));
                     fdb.run(context -> {
                         FDBRecordStore store = recordStore.asBuilder().setContext(context).build();
+                        LOGGER.info(KeyValueLogMessage.of("inserting record batch",
+                                LogMessageKeys.PRIMARY_KEY, thisBatch.stream().map(recordHandler::getPrimaryKey).collect(Collectors.toList())));
                         thisBatch.forEach(store::saveRecord);
                         return null;
                     });
@@ -268,6 +271,8 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                     List<Tuple> thisBatch = deleteWhileBuilding.subList(i, Math.min(i + 10, deleteWhileBuilding.size()));
                     fdb.run(context -> {
                         FDBRecordStore store = recordStore.asBuilder().setContext(context).build();
+                        LOGGER.info(KeyValueLogMessage.of("deleting record batch",
+                                LogMessageKeys.PRIMARY_KEY, thisBatch));
                         thisBatch.forEach(store::deleteRecord);
                         return null;
                     });

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildJoinedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildJoinedIndexTest.java
@@ -1,0 +1,530 @@
+/*
+ * OnlineIndexerBuildJoinedIndexTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecordsJoinIndexProto;
+import com.apple.foundationdb.record.TupleFieldsProto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.JoinedRecordTypeBuilder;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.TupleFieldsHelper;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
+import com.apple.test.Tags;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for building indexes on {@link com.apple.foundationdb.record.metadata.JoinedRecordType}s.
+ */
+@SuppressWarnings("try")
+abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndexTest {
+    OnlineIndexerBuildJoinedIndexTest(boolean safeBuild) {
+        super(safeBuild);
+    }
+
+    static class OnlineIndexerJoinedRecordHandler implements OnlineIndexerTestRecordHandler<Message> {
+        private static final OnlineIndexerJoinedRecordHandler INSTANCE = new OnlineIndexerJoinedRecordHandler();
+
+        private OnlineIndexerJoinedRecordHandler() {
+        }
+
+        private static final Set<Descriptors.Descriptor> recNoDescriptors = Set.of(
+                TestRecordsJoinIndexProto.MySimpleRecord.getDescriptor(),
+                TestRecordsJoinIndexProto.MyOtherRecord.getDescriptor(),
+                TestRecordsJoinIndexProto.JoiningRecord.getDescriptor(),
+                TestRecordsJoinIndexProto.TypeA.getDescriptor(),
+                TestRecordsJoinIndexProto.TypeB.getDescriptor(),
+                TestRecordsJoinIndexProto.TypeC.getDescriptor(),
+                TestRecordsJoinIndexProto.NestedA.getDescriptor(),
+                TestRecordsJoinIndexProto.NestedB.getDescriptor()
+        );
+        private static final Set<Descriptors.Descriptor> uuidDescriptors = Set.of(
+                TestRecordsJoinIndexProto.Customer.getDescriptor(),
+                TestRecordsJoinIndexProto.Order.getDescriptor(),
+                TestRecordsJoinIndexProto.Item.getDescriptor()
+        );
+        private static final Set<Descriptors.Descriptor> headerDescriptors = Set.of(
+                TestRecordsJoinIndexProto.CustomerWithHeader.getDescriptor(),
+                TestRecordsJoinIndexProto.OrderWithHeader.getDescriptor()
+        );
+
+        private static final String SIMPLE_OTHER_JOIN_TYPE = "SimpleOtherJoin";
+
+        @Override
+        public Descriptors.FileDescriptor getFileDescriptor() {
+            return TestRecordsJoinIndexProto.getDescriptor();
+        }
+
+        @Nonnull
+        private FDBRecordStoreTestBase.RecordMetaDataHook setPrimaryKeyHook() {
+            return metaDataBuilder -> {
+                metaDataBuilder.getRecordType("CustomerWithHeader").setPrimaryKey(field("___header").nest(concatenateFields("z_key", "rec_id")));
+                metaDataBuilder.getRecordType("OrderWithHeader").setPrimaryKey(field("___header").nest(concatenateFields("z_key", "rec_id")));
+            };
+        }
+
+        @Nonnull
+        private FDBRecordStoreTestBase.RecordMetaDataHook addSimpleOtherJoinTypeHook() {
+            return metaDataBuilder -> {
+                final JoinedRecordTypeBuilder joinedRecordTypeBuilder = metaDataBuilder.addJoinedRecordType(SIMPLE_OTHER_JOIN_TYPE);
+                joinedRecordTypeBuilder.addConstituent("simple", metaDataBuilder.getRecordType("MySimpleRecord"));
+                joinedRecordTypeBuilder.addConstituent("other", metaDataBuilder.getRecordType("MyOtherRecord"));
+                joinedRecordTypeBuilder.addJoin("simple", "num_value", "other", "num_value");
+                joinedRecordTypeBuilder.addJoin("simple", "other_rec_no", "other", "rec_no");
+
+                // Add an index on MySimpleRecord to use when executing the join
+                metaDataBuilder.addIndex("MySimpleRecord", "num_value", "other_rec_no");
+            };
+        }
+
+        @Nonnull
+        @Override
+        public FDBRecordStoreTestBase.RecordMetaDataHook baseHook(final boolean splitLongRecords, @Nullable final Index sourceIndex) {
+            return setPrimaryKeyHook().andThen(addSimpleOtherJoinTypeHook()).andThen(metaDataBuilder -> {
+                metaDataBuilder.setSplitLongRecords(splitLongRecords);
+                assertNull(sourceIndex, "Join indexes do not support building from a source index");
+            });
+        }
+
+        @Nonnull
+        @Override
+        public FDBRecordStoreTestBase.RecordMetaDataHook addIndexHook(@Nonnull final Index index) {
+            return metaDataBuilder -> metaDataBuilder.addIndex(SIMPLE_OTHER_JOIN_TYPE, index);
+        }
+
+        @Nonnull
+        @Override
+        public Tuple getPrimaryKey(@Nonnull final Message message) {
+            if (recNoDescriptors.contains(message.getDescriptorForType())) {
+                final Descriptors.FieldDescriptor recNoDescriptor = message.getDescriptorForType().findFieldByName("rec_no");
+                return Tuple.from(message.getField(recNoDescriptor));
+            } else if (uuidDescriptors.contains(message.getDescriptorForType())) {
+                final Descriptors.FieldDescriptor uuidDescriptor = message.getDescriptorForType().findFieldByName("uuid");
+                final Message uuidMessage = (Message) message.getField(uuidDescriptor);
+                final TupleFieldsProto.UUID uuid = TupleFieldsProto.UUID.newBuilder()
+                        .mergeFrom(uuidMessage)
+                        .build();
+                return Tuple.from(TupleFieldsHelper.fromProto(uuid));
+            } else if (headerDescriptors.contains(message.getDescriptorForType())) {
+                final Descriptors.FieldDescriptor headerFieldDescriptor = message.getDescriptorForType().findFieldByName("___header");
+                final Message headerMessage = (Message) message.getField(headerFieldDescriptor);
+                final TestRecordsJoinIndexProto.Header header = TestRecordsJoinIndexProto.Header.newBuilder()
+                        .mergeFrom(headerMessage)
+                        .build();
+                return Tuple.from(header.getZKey(), header.getRecId());
+            } else {
+                return fail("Unable to get primary key for message: " + message);
+            }
+        }
+
+        public static OnlineIndexerJoinedRecordHandler instance() {
+            return INSTANCE;
+        }
+    }
+
+    @Nonnull
+    private List<IndexEntry> joinValueIndexEntries(@Nonnull Index index, @Nonnull final List<Message> messages) {
+        final Map<Integer, Map<Long, TestRecordsJoinIndexProto.MyOtherRecord>> otherRecords = new HashMap<>();
+        // Collect all of the other records. Sort by num_value and rec_no
+        for (Message message : messages) {
+            if (message instanceof TestRecordsJoinIndexProto.MyOtherRecord) {
+                TestRecordsJoinIndexProto.MyOtherRecord otherRecord = (TestRecordsJoinIndexProto.MyOtherRecord) message;
+                Map<Long, TestRecordsJoinIndexProto.MyOtherRecord> otherRecordsByNumValue = otherRecords.computeIfAbsent(otherRecord.getNumValue(), HashMap::new);
+                otherRecordsByNumValue.put(otherRecord.getRecNo(), otherRecord);
+            }
+        }
+        // For each simple record, look for corresponding other records
+        final List<IndexEntry> indexEntries = new ArrayList<>();
+        final RecordType joinedRecordType = metaData.getSyntheticRecordType(OnlineIndexerJoinedRecordHandler.SIMPLE_OTHER_JOIN_TYPE);
+        for (Message message : messages) {
+            if (message instanceof TestRecordsJoinIndexProto.MySimpleRecord) {
+                TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = (TestRecordsJoinIndexProto.MySimpleRecord) message;
+                Map<Long, TestRecordsJoinIndexProto.MyOtherRecord> otherRecordsByNumValue = otherRecords.get(simpleRecord.getNumValue());
+                if (otherRecordsByNumValue != null) {
+                    TestRecordsJoinIndexProto.MyOtherRecord otherRecord = otherRecordsByNumValue.get(simpleRecord.getOtherRecNo());
+                    if (otherRecord != null) {
+                        final Tuple indexKey = Tuple.from(simpleRecord.getNumValue(), otherRecord.getNumValue3(), simpleRecord.getNumValue2());
+                        final Tuple primaryKey = Tuple.from(joinedRecordType.getRecordTypeKey(), Tuple.from(simpleRecord.getRecNo()), Tuple.from(otherRecord.getRecNo()));
+                        indexEntries.add(new IndexEntry(index, indexKey.addAll(primaryKey), TupleHelpers.EMPTY, primaryKey));
+                    }
+                }
+            }
+        }
+        // Sort by key
+        indexEntries.sort(Comparator.comparing(IndexEntry::getKey));
+        return indexEntries;
+    }
+
+    void singleValueIndexRebuild(@Nonnull List<Message> records, @Nonnull List<Message> recordsWhileBuilding, @Nonnull List<Tuple> deleteWhileBuilding, int agents, boolean overlap) {
+        final OnlineIndexerJoinedRecordHandler recordHandler = OnlineIndexerJoinedRecordHandler.instance();
+
+        final Index joinIndex = new Index("joinIndex", concat(field("simple").nest("num_value"), field("other").nest("num_value_3"), field("simple").nest("num_value_2")));
+        final String numValueParam = "numValue";
+        final String numValue3Param = "numValue3";
+        final RecordQuery joinQuery = RecordQuery.newBuilder()
+                .setRecordType(OnlineIndexerJoinedRecordHandler.SIMPLE_OTHER_JOIN_TYPE)
+                .setFilter(Query.and(
+                        Query.field("simple").matches(Query.field("num_value").equalsParameter(numValueParam)),
+                        Query.field("other").matches(Query.field("num_value_3").equalsParameter(numValue3Param))
+                ))
+                .setSort(field("simple").nest("num_value_2"))
+                .build();
+
+        final Runnable beforeBuild = () -> {
+            try (FDBRecordContext context = openContext()) {
+                assertThrows(RecordCoreException.class, () -> recordStore.planQuery(joinQuery));
+            }
+        };
+        final Runnable afterBuild = () -> {
+            try (FDBRecordContext context = openContext()) {
+                assertThrows(RecordCoreException.class, () -> recordStore.planQuery(joinQuery));
+            }
+        };
+        final Runnable afterReadable = () -> {
+            try (FDBRecordContext context = openContext()) {
+                final RecordQueryPlan plan = recordStore.planQuery(joinQuery);
+                assertThat(plan.toString(), Matchers.containsString("Index(" + joinIndex.getName() + " [EQUALS $" + numValueParam + ", EQUALS $" + numValue3Param + "])"));
+
+                final List<Message> updatedRecords = updated(recordHandler, records, recordsWhileBuilding, deleteWhileBuilding);
+                final List<IndexEntry> expectedEntries = joinValueIndexEntries(joinIndex, updatedRecords);
+                try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(joinIndex, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                    List<IndexEntry> scannedEntries = cursor.asList().join();
+                    assertEquals(expectedEntries, scannedEntries);
+                }
+            }
+        };
+        singleRebuild(recordHandler, records, recordsWhileBuilding, deleteWhileBuilding, agents, overlap, true, joinIndex, null, beforeBuild, afterBuild, afterReadable);
+    }
+
+    void singleValueIndexRebuild(@Nonnull List<Message> records, @Nullable List<Message> recordsWhileBuilding, @Nullable List<Tuple> deleteWhileBuilding) {
+        singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding, 1, false);
+    }
+
+    void singleCountIndexRebuild(@Nonnull List<Message> records, @Nullable List<Message> recordsWhileBuilding, @Nullable List<Tuple> deleteWhileBuilding, int agents, boolean overlap) {
+        final OnlineIndexerJoinedRecordHandler recordHandler = OnlineIndexerJoinedRecordHandler.instance();
+        final Index joinIndex = new Index("joinIndex", new GroupingKeyExpression(field("simple").nest("num_value"), 0), IndexTypes.COUNT);
+        final IndexAggregateFunction indexAggregateFunction = new IndexAggregateFunction(IndexTypes.COUNT, field("num_value"), joinIndex.getName());
+
+        final Runnable beforeBuild = () -> {
+            try (FDBRecordContext context = openContext()) {
+                assertThrows(RecordCoreException.class, () -> recordStore.evaluateAggregateFunction(List.of(OnlineIndexerJoinedRecordHandler.SIMPLE_OTHER_JOIN_TYPE), indexAggregateFunction, TupleRange.ALL, IsolationLevel.SERIALIZABLE).join());
+            }
+        };
+        final Runnable afterBuild = () -> {
+            try (FDBRecordContext context = openContext()) {
+                assertThrows(RecordCoreException.class, () -> recordStore.evaluateAggregateFunction(List.of(OnlineIndexerJoinedRecordHandler.SIMPLE_OTHER_JOIN_TYPE), indexAggregateFunction, TupleRange.ALL, IsolationLevel.SERIALIZABLE).join());
+            }
+        };
+        final Runnable afterReadable = () -> {
+            try (FDBRecordContext context = openContext()) {
+                final List<Message> updatedRecords = updated(recordHandler, records, recordsWhileBuilding, deleteWhileBuilding);
+                final List<IndexEntry> entries = joinValueIndexEntries(joinIndex, updatedRecords);
+
+                final Tuple wholeCount = recordStore.evaluateAggregateFunction(List.of(OnlineIndexerJoinedRecordHandler.SIMPLE_OTHER_JOIN_TYPE), indexAggregateFunction, TupleRange.ALL, IsolationLevel.SERIALIZABLE).join();
+                assertEquals(entries.size(), wholeCount.getLong(0));
+
+                final Set<Long> numValues = entries.stream()
+                        .map(entry -> entry.getKey().getLong(0))
+                        .collect(Collectors.toSet());
+                for (long numValue : numValues) {
+                    final Tuple numValueCount = recordStore.evaluateAggregateFunction(List.of(OnlineIndexerJoinedRecordHandler.SIMPLE_OTHER_JOIN_TYPE), indexAggregateFunction, TupleRange.allOf(Tuple.from(numValue)), IsolationLevel.SERIALIZABLE).join();
+                    long expectedCount = entries.stream()
+                            .map(entry -> entry.getKey().getLong(0))
+                            .filter(entryNumValue -> entryNumValue == numValue)
+                            .count();
+                    assertEquals(expectedCount, numValueCount.getLong(0));
+                }
+                context.commit();
+            }
+        };
+        singleRebuild(recordHandler, records, recordsWhileBuilding, deleteWhileBuilding, agents, overlap, true, joinIndex, null, beforeBuild, afterBuild, afterReadable);
+    }
+
+    void singleCountIndexRebuild(@Nonnull List<Message> records, @Nullable List<Message> recordsWhileBuilding, @Nullable List<Tuple> deleteWhileBuilding) {
+        singleCountIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding, 1, false);
+    }
+
+    @Nonnull
+    private TestRecordsJoinIndexProto.MySimpleRecord randomSimpleRecord(@Nonnull Random r, long recNo, int numValue, long otherRecNo) {
+        return TestRecordsJoinIndexProto.MySimpleRecord.newBuilder()
+                .setRecNo(recNo)
+                .setNumValue(numValue)
+                .setOtherRecNo(otherRecNo)
+                .setNumValue2(r.nextInt(20))
+                .build();
+    }
+
+    @Nonnull
+    private TestRecordsJoinIndexProto.MySimpleRecord randomSimpleRecord(@Nonnull Random r, long recNo) {
+        return randomSimpleRecord(r, recNo, r.nextInt(5), r.nextLong());
+    }
+
+    @Nonnull
+    private TestRecordsJoinIndexProto.MySimpleRecord randomSimpleRecord(@Nonnull Random r) {
+        return randomSimpleRecord(r, r.nextLong());
+    }
+
+    @Nonnull
+    private TestRecordsJoinIndexProto.MySimpleRecord randomJoinedSimpleRecord(@Nonnull Random r, @Nonnull TestRecordsJoinIndexProto.MyOtherRecord otherRecord) {
+        return randomSimpleRecord(r, r.nextLong(), otherRecord.getNumValue(), otherRecord.getRecNo());
+    }
+
+    @Nonnull
+    private TestRecordsJoinIndexProto.MyOtherRecord randomOtherRecord(@Nonnull Random r, int numValue, long recNo) {
+        return TestRecordsJoinIndexProto.MyOtherRecord.newBuilder()
+                .setRecNo(recNo)
+                .setNumValue3(r.nextInt(10))
+                .setNumValue(numValue)
+                .build();
+    }
+
+    @Nonnull
+    private TestRecordsJoinIndexProto.MyOtherRecord randomOtherRecord(@Nonnull Random r) {
+        return randomOtherRecord(r, r.nextInt(5), r.nextLong());
+    }
+
+    @Nonnull
+    private TestRecordsJoinIndexProto.MyOtherRecord randomJoinedOther(@Nonnull Random r, @Nonnull TestRecordsJoinIndexProto.MySimpleRecord simpleRecord) {
+        return randomOtherRecord(r, simpleRecord.getNumValue(), simpleRecord.getOtherRecNo());
+    }
+
+    private void addRandomUpdate(@Nonnull Random r, @Nonnull Message rec, @Nonnull List<Message> recordsWhileBuilding, @Nonnull List<Tuple> deleteWhileBuilding) {
+        double choice = r.nextDouble();
+        if (choice < 0.1) {
+            // Delete this record
+            deleteWhileBuilding.add(OnlineIndexerJoinedRecordHandler.instance().getPrimaryKey(rec));
+        } else if (choice < 0.2) {
+            // Rewrite this record, but preserve the join
+            if (rec instanceof TestRecordsJoinIndexProto.MySimpleRecord) {
+                TestRecordsJoinIndexProto.MySimpleRecord simple = (TestRecordsJoinIndexProto.MySimpleRecord)rec;
+                recordsWhileBuilding.add(randomSimpleRecord(r, simple.getRecNo(), simple.getNumValue(), simple.getOtherRecNo()));
+            } else if (rec instanceof TestRecordsJoinIndexProto.MyOtherRecord) {
+                TestRecordsJoinIndexProto.MyOtherRecord other = (TestRecordsJoinIndexProto.MyOtherRecord)rec;
+                recordsWhileBuilding.add(randomOtherRecord(r, other.getNumValue(), other.getRecNo()));
+            }
+        } else if (choice < 0.4) {
+            // Rewrite this record, breaking the join
+            if (rec instanceof TestRecordsJoinIndexProto.MySimpleRecord) {
+                TestRecordsJoinIndexProto.MySimpleRecord simple = (TestRecordsJoinIndexProto.MySimpleRecord)rec;
+                recordsWhileBuilding.add(randomSimpleRecord(r, simple.getRecNo()));
+            } else if (rec instanceof TestRecordsJoinIndexProto.MyOtherRecord) {
+                TestRecordsJoinIndexProto.MyOtherRecord other = (TestRecordsJoinIndexProto.MyOtherRecord)rec;
+                recordsWhileBuilding.add(randomOtherRecord(r, r.nextInt(5), other.getRecNo()));
+            }
+        } else if (choice < 0.6) {
+            // Remove the join from the original record, and replace it with a new one
+            if (rec instanceof TestRecordsJoinIndexProto.MySimpleRecord) {
+                TestRecordsJoinIndexProto.MySimpleRecord simple = (TestRecordsJoinIndexProto.MySimpleRecord)rec;
+                TestRecordsJoinIndexProto.MySimpleRecord newSimple = randomSimpleRecord(r, simple.getRecNo());
+                recordsWhileBuilding.add(newSimple);
+                recordsWhileBuilding.add(randomJoinedOther(r, newSimple));
+            } else if (rec instanceof TestRecordsJoinIndexProto.MyOtherRecord) {
+                TestRecordsJoinIndexProto.MyOtherRecord other = (TestRecordsJoinIndexProto.MyOtherRecord)rec;
+                TestRecordsJoinIndexProto.MyOtherRecord newOther = randomOtherRecord(r, r.nextInt(5), other.getRecNo());
+                recordsWhileBuilding.add(newOther);
+                recordsWhileBuilding.add(randomJoinedSimpleRecord(r, newOther));
+            }
+        } else if (choice < 0.8) {
+            // Add new records
+            double newRecordChoice = r.nextDouble();
+            if (newRecordChoice < 0.2) {
+                recordsWhileBuilding.add(randomSimpleRecord(r));
+            } else if (newRecordChoice < 0.4) {
+                recordsWhileBuilding.add(randomOtherRecord(r));
+            } else {
+                TestRecordsJoinIndexProto.MySimpleRecord newSimple = randomSimpleRecord(r);
+                recordsWhileBuilding.add(newSimple);
+                recordsWhileBuilding.add(randomJoinedOther(r, newSimple));
+            }
+        }
+    }
+
+    @Test
+    void simpleTenJoinedRecords() {
+        final Random r = new Random(0x5ca1e);
+        final List<Message> records = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
+            records.add(simpleRecord);
+            records.add(randomJoinedOther(r, simpleRecord));
+        }
+        singleValueIndexRebuild(records, null, null);
+    }
+
+    @Test
+    void simpleJoinIsEmpty() {
+        final Random r = new Random(0x0fdb0fdbL);
+        final List<Message> records = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
+            records.add(simpleRecord);
+            records.add(randomOtherRecord(r, simpleRecord.getNumValue(), r.nextLong()));
+        }
+        singleValueIndexRebuild(records, null, null);
+        try (FDBRecordContext context = openContext()) {
+            // Validate that the index is empty
+            try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(metaData.getIndex("joinIndex"), IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                assertThat(cursor.asList().join(), Matchers.empty());
+            }
+        }
+    }
+
+    @Test
+    void simpleJoinWithExtraUnjoinedRecords() {
+        final Random r = new Random(0x5ca1e);
+        final List<Message> records = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
+            records.add(simpleRecord);
+            TestRecordsJoinIndexProto.MyOtherRecord otherRecord = randomJoinedOther(r, simpleRecord);
+            records.add(otherRecord);
+
+            TestRecordsJoinIndexProto.JoiningRecord joiningRecord = TestRecordsJoinIndexProto.JoiningRecord.newBuilder()
+                    .setRecNo(r.nextLong())
+                    .setSimpleRecNo(simpleRecord.getRecNo())
+                    .setOtherRecNo(otherRecord.getRecNo())
+                    .build();
+            records.add(joiningRecord);
+        }
+        singleValueIndexRebuild(records, null, null);
+    }
+
+    @Tag(Tags.Slow)
+    @Test
+    void simpleValueWithUpdatesAndDeletes() {
+        final Random r = new Random(0x5ca1e);
+        final List<Message> records = new ArrayList<>();
+        for (int i = 0; i < 400; i++) {
+            TestRecordsJoinIndexProto.MySimpleRecord simple = randomSimpleRecord(r);
+            records.add(simple);
+            TestRecordsJoinIndexProto.MyOtherRecord other = randomJoinedOther(r, simple);
+            records.add(other);
+        }
+        final OnlineIndexerJoinedRecordHandler recordHandler = OnlineIndexerJoinedRecordHandler.instance();
+        final List<Message> recordsWhileBuilding = new ArrayList<>();
+        final List<Tuple> deleteWhileBuilding = new ArrayList<>();
+        for (Message rec : records) {
+            addRandomUpdate(r, rec, recordsWhileBuilding, deleteWhileBuilding);
+        }
+        singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
+    }
+
+    @Test
+    void simpleTenJoinedCountRecords() {
+        final Random r = new Random(0x5ca1e);
+        final List<Message> records = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
+            records.add(simpleRecord);
+            records.add(randomJoinedOther(r, simpleRecord));
+        }
+        singleCountIndexRebuild(records, null, null);
+    }
+
+    @Test
+    void simpleJoinCountIsEmpty() {
+        final Random r = new Random(0x0fdb0fdbL);
+        final List<Message> records = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
+            records.add(simpleRecord);
+            records.add(randomOtherRecord(r, simpleRecord.getNumValue(), r.nextLong()));
+        }
+        singleCountIndexRebuild(records, null, null);
+        try (FDBRecordContext context = openContext()) {
+            // Validate that the index is empty
+            try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(metaData.getIndex("joinIndex"), IndexScanType.BY_GROUP, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                assertThat(cursor.asList().join(), Matchers.empty());
+            }
+            context.commit();
+        }
+    }
+
+    @Tag(Tags.Slow)
+    @Test
+    @Disabled("Updates to non-idempotent index during joined index build not correctly handled")
+    void simpleCountWithUpdatesAndDeletes() {
+        final Random r = new Random(0x5ca1e);
+        final List<Message> records = new ArrayList<>();
+        for (int i = 0; i < 400; i ++) {
+            TestRecordsJoinIndexProto.MySimpleRecord simple = randomSimpleRecord(r);
+            records.add(simple);
+            TestRecordsJoinIndexProto.MyOtherRecord other = randomJoinedOther(r, simple);
+            records.add(other);
+        }
+        final List<Message> recordsWhileBuilding = new ArrayList<>();
+        final List<Tuple> deleteWhileBuilding = new ArrayList<>();
+        for (Message rec : records) {
+            addRandomUpdate(r, rec, recordsWhileBuilding, deleteWhileBuilding);
+        }
+        singleCountIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
+    }
+
+    static class Unsafe extends OnlineIndexerBuildJoinedIndexTest {
+        Unsafe() {
+            super(false);
+        }
+    }
+
+    static class Safe extends OnlineIndexerBuildJoinedIndexTest {
+        Safe() {
+            super(true);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
@@ -1,0 +1,443 @@
+/*
+ * OnlineIndexerBuildUnnestedIndexTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecordsNestedMapProto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.UnnestedRecordTypeBuilder;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
+import com.apple.test.BooleanSource;
+import com.apple.test.Tags;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.expressions.KeyExpression.FanType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for building indexes on an unnested record type.
+ */
+@SuppressWarnings("try")
+abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildIndexTest {
+    @Nonnull
+    public static final String UNNESTED = "UnnestedMapType";
+    @Nonnull
+    private static final String PARENT_CONSTITUENT = "parent";
+    @Nonnull
+    private static final String ENTRY_CONSTITUENT = "entry";
+    @Nonnull
+    private static final String KEY_PARAM = "key";
+    @Nonnull
+    private static final RecordQuery UNNESTED_KEY_QUERY = RecordQuery.newBuilder()
+            .setRecordType(UNNESTED)
+            .setFilter(Query.field(ENTRY_CONSTITUENT).matches(Query.field("key").equalsParameter(KEY_PARAM)))
+            .setRequiredResults(List.of(field(PARENT_CONSTITUENT).nest("other_id"), field(ENTRY_CONSTITUENT).nest("value")))
+            .setSort(field(PARENT_CONSTITUENT).nest("other_id"))
+            .build();
+
+    @Nonnull
+    private static final List<String> KEYS = List.of("foo", "bar", "baz", "qux", "zop", "zork");
+
+    OnlineIndexerBuildUnnestedIndexTest(boolean safeBuild) {
+        super(safeBuild);
+    }
+
+    public static class OnlineIndexerTestUnnestedRecordHandler implements OnlineIndexerTestRecordHandler<Message> {
+        @Nonnull
+        private static OnlineIndexerTestUnnestedRecordHandler INSTANCE = new OnlineIndexerTestUnnestedRecordHandler();
+
+        private OnlineIndexerTestUnnestedRecordHandler() {
+        }
+
+        @Override
+        public Descriptors.FileDescriptor getFileDescriptor() {
+            return TestRecordsNestedMapProto.getDescriptor();
+        }
+
+        @Nonnull
+        @Override
+        public FDBRecordStoreTestBase.RecordMetaDataHook baseHook(final boolean splitLongRecords, @Nullable final Index sourceIndex) {
+            return metaDataBuilder -> {
+                metaDataBuilder.setSplitLongRecords(splitLongRecords);
+
+                final UnnestedRecordTypeBuilder unnestedBuilder = metaDataBuilder.addUnnestedRecordType(UNNESTED);
+                unnestedBuilder.addParentConstituent(PARENT_CONSTITUENT, metaDataBuilder.getRecordType("OuterRecord"));
+                unnestedBuilder.addNestedConstituent(ENTRY_CONSTITUENT, TestRecordsNestedMapProto.MapRecord.Entry.getDescriptor(), PARENT_CONSTITUENT,
+                        field("map").nest(field("entry", FanType.FanOut)));
+
+                if (sourceIndex != null) {
+                    // TODO: We should consider whether we are okay with source indexes on the unnested record type or not
+                    metaDataBuilder.addIndex("OuterRecord", sourceIndex);
+                }
+            };
+        }
+
+        @Nonnull
+        @Override
+        public FDBRecordStoreTestBase.RecordMetaDataHook addIndexHook(@Nonnull final Index index) {
+            return metaDataBuilder -> metaDataBuilder.addIndex(UNNESTED, index);
+        }
+
+        @Nonnull
+        @Override
+        public Tuple getPrimaryKey(@Nonnull final Message message) {
+            if (message instanceof TestRecordsNestedMapProto.OuterRecord) {
+                return Tuple.from(((TestRecordsNestedMapProto.OuterRecord)message).getRecId());
+            } else if (message instanceof TestRecordsNestedMapProto.OtherRecord) {
+                return Tuple.from(((TestRecordsNestedMapProto.OtherRecord)message).getRecId());
+            } else {
+                return fail("do not support message: " + message);
+            }
+        }
+
+        @Nonnull
+        static OnlineIndexerTestUnnestedRecordHandler instance() {
+            return INSTANCE;
+        }
+    }
+
+    private void assertUnnestedKeyQueryPlanFails() {
+        try (FDBRecordContext context = openContext()) {
+            assertThrows(RecordCoreException.class, () -> recordStore.planQuery(UNNESTED_KEY_QUERY));
+        }
+    }
+
+    @Nonnull
+    private TestRecordsNestedMapProto.OuterRecord randomOuterRecord(@Nonnull Random r, long recId, double keyInclusion) {
+        final TestRecordsNestedMapProto.OuterRecord.Builder builder = TestRecordsNestedMapProto.OuterRecord.newBuilder()
+                .setRecId(recId)
+                .setOtherId(r.nextInt(50));
+        for (String key : KEYS) {
+            if (r.nextDouble() < keyInclusion) {
+                builder.getMapBuilder().addEntryBuilder()
+                        .setKey(key)
+                        .setValue("" + r.nextDouble())
+                        .setIntValue(r.nextInt(50));
+            }
+        }
+        return builder.build();
+    }
+
+    @Nonnull
+    private TestRecordsNestedMapProto.OuterRecord randomOuterRecord(@Nonnull Random r, long recId) {
+        return randomOuterRecord(r, recId, 0.5);
+    }
+
+    @Nonnull
+    private TestRecordsNestedMapProto.OuterRecord randomOuterRecord(@Nonnull Random r) {
+        return randomOuterRecord(r, r.nextLong());
+    }
+
+    @Nonnull
+    private TestRecordsNestedMapProto.OtherRecord randomOtherRecord(@Nonnull Random r, long recId) {
+        return TestRecordsNestedMapProto.OtherRecord.newBuilder()
+                .setRecId(recId)
+                .setOtherId(r.nextInt(50))
+                .setOtherValue(KEYS.get(r.nextInt(KEYS.size())))
+                .build();
+    }
+
+    @Nonnull
+    private TestRecordsNestedMapProto.OtherRecord randomOtherRecord(@Nonnull Random r) {
+        return randomOtherRecord(r, r.nextLong());
+    }
+
+    @Nonnull
+    private List<IndexEntry> unnestedEntriesForOuterRecords(@Nonnull Index index,
+                                                            @Nonnull List<? extends Message> records) {
+        List<IndexEntry> indexEntries = new ArrayList<>();
+        final RecordType unnestedType = metaData.getSyntheticRecordType(UNNESTED);
+        for (Message rec : records) {
+            if (rec instanceof TestRecordsNestedMapProto.OuterRecord) {
+                TestRecordsNestedMapProto.OuterRecord outerRecord = (TestRecordsNestedMapProto.OuterRecord)rec;
+                for (int i = 0; i < outerRecord.getMap().getEntryCount(); i++) {
+                    TestRecordsNestedMapProto.MapRecord.Entry entry = outerRecord.getMap().getEntry(i);
+                    final Tuple primaryKey = Tuple.from(unnestedType.getRecordTypeKey(), Tuple.from(outerRecord.getRecId()), Tuple.from(i));
+                    final Tuple indexKey = Tuple.from(entry.getKey(), outerRecord.getOtherId(), entry.getValue());
+                    indexEntries.add(new IndexEntry(index, indexKey.addAll(primaryKey), TupleHelpers.EMPTY, primaryKey));
+                }
+            }
+        }
+        indexEntries.sort(Comparator.comparing(IndexEntry::getKey));
+        return indexEntries;
+    }
+
+    void singleValueIndexRebuild(@Nonnull List<Message> records,
+                                 @Nullable List<Message> recordsWhileBuilding,
+                                 @Nullable List<Tuple> deleteWhileBuilding,
+                                 int agents, boolean overlap) {
+        final OnlineIndexerTestRecordHandler<Message> recordHandler = OnlineIndexerTestUnnestedRecordHandler.instance();
+        final Index index = new Index("keyOtherValueIndex", concat(field(ENTRY_CONSTITUENT).nest("key"), field(PARENT_CONSTITUENT).nest("other_id"), field(ENTRY_CONSTITUENT).nest("value")));
+        final Runnable beforeBuild = this::assertUnnestedKeyQueryPlanFails;
+        final Runnable afterBuild = this::assertUnnestedKeyQueryPlanFails;
+
+        final Runnable afterReadable = () -> {
+            try (FDBRecordContext context = openContext()) {
+                final RecordQueryPlan plan = recordStore.planQuery(UNNESTED_KEY_QUERY);
+                assertThat(plan.toString(), Matchers.containsString("Covering(Index(" + index.getName() + " [EQUALS $" + KEY_PARAM + "])"));
+
+                final List<Message> updatedRecords = updated(recordHandler, records, recordsWhileBuilding, deleteWhileBuilding);
+                final List<IndexEntry> expectedEntries = unnestedEntriesForOuterRecords(index, updatedRecords);
+                try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(index, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)) {
+                    final List<IndexEntry> scannedEntries = cursor.asList().join();
+                    assertEquals(expectedEntries, scannedEntries);
+                }
+
+                for (String key : KEYS) {
+                    final List<IndexEntry> expectedEntriesForKey = expectedEntries.stream()
+                            .filter(entry -> key.equals(entry.getKey().getString(0)))
+                            .collect(Collectors.toList());
+                    final EvaluationContext evaluationContext = EvaluationContext.forBinding(KEY_PARAM, key);
+                    try (RecordCursor<FDBQueriedRecord<Message>> cursor = plan.execute(recordStore, evaluationContext)) {
+                        final List<IndexEntry> queriedEntries = cursor.map(FDBQueriedRecord::getIndexEntry).asList().join();
+                        assertEquals(expectedEntriesForKey, queriedEntries);
+                    }
+                }
+            }
+        };
+
+        singleRebuild(recordHandler, records, recordsWhileBuilding, deleteWhileBuilding, agents, overlap, true,
+                index, null, beforeBuild, afterBuild, afterReadable);
+    }
+
+    void singleValueIndexRebuild(@Nonnull List<Message> records,
+                                 @Nullable List<Message> recordsWhileBuilding,
+                                 @Nullable List<Tuple> deleteWhileBuilding) {
+        singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding, 1, false);
+    }
+
+    @Test
+    void simpleTenRecordRebuild() {
+        final Random r = new Random(0x5ca1e);
+        List<Message> records = Stream.generate(() -> randomOuterRecord(r))
+                .limit(10)
+                .collect(Collectors.toList());
+        singleValueIndexRebuild(records, null, null);
+    }
+
+    @Test
+    void tenEmptyMapBuild() {
+        final Random r = new Random(0x0fdb0fdb);
+        List<Message> records = Stream.generate(() -> randomOuterRecord(r, r.nextLong(), -1.0))
+                .limit(10)
+                .collect(Collectors.toList());
+        for (Message rec : records) {
+            TestRecordsNestedMapProto.OuterRecord outerRecord = (TestRecordsNestedMapProto.OuterRecord)rec;
+            assertThat(outerRecord.getMap().getEntryList(), empty());
+        }
+        singleValueIndexRebuild(records, null, null);
+    }
+
+    @Test
+    void tenOuterAndTenOtherRecordRebuild() {
+        final Random r = new Random(0x5ca1e);
+        List<Message> records = Stream.generate(() -> Stream.of(randomOuterRecord(r), randomOtherRecord(r)))
+                .flatMap(Function.identity())
+                .limit(20)
+                .collect(Collectors.toList());
+        singleValueIndexRebuild(records, null, null);
+    }
+
+    @Test
+    @Tag(Tags.Slow)
+    void simpleHundredRecordRebuild() {
+        final Random r = new Random(0x5ca1e);
+        List<Message> records = Stream.generate(() -> randomOuterRecord(r))
+                .limit(100)
+                .collect(Collectors.toList());
+        singleValueIndexRebuild(records, null, null);
+    }
+
+    @Test
+    @Tag(Tags.Slow)
+    void simpleFiveHundredWithUpdates() {
+        final Random r = new Random(0xfdb0);
+        List<Message> records = Stream.generate(() -> randomOuterRecord(r))
+                .limit(500)
+                .collect(Collectors.toList());
+        List<Message> recordsWhileBuilding = records.stream()
+                .filter(rec -> r.nextDouble() < 0.3)
+                .map(rec -> randomOuterRecord(r, ((TestRecordsNestedMapProto.OuterRecord)rec).getRecId()))
+                .collect(Collectors.toList());
+        singleValueIndexRebuild(records, recordsWhileBuilding, null);
+    }
+
+    @Test
+    @Tag(Tags.Slow)
+    void simpleFiveHundredWithDeletes() {
+        final Random r = new Random(0xfdb5ca1eL);
+        List<Message> records = Stream.generate(() -> randomOuterRecord(r))
+                .limit(500)
+                .collect(Collectors.toList());
+        List<Tuple> deleteWhileBuilding = records.stream()
+                .filter(rec -> r.nextDouble() < 0.3)
+                .map(rec -> Tuple.from(((TestRecordsNestedMapProto.OuterRecord)rec).getRecId()))
+                .collect(Collectors.toList());
+        singleValueIndexRebuild(records, null, deleteWhileBuilding);
+    }
+
+    @Test
+    @Tag(Tags.Slow)
+    void simpleFiveHundredWithDeletesAndUpdates() {
+        final Random r = new Random(0x13370fdbL);
+        List<Message> records = Stream.generate(() -> randomOuterRecord(r))
+                .limit(500)
+                .collect(Collectors.toList());
+
+        List<Message> recordsWhileBuilding = new ArrayList<>();
+        List<Tuple> deleteWhileBuilding = new ArrayList<>();
+        records.forEach(rec -> {
+            long recId = ((TestRecordsNestedMapProto.OuterRecord)rec).getRecId();
+            double choice = r.nextDouble();
+            if (choice < 0.4) {
+                // Update an existing record
+                recordsWhileBuilding.add(randomOuterRecord(r, recId));
+            } else if (choice < 0.5) {
+                // Delete an existing record
+                deleteWhileBuilding.add(Tuple.from(recId));
+            } else if (choice < 0.7) {
+                // Insert a brand new record
+                recordsWhileBuilding.add(randomOuterRecord(r));
+            }
+        });
+        singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
+    }
+
+    @Test
+    @Tag(Tags.Slow)
+    void fiveHundredOfMixedTypesWithDeletesAndUpdates() {
+        final Random r = new Random(0xf007ba1L);
+        List<Message> records = Stream.generate(() -> r.nextBoolean() ? randomOuterRecord(r) : randomOtherRecord(r))
+                .limit(500)
+                .collect(Collectors.toList());
+
+        final OnlineIndexerTestRecordHandler<Message> recordHandler = OnlineIndexerTestUnnestedRecordHandler.instance();
+        List<Message> recordsWhileBuilding = new ArrayList<>();
+        List<Tuple> deleteWhileBuilding = new ArrayList<>();
+        records.forEach(rec -> {
+            Tuple primaryKey = recordHandler.getPrimaryKey(rec);
+            long recId = primaryKey.getLong(0);
+            double choice = r.nextDouble();
+            if (choice < 0.25) {
+                // Update, make an outer record
+                recordsWhileBuilding.add(randomOuterRecord(r, recId));
+            } else if (choice < 0.5) {
+                // Update, make an other record
+                recordsWhileBuilding.add(randomOtherRecord(r, recId));
+            } else if (choice < 0.7) {
+                // Delete
+                deleteWhileBuilding.add(primaryKey);
+            } else if (choice < 0.8) {
+                // Generate a new outer record
+                recordsWhileBuilding.add(randomOuterRecord(r));
+            } else if (choice < 0.9) {
+                // generate a new other record
+                recordsWhileBuilding.add(randomOtherRecord(r));
+            }
+        });
+        singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
+    }
+
+    @Tag(Tags.Slow)
+    @ParameterizedTest(name = "simpleParallelTwoHundredRebuild[overlap={0}]")
+    @BooleanSource
+    void simpleParallelTwoHundredRebuild(boolean overlap) {
+        final Random r = new Random(0x0fdb0fdb);
+        List<Message> records = LongStream.range(0L, 200L)
+                .mapToObj(id -> randomOuterRecord(r, id))
+                .collect(Collectors.toList());
+        singleValueIndexRebuild(records, null, null, 5, overlap);
+    }
+
+    @Tag(Tags.Slow)
+    @ParameterizedTest
+    @BooleanSource
+    void parallelBuildFiveHundredWithDeletesAndUpdates(boolean overlap) {
+        final Random r = new Random(0x0fdb5caL);
+        List<Message> records = LongStream.range(0L, 500L)
+                .mapToObj(id -> randomOuterRecord(r, id))
+                .collect(Collectors.toList());
+
+        List<Message> recordsWhileBuilding = new ArrayList<>();
+        List<Tuple> deleteWhileBuilding = new ArrayList<>();
+        records.forEach(rec -> {
+            TestRecordsNestedMapProto.OuterRecord outerRecord = (TestRecordsNestedMapProto.OuterRecord)rec;
+            double choice = r.nextDouble();
+            if (choice < 0.4) {
+                // Update an existing record
+                recordsWhileBuilding.add(randomOuterRecord(r, outerRecord.getRecId()));
+            } else if (choice < 0.5) {
+                // Delete an existing record
+                deleteWhileBuilding.add(Tuple.from(outerRecord.getRecId()));
+            } else if (choice < 0.7) {
+                // Insert a brand new record
+                recordsWhileBuilding.add(randomOuterRecord(r));
+            }
+        });
+        singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding, 5, overlap);
+    }
+
+    public static class Safe extends OnlineIndexerBuildUnnestedIndexTest {
+        Safe() {
+            super(true);
+        }
+
+    }
+
+    public static class Unsafe extends OnlineIndexerBuildUnnestedIndexTest {
+        Unsafe() {
+            super(false);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
@@ -57,6 +57,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
 
     private void valueRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
                               int agents, boolean overlap, boolean splitLongRecords) {
+        final OnlineIndexerTestRecordHandler<TestRecords1Proto.MySimpleRecord> recordHandler = OnlineIndexerTestSimpleRecordHandler.instance();
         Index index = new Index("newIndex", field("num_value_2"));
         Function<FDBQueriedRecord<Message>, Integer> projection = rec -> {
             TestRecords1Proto.MySimpleRecord simple = TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(rec.getRecord()).build();
@@ -96,12 +97,12 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         List<TestRecords1Proto.MySimpleRecord> updatedRecords;
         List<RecordQuery> updatedQueries;
         Map<Integer, List<Message>> updatedValueMap;
-        if (recordsWhileBuilding == null || recordsWhileBuilding.size() == 0) {
+        if (recordsWhileBuilding == null || recordsWhileBuilding.isEmpty()) {
             updatedRecords = records;
             updatedQueries = queries;
             updatedValueMap = valueMap;
         } else {
-            updatedRecords = updated(records, recordsWhileBuilding);
+            updatedRecords = updated(recordHandler, records, recordsWhileBuilding, null);
             updatedQueries = updatedRecords.stream()
                     .map(record -> {
                         Integer value2 = (record.hasNumValue2()) ? record.getNumValue2() : null;
@@ -146,7 +147,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
             }
         };
 
-        singleRebuild(records, recordsWhileBuilding, null, agents, overlap, splitLongRecords, index, null, beforeBuild, afterBuild, afterReadable);
+        singleRebuild(recordHandler, records, recordsWhileBuilding, null, agents, overlap, splitLongRecords, index, null, beforeBuild, afterBuild, afterReadable);
     }
 
     private void valueRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -121,13 +121,13 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
         });
     }
 
-    private void openMetaData(@Nonnull Descriptors.FileDescriptor descriptor, @Nonnull RecordMetaDataHook hook) {
+    void openMetaData(@Nonnull Descriptors.FileDescriptor descriptor, @Nonnull RecordMetaDataHook hook) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(descriptor);
         hook.apply(metaDataBuilder);
         metaData = metaDataBuilder.getRecordMetaData();
     }
 
-    private void openMetaData(@Nonnull Descriptors.FileDescriptor descriptor) {
+    void openMetaData(@Nonnull Descriptors.FileDescriptor descriptor) {
         openMetaData(descriptor, (metaDataBuilder) -> {
         });
     }
@@ -136,7 +136,7 @@ public abstract class OnlineIndexerTest extends FDBTestBase {
         openMetaData(TestRecords1Proto.getDescriptor());
     }
 
-    void openSimpleMetaData(RecordMetaDataHook hook) {
+    void openSimpleMetaData(@Nonnull RecordMetaDataHook hook) {
         openMetaData(TestRecords1Proto.getDescriptor(), hook);
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTestRecordHandler.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTestRecordHandler.java
@@ -1,0 +1,50 @@
+/*
+ * OnlineIndexerTestRecordHandler.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Interface for use within {@link OnlineIndexerTest}s that provides information like the file descriptor and the
+ * way to extract a primary key.
+ *
+ * @param <M> message type handled by this record handler
+ * @see OnlineIndexerTestSimpleRecordHandler for the record handler to use when working with {@link com.apple.foundationdb.record.TestRecords1Proto.MySimpleRecord}s
+ */
+interface OnlineIndexerTestRecordHandler<M extends Message> {
+
+    Descriptors.FileDescriptor getFileDescriptor();
+
+    @Nonnull
+    FDBRecordStoreTestBase.RecordMetaDataHook baseHook(boolean splitLongRecords, @Nullable Index sourceIndex);
+
+    @Nonnull
+    FDBRecordStoreTestBase.RecordMetaDataHook addIndexHook(@Nonnull Index index);
+
+    @Nonnull
+    Tuple getPrimaryKey(@Nonnull M message);
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTestSimpleRecordHandler.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTestSimpleRecordHandler.java
@@ -1,0 +1,75 @@
+/*
+ * OnlineIndexerTestSimpleRecordHandler.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.Descriptors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Record handler to use within online index tests to handle {@link com.apple.foundationdb.record.TestRecords1Proto.MySimpleRecord}s.
+ */
+class OnlineIndexerTestSimpleRecordHandler implements OnlineIndexerTestRecordHandler<TestRecords1Proto.MySimpleRecord> {
+    private static final OnlineIndexerTestSimpleRecordHandler INSTANCE = new OnlineIndexerTestSimpleRecordHandler();
+
+    private OnlineIndexerTestSimpleRecordHandler() {
+    }
+
+    @Override
+    public Descriptors.FileDescriptor getFileDescriptor() {
+        return TestRecords1Proto.getDescriptor();
+    }
+
+    @Nonnull
+    @Override
+    public FDBRecordStoreTestBase.RecordMetaDataHook baseHook(final boolean splitLongRecords, @Nullable final Index sourceIndex) {
+        return metaDataBuilder -> {
+            if (splitLongRecords) {
+                metaDataBuilder.setSplitLongRecords(splitLongRecords);
+                metaDataBuilder.removeIndex("MySimpleRecord$str_value_indexed");
+            }
+            if (sourceIndex != null) {
+                metaDataBuilder.addIndex("MySimpleRecord", sourceIndex);
+            }
+        };
+    }
+
+    @Nonnull
+    @Override
+    public FDBRecordStoreTestBase.RecordMetaDataHook addIndexHook(@Nonnull final Index index) {
+        return metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+    }
+
+    @Nonnull
+    @Override
+    public Tuple getPrimaryKey(@Nonnull final TestRecords1Proto.MySimpleRecord message) {
+        return Tuple.from(message.getRecNo());
+    }
+
+    @Nonnull
+    public static OnlineIndexerTestSimpleRecordHandler instance() {
+        return INSTANCE;
+    }
+}

--- a/fdb-record-layer-core/src/test/proto/test_records_1_evolved_with_map.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_1_evolved_with_map.proto
@@ -1,0 +1,60 @@
+/*
+ * test_records_1_evolved_with_map.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.apple.foundationdb.record.test1withmap;
+
+option java_package = "com.apple.foundationdb.record";
+option java_outer_classname = "TestRecords1EvolvedWithMapProto";
+
+import "record_metadata_options.proto";
+
+option (schema).store_record_versions = true;
+
+message MySimpleRecord {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  optional string str_value_indexed = 2 [(field).index = {}];
+  optional int32 num_value_unique = 3 [(field).index = { unique: true }];
+  optional int32 num_value_2 = 4;
+  optional int32 num_value_3_indexed = 5 [(field).index = {}];
+  repeated int32 repeater = 6;
+}
+
+message MyOtherRecord {
+  required int64 rec_no = 1 [(field).primary_key = true];
+  optional int32 num_value_2 = 4;
+  optional int32 num_value_3_indexed = 5;
+}
+
+message MyMapRecord {
+  optional int64 rec_no = 1 [(field).primary_key = true];
+  repeated Entry map_str_to_long = 2;
+  message Entry {
+    optional string key = 1;
+    optional int64 value = 2;
+  }
+  optional string other_str = 3;
+}
+
+message RecordTypeUnion {
+  optional MySimpleRecord _MySimpleRecord = 1;
+  optional MyOtherRecord _MyOtherRecord = 2;
+  optional MyMapRecord _MyMapRecord = 3;
+}

--- a/fdb-record-layer-core/src/test/proto/test_records_join_index.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_join_index.proto
@@ -43,7 +43,7 @@ message MyOtherRecord {
 
 message JoiningRecord {
   required int64 rec_no = 1 [(field).primary_key = true];
-  optional int32 simple_rec_no = 2 [(field).index = {}];
+  optional int64 simple_rec_no = 2 [(field).index = {}];
   optional int64 other_rec_no = 3 [(field).index = {}];
 }
 

--- a/fdb-record-layer-core/src/test/proto/test_records_map.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_map.proto
@@ -22,6 +22,13 @@ message MapRecord {
     repeated Entry entry = 1;
 }
 
+message OtherRecord {
+    optional int64 rec_id = 1 [(field).primary_key = true];
+    optional int64 other_id = 2;
+    optional string other_value = 3;
+}
+
 message RecordTypeUnion {
     optional OuterRecord _OuterRecord = 1;
+    optional OtherRecord _OtherRecord = 2;
 }


### PR DESCRIPTION
This PR contains the following changes:

1. The main thing is updating how synthetic records are handled by the scrubber so that they handle synthetic records properly. As it turns out, this logic was divorced from the logic in the builder, which is why the scrubbers (and not the builder) had this issue
2. Modify the way that `checkVersion` handles synthetic records. Previously, it could get tricked into thinking a synthetic type had no records as it would scan the primary key space looking for records prefixed by the record type key of the synthetic record type. This modifies the check so that it looks at the underlying stored record types instead
3. Adds a bunch of tests around index builds for synthetic record types. Working on these tests led me to those other two issues. There's also a test now for the scrubber on synthetic types

This fixes #2513.