### PR TITLE
Display display names in gradle test output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,6 @@ allprojects {
     // Configure JUnit tests
     tasks.withType(Test) {
         reports.junitXml.destination = project.file("${->project.buildDir}/test-results")
-        testLogging.events = ["passed", "skipped", "failed"]
     }
 
     // Configure JAR generation

--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -66,7 +66,7 @@ tasks.withType(Test) { theTask ->
         theTask.systemProperties['tests.seed'] = "C185081D42F0F43C" // a fixed seed, should pass reliably in prb/release
     }
     if (project.hasProperty('tests.luceneIterations')) {
-        theTask.systemProperties['tests.iters'] = project.getProperty('tests.iterations')
+        theTask.systemProperties['tests.iters'] = project.getProperty('tests.luceneIterations') // TODO this is broken on main...
     }
     if (project.hasProperty('tests.luceneNightly')) {
         theTask.systemProperties['tests.nightly'] = 'true'

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -151,6 +151,7 @@ tasks.withType(Test) { theTask ->
     afterTest { descriptor, result ->
         def duration = result.endTime - result.startTime
         println "${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
+        println()
     }
     reports {
         junitXml.outputPerTestCase = true

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -52,6 +52,30 @@ task performanceTest(type: Test) {
     }
 }
 
+def getFullDisplayName(descriptor) {
+    def fullName = ""
+    fullName = descriptor.displayName
+    descriptor = descriptor.parent
+    while (descriptor != null) {
+        // don't display this or any of the parents. Let's assume that nobody ever
+        // sets the display name in code to start with "Gradle Test Executor".
+        // it appears to be suffixed with a number, but I didn't investigate why
+        if (descriptor.displayName.startsWith("Gradle Test Executor")) {
+            break
+        }
+        def openParen = descriptor.displayName.indexOf("(")
+        // in the case where someone sets the display name to include the method name, it's best
+        // to skip the method name itself, e.g.:
+        // LuceneIndexMaintenanceTest > randomizedRepartitionTest(boolean, boolean, boolean, int, int, int, long) > randomizedRepartitionTest(true, false, false, 13, 3, 20, 9237590782644) STARTED
+        // LuceneIndexMaintenanceTest > randomizedRepartitionTest(boolean, boolean, boolean, int, int, int, long) > randomizedRepartitionTest(true, false, false, 13, 3, 20, 9237590782644) SUCCESS (1985ms)
+        if (openParen < 0 || !fullName.startsWith(descriptor.displayName.substring(0, openParen))) {
+            fullName = "${descriptor.displayName}" + " > " + fullName
+        }
+        descriptor = descriptor.parent
+    }
+    return fullName
+}
+
 def configureTestTask = { propertyPrefix, task ->
     def handled = [propertyPrefix + '.ignoreFailures',
                    propertyPrefix + '.debug',
@@ -118,8 +142,15 @@ tasks.withType(Test) { theTask ->
     configureTestTask('allTest', theTask)
     configureTestTask(theTask.name, theTask)
     testLogging {
-        events 'started', 'passed', 'failed', 'skipped'
+        events 'failed'
         exceptionFormat = 'full'
+    }
+    beforeTest { descriptor -> 
+        println "${getFullDisplayName(descriptor)} STARTED"
+    } 
+    afterTest { descriptor, result ->
+        def duration = result.endTime - result.startTime
+        println "${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
     }
     reports {
         junitXml.outputPerTestCase = true


### PR DESCRIPTION
The default test output always uses the name, so you end up with:
```
LuceneHighlighterTest > highlightsSpecialCharacterTerm(String, Analyzer, Analyzer, String) > com.apple.foundationdb.record.lucene.highlight.LuceneHighlighterTest.highlightsSpecialCharacterTerm(String, Analyzer, Analyzer, String)[1] STARTED

LuceneHighlighterTest > highlightsSpecialCharacterTerm(String, Analyzer, Analyzer, String) >
com.apple.foundationdb.record.lucene.highlight.LuceneHighlighterTest.highlightsSpecialCharacterTerm(String, Analyzer,
Analyzer, String)[1] PASSED
```

Which is not great, this adds our own logging that renders the display name. So the above would become something like:
```
LuceneHighlighterTest > highlightsSpecialCharacterTerm(String, Analyzer, Analyzer, String) > AlphaCjk-Synonyms,Ϲ STARTED
LuceneHighlighterTest > highlightsSpecialCharacterTerm(String, Analyzer, Analyzer, String) > AlphaCjk-Synonyms,Ϲ
SUCCESS (0ms)
```

As you may note, I took the liberty of adding the duration of the test in milliseconds.