### PR TITLE
Fixes #2678: Default collation function depends on JVM setting for locale

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -33,7 +33,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Breaking change** The default collation order is now based on the root locale instead of the system default. Users relying on a specific locale should update any indexes using ta collation function to include the locale in the function arguments before updating [(Issue #2678)](https://github.com/FoundationDB/fdb-record-layer/issues/2678)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextCollatorRegistryJRE.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextCollatorRegistryJRE.java
@@ -67,7 +67,7 @@ public class TextCollatorRegistryJRE implements TextCollatorRegistry {
     public TextCollator getTextCollator(@Nonnull String locale, int strength) {
         return MapUtils.computeIfAbsent(collators, NonnullPair.of(locale, strength), key -> {
             final Collator collator = DEFAULT_LOCALE.equals(locale) ?
-                                      Collator.getInstance() :
+                                      Collator.getInstance(Locale.ROOT) :
                                       // Some minimal consistency between BCP 47 and C-like identifiers.
                                       Collator.getInstance(Locale.forLanguageTag(locale.replace("_", "-")));
             collator.setStrength(strength);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/CollateFunctionKeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/CollateFunctionKeyExpressionTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.metadata.expressions;
 
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.metadata.Key;
+import com.google.common.collect.Iterables;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,8 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.value;
 import static com.apple.foundationdb.record.metadata.KeyExpressionTest.evaluate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -66,34 +69,85 @@ public abstract class CollateFunctionKeyExpressionTest {
                 .build();
     }
 
-    @Test
-    public void ignoreCase() throws Exception {
-        final KeyExpression expression = function(collateFunctionName, STR_FIELD);
-        List<Key.Evaluated> eval1 = evaluate(expression, buildMessage("foo"));
-        List<Key.Evaluated> eval2 = evaluate(expression, buildMessage("FOO"));
-        assertEquals(eval1, eval2);
-    }
-
-    @Test
-    public void ignoreCaseAndAccents() throws Exception {
-        final KeyExpression expression = function(collateFunctionName, concat(STR_FIELD, value("en_US")));
-        List<Key.Evaluated> eval1a = evaluate(expression, buildMessage("fOoBaR"));
-        List<Key.Evaluated> eval2a = evaluate(expression, buildMessage("FoObAr"));
+    private void assertIgnoresCase(@Nonnull KeyExpression expression) {
+        List<Key.Evaluated> eval1a = evaluate(expression, buildMessage("foo"));
+        List<Key.Evaluated> eval2a = evaluate(expression, buildMessage("FOO"));
         assertEquals(eval1a, eval2a);
-        List<Key.Evaluated> eval1b = evaluate(expression, buildMessage("cliche"));
-        List<Key.Evaluated> eval2b = evaluate(expression, buildMessage("cliché"));
+
+        List<Key.Evaluated> eval1b = evaluate(expression, buildMessage("fOoBaR"));
+        List<Key.Evaluated> eval2b = evaluate(expression, buildMessage("FoObAr"));
         assertEquals(eval1b, eval2b);
     }
 
-    @Test
-    public void ignoreCaseOnly() throws Exception {
-        final KeyExpression expression = function(collateFunctionName, concat(STR_FIELD, value("en_US"), value(1)));
-        List<Key.Evaluated> eval1a = evaluate(expression, buildMessage("fOoBaR"));
-        List<Key.Evaluated> eval2a = evaluate(expression, buildMessage("FoObAr"));
-        assertEquals(eval1a, eval2a);
-        List<Key.Evaluated> eval1b = evaluate(expression, buildMessage("cliche"));
-        List<Key.Evaluated> eval2b = evaluate(expression, buildMessage("cliché"));
-        assertNotEquals(eval1b, eval2b);
+    @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
+    private void assertAccents(@Nonnull KeyExpression expression, boolean ignored) {
+        List<Key.Evaluated> eval1a = evaluate(expression, buildMessage("cliche"));
+        List<Key.Evaluated> eval2a = evaluate(expression, buildMessage("cliché"));
+        if (ignored) {
+            assertEquals(eval1a, eval2a);
+        } else {
+            assertNotEquals(eval1a, eval2a);
+        }
+
+        // These two forms are different normalized forms for the same accented form.
+        // The former uses the combined composition (i.e., one character for é), and
+        // the latter uses the decomposed form (i.e., one character for e and a combining
+        // character for the acute accent).
+        // They should normalize to the same thing after the collation function
+        List<Key.Evaluated> eval1b = evaluate(expression, buildMessage("clich\u00e9"));
+        List<Key.Evaluated> eval2b = evaluate(expression, buildMessage("cliche\u0301"));
+        assertEquals(eval1b, eval2b);
+
+        assertEquals(eval1b, eval2a);
+        if (ignored) {
+            assertEquals(eval1a, eval1b);
+        } else {
+            assertNotEquals(eval1a, eval1b);
+        }
     }
 
+    private void assertExpectedOrder(@Nonnull KeyExpression expression, @Nonnull String... preCollationStrings) {
+        String previous = null;
+        Key.Evaluated previousEval = null;
+        for (String value : preCollationStrings) {
+            Key.Evaluated eval = Iterables.getOnlyElement(evaluate(expression, buildMessage(value)));
+            if (previousEval != null) {
+                assertThat("Key for \"" + value + "\" should be after key for \"" + previous + "\"",
+                        eval.toTuple(), greaterThanOrEqualTo(previousEval.toTuple()));
+            }
+            previousEval = eval;
+            previous = value;
+        }
+    }
+
+    @Test
+    void ignoreCase() {
+        final KeyExpression expression = function(collateFunctionName, STR_FIELD);
+        assertIgnoresCase(expression);
+    }
+
+    @Test
+    void ignoreCaseAndAccents() {
+        final KeyExpression expression = function(collateFunctionName, concat(STR_FIELD, value("en_US")));
+        assertIgnoresCase(expression);
+        assertAccents(expression, true);
+    }
+
+    @Test
+    void ignoreCaseOnly() {
+        final KeyExpression expression = function(collateFunctionName, concat(STR_FIELD, value("en_US"), value(1)));
+        assertIgnoresCase(expression);
+        assertAccents(expression, false);
+    }
+
+    @Test
+    void defaultCollation() {
+        final KeyExpression expression = function(collateFunctionName, STR_FIELD);
+        assertIgnoresCase(expression);
+        assertAccents(expression, true);
+        assertExpectedOrder(expression,
+                "0", "08", "7",
+                "A", "a", "aA", "Ba", "bc", "cf", "ch", "cz", "d", "e f", "ef",
+                "Γ", "Д", "ف", "你好");
+    }
 }

--- a/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/TextCollatorRegistryICU.java
+++ b/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/TextCollatorRegistryICU.java
@@ -31,6 +31,7 @@ import com.ibm.icu.text.Collator;
 import com.ibm.icu.util.ULocale;
 
 import javax.annotation.Nonnull;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -69,7 +70,7 @@ public class TextCollatorRegistryICU implements TextCollatorRegistry {
     public TextCollator getTextCollator(@Nonnull String locale, int strength) {
         return MapUtils.computeIfAbsent(collators, NonnullPair.of(locale, strength), key -> {
             final Collator collator = DEFAULT_LOCALE.equals(locale) ?
-                                      Collator.getInstance() :
+                                      Collator.getInstance(ULocale.forLocale(Locale.ROOT)) :
                                       Collator.getInstance(new ULocale(locale));
             collator.setStrength(strength);
             return new TextCollatorICU(collator);


### PR DESCRIPTION
If unspecified, collation `FunctionKeyExpression`s now set their locale to `Locale.ROOT` instead of the machine's default Locale. This makes the contents of index entries more resilient to users changing their machine's default values. This does mean that users who are running with an incompatible locale will need to update their index definitions to reference the appropriate locale or will need to rebuild any indexes that don't already set a locale.

This fixes #2678. This is a specific instance of #2672.