### PR TITLE
Fix merge skew between #2604 and #2622

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Extension that allows the user to specify the database. It ensures that FDB has been properly initialized
@@ -144,12 +145,16 @@ public class FDBDatabaseExtension implements AfterEachCallback {
         return db;
     }
 
+    public void checkForOpenContexts() {
+        assertNotNull(db, "Should not check for open contexts on a null database");
+        assertEquals(0, db.warnAndCloseOldTrackedOpenContexts(0), "should not have left any contexts open");
+    }
+
     @Override
     public void afterEach(final ExtensionContext extensionContext) {
         if (db != null) {
-            // Validate that the test closes all of the transactions that it opens
-            int count = db.warnAndCloseOldTrackedOpenContexts(0);
-            assertEquals(0, count, "should not have left any contexts open");
+            // Validate that the test closes all the transactions that it opens
+            checkForOpenContexts();
             db.close();
             db = null;
             getDatabaseFactory().clear();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -383,7 +383,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreTestBase {
                     Assertions.assertEquals(TimeUnit.NANOSECONDS, timeoutException.getLogInfo().get(LogMessageKeys.TIME_UNIT.toString()), i + " " + e.getMessage());
                 }
                 fdb.setAsyncToSyncTimeout(oldAsyncToSyncTimeout);
-                checkForOpenContexts(); // validate after every loop that we didn't leave any contexts open
+                dbExtension.checkForOpenContexts(); // validate after every loop that we didn't leave any contexts open
                 LOGGER.debug(KeyValueLogMessage.of("Validating",
                         "iteration", i));
                 new LuceneIndexTestValidator(() -> openContext(contextProps), context -> {
@@ -392,7 +392,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreTestBase {
                 }).validate(index, ids, Integer.MAX_VALUE, isSynthetic ? "child_str_value:forth" : "text_value:about", !success);
                 LOGGER.debug(KeyValueLogMessage.of("Done Validating",
                         "iteration", i));
-                checkForOpenContexts(); // just in case the validation code leaks a context
+                dbExtension.checkForOpenContexts(); // just in case the validation code leaks a context
             }
         } finally {
             fdb.setAsyncToSyncTimeout(oldAsyncToSyncTimeout);


### PR DESCRIPTION
PR #2604 removed the `checkForOpenContexts` method from `FDBRecordStoreTestBase`. Meanwhile, `LuceneIndexMaintenanceTest` added some explicit calls to that method in #2622 in order to validated that the `AgilityContext` did not leak contexts. This fixes the merge skew by exposing the method in the `FDBDatabaseExtension` and then referencing the method in the extension instead of in the super class.