### PR TITLE
Cleanup AgilityContext failure logic

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Commit after successful calls to AgilityContext.apply [(Issue #2618)](https://github.com/FoundationDB/fdb-record-layer/issues/2618)
 * **Bug fix** Rename LuceneLogMessageKeys.PARTITION -> INDEX_PARTITION [(Issue #2614)](https://github.com/FoundationDB/fdb-record-layer/issues/2614)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** AgilityContext.accept: release write lock in finally  [(Issue #2619)](https://github.com/FoundationDB/fdb-record-layer/issues/2619)
 * **Bug fix** Commit after successful calls to AgilityContext.apply [(Issue #2618)](https://github.com/FoundationDB/fdb-record-layer/issues/2618)
 * **Bug fix** Rename LuceneLogMessageKeys.PARTITION -> INDEX_PARTITION [(Issue #2614)](https://github.com/FoundationDB/fdb-record-layer/issues/2614)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -300,7 +300,15 @@ public interface AgilityContext {
         public <R> CompletableFuture<R> apply(Function<FDBRecordContext, CompletableFuture<R>> function) {
             ensureOpen();
             final long stamp = lock.readLock();
-            createIfNeeded();
+            boolean successfulCreate = false;
+            try {
+                createIfNeeded();
+                successfulCreate = true;
+            } finally {
+                if (!successfulCreate) {
+                    lock.unlock(stamp);
+                }
+            }
             return function.apply(currentContext).whenComplete((result, exception) -> {
                 lock.unlock(stamp);
                 if (exception == null) {
@@ -313,9 +321,12 @@ public interface AgilityContext {
         public void accept(final Consumer<FDBRecordContext> function) {
             ensureOpen();
             final long stamp = lock.readLock();
-            createIfNeeded();
-            function.accept(currentContext);
-            lock.unlock(stamp);
+            try {
+                createIfNeeded();
+                function.accept(currentContext);
+            } finally {
+                lock.unlock(stamp);
+            }
             commitIfNeeded();
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -303,7 +303,7 @@ public interface AgilityContext {
             createIfNeeded();
             return function.apply(currentContext).whenComplete((result, exception) -> {
                 lock.unlock(stamp);
-                if (exception != null) {
+                if (exception == null) {
                     commitIfNeeded();
                 }
             });


### PR DESCRIPTION
1. In an unrelated effort I noticed issue #2618 which this fixes.
2. Inspired by that, I thought I would add some tests for the failure scenarios for accept/apply, and when running the tests, one of them stalled, and so I changed it to release the lock in a finally block (#2619)
3. I did an audit of the usages of the `lock` field and also ensured that if creation of a context failed it would unlock.