### PR TITLE
Resolve #2575: Lucene file lock may not be cleaned up in a failed merge

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -920,7 +920,7 @@ public class FDBDirectory extends Directory  {
         try {
             clearLockIfLocked();
             agilityContext.flush();
-        } catch (RecordCoreException ex) {
+        } catch (RuntimeException ex) {
             // Here: got exception, it is important to clear the file lock, or it will prevent retry-recovery
             agilityContext.abortAndReset();
             clearLockIfLocked();


### PR DESCRIPTION
   A quick typo fix for https://github.com/FoundationDB/fdb-record-layer/pull/2594