### PR TITLE
Fixes #2543: Permuted min/max indexes on keys producing duplicates only index the first entry

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Permuted min and max indexes on repeated fields now index all entries if defined on a `FanOut` expression [(Issue #2543)](https://github.com/FoundationDB/fdb-record-layer/issues/2543)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** The `PlanOrderingKey` can now handle multiple instances of the same expression appearing within the same key [(Issue #2452)](https://github.com/FoundationDB/fdb-record-layer/issues/2462)
@@ -38,7 +38,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Permuted min or max indexes on repeated fields need to be rebuilt to ensure completeness [(Issue #2543)](https://github.com/FoundationDB/fdb-record-layer/issues/2543)
 
 // end next release
 -->


### PR DESCRIPTION
The core issue was that there was an early-out in the `PermutedMinMaxIndexMaintainer`'s implementation of `updateIndexKeys`. This updates the loop so that it no longer early outs, and thus all entries will get included in the index. Some care has been taken so that if the same record produces multiple entries in the same group (which can happen if the repeated field is in the grouping key and the same value appears multiple time in the repeated field OR if the repeated field is in the aggregate value), then only the most extreme value for the record is used to determine what new entries to add to the permuted space. All values still get added to the primary index space, though, so that part of the index should behave exactly like a normal value index on the whole key (i.e., ignoring the `GroupingKeyExpression`).

This fixes #2543.