### PR TITLE
Additional information around when we find merges in a non-agile context

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
@@ -255,12 +256,12 @@ class FDBDirectoryWrapper implements AutoCloseable {
 
     @Nonnull
     @SuppressWarnings("PMD.CloseResource")
-    public IndexWriter getWriter(@Nonnull LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
+    public IndexWriter getWriter(@Nonnull LuceneAnalyzerWrapper analyzerWrapper, @Nullable final Exception exceptionAtCreation) throws IOException {
         if (writer == null || !writerAnalyzerId.equals(analyzerWrapper.getUniqueIdentifier())) {
             synchronized (this) {
                 if (writer == null || !writerAnalyzerId.equals(analyzerWrapper.getUniqueIdentifier())) {
                     final IndexDeferredMaintenanceControl mergeControl = state.store.getIndexDeferredMaintenanceControl();
-                    TieredMergePolicy tieredMergePolicy = new FDBTieredMergePolicy(mergeControl, agilityContext, state.indexSubspace, key)
+                    TieredMergePolicy tieredMergePolicy = new FDBTieredMergePolicy(mergeControl, agilityContext, state.indexSubspace, key, exceptionAtCreation)
                             .setMaxMergedSegmentMB(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_MAX_SIZE))
                             .setSegmentsPerTier(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER));
                     tieredMergePolicy.setNoCFSRatio(1.00);
@@ -305,7 +306,7 @@ class FDBDirectoryWrapper implements AutoCloseable {
         directory.close();
     }
 
-    public void mergeIndex(@Nonnull LuceneAnalyzerWrapper analyzerWrapper) throws IOException {
-        getWriter(analyzerWrapper).maybeMerge();
+    public void mergeIndex(@Nonnull LuceneAnalyzerWrapper analyzerWrapper, final Exception exceptionAtCreation) throws IOException {
+        getWriter(analyzerWrapper, exceptionAtCreation).maybeMerge();
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
@@ -57,11 +57,28 @@ class MergeUtils {
                                @Nonnull final Subspace indexSubspace,
                                @Nullable final Tuple key,
                                @Nonnull final MergeTrigger mergeTrigger,
-                               @Nullable final MergePolicy.MergeSpecification merges) {
+                               @Nullable final MergePolicy.MergeSpecification merges,
+                               @Nullable final Exception exceptionAtCreation) {
         if (merges != null && logger.isDebugEnabled()) {
             final KeyValueLogMessage message = baseLogMessage(staticMessage, context, indexSubspace, key, mergeTrigger);
             message.addKeyAndValue(LuceneLogMessageKeys.MERGE_SOURCE, simpleSpec(merges));
             logWithExceptionIfNotAgile(logger, context, message);
+            logWithCreationMessageIfNotAgile(logger, staticMessage, context, indexSubspace, key, mergeTrigger, merges, exceptionAtCreation);
+        }
+    }
+
+    private static void logWithCreationMessageIfNotAgile(final @Nonnull Logger logger,
+                                                         final @Nonnull String staticMessage,
+                                                         final @Nonnull AgilityContext context,
+                                                         final @Nonnull Subspace indexSubspace,
+                                                         final @Nullable Tuple key,
+                                                         final @Nonnull MergeTrigger mergeTrigger,
+                                                         final @Nonnull MergePolicy.MergeSpecification merges,
+                                                         final @Nullable Exception exceptionAtCreation) {
+        if (!(context instanceof AgilityContext.Agile)) {
+            final KeyValueLogMessage message = baseLogMessage(staticMessage, context, indexSubspace, key, mergeTrigger);
+            message.addKeyAndValue(LuceneLogMessageKeys.MERGE_SOURCE, simpleSpec(merges));
+            logger.debug(message + " (Creation)", exceptionAtCreation);
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
@@ -67,6 +67,7 @@ class MergeUtils {
         }
     }
 
+    @SuppressWarnings("PMD.GuardLogStatement") // method is only called in a guard for isDebugEnabled
     private static void logWithCreationMessageIfNotAgile(final @Nonnull Logger logger,
                                                          final @Nonnull String staticMessage,
                                                          final @Nonnull AgilityContext context,


### PR DESCRIPTION
The existing observability shows us that the exception is in the pre-commit hook, but we don't know why that is being created with NonAgile. Hopefully this will help.

Once we figure this out, we should remove this additional logging.