### PR TITLE
Resolves #2663: Add query support for indexed arithmetic functions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -31,7 +31,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Support for basic arithmetic functions in added as default `FunctionKeyExpression`s with query support in both the old and Cascades planners [(Issue #2663)](https://github.com/FoundationDB/fdb-record-layer/issues/2663)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FunctionNames.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FunctionNames.java
@@ -61,6 +61,17 @@ public class FunctionNames {
     /* Bitmap of matching positions */
     public static final String BITMAP_VALUE = "bitmap_value";
 
+    /* Arithmetic functions */
+    public static final String ADD = "add";
+    public static final String SUBTRACT = "subtract";
+    public static final String MULTIPLY = "multiply";
+    public static final String DIVIDE = "divide";
+    public static final String MOD = "mod";
+    public static final String BITAND = "bitand";
+    public static final String BITOR = "bitor";
+    public static final String BITXOR = "bitxor";
+    public static final String BITNOT = "bitnot";
+
     private FunctionNames() {
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/CollateFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/CollateFunctionKeyExpression.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.provider.common.text.TextCollator;
 import com.apple.foundationdb.record.provider.common.text.TextCollatorRegistry;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.protobuf.Message;
 
@@ -180,6 +181,7 @@ public class CollateFunctionKeyExpression extends FunctionKeyExpression implemen
     @Nonnull
     @Override
     public Value toValue(@Nonnull final CorrelationIdentifier baseAlias,
+                         @Nonnull final Type baseType,
                          @Nonnull final List<String> fieldNamePrefix) {
         // TODO support this
         throw new UnsupportedOperationException();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpressionWithValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpressionWithValue.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.metadata.expressions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.KeyExpressionVisitor;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 
 import javax.annotation.Nonnull;
@@ -39,7 +40,7 @@ import java.util.List;
 @API(API.Status.EXPERIMENTAL)
 public interface KeyExpressionWithValue extends KeyExpression {
     @Nonnull
-    Value toValue(@Nonnull CorrelationIdentifier baseAlias, @Nonnull List<String> fieldNamePrefix);
+    Value toValue(@Nonnull CorrelationIdentifier baseAlias, @Nonnull Type baseType, @Nonnull List<String> fieldNamePrefix);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LiteralKeyExpression.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.util.HashUtils;
@@ -103,6 +104,7 @@ public class LiteralKeyExpression<T> extends BaseKeyExpression implements AtomKe
     @Nonnull
     @Override
     public Value toValue(@Nonnull final CorrelationIdentifier baseAlias,
+                         @Nonnull final Type baseType,
                          @Nonnull final List<String> fieldNamePrefix) {
         return LiteralValue.ofScalar(value);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LongArithmethicFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LongArithmethicFunctionKeyExpression.java
@@ -1,0 +1,226 @@
+/*
+ * ArithmethicFunctionKeyExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.KeyExpressionVisitor;
+import com.apple.foundationdb.record.query.plan.cascades.ScalarTranslationVisitor;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.FunctionCatalog;
+import com.apple.foundationdb.record.query.plan.cascades.values.PromoteValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BinaryOperator;
+import java.util.function.UnaryOperator;
+
+/**
+ * Function key expression representing evaluating arithmetic functions on {@code long}s.
+ */
+public class LongArithmethicFunctionKeyExpression extends FunctionKeyExpression implements QueryableKeyExpression {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Long-Arithmetic-Key-Expression-Function");
+
+    private final int minArguments;
+    private final int maxArguments;
+
+    @Nullable
+    private final UnaryOperator<Long> unaryOperator;
+    @Nullable
+    private final BinaryOperator<Long> binaryOperator;
+
+    private LongArithmethicFunctionKeyExpression(@Nonnull String name, @Nonnull KeyExpression arguments, int minArguments, int maxArguments, @Nullable UnaryOperator<Long> unaryOperator, @Nullable BinaryOperator<Long> binaryOperator) {
+        super(name, arguments);
+        this.minArguments = minArguments;
+        this.maxArguments = maxArguments;
+        this.unaryOperator = unaryOperator;
+        this.binaryOperator = binaryOperator;
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode hashMode) {
+        return super.basePlanHash(hashMode, BASE_HASH);
+    }
+
+    @Override
+    public int queryHash(@Nonnull final QueryHashKind hashKind) {
+        return super.baseQueryHash(hashKind, BASE_HASH);
+    }
+
+    @Override
+    public int getMinArguments() {
+        return minArguments;
+    }
+
+    @Override
+    public int getMaxArguments() {
+        return maxArguments;
+    }
+
+    @Nonnull
+    @Override
+    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable final FDBRecord<M> record, @Nullable final Message message, @Nonnull final Key.Evaluated arguments) {
+        Long result;
+        if (arguments.size() == 1) {
+            final Long x = arguments.getNullableLong(0);
+            result = x == null ? null : Objects.requireNonNull(unaryOperator).apply(x);
+        } else {
+            final Long l = arguments.getNullableLong(0);
+            final Long r = arguments.getNullableLong(1);
+            result = (l == null || r == null) ? null : Objects.requireNonNull(binaryOperator).apply(l, r);
+        }
+        return ImmutableList.of(Key.Evaluated.scalar(result));
+    }
+
+    @Override
+    public boolean createsDuplicates() {
+        return arguments.createsDuplicates();
+    }
+
+    @Override
+    public int getColumnSize() {
+        return 1;
+    }
+
+    @Nonnull
+    @Override
+    public <S extends KeyExpressionVisitor.State, R> R expand(@Nonnull final KeyExpressionVisitor<S, R> visitor) {
+        return visitor.visitExpression(this);
+    }
+
+    @Nonnull
+    @Override
+    public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final Type baseType, @Nonnull final List<String> fieldNamePrefix) {
+        ScalarTranslationVisitor scalarTranslationVisitor = new ScalarTranslationVisitor(arguments);
+        scalarTranslationVisitor.push(ScalarTranslationVisitor.ScalarVisitorState.of(baseAlias, baseType, fieldNamePrefix));
+        List<Value> argumentValues = new ArrayList<>(arguments.getColumnSize());
+        for (KeyExpression expression : arguments.normalizeKeyForPositions()) {
+            Value argValue = expression.expand(scalarTranslationVisitor);
+
+            final Type argType = argValue.getResultType();
+            final Type targetType = Type.primitiveType(Type.TypeCode.LONG, argType.isNullable());
+            argumentValues.add(PromoteValue.inject(argValue, targetType));
+        }
+        BuiltInFunction<?> builtInFunction = FunctionCatalog.resolve(getName(), arguments.getColumnSize()).orElseThrow(() -> new RecordCoreArgumentException("unknown function", LogMessageKeys.FUNCTION, getName()));
+        return (Value) builtInFunction.encapsulate(argumentValues);
+    }
+
+    /**
+     * Builder for {@link LongArithmethicFunctionKeyExpression}s.
+     */
+    public static class Builder extends FunctionKeyExpression.Builder {
+        private final int minArguments;
+        private final int maxArguments;
+        @Nullable
+        private final UnaryOperator<Long> unaryOperator;
+        @Nullable
+        private final BinaryOperator<Long> binaryOperator;
+
+        private Builder(@Nonnull String functionName, int minArguments, int maxArguments, @Nullable UnaryOperator<Long> unaryOperator, @Nullable BinaryOperator<Long> binaryOperator) {
+            super(functionName);
+            this.minArguments = minArguments;
+            this.maxArguments = maxArguments;
+            this.unaryOperator = unaryOperator;
+            this.binaryOperator = binaryOperator;
+        }
+
+        @Nonnull
+        @Override
+        public FunctionKeyExpression build(@Nonnull final KeyExpression arguments) {
+            return new LongArithmethicFunctionKeyExpression(functionName, arguments, minArguments, maxArguments, unaryOperator, binaryOperator);
+        }
+
+        /**
+         * Create a new builder of a unary function. The resulting {@link LongArithmethicFunctionKeyExpression}
+         * will only support operating on a single argument.
+         *
+         * @param name the name of the function
+         * @param operator a lambda representing function execution
+         * @return a new {@code Builder} of a unary arithmethic function expression
+         */
+        @Nonnull
+        public static Builder unaryFunction(@Nonnull String name, @Nonnull UnaryOperator<Long> operator) {
+            return new Builder(name, 1, 1, operator, null);
+        }
+
+        /**
+         * Create a new builder of a binary function. The resulting {@link LongArithmethicFunctionKeyExpression}
+         * will only support operating on exactly two arguments.
+         *
+         * @param name the name of the function
+         * @param operator a lambda representing function execution
+         * @return a new {@code Builder} of a binary arithmethic function expression
+         */
+        @Nonnull
+        public static Builder binaryFunction(@Nonnull String name, @Nonnull BinaryOperator<Long> operator) {
+            return new Builder(name, 2, 2, null, operator);
+        }
+
+        /**
+         * Create a new builder of a function that can be either unary or binary.
+         *
+         * @param name the name of the function
+         * @param unaryOperator the function to execute if a single argument is provided
+         * @param binaryOperator the function to execute if two arguments are provided
+         * @return a new {@code Builder} of a function that can be unary or binary
+         */
+        @Nonnull
+        public static Builder bothFunction(@Nonnull String name, @Nonnull UnaryOperator<Long> unaryOperator, @Nonnull BinaryOperator<Long> binaryOperator) {
+            return new Builder(name, 1, 2, unaryOperator, binaryOperator);
+        }
+    }
+
+    /**
+     * Factory for constructing built-in arithmetic functions that operate on {@code long}s.
+     */
+    @AutoService(FunctionKeyExpression.Factory.class)
+    public static class LongArithmethicFunctionKeyExpressionFactory implements FunctionKeyExpression.Factory {
+        @Nonnull
+        private static final List<FunctionKeyExpression.Builder> BUILDERS = ImmutableList.<FunctionKeyExpression.Builder>builder()
+                .add(Builder.binaryFunction("bitor", (l, r) -> l | r))
+                .add(Builder.binaryFunction("bitand", (l, r) -> l & r))
+                .add(Builder.binaryFunction("bitxor", (l, r) -> l ^ r))
+                .add(Builder.unaryFunction("bitnot", x -> ~x))
+                .add(Builder.binaryFunction("add", (l, r) -> l + r))
+                .add(Builder.bothFunction("subtract", x -> -x, (l, r) -> l - r))
+                .add(Builder.binaryFunction("multiply", (l, r) -> l * r))
+                .add(Builder.binaryFunction("divide", (l, r) -> l / r))
+                .build();
+
+        @Nonnull
+        @Override
+        public List<FunctionKeyExpression.Builder> getBuilders() {
+            return BUILDERS;
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LongArithmethicFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LongArithmethicFunctionKeyExpression.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.record.query.plan.cascades.KeyExpressionVisitor;
 import com.apple.foundationdb.record.query.plan.cascades.ScalarTranslationVisitor;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FunctionCatalog;
-import com.apple.foundationdb.record.query.plan.cascades.values.PromoteValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
@@ -135,11 +134,7 @@ public class LongArithmethicFunctionKeyExpression extends FunctionKeyExpression 
         scalarTranslationVisitor.push(ScalarTranslationVisitor.ScalarVisitorState.of(baseAlias, baseType, fieldNamePrefix));
         List<Value> argumentValues = new ArrayList<>(arguments.getColumnSize());
         for (KeyExpression expression : arguments.normalizeKeyForPositions()) {
-            Value argValue = expression.expand(scalarTranslationVisitor);
-
-            final Type argType = argValue.getResultType();
-            final Type targetType = Type.primitiveType(Type.TypeCode.LONG, argType.isNullable());
-            argumentValues.add(PromoteValue.inject(argValue, targetType));
+            argumentValues.add(expression.expand(scalarTranslationVisitor));
         }
         BuiltInFunction<?> builtInFunction = FunctionCatalog.resolve(valueFunctionName, arguments.getColumnSize()).orElseThrow(() -> new RecordCoreArgumentException("unknown function", LogMessageKeys.FUNCTION, getName()));
         return (Value) builtInFunction.encapsulate(argumentValues);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/OrderFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/OrderFunctionKeyExpression.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleOrdering;
@@ -91,6 +92,7 @@ public class OrderFunctionKeyExpression extends InvertibleFunctionKeyExpression 
     @Nonnull
     @Override
     public Value toValue(@Nonnull final CorrelationIdentifier baseAlias,
+                         @Nonnull final Type baseType,
                          @Nonnull final List<String> fieldNamePrefix) {
         // TODO need inner Value for match and Ordering info from direction.
         throw new UnsupportedOperationException();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/RecordTypeKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/RecordTypeKeyExpression.java
@@ -118,7 +118,7 @@ public class RecordTypeKeyExpression extends BaseKeyExpression implements AtomKe
 
     @Nonnull
     @Override
-    public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+    public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull Type baseType, @Nonnull final List<String> fieldNamePrefix) {
         return new RecordTypeValue(QuantifiedObjectValue.of(baseAlias, new Type.AnyRecord(true)));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/VersionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/VersionKeyExpression.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.VersionValue;
 import com.apple.foundationdb.record.util.HashUtils;
@@ -107,7 +108,7 @@ public class VersionKeyExpression extends BaseKeyExpression implements AtomKeyEx
 
     @Nonnull
     @Override
-    public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+    public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final Type baseType, @Nonnull final List<String> fieldNamePrefix) {
         return new VersionValue(baseAlias);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithComparison.java
@@ -83,7 +83,7 @@ public class QueryKeyExpressionWithComparison implements ComponentWithComparison
     public GraphExpansion expand(@Nonnull final Quantifier.ForEach baseQuantifier,
                                  @Nonnull final Supplier<Quantifier.ForEach> outerQuantifierSupplier,
                                  @Nonnull final List<String> fieldNamePrefix) {
-        return GraphExpansion.ofPredicate(keyExpression.toValue(baseQuantifier.getAlias(), fieldNamePrefix).withComparison(comparison));
+        return GraphExpansion.ofPredicate(keyExpression.toValue(baseQuantifier.getAlias(), baseQuantifier.getFlowedObjectType(), fieldNamePrefix).withComparison(comparison));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithOneOfComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithOneOfComparison.java
@@ -90,7 +90,7 @@ public class QueryKeyExpressionWithOneOfComparison implements ComponentWithCompa
     public GraphExpansion expand(@Nonnull final Quantifier.ForEach baseQuantifier,
                                  @Nonnull final Supplier<Quantifier.ForEach> outerQuantifierSupplier,
                                  @Nonnull final List<String> fieldNamePrefix) {
-        return GraphExpansion.ofPredicate(keyExpression.toValue(baseQuantifier.getAlias(), fieldNamePrefix).withComparison(comparison));
+        return GraphExpansion.ofPredicate(keyExpression.toValue(baseQuantifier.getAlias(), baseQuantifier.getFlowedObjectType(), fieldNamePrefix).withComparison(comparison));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
@@ -160,7 +160,7 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
     @Override
     public GraphExpansion visitExpression(@Nonnull final KeyExpressionWithValue keyExpressionWithValue) {
         final VisitorState state = getCurrentState();
-        final Value value = state.registerValue(keyExpressionWithValue.toValue(state.getBaseQuantifier().getAlias(), state.getFieldNamePrefix()));
+        final Value value = state.registerValue(keyExpressionWithValue.toValue(state.getBaseQuantifier().getAlias(), state.getBaseQuantifier().getFlowedObjectType(), state.getFieldNamePrefix()));
         if (state.isKey()) {
             return GraphExpansion.ofResultColumnAndPlaceholder(Column.unnamedOf(value), value.asPlaceholder(newParameterAlias()));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
@@ -137,7 +137,7 @@ public class ScalarTranslationVisitor implements KeyExpressionVisitor<ScalarTran
     @Override
     public Value visitExpression(@Nonnull final KeyExpressionWithValue keyExpressionWithValue) {
         final ScalarVisitorState state = getCurrentState();
-        return keyExpressionWithValue.toValue(state.getBaseAlias(), state.getFieldNamePrefix());
+        return keyExpressionWithValue.toValue(state.getBaseAlias(), state.inputType, state.getFieldNamePrefix());
     }
     
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -440,10 +440,18 @@ public class ArithmeticValue extends AbstractValue {
         MOD_DD(LogicalOperator.MOD, TypeCode.DOUBLE, TypeCode.DOUBLE, TypeCode.DOUBLE, (l, r) -> (double)l % (double)r),
 
         BITOR_II(LogicalOperator.BITOR, TypeCode.INT, TypeCode.INT, TypeCode.INT, (l, r) -> (int)l | (int)r),
+        BITOR_IL(LogicalOperator.BITOR, TypeCode.INT, TypeCode.LONG, TypeCode.LONG, (l, r) -> (int)l | (long)r),
+        BITOR_LI(LogicalOperator.BITOR, TypeCode.LONG, TypeCode.INT, TypeCode.LONG, (l, r) -> (long)l | (int)r),
         BITOR_LL(LogicalOperator.BITOR, TypeCode.LONG, TypeCode.LONG, TypeCode.LONG, (l, r) -> (long)l | (long)r),
+
         BITAND_II(LogicalOperator.BITAND, TypeCode.INT, TypeCode.INT, TypeCode.INT, (l, r) -> (int)l & (int)r),
+        BITAND_IL(LogicalOperator.BITAND, TypeCode.INT, TypeCode.LONG, TypeCode.LONG, (l, r) -> (int)l & (long)r),
+        BITAND_LI(LogicalOperator.BITAND, TypeCode.LONG, TypeCode.INT, TypeCode.LONG, (l, r) -> (long)l & (int)r),
         BITAND_LL(LogicalOperator.BITAND, TypeCode.LONG, TypeCode.LONG, TypeCode.LONG, (l, r) -> (long)l & (long)r),
+
         BITXOR_II(LogicalOperator.BITXOR, TypeCode.INT, TypeCode.INT, TypeCode.INT, (l, r) -> (int)l ^ (int)r),
+        BITXOR_IL(LogicalOperator.BITXOR, TypeCode.INT, TypeCode.LONG, TypeCode.LONG, (l, r) -> (int)l ^ (long)r),
+        BITXOR_LI(LogicalOperator.BITXOR, TypeCode.LONG, TypeCode.INT, TypeCode.LONG, (l, r) -> (long)l ^ (int)r),
         BITXOR_LL(LogicalOperator.BITXOR, TypeCode.LONG, TypeCode.LONG, TypeCode.LONG, (l, r) -> (long)l ^ (long)r),
         ;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -232,7 +232,7 @@ public class ArithmeticValue extends AbstractValue {
     public static class AddFn extends BuiltInFunction<Value> {
         public AddFn() {
             super("add",
-                    ImmutableList.of(new Type.Any(), new Type.Any()), ArithmeticValue::encapsulateInternal);
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
         }
     }
 
@@ -243,7 +243,7 @@ public class ArithmeticValue extends AbstractValue {
     public static class SubFn extends BuiltInFunction<Value> {
         public SubFn() {
             super("sub",
-                    ImmutableList.of(new Type.Any(), new Type.Any()), ArithmeticValue::encapsulateInternal);
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
         }
     }
 
@@ -254,7 +254,7 @@ public class ArithmeticValue extends AbstractValue {
     public static class MulFn extends BuiltInFunction<Value> {
         public MulFn() {
             super("mul",
-                    ImmutableList.of(new Type.Any(), new Type.Any()), ArithmeticValue::encapsulateInternal);
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
         }
     }
 
@@ -265,7 +265,7 @@ public class ArithmeticValue extends AbstractValue {
     public static class DivFn extends BuiltInFunction<Value> {
         public DivFn() {
             super("div",
-                    ImmutableList.of(new Type.Any(), new Type.Any()), ArithmeticValue::encapsulateInternal);
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
         }
     }
 
@@ -276,7 +276,40 @@ public class ArithmeticValue extends AbstractValue {
     public static class ModFn extends BuiltInFunction<Value> {
         public ModFn() {
             super("mod",
-                    ImmutableList.of(new Type.Any(), new Type.Any()), ArithmeticValue::encapsulateInternal);
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
+        }
+    }
+
+    /**
+     * The bitwise {@code or} function.
+     */
+    @AutoService(BuiltInFunction.class)
+    public static class BitOrFn extends BuiltInFunction<Value> {
+        public BitOrFn() {
+            super("bitor",
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
+        }
+    }
+
+    /**
+     * The bitwise {@code and} function.
+     */
+    @AutoService(BuiltInFunction.class)
+    public static class BitAndFn extends BuiltInFunction<Value> {
+        public BitAndFn() {
+            super("bitand",
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
+        }
+    }
+
+    /**
+     * The bitwise {@code xor} function.
+     */
+    @AutoService(BuiltInFunction.class)
+    public static class BitXorFn extends BuiltInFunction<Value> {
+        public BitXorFn() {
+            super("bitxor",
+                    ImmutableList.of(Type.any(), Type.any()), ArithmeticValue::encapsulateInternal);
         }
     }
 
@@ -288,7 +321,11 @@ public class ArithmeticValue extends AbstractValue {
         SUB("-"),
         MUL("*"),
         DIV("/"),
-        MOD("%");
+        MOD("%"),
+        BITOR("|"),
+        BITAND("&"),
+        BITXOR("^"),
+        ;
 
         @Nonnull
         private final String infixNotation;
@@ -400,7 +437,15 @@ public class ArithmeticValue extends AbstractValue {
         MOD_DI(LogicalOperator.MOD, TypeCode.DOUBLE, TypeCode.INT, TypeCode.DOUBLE, (l, r) -> (double)l % (int)r),
         MOD_DL(LogicalOperator.MOD, TypeCode.DOUBLE, TypeCode.LONG, TypeCode.DOUBLE, (l, r) -> (double)l % (long)r),
         MOD_DF(LogicalOperator.MOD, TypeCode.DOUBLE, TypeCode.FLOAT, TypeCode.DOUBLE, (l, r) -> (double)l % (float)r),
-        MOD_DD(LogicalOperator.MOD, TypeCode.DOUBLE, TypeCode.DOUBLE, TypeCode.DOUBLE, (l, r) -> (double)l % (double)r);
+        MOD_DD(LogicalOperator.MOD, TypeCode.DOUBLE, TypeCode.DOUBLE, TypeCode.DOUBLE, (l, r) -> (double)l % (double)r),
+
+        BITOR_II(LogicalOperator.BITOR, TypeCode.INT, TypeCode.INT, TypeCode.INT, (l, r) -> (int)l | (int)r),
+        BITOR_LL(LogicalOperator.BITOR, TypeCode.LONG, TypeCode.LONG, TypeCode.LONG, (l, r) -> (long)l | (long)r),
+        BITAND_II(LogicalOperator.BITAND, TypeCode.INT, TypeCode.INT, TypeCode.INT, (l, r) -> (int)l & (int)r),
+        BITAND_LL(LogicalOperator.BITAND, TypeCode.LONG, TypeCode.LONG, TypeCode.LONG, (l, r) -> (long)l & (long)r),
+        BITXOR_II(LogicalOperator.BITXOR, TypeCode.INT, TypeCode.INT, TypeCode.INT, (l, r) -> (int)l ^ (int)r),
+        BITXOR_LL(LogicalOperator.BITXOR, TypeCode.LONG, TypeCode.LONG, TypeCode.LONG, (l, r) -> (long)l ^ (long)r),
+        ;
 
         @Nonnull
         private static final Supplier<BiMap<PhysicalOperator, PPhysicalOperator>> protoEnumBiMapSupplier =

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -357,11 +357,19 @@ message PArithmeticValue {
       MOD_DD = 89;
 
       BITOR_II = 90;
-      BITOR_LL = 91;
-      BITAND_II = 92;
-      BITAND_LL = 93;
-      BITXOR_II = 94;
-      BITXOR_LL = 95;
+      BITOR_IL = 91;
+      BITOR_LI = 92;
+      BITOR_LL = 93;
+
+      BITAND_II = 94;
+      BITAND_IL = 95;
+      BITAND_LI = 96;
+      BITAND_LL = 97;
+
+      BITXOR_II = 98;
+      BITXOR_IL = 99;
+      BITXOR_LI = 100;
+      BITXOR_LL = 101;
   }
 
   optional PPhysicalOperator operator = 1;

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -355,6 +355,13 @@ message PArithmeticValue {
       MOD_DL = 87;
       MOD_DF = 88;
       MOD_DD = 89;
+
+      BITOR_II = 90;
+      BITOR_LL = 91;
+      BITAND_II = 92;
+      BITAND_LL = 93;
+      BITXOR_II = 94;
+      BITXOR_LL = 95;
   }
 
   optional PPhysicalOperator operator = 1;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -42,6 +42,7 @@ import com.apple.foundationdb.record.metadata.expressions.SplitKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
@@ -1097,7 +1098,7 @@ public class KeyExpressionTest {
 
         @Nonnull
         @Override
-        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final Type baseType, @Nonnull final List<String> fieldNamePrefix) {
             throw new UnsupportedOperationException();
         }
 
@@ -1156,7 +1157,7 @@ public class KeyExpressionTest {
 
         @Nonnull
         @Override
-        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final Type baseType, @Nonnull final List<String> fieldNamePrefix) {
             throw new UnsupportedOperationException();
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCoveringIndexQueryTest.java
@@ -45,6 +45,7 @@ import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRuleSet;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.util.pair.Pair;
@@ -971,7 +972,7 @@ class FDBCoveringIndexQueryTest extends FDBRecordStoreQueryTestBase {
 
         @Nonnull
         @Override
-        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final Type baseType, @Nonnull final List<String> fieldNamePrefix) {
             throw new UnsupportedOperationException("not supported");
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBLongArithmeticFunctionQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBLongArithmeticFunctionQueryTest.java
@@ -1,0 +1,472 @@
+/*
+ * FDBBitwiseFunctionQueryTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.query;
+
+import com.apple.foundationdb.record.Bindings;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorIterator;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.TestHelpers;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.expressions.Query;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.Column;
+import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.PrimitiveMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.ArithmeticValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.PromoteValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.plans.QueryResult;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.LongStream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.query.plan.ScanComparisons.range;
+import static com.apple.foundationdb.record.query.plan.ScanComparisons.unbounded;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.filterPlan;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexName;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.indexPlan;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.mapPlan;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.predicatesFilter;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.recordTypes;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.scanComparisons;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.scanPlan;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers.typeFilterPlan;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests of indexes and queries on {@link com.apple.foundationdb.record.metadata.expressions.LongArithmethicFunctionKeyExpression}s.
+ */
+public class FDBLongArithmeticFunctionQueryTest extends FDBRecordStoreQueryTestBase {
+
+    @Nonnull
+    private static KeyExpression sumExpression(@Nonnull String leftField, @Nonnull String rightField) {
+        return sumExpression(field(leftField), field(rightField));
+    }
+
+    @Nonnull
+    private static KeyExpression sumExpression(@Nonnull KeyExpression leftExpr, @Nonnull KeyExpression rightExpr) {
+        return Key.Expressions.function("add", concat(leftExpr, rightExpr));
+    }
+
+    @Nonnull
+    private static KeyExpression bitMaskExpression(@Nonnull String fieldName, long mask) {
+        return bitMaskExpression(field(fieldName), mask);
+    }
+
+    @Nonnull
+    private static KeyExpression bitMaskExpression(@Nonnull KeyExpression fieldExpression, long mask) {
+        return Key.Expressions.function("bitand", concat(fieldExpression, Key.Expressions.value(mask)));
+    }
+
+    @Nonnull
+    private static Index sum2And3Index() {
+        return new Index("MySimpleRecord$num_value_2+num_value_3_indexed", sumExpression("num_value_2", "num_value_3_indexed"));
+    }
+
+    @Nonnull
+    private static Index maskedNumValue2Index(long mask) {
+        return new Index("MySimpleRecord$num_value_2&" + mask, bitMaskExpression("num_value_2", mask));
+    }
+
+    @DualPlannerTest
+    void sum2And3Query() {
+        final Index sumIndex = sum2And3Index();
+        final RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", sumIndex);
+        final List<TestRecords1Proto.MySimpleRecord> data = setupSimpleRecordStore(hook,
+                (i, builder) -> builder.setRecNo(i).setNumValue2(i % 5).setNumValue3Indexed(i % 3));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            final String sumValueParam = "sum";
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.keyExpression(sumIndex.getRootExpression()).equalsParameter(sumValueParam))
+                    .build();
+            final RecordQueryPlan plan = planQuery(query);
+            assertMatchesExactly(plan,
+                    indexPlan()
+                            .where(indexName(sumIndex.getName()))
+                            .and(scanComparisons(range("[EQUALS $" + sumValueParam + "]")))
+            );
+            assertEquals(1466369563, plan.planHash(PlanHashable.CURRENT_LEGACY));
+            assertEquals(-730052000, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+
+            LongStream.range(-1, 11).forEach(sum ->
+                    assertQueryResults(data, plan,
+                            Bindings.newBuilder().set(sumValueParam, sum).build(),
+                            rec -> rec.getNumValue2() + rec.getNumValue3Indexed() == sum)
+            );
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest
+    void numValue2MaskQuery() {
+        final Index maskedIndex = maskedNumValue2Index(2);
+        final RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", maskedIndex);
+        final List<TestRecords1Proto.MySimpleRecord> data = setupSimpleRecordStore(hook,
+                (i, builder) -> builder.setRecNo(i).setNumValue2(i));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            final String maskedValueParam = "mask";
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.keyExpression(maskedIndex.getRootExpression()).equalsParameter(maskedValueParam))
+                    .build();
+            final RecordQueryPlan plan = planQuery(query);
+            assertMatchesExactly(plan,
+                    indexPlan()
+                            .where(indexName(maskedIndex.getName()))
+                            .and(scanComparisons(range("[EQUALS $" + maskedValueParam + "]")))
+            );
+            assertEquals(-1548863947, plan.planHash(PlanHashable.CURRENT_LEGACY));
+            assertEquals(857912600, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+
+            LongStream.range(0, 3).forEach(mask ->
+                    assertQueryResults(data, plan,
+                            Bindings.newBuilder().set(maskedValueParam, mask).build(),
+                            rec -> (rec.getNumValue2() & 2) == mask)
+            );
+
+            TestHelpers.assertDiscardedNone(context);
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest
+    void doesNotMatchIncorrectMask() {
+        final Index maskedIndex = maskedNumValue2Index(1);
+        final RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", maskedIndex);
+        final List<TestRecords1Proto.MySimpleRecord> data = setupSimpleRecordStore(hook,
+                (i, builder) -> builder.setRecNo(i).setNumValue2(i));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            final String maskParam = "mask";
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.keyExpression(bitMaskExpression("num_value_2", 2)).equalsParameter(maskParam))
+                    .build();
+            final RecordQueryPlan plan = planQuery(query);
+            final BindingMatcher<RecordQueryTypeFilterPlan> typeFilterMatcher = typeFilterPlan(
+                    scanPlan().where(scanComparisons(unbounded()))
+            ).where(recordTypes(PrimitiveMatchers.containsAll(ImmutableSet.of("MySimpleRecord"))));
+
+            if (useCascadesPlanner) {
+                assertMatchesExactly(plan, predicatesFilter(QuantifierMatchers.anyQuantifier(typeFilterMatcher)));
+                assertEquals(-2146084520, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(-1239440071, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            } else {
+                assertMatchesExactly(plan, filterPlan(typeFilterMatcher));
+                assertEquals(-1686224670, plan.planHash(PlanHashable.CURRENT_LEGACY));
+                assertEquals(1275558918, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+            }
+
+            LongStream.range(0, 3).forEach(mask ->
+                    assertQueryResults(data, plan,
+                            Bindings.newBuilder().set(maskParam, mask).build(),
+                            rec -> (rec.getNumValue2() & 2) == mask)
+            );
+
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest
+    void complexIndex() {
+        final Index index = new Index("complexIndex", concat(
+                field("str_value_indexed"),
+                sumExpression("num_value_2", "num_value_3_indexed"),
+                bitMaskExpression("num_value_unique", 4))
+        );
+        final RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+        final List<TestRecords1Proto.MySimpleRecord> data = setupSimpleRecordStore(hook,
+                (i, builder) -> builder.setRecNo(i).setNumValue3Indexed(i % 3).setNumValue2(i % 5).setStrValueIndexed(i % 2 == 0 ? "even" : "odd").setNumValueUnique(i));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            final String strValueParam = "strValue";
+            final RecordQuery query = RecordQuery.newBuilder()
+                    .setRecordType("MySimpleRecord")
+                    .setFilter(Query.and(
+                            Query.field("str_value_indexed").equalsParameter(strValueParam),
+                            Query.keyExpression(sumExpression("num_value_2", "num_value_3_indexed")).greaterThanOrEquals(1),
+                            Query.keyExpression(sumExpression("num_value_2", "num_value_3_indexed")).lessThanOrEquals(4)
+                    ))
+                    .setSort(concat(sumExpression("num_value_2", "num_value_3_indexed"), bitMaskExpression("num_value_unique", 4)))
+                    .setRequiredResults(List.of(bitMaskExpression("num_value_unique", 4)))
+                    .build();
+            final RecordQueryPlan plan = planQuery(query);
+
+            // Even though the only required result is in the index, there's not a clean way to surface it, so we end up not using a covering index here
+            assertMatchesExactly(plan, indexPlan()
+                    .where(indexName(index.getName()))
+                    .and(scanComparisons(range("[EQUALS $" + strValueParam + ", [GREATER_THAN_OR_EQUALS 1 && LESS_THAN_OR_EQUALS 4]]")))
+            );
+            assertEquals(-83447963, plan.planHash(PlanHashable.CURRENT_LEGACY));
+            assertEquals(929715426, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+
+            for (String strValue : List.of("even", "odd")) {
+                assertQueryResults(data, plan,
+                        Bindings.newBuilder().set(strValueParam, strValue).build(),
+                        rec -> rec.getStrValueIndexed().equals(strValue) && ((rec.getNumValue2() + rec.getNumValue3Indexed()) >= 1 && (rec.getNumValue2() + rec.getNumValue3Indexed()) <= 4),
+                        rec -> Tuple.from(rec.getNumValue2() + rec.getNumValue3Indexed(), rec.getNumValueUnique() & 4));
+            }
+
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    void complexIndexGraphQueryWithMaskInResults() {
+        final Index index = new Index("complexIndex", concat(
+                field("str_value_indexed"),
+                sumExpression("num_value_2", "num_value_3_indexed"),
+                bitMaskExpression("num_value_unique", 4))
+        );
+        final RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+        final List<TestRecords1Proto.MySimpleRecord> data = setupSimpleRecordStore(hook,
+                (i, builder) -> builder.setRecNo(i).setNumValue3Indexed(i % 3).setNumValue2(i % 5).setStrValueIndexed(i % 2 == 0 ? "even" : "odd").setNumValueUnique(i));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            final String strValueParam = "str";
+            final String sumLowerBound = "sumLowerBound";
+            final String sumUpperBound = "sumUpperBound";
+            final RecordQueryPlan plan = planGraph(() -> {
+                Quantifier typeQun = FDBSimpleQueryGraphTest.fullTypeScan(recordStore.getRecordMetaData(), "MySimpleRecord");
+
+                final FieldValue strValue = FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "str_value_indexed");
+                final FieldValue num2Value = FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "num_value_2");
+                final FieldValue num3Value = FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "num_value_3_indexed");
+                final FieldValue numUniqueValue = FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "num_value_unique");
+                final Value sumValue = (Value) new ArithmeticValue.AddFn().encapsulate(ImmutableList.of(
+                        PromoteValue.inject(num2Value, Type.primitiveType(Type.TypeCode.LONG)),
+                        PromoteValue.inject(num3Value, Type.primitiveType(Type.TypeCode.LONG))
+                ));
+                final Value maskValue = (Value) new ArithmeticValue.BitAndFn().encapsulate(ImmutableList.of(
+                        PromoteValue.inject(numUniqueValue, Type.primitiveType(Type.TypeCode.LONG)),
+                        LiteralValue.ofScalar(4L)
+                ));
+                SelectExpression select = GraphExpansion.builder()
+                        .addQuantifier(typeQun)
+                        .addPredicate(new ValuePredicate(strValue, new Comparisons.ParameterComparison(Comparisons.Type.EQUALS, strValueParam)))
+                        .addPredicate(new ValuePredicate(sumValue, new Comparisons.ParameterComparison(Comparisons.Type.GREATER_THAN_OR_EQUALS, sumLowerBound)))
+                        .addPredicate(new ValuePredicate(sumValue, new Comparisons.ParameterComparison(Comparisons.Type.LESS_THAN_OR_EQUALS, sumUpperBound)))
+                        .addResultColumn(Column.of(Optional.of("sum"), sumValue))
+                        .addResultColumn(Column.of(Optional.of("mask"), maskValue))
+                        .addResultColumn(Column.of(Optional.of("id"), FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "rec_no")))
+                        .build()
+                        .buildSelect();
+                Quantifier selectQun = Quantifier.forEach(Reference.of(select));
+                return Reference.of(new LogicalSortExpression(ImmutableList.of(FieldValue.ofFieldName(selectQun.getFlowedObjectValue(), "sum").rebase(AliasMap.ofAliases(selectQun.getAlias(), Quantifier.current()))), false, selectQun));
+            });
+            // Note: This should be a covering index scan, as the mask value can be extracted from the index entries, though the matching isn't quite there
+            assertMatchesExactly(plan, mapPlan(
+                    indexPlan()
+                            .where(indexName(index.getName()))
+                            .and(scanComparisons(range("[EQUALS $" + strValueParam + ", [GREATER_THAN_OR_EQUALS $" + sumLowerBound + " && LESS_THAN_OR_EQUALS $" + sumUpperBound + "]]")))
+            ));
+            assertEquals(600168016, plan.planHash(PlanHashable.CURRENT_LEGACY));
+            assertEquals(-35779047, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+
+            for (String strValue : List.of("even", "odd")) {
+                LongStream.range(-1, 9).forEach(lowerSum ->
+                        LongStream.range(lowerSum, 10).forEach(upperSum -> {
+                            Bindings bindings = Bindings.newBuilder()
+                                    .set(strValueParam, strValue)
+                                    .set(sumLowerBound, lowerSum)
+                                    .set(sumUpperBound, upperSum)
+                                    .build();
+
+                            Set<Map<String, Long>> results = new HashSet<>();
+                            try (RecordCursor<QueryResult> cursor = FDBSimpleQueryGraphTest.executeCascades(recordStore, plan, bindings)) {
+                                long previousSum = Long.MIN_VALUE;
+                                for (RecordCursorResult<QueryResult> queryResult = cursor.getNext(); queryResult.hasNext(); queryResult = cursor.getNext()) {
+                                    Message msg = queryResult.get().getMessage();
+                                    assertNotNull(msg);
+                                    Descriptors.Descriptor descriptor = msg.getDescriptorForType();
+                                    Map<String, Long> result = ImmutableMap.of(
+                                            "sum", (long) msg.getField(descriptor.findFieldByName("sum")),
+                                            "mask", (long) msg.getField(descriptor.findFieldByName("mask")),
+                                            "id", (long) msg.getField(descriptor.findFieldByName("id"))
+                                    );
+                                    long sumValue = result.get("sum");
+                                    assertThat("Sum value should be in query predicate range", sumValue, both(greaterThanOrEqualTo(lowerSum)).and(lessThanOrEqualTo(upperSum)));
+                                    assertThat("Results should be sorted by sum value", sumValue, greaterThanOrEqualTo(previousSum));
+                                    results.add(result);
+                                }
+                            }
+
+                            Object[] expected = data.stream()
+                                    .filter(rec -> rec.getStrValueIndexed().equals(strValue))
+                                    .map(rec -> ImmutableMap.of("sum", (long)(rec.getNumValue2() + rec.getNumValue3Indexed()), "mask", ((long)rec.getNumValueUnique()) & 4L, "id", rec.getRecNo()))
+                                    .filter(res -> {
+                                        long sum = res.get("sum");
+                                        return sum >= lowerSum && sum <= upperSum;
+                                    })
+                                    .toArray();
+                            assertThat(results, containsInAnyOrder(expected));
+                        })
+                );
+            }
+
+            TestHelpers.assertDiscardedNone(context);
+            commit(context);
+        }
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    void calculateFunctionFromCoveringIndexScan() {
+        final Index index = new Index("MySimpleRecord$num_value_2-num_value_3_indexed", "num_value_2", "num_value_3_indexed");
+        final RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+        final List<TestRecords1Proto.MySimpleRecord> data = setupSimpleRecordStore(hook,
+                (i, builder) -> builder.setRecNo(i).setNumValue2(i % 7).setNumValue3Indexed(i % 6));
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            final RecordQueryPlan plan = planGraph(() -> {
+                Quantifier typeQun = FDBSimpleQueryGraphTest.fullTypeScan(recordStore.getRecordMetaData(), "MySimpleRecord");
+
+                final Value addValue = (Value) new ArithmeticValue.AddFn().encapsulate(List.of(
+                        FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "num_value_2"),
+                        FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "num_value_3_indexed")
+                ));
+                final SelectExpression select = GraphExpansion.builder()
+                        .addQuantifier(typeQun)
+                        .addResultColumn(Column.of(Optional.of("sum"), addValue))
+                        .addResultColumn(Column.of(Optional.of("rec_no"), FieldValue.ofFieldName(typeQun.getFlowedObjectValue(), "rec_no")))
+                        .build()
+                        .buildSelect();
+                Quantifier selectQun = Quantifier.forEach(Reference.of(select));
+                return Reference.of(new LogicalSortExpression(ImmutableList.of(), false, selectQun));
+            });
+            // This should be planned as a covering index scan of the index because the functions can be calculated from the values
+            // in the index. Until matching improves, we can get by with this plan
+            assertMatchesExactly(plan, mapPlan(
+                    typeFilterPlan(
+                            scanPlan().where(scanComparisons(unbounded()))
+                    )
+            ));
+            assertEquals(1263343956, plan.planHash(PlanHashable.CURRENT_LEGACY));
+            assertEquals(-2029074143, plan.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+
+            Set<Map<String, Object>> results = new HashSet<>();
+            try (RecordCursor<QueryResult> cursor = FDBSimpleQueryGraphTest.executeCascades(recordStore, plan)) {
+                for (RecordCursorResult<QueryResult> queryResult = cursor.getNext(); queryResult.hasNext(); queryResult = cursor.getNext()) {
+                    Message msg = queryResult.get().getMessage();
+                    assertNotNull(msg);
+                    Descriptors.Descriptor descriptor = msg.getDescriptorForType();
+                    results.add(ImmutableMap.of(
+                            "sum", msg.getField(descriptor.findFieldByName("sum")),
+                            "rec_no", msg.getField(descriptor.findFieldByName("rec_no"))
+                    ));
+                }
+            }
+            Object[] expected = data.stream()
+                    .map(rec -> ImmutableMap.of("sum", rec.getNumValue2() + rec.getNumValue3Indexed(), "rec_no", rec.getRecNo()))
+                    .toArray();
+            assertThat(results, containsInAnyOrder(expected));
+
+            commit(context);
+        }
+    }
+
+    private void assertQueryResults(@Nonnull List<TestRecords1Proto.MySimpleRecord> data,
+                                    @Nonnull RecordQueryPlan plan,
+                                    @Nonnull Bindings bindings,
+                                    @Nonnull Predicate<TestRecords1Proto.MySimpleRecord> filter) {
+        assertQueryResults(data, plan, bindings, filter, null);
+
+    }
+
+    private void assertQueryResults(@Nonnull List<TestRecords1Proto.MySimpleRecord> data,
+                                    @Nonnull RecordQueryPlan plan,
+                                    @Nonnull Bindings bindings,
+                                    @Nonnull Predicate<TestRecords1Proto.MySimpleRecord> filter,
+                                    @Nullable Function<TestRecords1Proto.MySimpleRecord, Tuple> sortComparisonKey) {
+        final List<TestRecords1Proto.MySimpleRecord> queried = new ArrayList<>();
+        try (RecordCursorIterator<FDBQueriedRecord<Message>> iterator = executeQuery(plan, bindings)) {
+            while (iterator.hasNext()) {
+                FDBQueriedRecord<Message> rec = iterator.next();
+                queried.add(TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(rec.getRecord()).build());
+            }
+        }
+        if (sortComparisonKey == null) {
+            assertThat(queried, containsInAnyOrder(data.stream().filter(filter).toArray()));
+        } else {
+            assertThat(queried, contains(data.stream().filter(filter).sorted(Comparator.comparing(sortComparisonKey)).toArray()));
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -66,6 +66,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.serialization.DefaultPlanSerializationRegistry;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -104,18 +105,22 @@ import static org.junit.jupiter.api.Assertions.fail;
  * A base class for common infrastructure used by tests in {@link com.apple.foundationdb.record.provider.foundationdb.query}.
  */
 public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase {
-    protected void setupSimpleRecordStore(RecordMetaDataHook recordMetaDataHook,
-                                          BiConsumer<Integer, TestRecords1Proto.MySimpleRecord.Builder> buildRecord) {
+    protected List<TestRecords1Proto.MySimpleRecord> setupSimpleRecordStore(RecordMetaDataHook recordMetaDataHook,
+                                                                            BiConsumer<Integer, TestRecords1Proto.MySimpleRecord.Builder> buildRecord) {
+        ImmutableList.Builder<TestRecords1Proto.MySimpleRecord> listBuilder = ImmutableList.builder();
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, recordMetaDataHook);
 
             for (int i = 0; i < 100; i++) {
-                TestRecords1Proto.MySimpleRecord.Builder record = TestRecords1Proto.MySimpleRecord.newBuilder();
-                buildRecord.accept(i, record);
-                recordStore.saveRecord(record.build());
+                TestRecords1Proto.MySimpleRecord.Builder recordBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
+                buildRecord.accept(i, recordBuilder);
+                TestRecords1Proto.MySimpleRecord rec = recordBuilder.build();
+                recordStore.saveRecord(rec);
+                listBuilder.add(rec);
             }
             commit(context);
         }
+        return listBuilder.build();
     }
 
     protected int querySimpleRecordStore(RecordMetaDataHook recordMetaDataHook, RecordQueryPlan plan,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/QueryToKeyMatcherTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/QueryToKeyMatcherTest.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.expressions.RecordTypeKeyComparison;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.auto.service.AutoService;
 import com.google.protobuf.Message;
@@ -792,7 +793,7 @@ public class QueryToKeyMatcherTest {
 
         @Nonnull
         @Override
-        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final List<String> fieldNamePrefix) {
+        public Value toValue(@Nonnull final CorrelationIdentifier baseAlias, @Nonnull final Type baseType, @Nonnull final List<String> fieldNamePrefix) {
             throw new UnsupportedOperationException("not supported");
         }
 


### PR DESCRIPTION
This adds a new `FunctionKeyExpression` representing some basic arithmetic functions on `long`s, including `sum` and `bitand` (useful for when long fields are used as bitsets, and the user wants to define an index on individual bits in the bitset). This includes adding support for expressing the expression as a `Value` so that it can be matched within the Cascades planner. From the first test fixture added, it appears that the planner can already handle basic queries on this field, though it doesn't always recognize when it can skip a record resolution (e.g., when the function value is in both the result set and the index or when the argument fields are indexed).

This resolves #2663.