### PR TITLE
Disconnect lucene framework tests from record layer gradle properties

### DIFF
--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -57,18 +57,18 @@ test.systemProperties['tests.directory'] = 'com.apple.foundationdb.record.lucene
 // it might differ
 // test.systemProperties['tests.directory'] = 'org.apache.lucene.store.RAMDirectory'
 
-// Uncomment below line to run nightly tests
-// test.systemProperties['tests.nightly'] = 'true'
-
 tasks.withType(Test) { theTask ->
-    if (!project.hasProperty('tests.includeRandom')) {
+    // We use special lucene properties here, because lucene still fails sometimes
+    // see: https://github.com/FoundationDB/fdb-record-layer/issues/2480
+    // When that issue is resolved these can be changed align with the global properties
+    if (!project.hasProperty('tests.luceneIncludeRandom')) {
         println("Fixing seed for lucene tests")
         theTask.systemProperties['tests.seed'] = "C185081D42F0F43C" // a fixed seed, should pass reliably in prb/release
     }
-    if (project.hasProperty('tests.iterations')) {
+    if (project.hasProperty('tests.luceneIterations')) {
         theTask.systemProperties['tests.iters'] = project.getProperty('tests.iterations')
     }
-    if (project.hasProperty('tests.nightly')) {
+    if (project.hasProperty('tests.luceneNightly')) {
         theTask.systemProperties['tests.nightly'] = 'true'
     }
 }


### PR DESCRIPTION
Until #2480 is resolved, we don't want to run the lucene framework tests with random seeds, or the nightly ones to avoid the noise.