### PR TITLE
Resolves #2582: Randomize index build tests

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/test/RandomizedTestUtils.java
+++ b/fdb-extensions/src/test/java/com/apple/test/RandomizedTestUtils.java
@@ -33,6 +33,8 @@ import java.util.stream.Stream;
  * A Utility class for adding randomness to tests.
  */
 public final class RandomizedTestUtils {
+    private static final long FIXED_SEED = 0xf17ed5eedL;
+
     private RandomizedTestUtils() {
     }
 
@@ -62,12 +64,19 @@ public final class RandomizedTestUtils {
      * the seed can be included in the test display name, which means that a failing seed can be
      * recorded and the test re-run with that seed.
      *
+     * <p>
+     * To ensure tests are consistent when random tests are not included, users are encouraged
+     * to provide a set of random seeds that are always included in the returned stream via
+     * the {@code staticSeeds} parameter. However, if this argument is left empty, this will
+     * still always include at least one fixed seed, {@value FIXED_SEED}.
+     * </p>
+     *
      * @param staticSeeds a set of seeds to always include in the returned random seeds
      * @return a stream of random {@code long}s to initialize {@link Random}s
      */
     @Nonnull
     public static Stream<Long> randomSeeds(long... staticSeeds) {
-        LongStream longStream = LongStream.of(staticSeeds);
+        LongStream longStream = staticSeeds.length == 0 ? LongStream.of(FIXED_SEED) : LongStream.of(staticSeeds);
         if (includeRandomTests()) {
             Random random = ThreadLocalRandom.current();
             longStream = LongStream.concat(longStream,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildGroupedCountIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildGroupedCountIndexTest.java
@@ -74,11 +74,11 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         return Stream.of(null, "MySimpleRecord$primary_key", NUM_VALUE_2_INDEX.getName(), STR_VALUE_INDEX.getName());
     }
 
-    static Stream<Arguments> sourceIndexes() {
+    @Nonnull
+    static Stream<Arguments> sourceIndexesAndRandomSeeds() {
         return sourceIndexNames()
-                .flatMap(sourceIndexName ->
-                        OnlineIndexerBuildIndexTest.randomSeeds().map(seed ->
-                                Arguments.of(sourceIndexName, seed)));
+                .flatMap(sourceIndexName -> OnlineIndexerBuildIndexTest.randomSeeds()
+                        .map(seed -> Arguments.of(sourceIndexName, seed)));
     }
 
     private static String randomString(@Nonnull Random r) {
@@ -219,7 +219,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildOneHundredGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -230,7 +230,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildOneHundredWithOthersGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -244,7 +244,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildWhileInsertingGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -272,7 +272,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildWhileUpdatingGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -299,7 +299,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildWhileDeletingGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -327,7 +327,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildWhileConvertingTypeGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -388,7 +388,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildWhileDeletingGroupsGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -417,7 +417,7 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void buildWhileRandomlyMutatingGroupedCount(String sourceIndex, long seed) {
         Random r = new Random(seed);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildGroupedCountIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildGroupedCountIndexTest.java
@@ -76,7 +76,9 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
 
     static Stream<Arguments> sourceIndexes() {
         return sourceIndexNames()
-                .map(Arguments::of);
+                .flatMap(sourceIndexName ->
+                        OnlineIndexerBuildIndexTest.randomSeeds().map(seed ->
+                                Arguments.of(sourceIndexName, seed)));
     }
 
     private static String randomString(@Nonnull Random r) {
@@ -216,22 +218,22 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         rebuildGroupedCount(recordsBefore, otherRecordsBefore, sourceIndex, NO_UPDATES);
     }
 
-    @ParameterizedTest(name = "buildOneHundredGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildOneHundredGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildOneHundredGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(100)
                 .collect(Collectors.toList());
         rebuildGroupedCount(records, null, sourceIndex);
     }
 
-    @ParameterizedTest(name = "buildOneHundredWithOthersGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildOneHundredWithOthersGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildOneHundredWithOthersGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(100)
                 .collect(Collectors.toList());
@@ -241,11 +243,11 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         rebuildGroupedCount(records, otherRecords, sourceIndex);
     }
 
-    @ParameterizedTest(name = "buildWhileInsertingGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildWhileInsertingGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildWhileInsertingGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(200)
                 .collect(Collectors.toList());
@@ -269,11 +271,11 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         });
     }
 
-    @ParameterizedTest(name = "buildWhileUpdatingGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildWhileUpdatingGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildWhileUpdatingGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(200)
                 .collect(Collectors.toList());
@@ -296,11 +298,11 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         });
     }
 
-    @ParameterizedTest(name = "buildWhileDeletingGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildWhileDeletingGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildWhileDeletingGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(200)
                 .collect(Collectors.toList());
@@ -324,11 +326,11 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         });
     }
 
-    @ParameterizedTest(name = "buildWhileDeletingGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildWhileConvertingTypeGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildWhileConvertingTypeGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(200)
                 .collect(Collectors.toList());
@@ -385,11 +387,11 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         });
     }
 
-    @ParameterizedTest(name = "buildWhileDeletingGroupsGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildWhileDeletingGroupsGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildWhileDeletingGroupsGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(200)
                 .collect(Collectors.toList());
@@ -414,11 +416,11 @@ public class OnlineIndexerBuildGroupedCountIndexTest extends OnlineIndexerTest {
         });
     }
 
-    @ParameterizedTest(name = "buildWhileRandomlyMutatingGroupedCount[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    void buildWhileRandomlyMutatingGroupedCount(String sourceIndex) {
-        Random r = new Random();
+    void buildWhileRandomlyMutatingGroupedCount(String sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() -> randomSimpleRecord(r))
                 .limit(400)
                 .collect(Collectors.toList());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.RandomizedTestUtils;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
@@ -53,6 +54,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -416,5 +418,10 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                 .setRecordType(recordStore.getRecordMetaData().getRecordType(rec.getDescriptorForType().getName()))
                 .setRecord(rec)
                 .build();
+    }
+
+    @Nonnull
+    static Stream<Long> randomSeeds() {
+        return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildJoinedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildJoinedIndexTest.java
@@ -47,7 +47,8 @@ import com.google.protobuf.Message;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -395,9 +396,10 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
         }
     }
 
-    @Test
-    void simpleTenJoinedRecords() {
-        final Random r = new Random(0x5ca1e);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleTenJoinedRecords(long seed) {
+        final Random r = new Random(seed);
         final List<Message> records = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
@@ -407,9 +409,10 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
         singleValueIndexRebuild(records, null, null);
     }
 
-    @Test
-    void simpleJoinIsEmpty() {
-        final Random r = new Random(0x0fdb0fdbL);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleJoinIsEmpty(long seed) {
+        final Random r = new Random(seed);
         final List<Message> records = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
@@ -425,9 +428,10 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
         }
     }
 
-    @Test
-    void simpleJoinWithExtraUnjoinedRecords() {
-        final Random r = new Random(0x5ca1e);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleJoinWithExtraUnjoinedRecords(long seed) {
+        final Random r = new Random(seed);
         final List<Message> records = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
@@ -445,10 +449,11 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
         singleValueIndexRebuild(records, null, null);
     }
 
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    @Test
-    void simpleValueWithUpdatesAndDeletes() {
-        final Random r = new Random(0x5ca1e);
+    void simpleValueWithUpdatesAndDeletes(long seed) {
+        final Random r = new Random(seed);
         final List<Message> records = new ArrayList<>();
         for (int i = 0; i < 400; i++) {
             TestRecordsJoinIndexProto.MySimpleRecord simple = randomSimpleRecord(r);
@@ -465,9 +470,10 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
         singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
     }
 
-    @Test
-    void simpleTenJoinedCountRecords() {
-        final Random r = new Random(0x5ca1e);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleTenJoinedCountRecords(long seed) {
+        final Random r = new Random(seed);
         final List<Message> records = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
@@ -477,9 +483,10 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
         singleCountIndexRebuild(records, null, null);
     }
 
-    @Test
-    void simpleJoinCountIsEmpty() {
-        final Random r = new Random(0x0fdb0fdbL);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleJoinCountIsEmpty(long seed) {
+        final Random r = new Random(seed);
         final List<Message> records = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             TestRecordsJoinIndexProto.MySimpleRecord simpleRecord = randomSimpleRecord(r);
@@ -497,10 +504,11 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
     }
 
     @Tag(Tags.Slow)
-    @Test
     @Disabled("Updates to non-idempotent index during joined index build not correctly handled")
-    void simpleCountWithUpdatesAndDeletes() {
-        final Random r = new Random(0x5ca1e);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleCountWithUpdatesAndDeletes(long seed) {
+        final Random r = new Random(seed);
         final List<Message> records = new ArrayList<>();
         for (int i = 0; i < 400; i ++) {
             TestRecordsJoinIndexProto.MySimpleRecord simple = randomSimpleRecord(r);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
@@ -31,6 +31,8 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -192,7 +194,7 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
     }
 
     @Test
-    public void singleElementRank() {
+    void singleElementRank() {
         TestRecords1Proto.MySimpleRecord record = TestRecords1Proto.MySimpleRecord.newBuilder()
                 .setRecNo(1517)
                 .setNumValue2(95)
@@ -200,40 +202,44 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
         rankRebuild(Collections.singletonList(record));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsRank() {
-        Random r = new Random(0x5ca1ab1e);
+    void oneHundredElementsRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         rankRebuild(records);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelRank() {
-        Random r = new Random(0x5ca1ab1e);
+    void oneHundredElementsParallelRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         rankRebuild(records, null, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelOverlapRank() {
-        Random r = new Random(0xf005ba11);
+    public void oneHundredElementsParallelOverlapRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         rankRebuild(records, null, 5, true);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingRank() {
-        Random r = new Random(0xdeadc0de);
+    public void addWhileBuildingRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -243,10 +249,11 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
         rankRebuild(records, recordsWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingParallelRank() {
-        Random r = new Random(0xdeadc0de);
+    void addWhileBuildingParallelRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(150).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -256,10 +263,11 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
         rankRebuild(records, recordsWhileBuilding, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void somePreloadedRank() {
-        Random r = new Random(0x5ca1ab1e);
+    void somePreloadedRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -275,10 +283,11 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
         rankRebuild(records);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuildingRank() {
-        Random r = new Random(0xba5eba11);
+    void addSequentialWhileBuildingRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());
@@ -288,10 +297,11 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
         rankRebuild(records, recordsWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuildingParallelRank() {
-        Random r = new Random(0xba5eba11);
+    void addSequentialWhileBuildingParallelRank(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj( val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
@@ -183,22 +183,24 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
 
     static Stream<Arguments> sourceIndexes() {
         return Stream.of(null, REC_NO_INDEX, NUM_VALUE_2_INDEX)
-                .map(Arguments::of);
+                .flatMap(indexName -> OnlineIndexerBuildIndexTest.randomSeeds()
+                        .map(seed -> Arguments.of(indexName, seed)));
     }
 
     static Stream<Arguments> sourceIndexesAndFiltered() {
         return Stream.of(null, REC_NO_INDEX, NUM_VALUE_2_INDEX)
                 .flatMap(sourceIndex -> Stream.of(false, true)
-                        .map(filtered -> Arguments.of(sourceIndex, filtered)));
+                        .flatMap(filtered -> OnlineIndexerBuildIndexTest.randomSeeds()
+                                .map(seed -> Arguments.of(sourceIndex, filtered, seed))));
     }
 
     @Test
-    public void emptyRangeSum() {
+    void emptyRangeSum() {
         sumRebuild(Collections.emptyList());
     }
 
     @Test
-    public void singleElementSum() {
+    void singleElementSum() {
         TestRecords1Proto.MySimpleRecord record = TestRecords1Proto.MySimpleRecord.newBuilder()
                 .setRecNo(1517)
                 .setNumValue2(95)
@@ -206,11 +208,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(Collections.singletonList(record));
     }
 
-    @ParameterizedTest(name = "oneHundredElementsSum[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    public void oneHundredElementsSum(@Nullable Index sourceIndex) {
-        Random r = new Random(0x5ca1ab1e);
+    void oneHundredElementsSum(@Nullable Index sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
@@ -220,10 +222,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, null, sourceIndex);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelSum() {
-        Random r = new Random(0x5ca1ab1e);
+    void oneHundredElementsParallelSum(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong() / 2)
@@ -233,10 +236,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, null, null, null, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelOverlapSum() {
-        Random r = new Random(0xf005ba11);
+    void oneHundredElementsParallelOverlapSum(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong() / 2)
@@ -246,11 +250,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, null, null, null, 5, true);
     }
 
-    @ParameterizedTest(name = "addWhileBuildingSum[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    public void addWhileBuildingSum(Index sourceIndex) {
-        Random r = new Random(0xdeadc0de);
+    void addWhileBuildingSum(Index sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
@@ -263,10 +267,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, sourceIndex);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingParallelSum() {
-        Random r = new Random(0xdeadc0de);
+    void addWhileBuildingParallelSum(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong() / 2)
@@ -279,11 +284,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, null, null, 5, false);
     }
 
-    @ParameterizedTest(name = "somePreloadedSum[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    public void somePreloadedSum(Index sourceIndex) {
-        Random r = new Random(0x5ca1ab1e);
+    public void somePreloadedSum(@Nullable Index sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
@@ -309,11 +314,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, null, sourceIndex);
     }
 
-    @ParameterizedTest(name = "addSequentialWhileBuildingSum[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuildingSum(Index sourceIndex) {
-        Random r = new Random(0xba5eba11);
+    void addSequentialWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(val)
@@ -326,10 +331,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, sourceIndex);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuildingParallelSum() {
-        Random r = new Random(0xba5eba11);
+    void addSequentialWhileBuildingParallelSum(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj( val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(val)
@@ -342,11 +348,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, null, null, 5, false);
     }
 
-    @ParameterizedTest(name = "updateRecordsWhileBuildingSum[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    public void updateRecordsWhileBuildingSum(@Nullable Index sourceIndex) {
-        Random r = new Random();
+    public void updateRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
@@ -360,11 +366,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, sourceIndex);
     }
 
-    @ParameterizedTest(name = "deleteRecordsWhileBuildingSum[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    public void deleteRecordsWhileBuildingSum(@Nullable Index sourceIndex) {
-        Random r = new Random();
+    public void deleteRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
@@ -378,11 +384,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, null, toDelete, sourceIndex, 1, false);
     }
 
-    @ParameterizedTest(name = "updateAndDeleteRecordsWhileBuildingSum[sourceIndex={0}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexes")
     @Tag(Tags.Slow)
-    public void updateAndDeleteRecordsWhileBuildingSum(@Nullable Index sourceIndex) {
-        Random r = new Random();
+    public void updateAndDeleteRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
@@ -400,11 +406,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, toDelete, sourceIndex, 1, false);
     }
 
-    @ParameterizedTest(name = "oneHundredFilteredSum[sourceIndex={0}, filterSource={1}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexesAndFiltered")
     @Tag(Tags.Slow)
-    public void oneHundredFilteredSum(@Nullable Index sourceIndex, boolean filterSource) {
-        Random r = new Random();
+    public void oneHundredFilteredSum(@Nullable Index sourceIndex, boolean filterSource, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(val)
@@ -415,11 +421,11 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuildFiltered(records, null, null, sourceIndex, filterSource);
     }
 
-    @ParameterizedTest(name = "updateWhileBuildingFilteredSum[sourceIndex={0}, filterSource={1}]")
+    @ParameterizedTest
     @MethodSource("sourceIndexesAndFiltered")
     @Tag(Tags.Slow)
-    public void updateWhileBuildingFilteredSum(@Nullable Index sourceIndex, boolean filterSource) {
-        Random r = new Random();
+    public void updateWhileBuildingFilteredSum(@Nullable Index sourceIndex, boolean filterSource, long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 500).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
@@ -181,13 +181,15 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
         sumRebuild(records, recordsWhileBuilding, deletedIds, filter, ODD_NUM_VALUE_3_RECORDS_SUM, sourceIndex, 1, false);
     }
 
-    static Stream<Arguments> sourceIndexes() {
+    @Nonnull
+    static Stream<Arguments> sourceIndexesAndRandomSeeds() {
         return Stream.of(null, REC_NO_INDEX, NUM_VALUE_2_INDEX)
                 .flatMap(indexName -> OnlineIndexerBuildIndexTest.randomSeeds()
                         .map(seed -> Arguments.of(indexName, seed)));
     }
 
-    static Stream<Arguments> sourceIndexesAndFiltered() {
+    @Nonnull
+    static Stream<Arguments> sourceIndexesFilteredAndRandomSeeds() {
         return Stream.of(null, REC_NO_INDEX, NUM_VALUE_2_INDEX)
                 .flatMap(sourceIndex -> Stream.of(false, true)
                         .flatMap(filtered -> OnlineIndexerBuildIndexTest.randomSeeds()
@@ -209,7 +211,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void oneHundredElementsSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -251,7 +253,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void addWhileBuildingSum(Index sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -285,7 +287,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     public void somePreloadedSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -315,7 +317,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     void addSequentialWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -349,7 +351,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     public void updateRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -367,7 +369,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     public void deleteRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -385,7 +387,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexes")
+    @MethodSource("sourceIndexesAndRandomSeeds")
     @Tag(Tags.Slow)
     public void updateAndDeleteRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
@@ -407,7 +409,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexesAndFiltered")
+    @MethodSource("sourceIndexesFilteredAndRandomSeeds")
     @Tag(Tags.Slow)
     public void oneHundredFilteredSum(@Nullable Index sourceIndex, boolean filterSource, long seed) {
         Random r = new Random(seed);
@@ -422,7 +424,7 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     }
 
     @ParameterizedTest
-    @MethodSource("sourceIndexesAndFiltered")
+    @MethodSource("sourceIndexesFilteredAndRandomSeeds")
     @Tag(Tags.Slow)
     public void updateWhileBuildingFilteredSum(@Nullable Index sourceIndex, boolean filterSource, long seed) {
         Random r = new Random(seed);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
@@ -159,7 +159,8 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         }
     }
 
-    private static Stream<Arguments> overlapArgs() {
+    @Nonnull
+    private static Stream<Arguments> overlapAndRandomSeeds() {
         return Stream.of(false, true)
                 .flatMap(overlap -> OnlineIndexerBuildIndexTest.randomSeeds()
                         .map(seed -> Arguments.of(overlap, seed)));
@@ -576,7 +577,7 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
     }
 
     @ParameterizedTest
-    @MethodSource("overlapArgs")
+    @MethodSource("overlapAndRandomSeeds")
     void sumFiveHundredParallelBuild(boolean overlap, long seed) {
         final Random r = new Random(seed);
         List<Message> records = LongStream.range(1L, 501L)
@@ -603,7 +604,7 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
 
     @Tag(Tags.Slow)
     @ParameterizedTest
-    @MethodSource("overlapArgs")
+    @MethodSource("overlapAndRandomSeeds")
     void simpleParallelTwoHundredRebuild(boolean overlap, long seed) {
         final Random r = new Random(seed);
         List<Message> records = LongStream.range(0L, 200L)
@@ -614,7 +615,7 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
 
     @Tag(Tags.Slow)
     @ParameterizedTest
-    @MethodSource("overlapArgs")
+    @MethodSource("overlapAndRandomSeeds")
     void parallelBuildFiveHundredWithDeletesAndUpdates(boolean overlap, long seed) {
         final Random r = new Random(seed);
         List<Message> records = LongStream.range(0L, 500L)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
@@ -41,7 +41,6 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
-import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -50,6 +49,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -156,6 +157,12 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         static OnlineIndexerTestUnnestedRecordHandler instance() {
             return INSTANCE;
         }
+    }
+
+    private static Stream<Arguments> overlapArgs() {
+        return Stream.of(false, true)
+                .flatMap(overlap -> OnlineIndexerBuildIndexTest.randomSeeds()
+                        .map(seed -> Arguments.of(overlap, seed)));
     }
 
     private void assertUnnestedKeyQueryPlanFails() {
@@ -384,18 +391,20 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleSumIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding, 1, false);
     }
 
-    @Test
-    void simpleTenRecordRebuild() {
-        final Random r = new Random(0x5ca1e);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleTenRecordRebuild(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(10)
                 .collect(Collectors.toList());
         singleValueIndexRebuild(records, null, null);
     }
 
-    @Test
-    void tenEmptyMapBuild() {
-        final Random r = new Random(0x0fdb0fdb);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void tenEmptyMapBuild(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r, r.nextLong(), -1.0))
                 .limit(10)
                 .collect(Collectors.toList());
@@ -406,9 +415,10 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, null, null);
     }
 
-    @Test
-    void tenOuterAndTenOtherRecordRebuild() {
-        final Random r = new Random(0x5ca1e);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void tenOuterAndTenOtherRecordRebuild(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> Stream.of(randomOuterRecord(r), randomOtherRecord(r)))
                 .flatMap(Function.identity())
                 .limit(20)
@@ -416,9 +426,10 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, null, null);
     }
 
-    @Test
-    void simpleTenFromSourceIndex() {
-        final Random r = new Random(0xfdb05ca1eL);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void simpleTenFromSourceIndex(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(10)
                 .collect(Collectors.toList());
@@ -426,18 +437,20 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, null, null, 1, false, sourceIndex);
     }
 
-    @Test
-    void tenSumIndexRebuild() {
-        final Random r = new Random(0x5ca1e);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void tenSumIndexRebuild(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(10)
                 .collect(Collectors.toList());
         singleSumIndexRebuild(records, null, null);
     }
 
-    @Test
-    void tenEmptyMapSumBuild() {
-        final Random r = new Random(0x0fdb0fdb);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void tenEmptyMapSumBuild(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r, r.nextLong(), -1.0))
                 .limit(10)
                 .collect(Collectors.toList());
@@ -448,20 +461,22 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleSumIndexRebuild(records, null, null);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    void simpleHundredRecordRebuild() {
-        final Random r = new Random(0x5ca1e);
+    void simpleHundredRecordRebuild(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(100)
                 .collect(Collectors.toList());
         singleValueIndexRebuild(records, null, null);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    void simpleFiveHundredWithUpdates() {
-        final Random r = new Random(0xfdb0);
+    void simpleFiveHundredWithUpdates(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(500)
                 .collect(Collectors.toList());
@@ -472,10 +487,11 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, recordsWhileBuilding, null);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    void simpleFiveHundredWithDeletes() {
-        final Random r = new Random(0xfdb5ca1eL);
+    void simpleFiveHundredWithDeletes(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(500)
                 .collect(Collectors.toList());
@@ -486,10 +502,11 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, null, deleteWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    void fiveHundredWithDeletesAndUpdates() {
-        final Random r = new Random(0x13370fdbL);
+    void fiveHundredWithDeletesAndUpdates(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(500)
                 .collect(Collectors.toList());
@@ -513,10 +530,11 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    void fiveHundredOfMixedTypesWithDeletesAndUpdates() {
-        final Random r = new Random(0xf007ba1L);
+    void fiveHundredOfMixedTypesWithDeletesAndUpdates(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> r.nextBoolean() ? randomOuterRecord(r) : randomOtherRecord(r))
                 .limit(500)
                 .collect(Collectors.toList());
@@ -529,10 +547,11 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    void sixHundredOfMixedTypesWithDeletesUpdatesAndSourceIndex() {
-        final Random r = new Random(0x50cce4L);
+    void sixHundredOfMixedTypesWithDeletesUpdatesAndSourceIndex(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> r.nextBoolean() ? randomOuterRecord(r) : randomOtherRecord(r))
                 .limit(600)
                 .collect(Collectors.toList());
@@ -546,29 +565,31 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
         singleValueIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding, 1, false, sourceIndex);
     }
 
-    @Test
-    void sumFiveHundredRecords() {
-        final Random r = new Random(0xfdb5ca1eL);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void sumFiveHundredRecords(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> randomOuterRecord(r))
                 .limit(500)
                 .collect(Collectors.toList());
         singleSumIndexRebuild(records, null, null);
     }
 
-    @ParameterizedTest(name = "sumFiveHundredParallelBuild[overlap={0}]")
-    @BooleanSource
-    void sumFiveHundredParallelBuild(boolean overlap) {
-        final Random r = new Random(0xfdb5ca1eL);
+    @ParameterizedTest
+    @MethodSource("overlapArgs")
+    void sumFiveHundredParallelBuild(boolean overlap, long seed) {
+        final Random r = new Random(seed);
         List<Message> records = LongStream.range(1L, 501L)
                 .mapToObj(id -> randomOuterRecord(r, id))
                 .collect(Collectors.toList());
         singleSumIndexRebuild(records, null, null, 5, overlap);
     }
 
-    @Disabled("non-idempotent indexes on synthetic types do not checke the range set correctly")
-    @Test
-    void sumSixHundredWithUpdatesAndDeletes() {
-        final Random r = new Random(0xfdbfdbfdbL);
+    @Disabled("non-idempotent indexes on synthetic types do not check the range set correctly")
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void sumSixHundredWithUpdatesAndDeletes(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = Stream.generate(() -> r.nextBoolean() ? randomOuterRecord(r) : randomOtherRecord(r))
                 .limit(600)
                 .collect(Collectors.toList());
@@ -581,10 +602,10 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
     }
 
     @Tag(Tags.Slow)
-    @ParameterizedTest(name = "simpleParallelTwoHundredRebuild[overlap={0}]")
-    @BooleanSource
-    void simpleParallelTwoHundredRebuild(boolean overlap) {
-        final Random r = new Random(0x0fdb0fdb);
+    @ParameterizedTest
+    @MethodSource("overlapArgs")
+    void simpleParallelTwoHundredRebuild(boolean overlap, long seed) {
+        final Random r = new Random(seed);
         List<Message> records = LongStream.range(0L, 200L)
                 .mapToObj(id -> randomOuterRecord(r, id))
                 .collect(Collectors.toList());
@@ -593,9 +614,9 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
 
     @Tag(Tags.Slow)
     @ParameterizedTest
-    @BooleanSource
-    void parallelBuildFiveHundredWithDeletesAndUpdates(boolean overlap) {
-        final Random r = new Random(0x0fdb5caL);
+    @MethodSource("overlapArgs")
+    void parallelBuildFiveHundredWithDeletesAndUpdates(boolean overlap, long seed) {
+        final Random r = new Random(seed);
         List<Message> records = LongStream.range(0L, 500L)
                 .mapToObj(id -> randomOuterRecord(r, id))
                 .collect(Collectors.toList());
@@ -609,9 +630,10 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
     }
 
     @Tag(Tags.Slow)
-    @Test
-    void parallelBuildSixHundredWithDeletesAndUpdatesFromIndex() {
-        final Random r = new Random(0x50caL);
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
+    void parallelBuildSixHundredWithDeletesAndUpdatesFromIndex(long seed) {
+        final Random r = new Random(seed);
         List<Message> records = LongStream.range(0L, 600L)
                 .mapToObj(id -> randomOuterRecord(r, id))
                 .collect(Collectors.toList());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
@@ -41,6 +41,7 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
+import com.apple.test.RandomizedTestUtils;
 import com.apple.test.Tags;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -161,9 +162,16 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
 
     @Nonnull
     private static Stream<Arguments> overlapAndRandomSeeds() {
-        return Stream.of(false, true)
-                .flatMap(overlap -> OnlineIndexerBuildIndexTest.randomSeeds()
-                        .map(seed -> Arguments.of(overlap, seed)));
+        return Stream.concat(
+                Stream.of(false, true)
+                        .flatMap(overlap -> Stream.of(0xba5eba1L, 0xb16da7a, 0xfdb05ca1eL)
+                                .map(seed -> Arguments.of(overlap, seed))),
+                RandomizedTestUtils.randomArguments(r -> {
+                    boolean overlap = r.nextBoolean();
+                    long seed = r.nextLong();
+                    return Arguments.of(overlap, seed);
+                })
+        );
     }
 
     private void assertUnnestedKeyQueryPlanFails() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
@@ -29,6 +29,8 @@ import com.google.common.base.Strings;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -168,12 +170,12 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void emptyRange() {
+    void emptyRange() {
         valueRebuild(Collections.emptyList());
     }
 
     @Test
-    public void singleElement() {
+    void singleElement() {
         TestRecords1Proto.MySimpleRecord record = TestRecords1Proto.MySimpleRecord.newBuilder()
                 .setRecNo(1517)
                 .setNumValue2(95)
@@ -182,7 +184,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void tenElements() {
+    void tenElements() {
         List<TestRecords1Proto.MySimpleRecord> records = IntStream.range(-5, 5).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val * 457).setNumValue2(Math.abs(val * 2)).build()
         ).collect(Collectors.toList());
@@ -190,7 +192,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void tenAdjacentElements() {
+    void tenAdjacentElements() {
         List<TestRecords1Proto.MySimpleRecord> records = IntStream.range(-5, 5).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(val).build()
         ).collect(Collectors.toList());
@@ -198,31 +200,33 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void fiftyElements() {
+    void fiftyElements() {
         List<TestRecords1Proto.MySimpleRecord> records = IntStream.range(-25, 25).mapToObj( val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val * 37).setNumValue2(Math.abs(val) % 5).build()
         ).collect(Collectors.toList());
         valueRebuild(records);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElements() {
-        Random r = new Random(0x5ca1ab1e);
+    void oneHundredElements(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         valueRebuild(records);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsWithWeakReads() {
+    void oneHundredElementsWithWeakReads(long seed) {
         boolean dbTracksReadVersionOnRead = fdb.isTrackLastSeenVersionOnRead();
         boolean dbTracksReadVersionOnCommit = fdb.isTrackLastSeenVersionOnCommit();
         try {
             fdb.setTrackLastSeenVersion(true);
-            Random r = new Random(0x5ca1ab1e);
+            Random r = new Random(seed);
             List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                     TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
             ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -233,24 +237,26 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallel() {
-        Random r = new Random(0x5ca1ab1e);
+    void oneHundredElementsParallel(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         valueRebuild(records, null, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelWithWeakReads() {
+    void oneHundredElementsParallelWithWeakReads(long seed) {
         boolean dbTracksReadVersionOnRead = fdb.isTrackLastSeenVersionOnRead();
         boolean dbTracksReadVersionOnCommit = fdb.isTrackLastSeenVersionOnCommit();
         try {
             fdb.setTrackLastSeenVersion(true);
-            Random r = new Random(0x5ca1ab1e);
+            Random r = new Random(seed);
             List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                     TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
             ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -261,10 +267,11 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelOverlap() {
-        Random r = new Random(0xf005ba11);
+    void oneHundredElementsParallelOverlap(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -272,7 +279,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void tenSplitElements() {
+    void tenSplitElements() {
         String bigOlString = Strings.repeat("x", SplitHelper.SPLIT_RECORD_SIZE + 2);
         List<TestRecords1Proto.MySimpleRecord> records = IntStream.range(-5, 5).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val * 431).setNumValue2(Math.abs(val) % 5).setStrValueIndexed(bigOlString).build()
@@ -281,7 +288,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void fiftySplitElements() {
+    void fiftySplitElements() {
         // Surely this can all fit in memory, no problem, right?
         String bigOlString = Strings.repeat("x", SplitHelper.SPLIT_RECORD_SIZE + 2);
         List<TestRecords1Proto.MySimpleRecord> records = IntStream.range(-25, 25).mapToObj(val ->
@@ -291,7 +298,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void withNullKey1() {
+    void withNullKey1() {
         List<TestRecords1Proto.MySimpleRecord> records = Arrays.asList(
                 TestRecords1Proto.MySimpleRecord.newBuilder().setNumValue2(17).build(),
                 TestRecords1Proto.MySimpleRecord.newBuilder().setNumValue2(76).setRecNo(123).build()
@@ -300,7 +307,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void withNullKey2() {
+    void withNullKey2() {
         List<TestRecords1Proto.MySimpleRecord> records = Collections.singletonList(
                 TestRecords1Proto.MySimpleRecord.newBuilder().setNumValue2(17).build()
         );
@@ -308,7 +315,7 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
     }
 
     @Test
-    public void withNullValue() {
+    void withNullValue() {
         List<TestRecords1Proto.MySimpleRecord> records = Arrays.asList(
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(1066).build(),
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(1776).build(),
@@ -317,10 +324,11 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         valueRebuild(records);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void somePreloaded() {
-        Random r = new Random(0x5ca1ab1e);
+    void somePreloaded(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(75).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -336,10 +344,11 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         valueRebuild(records);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuilding() {
-        Random r = new Random(0xdeadc0de);
+    void addWhileBuilding(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -349,10 +358,11 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         valueRebuild(records, recordsWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingParallel() {
-        Random r = new Random(0xdeadc0de);
+    void addWhileBuildingParallel(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(150).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
@@ -362,10 +372,11 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         valueRebuild(records, recordsWhileBuilding, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuilding() {
-        Random r = new Random(0xba5eba11);
+    void addSequentialWhileBuilding(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());
@@ -375,10 +386,11 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
         valueRebuild(records, recordsWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuildingParallel() {
-        Random r = new Random(0xba5eba11);
+    void addSequentialWhileBuildingParallel(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj( val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
@@ -32,7 +32,8 @@ import com.apple.test.Tags;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -215,40 +216,44 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, null);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsVersion() {
-        Random r = new Random(0x8badf00d);
+    void oneHundredElementsVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(100).collect(Collectors.toList());
         versionRebuild(records);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelVersion() {
-        Random r = new Random(0x8badf00d);
+    void oneHundredElementsParallelVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(100).collect(Collectors.toList());
         versionRebuild(records, null, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void oneHundredElementsParallelOverlapVersion() {
-        Random r = new Random(0x8badf00d);
+    void oneHundredElementsParallelOverlapVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(100).collect(Collectors.toList());
         versionRebuild(records, null, 5, true);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingVersion() {
-        Random r = new Random(0x8badf00d);
+    void addWhileBuildingVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong()).setNumValue2(r.nextInt(10)).build()
         ).limit(100).collect(Collectors.toList());
@@ -258,10 +263,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, recordsWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingParallelVersion() {
-        Random r = new Random(0x8badf00d);
+    void addWhileBuildingParallelVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(10)).build()
         ).limit(150).collect(Collectors.toList());
@@ -271,10 +277,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, recordsWhileBuilding, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuildingVersion() {
-        Random r = new Random(0x8badf00d);
+    void addSequentialWhileBuildingVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());
@@ -286,10 +293,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, recordsWhileBuilding);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addSequentialWhileBuildingParallelVersion() {
-        Random r = new Random(0x8badf00d);
+    void addSequentialWhileBuildingParallelVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj( val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).collect(Collectors.toList());
@@ -301,10 +309,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, recordsWhileBuilding, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void someWithoutVersion() {
-        Random r = new Random(0x8badf00d);
+    void someWithoutVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(20)).build()
         ).limit(100).collect(Collectors.toList());
@@ -316,10 +325,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, null, 1, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void someWithoutVersionParallel() {
-        Random r = new Random(0x8badf00d);
+    void someWithoutVersionParallel(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(20)).build()
         ).limit(100).collect(Collectors.toList());
@@ -331,10 +341,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, null, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingWithoutVersion() {
-        Random r = new Random(0x8badf00d);
+    void addWhileBuildingWithoutVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(20)).build()
         ).limit(100).collect(Collectors.toList());
@@ -349,10 +360,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, recordsWhileBuilding, 1, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void addWhileBuildingWithoutVersionParallel() {
-        Random r = new Random(0x8badf00d);
+    void addWhileBuildingWithoutVersionParallel(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextLong() / 2).setNumValue2(r.nextInt(20)).build()
         ).limit(100).collect(Collectors.toList());
@@ -367,10 +379,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, recordsWhileBuilding, 5, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void sequentialWithoutVersion() {
-        Random r = new Random(0x8badf00d);
+    void sequentialWithoutVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).limit(100).collect(Collectors.toList());
@@ -382,10 +395,11 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
         versionRebuild(records, null, 1, false);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("randomSeeds")
     @Tag(Tags.Slow)
-    public void sequentialWhileBuildingWithoutVersion() {
-        Random r = new Random(0x8badf00d);
+    void sequentialWhileBuildingWithoutVersion(long seed) {
+        Random r = new Random(seed);
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 100).mapToObj(val ->
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(val).setNumValue2(r.nextInt(20)).build()
         ).limit(100).collect(Collectors.toList());


### PR DESCRIPTION
The index build tests already largely randomly generated their data. This updates their source of seeds so that they take a random seed as a parameter, and it configures them to run with additional random seeds if randomized tests are enabled.

This resolves #2582.