### PR TITLE
Fixes #2588: Index planning can match against nested synthetic type primary key components incorrectly

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,8 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Record type key comparisons now can be used on synthetic types [(Issue #2587)](https://github.com/FoundationDB/fdb-record-layer/issues/2587)
+* **Bug fix** Scan comparison ranges on the synthetic record type primary key do not break apart list key expression components [(Issue #2588)](https://github.com/FoundationDB/fdb-record-layer/issues/2588)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -37,7 +37,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** Union plans on synthetic types can choose different union comparison keys from before so continuations from plans from earlier builds may not be re-used on those queries [(Issue #2588)](https://github.com/FoundationDB/fdb-record-layer/issues/2588)
 
 // end next release
 -->

--- a/fdb-extensions/src/test/java/com/apple/test/RandomizedTestUtils.java
+++ b/fdb-extensions/src/test/java/com/apple/test/RandomizedTestUtils.java
@@ -89,7 +89,7 @@ public final class RandomizedTestUtils {
         return Integer.parseInt(System.getProperty("tests.iterations", "0"));
     }
 
-    private static boolean includeRandomTests() {
+    public static boolean includeRandomTests() {
         return Boolean.parseBoolean(System.getProperty("tests.includeRandom", "false"));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/RecordTypeKeyComparison.java
@@ -206,7 +206,7 @@ public class RecordTypeKeyComparison implements ComponentWithComparison {
             if (store == null) {
                 throw Comparisons.EvaluationContextRequiredException.instance();
             }
-            return store.getRecordMetaData().getRecordType(recordTypeName).getRecordTypeKey();
+            return store.getRecordMetaData().getIndexableRecordType(recordTypeName).getRecordTypeKey();
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -708,16 +708,8 @@ public class RecordQueryPlanner implements QueryPlanner {
             final List<KeyExpression> keys = new ArrayList<>(commonPrimaryKey.normalizeKeyForPositions());
             index.trimPrimaryKey(keys);
             if (!keys.isEmpty()) {
-                final List<KeyExpression> children = new ArrayList<>(keys.size() + 1);
-                children.add(indexKeyExpression);
-                for (KeyExpression key : keys) {
-                    if (key.getColumnSize() == 1) {
-                        children.add(key);
-                    } else {
-                        children.add(Key.Expressions.list(key));
-                    }
-                }
-                indexKeyExpression = Key.Expressions.concat(children);
+                keys.add(0, indexKeyExpression);
+                indexKeyExpression = Key.Expressions.concat(keys);
             }
         }
         return indexKeyExpression;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -708,8 +708,16 @@ public class RecordQueryPlanner implements QueryPlanner {
             final List<KeyExpression> keys = new ArrayList<>(commonPrimaryKey.normalizeKeyForPositions());
             index.trimPrimaryKey(keys);
             if (!keys.isEmpty()) {
-                keys.add(0, indexKeyExpression);
-                indexKeyExpression = Key.Expressions.concat(keys);
+                final List<KeyExpression> children = new ArrayList<>(keys.size() + 1);
+                children.add(indexKeyExpression);
+                for (KeyExpression key : keys) {
+                    if (key.getColumnSize() == 1) {
+                        children.add(key);
+                    } else {
+                        children.add(Key.Expressions.list(key));
+                    }
+                }
+                indexKeyExpression = Key.Expressions.concat(children);
             }
         }
         return indexKeyExpression;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
@@ -661,13 +661,13 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
                     .addAll(recordStore.getRecordMetaData().getSyntheticRecordType(OUTER_WITH_ENTRIES).getPrimaryKey().normalizeKeyForPositions())
                     .build();
             assertThat(comparisonKeyComponents, hasSize(4));
-            assertEquals(5, comparisonKeyComponents.stream().mapToInt(KeyExpression::getColumnSize).sum());
+            assertEquals(4, comparisonKeyComponents.stream().mapToInt(KeyExpression::getColumnSize).sum());
             assertMatchesExactly(plan, unionOnExpressionPlan(
                     indexPlan().where(indexName(unnestedOtherKeyValueIndex.getName())).and(scanComparisons(range("[EQUALS $" + otherParam + ", EQUALS $" + k1Param + "]"))),
                     indexPlan().where(indexName(unnestedOtherKeyValueIndex.getName())).and(scanComparisons(range("[EQUALS $" + otherParam + ", EQUALS $" + k2Param + "]")))
-            ).where(comparisonKey(list(comparisonKeyComponents))));
-            assertEquals(reverse ? 1619321562L : 1619321529L, plan.planHash(CURRENT_LEGACY));
-            assertEquals(reverse ? -403164227L : -397444169L, plan.planHash(CURRENT_FOR_CONTINUATION));
+            ).where(comparisonKey(concat(comparisonKeyComponents))));
+            assertEquals(reverse ? 1619322554L : 1619322521L, plan.planHash(CURRENT_LEGACY));
+            assertEquals(reverse ? 803980444L : 809700502L, plan.planHash(CURRENT_FOR_CONTINUATION));
 
             for (long otherId : otherIds) {
                 for (String key1 : keys) {
@@ -748,9 +748,9 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
             assertMatchesExactly(plan, unionOnExpressionPlan(
                     indexPlan().where(indexName(keyIdValueIndex.getName())).and(scanComparisons(range("[EQUALS $" + key1Param + "]"))),
                     indexPlan().where(indexName(keyIdValueIndex.getName())).and(scanComparisons(range("[EQUALS $" + key2Param + "]")))
-            ).where(comparisonKey(concat(field(PARENT_CONSTITUENT).nest("rec_id"), field("entry").nest("value"), recordType(), field(UnnestedRecordType.POSITIONS_FIELD).nest("entry")))));
-            assertEquals(reverse ? 1518478779L : 1518478746L, plan.planHash(CURRENT_LEGACY));
-            assertEquals(reverse ? 1391408828L : 1397128886L, plan.planHash(CURRENT_FOR_CONTINUATION));
+            ).where(comparisonKey(concat(field(PARENT_CONSTITUENT).nest("rec_id"), field("entry").nest("value"), recordType(), list(field(PARENT_CONSTITUENT).nest("rec_id")), list(field(UnnestedRecordType.POSITIONS_FIELD).nest("entry"))))));
+            assertEquals(reverse ? -1283520453 : -1283520486, plan.planHash(CURRENT_LEGACY));
+            assertEquals(reverse ? -2138865240 : -2133145182, plan.planHash(CURRENT_FOR_CONTINUATION));
 
             for (String key1 : keys) {
                 for (String key2 : keys) {
@@ -835,14 +835,14 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
                     .addAll(recordStore.getRecordMetaData().getSyntheticRecordType(OUTER_WITH_ENTRIES).getPrimaryKey().normalizeKeyForPositions())
                     .build();
             assertThat(comparisonKeyComponents, hasSize(4));
-            assertEquals(5, comparisonKeyComponents.stream().mapToInt(KeyExpression::getColumnSize).sum());
+            assertEquals(4, comparisonKeyComponents.stream().mapToInt(KeyExpression::getColumnSize).sum());
             assertMatchesExactly(plan, inUnionOnExpressionPlan(indexPlan()
                     .where(indexName(unnestedOtherKeyValueIndex.getName()))
                     .and(scanComparisons(range("[EQUALS $" + otherParam + ", EQUALS $__in_key__0]")))
                     .and(reverse ? isReverse() : isNotReverse())
-            ).where(inUnionComparisonKey(list(comparisonKeyComponents))));
-            assertEquals(reverse ? -1181713337L : -1181714298L, plan.planHash(CURRENT_LEGACY));
-            assertEquals(reverse ? 1959162892L : 1959341638L, plan.planHash(CURRENT_FOR_CONTINUATION));
+            ).where(inUnionComparisonKey(concat(comparisonKeyComponents))));
+            assertEquals(reverse ? -1181712345L : -1181713306L, plan.planHash(CURRENT_LEGACY));
+            assertEquals(reverse ? -1128659733L : -1128480987L, plan.planHash(CURRENT_FOR_CONTINUATION));
 
             for (long otherId : otherIds) {
                 for (String key1 : keys) {


### PR DESCRIPTION
…rimary key components incorrectly

This adjusts the way the planner interacts with primary keys using a `ListKeyExpression` to avoid matching them incorrectly during an index scan. There was an additional problem, related to matching the `RecordTypeKeyExpression`, where the physical operator had a bug in that it didn't resolve the record type in a way that handled synthetic record types, and that bug has also been addressed.

This fixes #2587 and this fixes #2588.