### PR TITLE
Fixes #2605: Flush the AgileContext before executing the merge

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Lucene merge flush group/partition info AgileContext before executing a merge [(Issue #2605)](https://github.com/FoundationDB/fdb-record-layer/issues/2605)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
I couldn't figure out how to make a commitable test. The only thing I came up with was to inject some sleep code in `mergeIndexNow`. Namely this:
```diff
     private void mergeIndexNow(LuceneAnalyzerWrapper analyzerWrapper, Tuple groupingKey, @Nullable final Integer partitionId) {
         final AgilityContext agilityContext = getAgilityContext(true);
         final FDBDirectoryWrapper directoryWrapper = getDirectoryWrapper(groupingKey, partitionId, agilityContext);
+        long stopMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
         try {
             directoryWrapper.mergeIndex(analyzerWrapper, exceptionAtCreation);
-            agilityContext.flush(); // TODO: remove this flush if directory resource is being closed without delay after merging
+            while (System.currentTimeMillis() < stopMillis) {
+                agilityContext.flush(); // TODO: remove this flush if directory resource is being closed without delay after merging
+                try {
+                    System.out.println("Time left " + groupingKey + "@" + partitionId + ": " + (stopMillis - System.currentTimeMillis()));
+                    Thread.sleep(1000L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(KeyValueLogMessage.of("Lucene merge success",
```