### PR TITLE
Add timestamp to test logs

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -146,11 +146,11 @@ tasks.withType(Test) { theTask ->
         exceptionFormat = 'full'
     }
     beforeTest { descriptor -> 
-        println "${getFullDisplayName(descriptor)} STARTED"
+        println "${Instant.now()} ${getFullDisplayName(descriptor)} STARTED"
     } 
     afterTest { descriptor, result ->
         def duration = result.endTime - result.startTime
-        println "${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
+        println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
         println()
     }
     reports {


### PR DESCRIPTION
Example:
```
2024-04-22T14:02:07.233753Z RangeSetTest > concurrentlyExpandReadRange() STARTED
2024-04-22T14:02:07.357420Z RangeSetTest > concurrentlyExpandReadRange() SUCCESS (123ms)
```

This should make it easier to diagnose if there is a timeout on a build what was happening, and wether the test running at the end took a crazy long time, or if something else took a long time.