### PR TITLE
Revert #2557: FailedInJoinAsUnion support for unordered distinct

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Revert [#2557](https://github.com/FoundationDB/fdb-record-layer/pull/2557) to avoid picking union ordering keys with duplicates [(Issue #2563)](https://github.com/FoundationDB/fdb-record-layer/issues/2563)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Use metrics instead of info log when rebalancing lucene partitions [(Issue #2509)](https://github.com/FoundationDB/fdb-record-layer/issues/2509)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanOrderingKey.java
@@ -39,8 +39,6 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionOnKeyExpressionPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistinctPlan;
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
@@ -141,9 +139,7 @@ public class PlanOrderingKey {
         while (queryPlan instanceof RecordQueryPlanWithChild) {
             // as long as we can tunnel through single-child plans
             if (queryPlan instanceof RecordQueryFilterPlan ||
-                    queryPlan instanceof RecordQueryTypeFilterPlan ||
-                    queryPlan instanceof RecordQueryUnorderedDistinctPlan ||
-                    queryPlan instanceof RecordQueryUnorderedPrimaryKeyDistinctPlan) {
+                    queryPlan instanceof RecordQueryTypeFilterPlan) {
                 // if we know the kind of plan does not modify the ordered-ness
                 queryPlan = ((RecordQueryPlanWithChild)queryPlan).getChild();
             } else {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBInQueryTest.java
@@ -1589,53 +1589,6 @@ class FDBInQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
     /**
-     * Verify that one-of-them queries work with IN when sorted on a second field, if union is allowed.
-     */
-    @ParameterizedTest
-    @EnumSource(InAsOrUnionMode.class)
-    void testOneOfThemInSortBySecondField(InAsOrUnionMode inAsOrMode) throws Exception {
-        RecordMetaDataHook recordMetaDataHook = metadata ->
-                metadata.addIndex("MySimpleRecord", "ind",
-                        concat(field("repeater", FanType.FanOut), field("str_value_indexed")));
-        setupSimpleRecordStore(recordMetaDataHook,
-                (i, builder) -> builder.setRecNo(i)
-                        .setStrValueIndexed((i & 1) == 1 ? "odd" : "even")
-                        .addAllRepeater(Arrays.asList(10 + i % 4, 20 + i % 4)));
-        List<Integer> inList = Arrays.asList(13, 22);
-        QueryComponent filter = Query.field("repeater").oneOfThem().in(inList);
-        RecordQuery query = RecordQuery.newBuilder()
-                .setRecordType("MySimpleRecord")
-                .setFilter(filter)
-                .setSort(field("str_value_indexed"))
-                .build();
-        assertTrue(planner instanceof RecordQueryPlanner);
-        planner.setConfiguration(inAsOrMode.configure(planner.getConfiguration().asBuilder())
-                .build());
-        RecordQueryPlan plan = planQuery(query);
-        // ∪(__in_repeater__0 IN [13, 22]) Index(ind [EQUALS $__in_repeater__0]) | UnorderedPrimaryKeyDistinct()
-        // Index(MySimpleRecord$str_value_indexed <,>) | one of repeater IN [13, 22]
-        boolean asUnion = inAsOrMode == InAsOrUnionMode.AS_UNION;
-        assertMatchesExactly(plan,
-                asUnion ?
-                unorderedPrimaryKeyDistinctPlan(
-                        inUnionOnExpressionPlan(indexPlan().where(indexName("ind"))
-                                .and(scanComparisons(range("[EQUALS $__in_repeater__0]"))))
-                                .where(inUnionComparisonKey(concat(field("str_value_indexed"), primaryKey("MySimpleRecord"))))
-                                .and(inUnionValuesSources(exactly(inUnionInValues(equalsObject(inList))
-                                        .and(inUnionBindingName("__in_repeater__0")))))) :
-                filterPlan(indexPlan()
-                        .where(indexName("MySimpleRecord$str_value_indexed"))
-                        .and(scanComparisons(unbounded()))
-                ).where(queryComponents(exactly(equalsObject(filter)))));
-        assertEquals(asUnion ? 1408337059 : 324839336, plan.planHash(PlanHashable.CURRENT_LEGACY));
-        assertEquals(50, querySimpleRecordStore(recordMetaDataHook, plan, EvaluationContext::empty,
-                rec -> assertThat(rec.getRecNo() % 4, anyOf(is(3L), is(2L))),
-                asUnion ?
-                TestHelpers::assertDiscardedNone :
-                context -> TestHelpers.assertDiscardedExactly(50, context)));
-    }
-
-    /**
      * Verify that IN works with grouped rank indexes.
      */
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedFieldQueryTest.java
@@ -85,7 +85,6 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlanOf;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexScanType;
-import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.intersectionOnExpressionPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicates;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicatesFilterPlan;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.queryComponents;
@@ -407,11 +406,8 @@ class FDBNestedFieldQueryTest extends FDBRecordStoreQueryTestBase {
             // Does not understand duplicate condition, and so plans an extraneous (but harmless, semantically speaking)
             // intersection with the "duplicates" index
             assertMatchesExactly(plan,
-                    intersectionOnExpressionPlan(
-                            unorderedPrimaryKeyDistinctPlan(indexPlanMatcher),
-                            indexPlan()
-                                    .where(indexName("duplicates"))
-                                    .and(scanComparisons(range("[[something, something, 1],[something, something, 1]]")))));
+                    filterPlan(unorderedPrimaryKeyDistinctPlan(indexPlanMatcher))
+                            .where(queryComponents(only(equalsObject(Query.field("name").equalsValue("something"))))));
         } else {
             assertMatchesExactly(plan,
                     fetchFromPartialRecordPlan(


### PR DESCRIPTION
This reverts #2557 because of the issue alluded to in #2563.