### PR TITLE
FIXES #2580: from is greater than to in a partition info

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** from is greater than to in a partition info [(Issue #2580)](https://github.com/FoundationDB/fdb-record-layer/issues/2580)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -794,7 +794,6 @@ public class LucenePartitioner {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug(repartitionLogMessage("Repartitoned records", groupingKey, records.size(), partitionInfo));
                 }
-
                 // value of the "destination" partition's `from` value
                 final Tuple overflowPartitioningKey = toPartitionKey(records.get(0));
                 return findPartitionInfo(groupingKey, overflowPartitioningKey).thenCompose(previousPartition -> {
@@ -945,7 +944,7 @@ public class LucenePartitioner {
      * @return true if key is "newer" than partitionInfo
      */
     public static boolean isNewerThan(@Nonnull final Tuple key, @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
-        return key.compareTo(Tuple.fromBytes(partitionInfo.getFrom().toByteArray())) > 0;
+        return key.compareTo(Tuple.fromBytes(partitionInfo.getTo().toByteArray())) > 0;
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -78,7 +78,8 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreTestBase {
                         Arguments.of(true, false, false, 13, 3, 20, 9237590782644L),
                         Arguments.of(true, true, true, 10, 2, 23, -644766138635622644L),
                         Arguments.of(false, true, true, 11, 4, 20, -1089113174774589435L),
-                        Arguments.of(false, false, false, 5, 1, 18, 6223372946177329440L)),
+                        Arguments.of(false, false, false, 5, 1, 18, 6223372946177329440L),
+                        Arguments.of(true, false, false, 14, 6, 0, 2451719304283565963L)),
                 RandomizedTestUtils.randomArguments(random ->
                         Arguments.of(random.nextBoolean(),
                                 random.nextBoolean(),


### PR DESCRIPTION
- cause: typo in `LucenePartitioner.isNewerThan()`