### PR TITLE
Fixes #2552: Nested fields can preserve field protobuf indexes incorrectly in index expansion

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Avoid protobuf validation errors when expanding nested repeated index expressions [(Issue #2552)](https://github.com/FoundationDB/fdb-record-layer/issues/2552)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
@@ -216,7 +216,7 @@ public class AggregateIndexExpansionVisitor extends KeyExpressionExpansionVisito
         Stream.concat(Stream.of(baseQuantifier), baseExpansion.getQuantifiers().stream())
                 .forEach(qun -> {
                     final var quantifiedValue = QuantifiedObjectValue.of(qun.getAlias(), qun.getFlowedObjectType());
-                    builder.addResultColumn(Column.of(Type.Record.Field.of(quantifiedValue.getResultType(), Optional.of(qun.getAlias().getId())), quantifiedValue));
+                    builder.addResultColumn(Column.of(Optional.of(qun.getAlias().getId()), quantifiedValue));
                 });
         builder.addAllPlaceholders(baseExpansion.getPlaceholders());
         builder.addAllPredicates(baseExpansion.getPredicates());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Column.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Column.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A class to hold a value computing a column together with information about the field of a record it supplies
@@ -75,6 +76,10 @@ public class Column<V extends Value> implements PlanHashable, PlanSerializable {
 
     public static <V extends Value> Column<V> unnamedOf(@Nonnull final V value) {
         return new Column<>(Field.unnamedOf(value.getResultType()), value);
+    }
+
+    public static <V extends Value> Column<V> of(@Nonnull Optional<String> fieldNameOptional, @Nonnull final V value) {
+        return new Column<>(Field.of(value.getResultType(), fieldNameOptional), value);
     }
 
     public static <V extends Value> Column<V> of(@Nonnull final Field field, @Nonnull final V value) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
@@ -321,11 +321,7 @@ public class GraphExpansion {
         final var quantifiersBuilder = ImmutableList.<Quantifier>builder();
         final var placeholdersBuilder = ImmutableList.<Placeholder>builder();
         for (final GraphExpansion expandedPredicate : graphExpansions) {
-            for (Column<?> resultColumn : expandedPredicate.getResultColumns()) {
-                // Preserve field names in the result columns, but do not preserve ordinal numbers, which will
-                // be recalculated based on the position of the field within the final expression
-                resultColumnsBuilder.add(Column.of(resultColumn.getField().getFieldNameOptional(), resultColumn.getValue()));
-            }
+            resultColumnsBuilder.addAll(expandedPredicate.getResultColumns());
             predicatesBuilder.addAll(expandedPredicate.getPredicates());
             quantifiersBuilder.addAll(expandedPredicate.getQuantifiers());
             placeholdersBuilder.addAll(expandedPredicate.getPlaceholders());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
@@ -321,7 +321,11 @@ public class GraphExpansion {
         final var quantifiersBuilder = ImmutableList.<Quantifier>builder();
         final var placeholdersBuilder = ImmutableList.<Placeholder>builder();
         for (final GraphExpansion expandedPredicate : graphExpansions) {
-            resultColumnsBuilder.addAll(expandedPredicate.getResultColumns());
+            for (Column<?> resultColumn : expandedPredicate.getResultColumns()) {
+                // Preserve field names in the result columns, but do not preserve ordinal numbers, which will
+                // be recalculated based on the position of the field within the final expression
+                resultColumnsBuilder.add(Column.of(resultColumn.getField().getFieldNameOptional(), resultColumn.getValue()));
+            }
             predicatesBuilder.addAll(expandedPredicate.getPredicates());
             quantifiersBuilder.addAll(expandedPredicate.getQuantifiers());
             placeholdersBuilder.addAll(expandedPredicate.getPlaceholders());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
@@ -43,7 +43,6 @@ import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Expansion visitor that implements the shared logic between primary scan data access and value index access.
@@ -128,7 +127,7 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
                 // explode this field and prefixes of this field
                 final Quantifier.ForEach childBase = fieldKeyExpression.explodeField(baseQuantifier, fieldNamePrefix);
                 value = state.registerValue(childBase.getFlowedObjectValue());
-                column = Column.of(Optional.of(fieldName), value);
+                column = Column.unnamedOf(value);
                 final GraphExpansion childExpansion;
                 if (state.isKey()) {
                     childExpansion = GraphExpansion.ofResultColumnAndPlaceholder(column, value.asPlaceholder(newParameterAlias()));
@@ -146,7 +145,7 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
                         .builderWithInheritedPlaceholders().pullUpQuantifier(childQuantifier).build();
             case None:
                 value = state.registerValue(FieldValue.ofFieldNames(baseQuantifier.getFlowedObjectValue(), fieldNames));
-                column = Column.of(Optional.of(fieldName), value);
+                column = Column.unnamedOf(value);
                 if (state.isKey()) {
                     return GraphExpansion.ofResultColumnAndPlaceholder(column, value.asPlaceholder(newParameterAlias()));
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/UpdateExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/UpdateExpression.java
@@ -229,9 +229,9 @@ public class UpdateExpression implements RelationalExpressionWithChildren, Plann
     @Nonnull
     public static Value makeComputationValue(@Nonnull final Quantifier inner, @Nonnull final Type targetType) {
         final var oldColumn =
-                Column.of(Type.Record.Field.of(inner.getFlowedObjectType(), Optional.of(OLD_FIELD_NAME)), inner.getFlowedObjectValue());
+                Column.of(Optional.of(OLD_FIELD_NAME), inner.getFlowedObjectValue());
         final var newColumn =
-                Column.of(Type.Record.Field.of(targetType, Optional.of(NEW_FIELD_NAME)), ObjectValue.of(RecordQueryAbstractDataModificationPlan.currentModifiedRecordAlias(), targetType));
+                Column.of(Optional.of(NEW_FIELD_NAME), ObjectValue.of(RecordQueryAbstractDataModificationPlan.currentModifiedRecordAlias(), targetType));
         return RecordConstructorValue.ofColumns(ImmutableList.of(oldColumn, newColumn));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
@@ -2130,6 +2130,7 @@ public interface Type extends Narrowable<Type>, PlanSerializable {
                 }
                 if (field.fieldIndexOptional.isPresent() && !fieldIndexesSeen.add(field.getFieldIndex())) {
                     override = true;
+                    break;
                 }
             }
 
@@ -2154,7 +2155,7 @@ public interface Type extends Narrowable<Type>, PlanSerializable {
                     fieldToBeAdded =
                             new Field(field.getFieldType(),
                                     Optional.of(explicitFieldName),
-                                    Optional.of(field.getFieldIndexOptional().orElse(i + 1)));
+                                    Optional.of(i + 1));
                 }
 
                 if (!(fieldNamesSeen.add(fieldToBeAdded.getFieldName()))) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
@@ -83,6 +83,7 @@ import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Tag;
@@ -185,6 +186,8 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
     private static final String SUM_VALUE_BY_KEY_UNNESTED = "sumValueByKeyUnnested";
     private static final String SUM_WHOLE_RECORD_VALUE_BY_KEY = "sumWholeRecordValueByKey";
     private static final String SUM_WHOLE_RECORD_VALUE_BY_KEY_UNNESTED = "sumValueByKey";
+    private static final String SUM_VALUE_BY_KEY_AND_OTHER = "sumValueByKeyAndOther";
+    private static final String SUM_VALUE_BY_KEY_AND_OTHER_UNNESTED = "sumValueByOtherAndKeyUnnested";
     private static final String BITMAP_VALUE_BY_KEY = "bitmapValueByKey";
     private static final String BITMAP_VALUE_BY_KEY_UNNESTED = "bitmapValueByKeyUnnested";
     private static final String BITMAP_VALUE_OTHER_KEY = "bitmapValueByOuterKey";
@@ -304,6 +307,14 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
 
     private static Index sumWholeRecordByKeyUnnested() {
         return new Index(SUM_WHOLE_RECORD_VALUE_BY_KEY_UNNESTED, field("e2").nest("int_value").groupBy(field("e1").nest("key")), IndexTypes.SUM);
+    }
+
+    private static Index sumValueByKeyAndOther() {
+        return new Index(SUM_VALUE_BY_KEY_AND_OTHER, new GroupingKeyExpression(concat(field("other_id"), onEntry(() -> concatenateFields("key", "int_value"))), 1), IndexTypes.SUM);
+    }
+
+    private static Index sumValueByKeyAndOtherUnnested() {
+        return new Index(SUM_VALUE_BY_KEY_AND_OTHER_UNNESTED, field("entry").nest("int_value").groupBy(field(PARENT_CONSTITUENT).nest("other_id"), field("entry").nest("key")), IndexTypes.SUM);
     }
 
     private static Index bitmapValueByKey() {
@@ -1511,6 +1522,93 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
         }, this::querySumIntValueForRecordByKey);
     }
 
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    void sumByKeyAndOther() {
+        final RecordMetaDataHook hook = addUnnestedType().andThen(metaDataBuilder -> {
+            metaDataBuilder.addIndex(OUTER, sumValueByKeyAndOther());
+            metaDataBuilder.addIndex(OUTER_WITH_ENTRIES, sumValueByKeyAndOtherUnnested());
+        });
+
+        List<TestRecordsNestedMapProto.OuterRecord> data = setUpDataWithInts(hook);
+        final Map<Tuple, Long> sumsByGroup = new HashMap<>();
+        for (TestRecordsNestedMapProto.OuterRecord outerRecord : data) {
+            for (TestRecordsNestedMapProto.MapRecord.Entry entry : outerRecord.getMap().getEntryList()) {
+                Tuple group = Tuple.from(outerRecord.getOtherId(), entry.getKey());
+                sumsByGroup.compute(group, (key, oldValue) -> oldValue == null ? entry.getIntValue() : oldValue + entry.getIntValue());
+            }
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            createOrOpenMapStore(context, hook);
+
+            // Execute a Cascades query that will return each group
+            final RecordQueryPlan plan = planGraph(() -> {
+                final Quantifier outerQun = outerRecQun();
+                final Quantifier explodeEntryQun = explodeEntryQun(outerQun, "key", "int_value");
+
+                // Create select where, group by other_id and key
+                final RecordConstructorValue groupingValue = RecordConstructorValue.ofColumns(List.of(
+                        Column.of(Optional.of("other_id"), FieldValue.ofFieldName(outerQun.getFlowedObjectValue(), "other_id")),
+                        Column.of(Optional.of("key"), FieldValue.ofFieldName(explodeEntryQun.getFlowedObjectValue(), "key"))
+                ));
+                final Quantifier selectWhereGroupBy = Quantifier.forEach(GroupExpressionRef.of(GraphExpansion.builder()
+                        .addQuantifier(outerQun)
+                        .addQuantifier(explodeEntryQun)
+                        .addResultColumn(Column.unnamedOf(groupingValue))
+                        .addResultColumn(Column.of(Optional.of(outerQun.getAlias().getId()), outerQun.getFlowedObjectValue()))
+                        .addResultColumn(Column.of(Optional.of(explodeEntryQun.getAlias().getId()), explodeEntryQun.getFlowedObjectValue()))
+                        .build()
+                        .buildSelect()));
+
+                // Aggregate int_value (by group)
+                final FieldValue aggregatedValue = FieldValue.ofFieldNames(selectWhereGroupBy.getFlowedObjectValue(), List.of(explodeEntryQun.getAlias().getId(), "int_value"));
+                final Quantifier groupBy = groupAggregateByKey(selectWhereGroupBy, new NumericAggregationValue.Sum.SumFn(), aggregatedValue);
+
+                // Select both grouping keys plus the aggregate value
+                final Quantifier selectHaving = Quantifier.forEach(GroupExpressionRef.of(GraphExpansion.builder()
+                        .addQuantifier(groupBy)
+                        .addResultColumn(Column.of(Optional.of("other_id"), FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupBy.getFlowedObjectValue(), 0), 0)))
+                        .addResultColumn(Column.of(Optional.of("key"), FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupBy.getFlowedObjectValue(), 0), 1)))
+                        .addResultColumn(Column.of(Optional.of("sum"), FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupBy.getFlowedObjectValue(), 1), 0)))
+                        .build()
+                        .buildSelect()));
+                return unsorted(selectHaving);
+            });
+            assertThat(plan.getUsedIndexes(), contains(SUM_VALUE_BY_KEY_AND_OTHER));
+
+            // Execute plan and assert that the sum by group matches expectations
+            final Map<Tuple, Long> queriedSumsByGroup = Maps.newHashMapWithExpectedSize(sumsByGroup.size());
+            try (RecordCursor<QueryResult> cursor = FDBSimpleQueryGraphTest.executeCascades(recordStore, plan)) {
+                cursor.forEach(queryResult -> {
+                    final Message queriedMessage = queryResult.getMessage();
+                    final Descriptors.Descriptor recDescriptor = queriedMessage.getDescriptorForType();
+                    Tuple group = Tuple.from(queriedMessage.getField(recDescriptor.findFieldByName("other_id")), queriedMessage.getField(recDescriptor.findFieldByName("key")));
+                    long value = (long) queriedMessage.getField(recDescriptor.findFieldByName("sum"));
+                    queriedSumsByGroup.put(group, value);
+                }).join();
+            }
+            assertEquals(sumsByGroup, queriedSumsByGroup);
+
+            // Evaluate index aggregate functions for each group and assert that the sum matches
+            final IndexAggregateFunction sumOuter = new IndexAggregateFunction(FunctionNames.SUM, concat(field("other_id"), onEntry(() -> field("key"))), SUM_VALUE_BY_KEY_AND_OTHER);
+            final IndexAggregateFunction sumUnnested = new IndexAggregateFunction(FunctionNames.SUM, concat(field(PARENT_CONSTITUENT).nest("other_id"), field("entry").nest("key")), SUM_VALUE_BY_KEY_AND_OTHER_UNNESTED);
+
+            for (Map.Entry<Tuple, Long> groupAndSum : sumsByGroup.entrySet()) {
+                final Tuple expectedSum = Tuple.from(groupAndSum.getValue());
+                final Tuple group = groupAndSum.getKey();
+                final Key.Evaluated groupEvaluated = Key.Evaluated.fromTuple(group);
+                Tuple byOuterIndex = recordStore.evaluateAggregateFunction(List.of(OUTER), sumOuter, groupEvaluated, IsolationLevel.SERIALIZABLE)
+                        .join();
+                assertEquals(expectedSum, byOuterIndex, () -> "mismatched aggregate value for group " + group + " when using index on outer record");
+                Tuple byUnnestedIndex = recordStore.evaluateAggregateFunction(List.of(OUTER_WITH_ENTRIES), sumUnnested, groupEvaluated, IsolationLevel.SERIALIZABLE)
+                        .join();
+                assertEquals(expectedSum, byUnnestedIndex, () -> "mismatched aggregate value for group " + group + " when using index on unnested record");
+            }
+
+            commit(context);
+        }
+    }
+
     private void testAggregateIndex(RecordMetaDataHook hook, List<TestRecordsNestedMapProto.OuterRecord> data,
                                     IndexAggregateFunction normalAggregate, IndexAggregateFunction unnestedAggregate,
                                     Function<List<TestRecordsNestedMapProto.OuterRecord>, Map<String, Tuple>> aggregator,
@@ -1921,9 +2019,9 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
         ));
         selectWhereBuilder
                 .addResultColumn(Column.unnamedOf(groupingValue))
-                .addResultColumn(Column.of(Type.Record.Field.of(outerQun.getFlowedObjectType(), Optional.of(outerQun.getAlias().getId())), outerQun.getFlowedObjectValue()));
+                .addResultColumn(Column.of(Optional.of(outerQun.getAlias().getId()), outerQun.getFlowedObjectValue()));
         for (Quantifier entryQun : entryQuns) {
-            selectWhereBuilder.addResultColumn(Column.of(Type.Record.Field.of(entryQun.getFlowedObjectType(), Optional.of(entryQun.getAlias().getId())), entryQun.getFlowedObjectValue()));
+            selectWhereBuilder.addResultColumn(Column.of(Optional.of(entryQun.getAlias().getId()), entryQun.getFlowedObjectValue()));
         }
         return Quantifier.forEach(GroupExpressionRef.of(selectWhereBuilder.build().buildSelect()));
     }
@@ -1942,8 +2040,8 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
         final FieldValue groupVal = FieldValue.ofOrdinalNumber(groupBy.getFlowedObjectValue(), 0);
         final FieldValue aggregate = FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupBy.getFlowedObjectValue(), 1), 0);
         final SelectExpression selectHaving = selectHavingBuilder
-                .addResultColumn(Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("key")), FieldValue.ofOrdinalNumberAndFuseIfPossible(groupVal, 0)))
-                .addResultColumn(Column.of(Type.Record.Field.of(aggregate.getResultType(), Optional.of("aggregate")), aggregate))
+                .addResultColumn(Column.of(Optional.of("key"), FieldValue.ofOrdinalNumberAndFuseIfPossible(groupVal, 0)))
+                .addResultColumn(Column.of(Optional.of("aggregate"), aggregate))
                 .build()
                 .buildSelect();
         return Quantifier.forEach(GroupExpressionRef.of(selectHaving));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBPermutedMinMaxQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBPermutedMinMaxQueryTest.java
@@ -43,7 +43,6 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSort
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
-import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
@@ -112,8 +111,8 @@ class FDBPermutedMinMaxQueryTest extends FDBRecordStoreQueryTestBase {
         final var num2Value = FieldValue.ofFieldName(baseQun.getFlowedObjectValue(), "num_value_2");
         final var num3Value = FieldValue.ofFieldName(baseQun.getFlowedObjectValue(), "num_value_3_indexed");
         final List<Column<? extends Value>> groupingColumns = List.of(
-                Column.of(Type.Record.Field.of(num2Value.getResultType(), Optional.of("num_value_2")), num2Value),
-                Column.of(Type.Record.Field.of(num3Value.getResultType(), Optional.of("num_value_3_indexed")), num3Value)
+                Column.of(Optional.of("num_value_2"), num2Value),
+                Column.of(Optional.of("num_value_3_indexed"), num3Value)
         );
         selectWhereBuilder
                 .addResultValue(RecordConstructorValue.ofColumns(groupingColumns))

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreRepeatedQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreRepeatedQueryTest.java
@@ -118,7 +118,7 @@ class FDBRecordStoreRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
         final var num3Value = FieldValue.ofFieldName(baseQun.getFlowedObjectValue(), "num_value_3_indexed");
         final List<Column<? extends Value>> groupingColumns = ImmutableList.of(
                 Column.unnamedOf(FieldValue.ofOrdinalNumber(repeatQun.getFlowedObjectValue(), 0)),
-                Column.of(Type.Record.Field.of(num3Value.getResultType(), Optional.of("num_value_3_indexed")), num3Value)
+                Column.of(Optional.of("num_value_3_indexed"), num3Value)
         );
         selectWhereBuilder
                 .addResultValue(RecordConstructorValue.ofColumns(groupingColumns))

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -141,7 +141,7 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
 
     @Nonnull
     static <V extends Value> Column<V> resultColumn(@Nonnull V value, @Nullable String name) {
-        return Column.of(Field.of(value.getResultType(), Optional.ofNullable(name)), value);
+        return Column.of(Optional.ofNullable(name), value);
     }
 
     static RecordCursor<QueryResult> executeCascades(FDBRecordStore store, RecordQueryPlan plan) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/GroupByTest.java
@@ -188,7 +188,7 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
 
         final var scanAlias = qun.getAlias();
         final var groupByColAlias = CorrelationIdentifier.of("select_grouping_cols");
-        final var groupingCol = Column.of(Type.Record.Field.of(num2Value.getResultType(), Optional.of("num_value_2")), num2Value);
+        final var groupingCol = Column.of(Optional.of("num_value_2"), num2Value);
         final var groupingColGroup = RecordConstructorValue.ofColumns(ImmutableList.of(groupingCol));
 
         // 1. build the underlying select, result expr = ( (num_value_2 as GB) <group1>, ($qun as qun) <group2>)
@@ -196,11 +196,11 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
             final var selectBuilder = GraphExpansion.builder();
 
             // <group1>
-            final var col1 = Column.of(Type.Record.Field.of(groupingColGroup.getResultType(), Optional.of(groupByColAlias.getId())), groupingColGroup);
+            final var col1 = Column.of(Optional.of(groupByColAlias.getId()), groupingColGroup);
 
             // <group2>
             final var quantifiedValue = QuantifiedObjectValue.of(qun.getAlias(), qun.getFlowedObjectType());
-            final var col2 = Column.of(Type.Record.Field.of(quantifiedValue.getResultType(), Optional.of(qun.getAlias().getId())), quantifiedValue);
+            final var col2 = Column.of(Optional.of(qun.getAlias().getId()), quantifiedValue);
 
             selectBuilder.addQuantifier(qun).addAllResultColumns(List.of(col1, col2));
 
@@ -230,7 +230,7 @@ public class GroupByTest extends FDBRecordStoreQueryTestBase {
         {
             // construct a result set that makes sense.
             final var numValue2FieldValue = FieldValue.ofFieldNameAndFuseIfPossible(FieldValue.ofOrdinalNumber(QuantifiedObjectValue.of(qun.getAlias(), qun.getFlowedObjectType()), 0), "num_value_2");
-            final var numValue2Reference = Column.of(Type.Record.Field.of(num2Value.getResultType(), Optional.of("num_value_2")), numValue2FieldValue);
+            final var numValue2Reference = Column.of(Optional.of("num_value_2"), numValue2FieldValue);
             final var aggregateReference = Column.unnamedOf(FieldValue.ofOrdinalNumber(FieldValue.ofOrdinalNumber(ObjectValue.of(qun.getAlias(), qun.getFlowedObjectType()), 0), 0));
 
             final var graphBuilder = GraphExpansion.builder().addQuantifier(qun).addAllResultColumns(ImmutableList.of(numValue2Reference,  aggregateReference));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/MessageTransformationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/MessageTransformationTest.java
@@ -176,7 +176,7 @@ class MessageTransformationTest {
         final var aValue =
                 RecordConstructorValue.ofColumns(
                         ImmutableList.of(
-                                Column.of(Type.Record.Field.of(aaValue.getResultType(), Optional.of("aa")), aaValue),
+                                Column.of(Optional.of("aa"), aaValue),
                                 Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("ab")), new LiteralValue<>(3)),
                                 Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("ac")), new LiteralValue<>("ac"))
                         ));
@@ -190,8 +190,8 @@ class MessageTransformationTest {
 
         final var expectedValue = RecordConstructorValue.ofColumns(
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(aValue.getResultType(), Optional.of("a")), aValue),
-                        Column.of(Type.Record.Field.of(xValue.getResultType(), Optional.of("x")), xValue),
+                        Column.of(Optional.of("a"), aValue),
+                        Column.of(Optional.of("x"), xValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("z")), new LiteralValue<>("z"))
                 ));
         final var expected = expectedValue.eval(null, evaluationContext);
@@ -235,7 +235,7 @@ class MessageTransformationTest {
         final var aValue =
                 RecordConstructorValue.ofColumns(
                         ImmutableList.of(
-                                Column.of(Type.Record.Field.of(aaValue.getResultType(), Optional.of("aa")), aaValue),
+                                Column.of(Optional.of("aa"), aaValue),
                                 Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("ab")), new LiteralValue<>(3)),
                                 Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("ac")), new LiteralValue<>("ac"))
                         ));
@@ -249,8 +249,8 @@ class MessageTransformationTest {
 
         final var expectedValue = RecordConstructorValue.ofColumns(
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(aValue.getResultType(), Optional.of("a")), aValue),
-                        Column.of(Type.Record.Field.of(xValue.getResultType(), Optional.of("x")), xValue),
+                        Column.of(Optional.of("a"), aValue),
+                        Column.of(Optional.of("x"), xValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("z")), new LiteralValue<>("z"))
                 ));
         final var expected = expectedValue.eval(null, evaluationContext);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/ValueSimplificationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/ValueSimplificationTest.java
@@ -55,8 +55,7 @@ class ValueSimplificationTest {
         // (_ as a)
         final ImmutableList<Column<? extends Value>> columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("a")),
-                                someCurrentValue));
+                        Column.of(Optional.of("a"), someCurrentValue));
         // (_ as a).a
         final var fieldValue = FieldValue.ofFieldName(RecordConstructorValue.ofColumns(columns), "a");
 
@@ -74,8 +73,7 @@ class ValueSimplificationTest {
         // (_ as a, 5 as b)
         final ImmutableList<Column<? extends Value>> columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("a")),
-                                someCurrentValue),
+                        Column.of(Optional.of("a"), someCurrentValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("b")),
                                 LiteralValue.ofScalar(5)));
         // (_ as a, 5 as b).a
@@ -95,8 +93,7 @@ class ValueSimplificationTest {
         // (_ as a, 10 as b)
         ImmutableList<Column<? extends Value>> columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("a")),
-                                someCurrentValue),
+                        Column.of(Optional.of("a"), someCurrentValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("b")),
                                 LiteralValue.ofScalar(10)));
         final var innerRecordConstructor = RecordConstructorValue.ofColumns(columns);
@@ -104,8 +101,7 @@ class ValueSimplificationTest {
         // ((_ as a, 10 as b) as x, 5 as y)
         columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(innerRecordConstructor.getResultType(), Optional.of("x")),
-                                innerRecordConstructor),
+                        Column.of(Optional.of("x"), innerRecordConstructor),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("y")),
                                 LiteralValue.ofScalar(5)));
         final var outerRecordConstructor = RecordConstructorValue.ofColumns(columns);
@@ -127,8 +123,7 @@ class ValueSimplificationTest {
         // (_ as a, 10 as b)
         ImmutableList<Column<? extends Value>> columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("a")),
-                                someCurrentValue),
+                        Column.of(Optional.of("a"), someCurrentValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("b")),
                                 LiteralValue.ofScalar(10)));
         final var innerRecordConstructor = RecordConstructorValue.ofColumns(columns);
@@ -136,8 +131,7 @@ class ValueSimplificationTest {
         // ((_ as a, 10 as b) as x, 5 as y)
         columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(innerRecordConstructor.getResultType(), Optional.of("x")),
-                                innerRecordConstructor),
+                        Column.of(Optional.of("x"), innerRecordConstructor),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("y")),
                                 LiteralValue.ofScalar(5)));
         final var outerRecordConstructor = RecordConstructorValue.ofColumns(columns);
@@ -159,8 +153,7 @@ class ValueSimplificationTest {
         // (_ as a, 10 as b)
         ImmutableList<Column<? extends Value>> columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("a")),
-                                someCurrentValue),
+                        Column.of(Optional.of("a"), someCurrentValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("b")),
                                 LiteralValue.ofScalar(10)));
         final var innerRecordConstructor = RecordConstructorValue.ofColumns(columns);
@@ -168,8 +161,7 @@ class ValueSimplificationTest {
         // ((_ as a, 10 as b) as x, 5 as y)
         columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(innerRecordConstructor.getResultType(), Optional.of("x")),
-                                innerRecordConstructor),
+                        Column.of(Optional.of("x"), innerRecordConstructor),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("y")),
                                 LiteralValue.ofScalar(5)));
         final var outerRecordConstructor = RecordConstructorValue.ofColumns(columns);
@@ -193,8 +185,7 @@ class ValueSimplificationTest {
         // (_ as a, 5 as b)
         final ImmutableList<Column<? extends Value>> columns =
                 ImmutableList.of(
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("a")),
-                                someCurrentValue),
+                        Column.of(Optional.of("a"), someCurrentValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("b")),
                                 LiteralValue.ofScalar(5)));
         // (_ as a, 5 as b)#0
@@ -246,8 +237,7 @@ class ValueSimplificationTest {
                 ImmutableList.of(
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("a")),
                                 LiteralValue.ofScalar("fieldValue")),
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("b")),
-                                someCurrentValue),
+                        Column.of(Optional.of("b"), someCurrentValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("c")),
                                 LiteralValue.ofScalar("World")));
         final var recordConstructor = RecordConstructorValue.ofColumns(columns);
@@ -277,8 +267,7 @@ class ValueSimplificationTest {
                 ImmutableList.of(
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("a")),
                                 LiteralValue.ofScalar("fieldValue")),
-                        Column.of(Type.Record.Field.of(someCurrentValue.getResultType(), Optional.of("b")),
-                                someCurrentValue),
+                        Column.of(Optional.of("b"), someCurrentValue),
                         Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("c")),
                                 LiteralValue.ofScalar("World")));
         final var recordConstructor = RecordConstructorValue.ofColumns(columns);


### PR DESCRIPTION
This updates the way that graph expansions get combined during index match candidate generation so that field protobuf indexes are not preserved. This updates the `normalizeFields` logic in `Type.Record` so that if any of the field indexes are unset or contain dupes, then we always set the field indexes (whereas before, we would preserve those indexes if they were there, even if we'd identified duplicate field indexes in the type).

This also introduces a new helper method to make it easier to write `Column`s without needing to repeat the type and uses that new abstraction in some existing code paths.

This fixes #2552.