### PR TITLE
Resolves #2680: Allow RecordSerializers to validate serialization

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -31,7 +31,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Record serializers now have a new default method that allows for validating bytes can be deserialized back to their original message [(Issue #2680)](https://github.com/FoundationDB/fdb-record-layer/issues/2680)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializationValidationException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/RecordSerializationValidationException.java
@@ -1,0 +1,58 @@
+/*
+ * RecordSerializationValidationException.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.common;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.util.LoggableKeysAndValues;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Exception class thrown by {@link RecordSerializer#validateSerialization(RecordMetaData, RecordType, Message, byte[], StoreTimer)}.
+ * This indicates that there was a mismatch between the original record and its deserialized form. This indicates
+ * that there is some kind of corruption during the serialization process, either because the serialized form is not
+ * parseable or because the serialization process leads to fields being modified in unexpected ways.
+ */
+@API(API.Status.MAINTAINED)
+@SuppressWarnings("serial")
+public class RecordSerializationValidationException extends RecordCoreException {
+    RecordSerializationValidationException(@Nonnull String message, @Nonnull RecordType recordType, @Nullable Tuple primaryKey, @Nullable Throwable cause) {
+        super(message, cause);
+        addLogInfo(LogMessageKeys.RECORD_TYPE, recordType);
+        if (primaryKey != null) {
+            addLogInfo(LogMessageKeys.PRIMARY_KEY, primaryKey);
+        }
+        if (cause instanceof LoggableKeysAndValues<?>) {
+            addLogInfo(((LoggableKeysAndValues<?>)cause).exportLogInfo());
+        }
+    }
+
+    RecordSerializationValidationException(@Nonnull String message, @Nonnull RecordType recordType, @Nonnull Tuple primaryKey) {
+        this(message, recordType, primaryKey, null);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerJCE.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerJCE.java
@@ -50,10 +50,11 @@ public class TransformedRecordSerializerJCE<M extends Message> extends Transform
                                              boolean compressWhenSerializing,
                                              int compressionLevel,
                                              boolean encryptWhenSerializing,
+                                             double writeValidationRatio,
                                              @Nullable String cipherName,
                                              @Nullable Key encryptionKey,
                                              @Nullable SecureRandom secureRandom) {
-        super(inner, compressWhenSerializing, compressionLevel, encryptWhenSerializing);
+        super(inner, compressWhenSerializing, compressionLevel, encryptWhenSerializing, writeValidationRatio);
         this.cipherName = cipherName;
         this.encryptionKey = encryptionKey;
         this.secureRandom = secureRandom;
@@ -166,12 +167,14 @@ public class TransformedRecordSerializerJCE<M extends Message> extends Transform
         }
 
         @Override
+        @Nonnull
         public Builder<M> setCompressWhenSerializing(boolean compressWhenSerializing) {
             super.setCompressWhenSerializing(compressWhenSerializing);
             return this;
         }
 
         @Override
+        @Nonnull
         public Builder<M> setCompressionLevel(int level) {
             super.setCompressionLevel(level);
             return this;
@@ -187,8 +190,22 @@ public class TransformedRecordSerializerJCE<M extends Message> extends Transform
          * @return this <code>Builder</code>
          */
         @Override
+        @Nonnull
         public Builder<M> setEncryptWhenSerializing(boolean encryptWhenSerializing) {
             super.setEncryptWhenSerializing(encryptWhenSerializing);
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @param writeValidationRatio what ratio of record serializations should be validated
+         * @return this <code>Builder</code>
+         */
+        @Override
+        @Nonnull
+        public Builder<M> setWriteValidationRatio(final double writeValidationRatio) {
+            super.setWriteValidationRatio(writeValidationRatio);
             return this;
         }
 
@@ -283,6 +300,7 @@ public class TransformedRecordSerializerJCE<M extends Message> extends Transform
                     compressWhenSerializing,
                     compressionLevel,
                     encryptWhenSerializing,
+                    writeValidationRatio,
                     cipherName,
                     encryptionKey,
                     secureRandom


### PR DESCRIPTION
There is a new method added to `RecordSerializer`, `validateSerialization`. This method takes both a `Message` and a serialized record, and it validates that calling `deserialize` on the bytes returns the original `Message`. In addition, there's a new configuration option on the `TransformedRecordSerializer` that allows it to be configured to validate a sample of serialized records (that sample configurable to "always" or "never") as this serializer has a somewhat more complicated story surrounding what it does to the bytes.

This resolves #2680.