### PR TITLE
More lucene metrics and logging

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Use metrics instead of info log when rebalancing lucene partitions [(Issue #2509)](https://github.com/FoundationDB/fdb-record-layer/issues/2509)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -117,6 +117,7 @@ public enum LogMessageKeys {
     INDEX_MERGE_LOCK,
     INDEX_REPARTITION_DOCUMENT_COUNT,
     INDEX_DEFERRED_ACTION_STEP,
+    AGILITY_CONTEXT,
     AGILITY_CONTEXT_AGE_MILLISECONDS,
     AGILITY_CONTEXT_PREV_CHECK_MILLISECONDS,
     AGILITY_CONTEXT_WRITE_SIZE_BYTES,
@@ -318,8 +319,7 @@ public enum LogMessageKeys {
 
     // Record context properties
     PROPERTY_NAME,
-    PROPERTY_TYPE,
-    ;
+    PROPERTY_TYPE;
 
     private final String logKey;
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -68,6 +68,14 @@ public class LuceneEvents {
         LUCENE_MERGE("Lucene merge"),
         /** Number of find merge calls (calculation of lucene's required merges). */
         LUCENE_FIND_MERGES("Lucene find merges"),
+        /**
+         * Amount of time spent in a transaction doing partition rebalancing.
+         */
+        LUCENE_REBALANCE_PARTITION_TRANSACTION("Lucene rebalance partition transaction"),
+        /**
+         * Amount of time spent moving documents during partition rebalancing.
+         */
+        LUCENE_REBALANCE_PARTITION("Lucene rebalance partition")
         ;
 
         private final String title;
@@ -272,6 +280,10 @@ public class LuceneEvents {
         LUCENE_WRITE("lucene index writes", true),
         /** Write Stored Fields operations on the FDBDirectory. */
         LUCENE_WRITE_STORED_FIELDS("lucene write stored fields"),
+        /**
+         * The number of docs moved during each transaction as part of partition rebalance.
+         */
+        LUCENE_REBALANCE_PARTITION_DOCS("lucene rebalance partition count"),
         ;
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -378,18 +378,19 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         AtomicReference<RecordCursorContinuation> continuation = new AtomicReference<>(RecordCursorStartContinuation.START);
         return AsyncUtil.whileTrue(
                 () -> runner.runAsync(
-                        context -> storeBuilder.setContext(context).openAsync().thenCompose(store -> {
-                            store.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
-                            return getPartitioner(index, store).rebalancePartitions(continuation.get(), documentCount)
-                                    .thenApply(newContinuation -> {
-                                        if (newContinuation.isEnd()) {
-                                            return false;
-                                        } else {
-                                            continuation.set(newContinuation);
-                                            return true;
-                                        }
-                                    });
-                        })));
+                        context -> context.instrument(LuceneEvents.Events.LUCENE_REBALANCE_PARTITION_TRANSACTION,
+                                storeBuilder.setContext(context).openAsync().thenCompose(store -> {
+                                    store.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
+                                    return getPartitioner(index, store).rebalancePartitions(continuation.get(), documentCount)
+                                            .thenApply(newContinuation -> {
+                                                if (newContinuation.isEnd()) {
+                                                    return false;
+                                                } else {
+                                                    continuation.set(newContinuation);
+                                                    return true;
+                                                }
+                                            });
+                                }))));
     }
 
     @Nonnull

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
@@ -80,9 +80,11 @@ public enum LuceneLogMessageKeys {
     NAME,
     GROUP,
     PARTITION,
+    PARTITION_HIGH_WATERMARK,
     RECORD_TIMESTAMP,
     COUNT,
-    TOTAL_COUNT;
+    TOTAL_COUNT,
+    ;
 
     private final String logKey;
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
@@ -60,6 +60,8 @@ public enum LuceneLogMessageKeys {
     INPUT,
     LENGTH,
     LOCK_NAME,
+    LOCK_UUID,
+    LOCK_TIMESTAMP,
     LOCK_EXISTING_TIMESTAMP,
     LOCK_EXISTING_UUID,
     LOCK_DIRECTORY,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -161,6 +161,16 @@ public interface AgilityContext {
             this.timeQuotaMillis = timeQuotaMillis;
             this.sizeQuotaBytes = sizeQuotaBytes;
             callerContext.getOrCreateCommitCheck("AgilityContext.Agile:", name -> () -> CompletableFuture.runAsync(this::flush));
+            logSelf("Starting agility context");
+        }
+
+        private void logSelf(final String staticMessage) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(KeyValueLogMessage.of(staticMessage,
+                        LogMessageKeys.TIME_LIMIT_MILLIS, this.timeQuotaMillis,
+                        LogMessageKeys.LIMIT, this.sizeQuotaBytes,
+                        LogMessageKeys.AGILITY_CONTEXT, this));
+            }
         }
 
         @Override
@@ -291,6 +301,12 @@ public interface AgilityContext {
         @Override
         public void flush() {
             commitNow();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(KeyValueLogMessage.of("Flushed agility context",
+                        LogMessageKeys.TIME_LIMIT_MILLIS, timeQuotaMillis,
+                        LogMessageKeys.LIMIT, sizeQuotaBytes,
+                        LogMessageKeys.AGILITY_CONTEXT, this));
+            }
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -579,9 +579,14 @@ public class FDBDirectory extends Directory  {
         long totalSize = 0L;
         long actualTotalSize = 0L;
         for (Map.Entry<String, FDBLuceneFileReference> entry: fileMap.entrySet()) {
-            displayList.add(entry.getKey());
+            if (displayList.size() < 200 || entry.getKey().startsWith("segments")) {
+                displayList.add(entry.getKey());
+            }
             totalSize += entry.getValue().getSize();
             actualTotalSize += entry.getValue().getActualSize();
+        }
+        if (displayList.size() >= 200) {
+            displayList.add("...");
         }
         final KeyValueLogMessage message = getKeyValueLogMessage(listAllFiles,
                 LuceneLogMessageKeys.FILE_COUNT, displayList.size(),

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.cursors.ChainedCursor;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
-import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.lucene.LuceneAnalyzerWrapper;
 import com.apple.foundationdb.record.lucene.LuceneIndexTypes;
 import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
@@ -50,8 +49,6 @@ import com.apple.foundationdb.tuple.TupleHelpers;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.MergeScheduler;
-import org.apache.lucene.index.MergeTrigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -318,14 +315,5 @@ public class FDBDirectoryManager implements AutoCloseable {
                 .stream()
                 .filter(i -> LuceneIndexTypes.LUCENE.equals(i.getType()))
                 .count());
-    }
-
-    public static String getMergeLogMessage(@Nonnull MergeScheduler.MergeSource mergeSource, @Nonnull MergeTrigger trigger,
-                                            @Nonnull IndexMaintainerState state, @Nonnull String logMessage) {
-        return KeyValueLogMessage.of(logMessage,
-                LuceneLogMessageKeys.MERGE_SOURCE, mergeSource,
-                LuceneLogMessageKeys.MERGE_TRIGGER, trigger,
-                LogMessageKeys.INDEX_NAME, state.index.getName(),
-                LogMessageKeys.INDEX_SUBSPACE, state.indexSubspace);
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBTieredMergePolicy.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBTieredMergePolicy.java
@@ -105,12 +105,17 @@ class FDBTieredMergePolicy extends TieredMergePolicy {
     private void logFoundMerges(@Nonnull final MergeTrigger mergeTrigger,
                                 @Nullable final MergeSpecification merges) {
         if (merges != null && LOGGER.isDebugEnabled()) {
-            LOGGER.debug(KeyValueLogMessage.of("Found Merges",
+            final String message = KeyValueLogMessage.of("Found Merges",
                     LogMessageKeys.INDEX_SUBSPACE, indexSubspace,
                     LogMessageKeys.KEY, key,
                     LuceneLogMessageKeys.MERGE_TRIGGER, mergeTrigger,
                     LogMessageKeys.AGILITY_CONTEXT, context.getClass().getSimpleName(),
-                    LuceneLogMessageKeys.MERGE_SOURCE, simpleSpec(merges)));
+                    LuceneLogMessageKeys.MERGE_SOURCE, simpleSpec(merges));
+            if (context instanceof AgilityContext.Agile) {
+                LOGGER.debug(message);
+            } else {
+                LOGGER.debug(message, new Exception());
+            }
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
@@ -1,0 +1,92 @@
+/*
+ * MergeUtils.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.directory;
+
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.MergeTrigger;
+import org.slf4j.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for helping {@link FDBTieredMergePolicy} and {@code FDBDirectoryMergeScheduler}.
+ */
+class MergeUtils {
+
+
+    public static void logExecutingMerge(@Nonnull final Logger logger,
+                                         @Nonnull final String staticMessage,
+                                         @Nonnull final AgilityContext agilityContext,
+                                         @Nonnull final Subspace indexSubspace,
+                                         @Nullable final Tuple key,
+                                         @Nonnull final MergeTrigger mergeTrigger) {
+        if (logger.isDebugEnabled()) {
+            final KeyValueLogMessage message = baseLogMessage(staticMessage, agilityContext, indexSubspace, key, mergeTrigger);
+            logWithExceptionIfNotAgile(logger, agilityContext, message);
+        }
+    }
+
+    static void logFoundMerges(@Nonnull final Logger logger,
+                               @Nonnull final String staticMessage,
+                               @Nonnull final AgilityContext context,
+                               @Nonnull final Subspace indexSubspace,
+                               @Nullable final Tuple key,
+                               @Nonnull final MergeTrigger mergeTrigger,
+                               @Nullable final MergePolicy.MergeSpecification merges) {
+        if (merges != null && logger.isDebugEnabled()) {
+            final KeyValueLogMessage message = baseLogMessage(staticMessage, context, indexSubspace, key, mergeTrigger);
+            message.addKeyAndValue(LuceneLogMessageKeys.MERGE_SOURCE, simpleSpec(merges));
+            logWithExceptionIfNotAgile(logger, context, message);
+        }
+    }
+
+    private static void logWithExceptionIfNotAgile(final @Nonnull Logger logger, final @Nonnull AgilityContext context, final KeyValueLogMessage message) {
+        if (context instanceof AgilityContext.Agile) {
+            logger.debug(message.toString());
+        } else {
+            logger.debug(message.toString(), new Exception());
+        }
+    }
+
+    @Nonnull
+    private static KeyValueLogMessage baseLogMessage(final @Nonnull String staticMessage, final @Nonnull AgilityContext context, final @Nonnull Subspace indexSubspace, final @Nullable Tuple key, final @Nonnull MergeTrigger mergeTrigger) {
+        final KeyValueLogMessage message = KeyValueLogMessage.build(staticMessage,
+                LogMessageKeys.INDEX_SUBSPACE, indexSubspace,
+                LogMessageKeys.KEY, key,
+                LuceneLogMessageKeys.MERGE_TRIGGER, mergeTrigger,
+                LogMessageKeys.AGILITY_CONTEXT, context.getClass().getSimpleName());
+        return message;
+    }
+
+    private static String simpleSpec(@Nonnull final MergePolicy.MergeSpecification merges) {
+        return merges.merges.stream().map(merge ->
+                        merge.segments.stream().map(segment -> segment.info.name)
+                                .collect(Collectors.joining(",", "", "")))
+                .collect(Collectors.joining(";"));
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -139,6 +139,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreTestBase {
             final int docCount = random.nextInt(10) + 1;
             try (FDBRecordContext context = openContext(contextProps)) {
                 schemaSetup.accept(context);
+                recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
                 for (int j = 0; j < docCount; j++) {
                     final int group = isGrouped ? random.nextInt(random.nextInt(10) + 1) : 0; // irrelevant if !isGrouped
                     final Tuple groupTuple = isGrouped ? Tuple.from(group) : Tuple.from();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -201,10 +201,11 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreTestBase {
     private Tuple saveRecords(final boolean isSynthetic, final int group, final int countInGroup, final long timestamp, final Random random) {
         var parent = TestRecordsGroupedParentChildProto.MyParentRecord.newBuilder()
                 .setGroup(group)
-                .setRecNo(1000L + countInGroup)
+                .setRecNo(1001L + countInGroup)
                 .setTimestamp(timestamp)
                 .setTextValue("A word about what I want to say")
                 .setIntValue(random.nextInt())
+                .setChildRecNo(1000L - countInGroup)
                 .build();
         Tuple primaryKey;
         if (isSynthetic) {


### PR DESCRIPTION
Resolves #2509: Use metrics for rebalancing partitions

Also adds a whole bunch of additional logging because we are seeing issues, and having trouble understanding why.
Also, fixed a couple issues with `LuceneIndexMaintenanceTest` because that's what I was using to validate the logs (for the most part)