### PR TITLE
RESOLVES #2616: Select Partition based on query filter

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -32,6 +32,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Select Partition based on query filter [(Issue #2616)](https://github.com/FoundationDB/fdb-record-layer/issues/2616)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneComparisonQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneComparisonQuery.java
@@ -1,0 +1,101 @@
+/*
+ * LuceneComparisonQuery.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Wrapper of a Lucene {@link Query} that contains accessible
+ * field name, comparison type, and comparand.
+ */
+public class LuceneComparisonQuery extends Query {
+    private final Query query;
+    private final String fieldName;
+    private final Comparisons.Type comparisonType;
+    private final Object comparand;
+
+    public LuceneComparisonQuery(@Nonnull final Query query,
+                                 @Nonnull final String fieldName,
+                                 @Nonnull final Comparisons.Type comparisonType,
+                                 @Nullable final Object comparand) {
+        this.query = query;
+        this.fieldName = fieldName;
+        this.comparisonType = comparisonType;
+        this.comparand = comparand;
+    }
+
+    @Override
+    public Weight createWeight(final IndexSearcher searcher, final ScoreMode scoreMode, final float boost) throws IOException {
+        return query.createWeight(searcher, scoreMode, boost);
+    }
+
+    @Override
+    public Query rewrite(final IndexReader reader) throws IOException {
+        return query.rewrite(reader);
+    }
+
+    @Override
+    public void visit(final QueryVisitor visitor) {
+        query.visit(visitor);
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Comparisons.Type getComparisonType() {
+        return comparisonType;
+    }
+
+    public Object getComparand() {
+        return comparand;
+    }
+
+    @Override
+    public String toString(final String field) {
+        return query.toString(field);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof LuceneComparisonQuery &&
+                Objects.equals(fieldName, ((LuceneComparisonQuery)obj).fieldName) &&
+                Objects.equals(comparisonType, ((LuceneComparisonQuery)obj).comparisonType) &&
+                Objects.equals(comparand, ((LuceneComparisonQuery)obj).comparand) &&
+                Objects.equals(query, ((LuceneComparisonQuery)obj).query);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, comparisonType, comparand, query);
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -162,7 +162,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         if (scanType.equals(LuceneScanTypes.BY_LUCENE)) {
             LuceneScanQuery scanQuery = (LuceneScanQuery)scanBounds;
             // if partitioning is enabled, a non-null continuation will include the current partition info
-            LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = continuation == null ? partitioner.selectQueryPartition(scanQuery.getGroupKey(), scanQuery.getSort()) : null;
+            LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = continuation == null ? partitioner.selectQueryPartition(scanQuery.getGroupKey(), scanQuery) : null;
             return new LuceneRecordCursor(executor, state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_EXECUTOR_SERVICE),
                     partitioner,
                     state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_CURSOR_PAGE_SIZE),

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -1182,5 +1182,13 @@ public class LucenePartitioner {
             this.canHaveMatches = canHaveMatches;
             this.startPartition = startPartition;
         }
+
+        @Override
+        public String toString() {
+            return "PartitionedQueryHint{" +
+                    "startPartition=" + startPartition +
+                    ", canHaveMatches=" + canHaveMatches +
+                    '}';
+        }
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -347,8 +347,10 @@ public class LucenePartitioner {
             List<BooleanClause> clauses = ((BooleanQuery) query).clauses();
             // we only care about "top level" clauses, and won't descend
             for (BooleanClause clause : clauses) {
-                if (clause.getOccur() != BooleanClause.Occur.MUST) {
+                if (clause.getOccur() != BooleanClause.Occur.MUST && clause.getOccur() != BooleanClause.Occur.FILTER) {
                     // we only care about clauses that are not optional
+                    // note that we don't deal with MUST_NOT clauses since it would require negating the clause for
+                    // determining the starting partition; support for this can be added in a future update.
                     continue;
                 }
                 Query clauseQuery = clause.getQuery();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
@@ -389,22 +389,46 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
             Comparisons.Comparison appliedComparison = applyComparisonConversion(fieldNameOverride, comparison);
             switch (appliedComparison.getType()) {
                 case EQUALS:
-                    return toBoundQuery(LongPoint.newExactQuery(appliedFieldName, (Long)comparand));
+                    return toBoundQuery(new LuceneComparisonQuery(LongPoint.newExactQuery(appliedFieldName, (Long)comparand),
+                            appliedFieldName,
+                            comparison.getType(),
+                            comparand));
                 case NOT_EQUALS: {
                     long value = (Long)comparand;
                     BooleanQuery.Builder builder = new BooleanQuery.Builder();
-                    builder.add(LongPoint.newRangeQuery(appliedFieldName, Long.MIN_VALUE, value - 1), BooleanClause.Occur.SHOULD);
-                    builder.add(LongPoint.newRangeQuery(appliedFieldName, value + 1, Long.MAX_VALUE), BooleanClause.Occur.SHOULD);
+                    builder.add(
+                            new LuceneComparisonQuery(LongPoint.newRangeQuery(appliedFieldName, Long.MIN_VALUE, value - 1),
+                                    appliedFieldName,
+                                    comparison.getType(),
+                                    comparand),
+                            BooleanClause.Occur.SHOULD);
+                    builder.add(new LuceneComparisonQuery(LongPoint.newRangeQuery(appliedFieldName, value + 1, Long.MAX_VALUE),
+                                    appliedFieldName,
+                                    comparison.getType(),
+                                    comparand),
+                            BooleanClause.Occur.SHOULD);
                     return toBoundQuery(builder.build());
                 }
                 case LESS_THAN:
-                    return toBoundQuery(LongPoint.newRangeQuery(appliedFieldName, Long.MIN_VALUE, (Long)comparand - 1));
+                    return toBoundQuery(new LuceneComparisonQuery(LongPoint.newRangeQuery(appliedFieldName, Long.MIN_VALUE, (Long)comparand - 1),
+                            appliedFieldName,
+                            comparison.getType(),
+                            comparand));
                 case LESS_THAN_OR_EQUALS:
-                    return toBoundQuery(LongPoint.newRangeQuery(appliedFieldName, Long.MIN_VALUE, (Long)comparand));
+                    return toBoundQuery(new LuceneComparisonQuery(LongPoint.newRangeQuery(appliedFieldName, Long.MIN_VALUE, (Long)comparand),
+                            appliedFieldName,
+                            comparison.getType(),
+                            comparand));
                 case GREATER_THAN:
-                    return toBoundQuery(LongPoint.newRangeQuery(appliedFieldName, (Long)comparand + 1, Long.MAX_VALUE));
+                    return toBoundQuery(new LuceneComparisonQuery(LongPoint.newRangeQuery(appliedFieldName, (Long)comparand + 1, Long.MAX_VALUE),
+                            appliedFieldName,
+                            comparison.getType(),
+                            comparand));
                 case GREATER_THAN_OR_EQUALS:
-                    return toBoundQuery(LongPoint.newRangeQuery(appliedFieldName, (Long)comparand, Long.MAX_VALUE));
+                    return toBoundQuery(new LuceneComparisonQuery(LongPoint.newRangeQuery(appliedFieldName, (Long)comparand, Long.MAX_VALUE),
+                            appliedFieldName,
+                            comparison.getType(),
+                            comparand));
                 case IN:
                     return toBoundQuery(LongPoint.newSetQuery(appliedFieldName, ((List<Long>)comparand)));
                 case NOT_NULL:

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -1573,7 +1573,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             Map<Comparisons.Type, Map<SortType, Integer>> expectationsForTime0 = Map.of(
                     Type.GREATER_THAN, Map.of(SortType.ASCENDING, 1, SortType.DESCENDING, 3, SortType.UNSORTED, 3),
                     Type.GREATER_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 3, SortType.UNSORTED, 3),
-                    Type.LESS_THAN, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 0, SortType.UNSORTED, 0),
+                    Type.LESS_THAN, Map.of(SortType.ASCENDING, -1, SortType.DESCENDING, -1, SortType.UNSORTED, -1),
                     Type.LESS_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 1, SortType.UNSORTED, 1),
                     Type.EQUALS, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 1, SortType.UNSORTED, 1));
             startingPartitionExpectation.put(time0, expectationsForTime0);
@@ -1617,20 +1617,20 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             Map<Comparisons.Type, Map<SortType, Integer>> expectationsForTimeTooOld = Map.of(
                     Type.GREATER_THAN, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 3, SortType.UNSORTED, 3),
                     Type.GREATER_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 3, SortType.UNSORTED, 3),
-                    Type.LESS_THAN, Map.of(SortType.ASCENDING, 3, SortType.DESCENDING, 0, SortType.UNSORTED, 0),
-                    Type.LESS_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, 3, SortType.DESCENDING, 0, SortType.UNSORTED, 0),
-                    Type.EQUALS, Map.of(SortType.ASCENDING, 3, SortType.DESCENDING, 0, SortType.UNSORTED, 0));
+                    Type.LESS_THAN, Map.of(SortType.ASCENDING, -1, SortType.DESCENDING, -1, SortType.UNSORTED, -1),
+                    Type.LESS_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, -1, SortType.DESCENDING, -1, SortType.UNSORTED, -1),
+                    Type.EQUALS, Map.of(SortType.ASCENDING, -1, SortType.DESCENDING, -1, SortType.UNSORTED, -1));
             startingPartitionExpectation.put(timeTooOld, expectationsForTimeTooOld);
 
             // =====================================
             // Expectations for timeTooNew
             // =====================================
             Map<Comparisons.Type, Map<SortType, Integer>> expectationsForTimeTooNew = Map.of(
-                    Type.GREATER_THAN, Map.of(SortType.ASCENDING, 3, SortType.DESCENDING, 0, SortType.UNSORTED, 0),
-                    Type.GREATER_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, 3, SortType.DESCENDING, 0, SortType.UNSORTED, 0),
+                    Type.GREATER_THAN, Map.of(SortType.ASCENDING, -1, SortType.DESCENDING, -1, SortType.UNSORTED, -1),
+                    Type.GREATER_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, -1, SortType.DESCENDING, -1, SortType.UNSORTED, -1),
                     Type.LESS_THAN, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 3, SortType.UNSORTED, 3),
                     Type.LESS_THAN_OR_EQUALS, Map.of(SortType.ASCENDING, 0, SortType.DESCENDING, 3, SortType.UNSORTED, 3),
-                    Type.EQUALS, Map.of(SortType.ASCENDING, 3, SortType.DESCENDING, 0, SortType.UNSORTED, 0));
+                    Type.EQUALS, Map.of(SortType.ASCENDING, -1, SortType.DESCENDING, -1, SortType.UNSORTED, -1));
             startingPartitionExpectation.put(timeTooNew, expectationsForTimeTooNew);
 
             // check all combinations against expectations

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -98,7 +98,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.util.LuceneTestCase;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -4735,7 +4735,7 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         }
     }
 
-    private static final List<String> spellcheckWords = java.util.List.of("hello", "monitor", "keyboard", "mouse", "trackpad", "cable", "help", "elmo", "elbow", "helps", "helm", "helms", "gulps");
+    private static final List<String> spellcheckWords = List.of("hello", "monitor", "keyboard", "mouse", "trackpad", "cable", "help", "elmo", "elbow", "helps", "helm", "helms", "gulps");
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
@@ -5797,8 +5797,8 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
         }
     }
 
-    protected static final List<String> autoCompletes = java.util.List.of("Good morning", "Good afternoon", "good evening", "Good night", "That's really good!", "I'm good", "Hello Record Layer", "Hello FoundationDB!", ENGINEER_JOKE);
-    protected static final List<String> autoCompletePhrases = java.util.List.of(
+    protected static final List<String> autoCompletes = List.of("Good morning", "Good afternoon", "good evening", "Good night", "That's really good!", "I'm good", "Hello Record Layer", "Hello FoundationDB!", ENGINEER_JOKE);
+    protected static final List<String> autoCompletePhrases = List.of(
             "united states of america",
             "welcome to the united states of america",
             "united kingdom, france, the states",


### PR DESCRIPTION
This update optimizes a given search query that contains a `partition field` predicate, to take advantage of the partition metadata and therefore to direct the searcher to start in the right _partition_ where applicable.
In order for a `partition field` predicate to be considered, the following conditions **must** be true:
1. the predicate's comparison operator is **not** `NOT_EQUALS`
2. Either the predicate is the only one in the filter, **OR** it is the only `partition field` predicate in a conjunction filter
