### PR TITLE
Resolves #2682: Support protocol version 7.3 in ClientLogEvents

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -31,7 +31,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Updated the set of known protocol versions for client log event parsing to include FDB 7.3 [(Issue #2682)](https://github.com/FoundationDB/fdb-record-layer/issues/2682)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
@@ -67,9 +67,10 @@ public class FDBClientLogEvents {
     public static final long PROTOCOL_VERSION_7_0 = 0x0FDB00B070010001L;
     public static final long PROTOCOL_VERSION_7_1 = 0x0FDB00B071010000L;
     public static final long PROTOCOL_VERSION_7_2 = 0x0FDB00B072000000L;
+    public static final long PROTOCOL_VERSION_7_3 = 0x0FDB00B073000000L;
     private static final long[] SUPPORTED_PROTOCOL_VERSIONS = {
             PROTOCOL_VERSION_5_2, PROTOCOL_VERSION_6_0, PROTOCOL_VERSION_6_1, PROTOCOL_VERSION_6_2, PROTOCOL_VERSION_6_3,
-            PROTOCOL_VERSION_7_0, PROTOCOL_VERSION_7_1, PROTOCOL_VERSION_7_2
+            PROTOCOL_VERSION_7_0, PROTOCOL_VERSION_7_1, PROTOCOL_VERSION_7_2, PROTOCOL_VERSION_7_3
     };
 
     //                    0               1         2         3         4         5         6         7

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/DatabaseClientLogEventsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/DatabaseClientLogEventsTest.java
@@ -44,7 +44,7 @@ class DatabaseClientLogEventsTest {
         if (args.length > 2) {
             end = ZonedDateTime.parse(args[2]).toInstant();
         }
-        FDB fdb = FDB.selectAPIVersion(630);
+        FDB fdb = FDB.selectAPIVersion(710);
         Database database = fdb.open(cluster);
         Executor executor = database.getExecutor();
         DatabaseClientLogEvents.EventConsumer consumer = (tr, event) -> {


### PR DESCRIPTION
The client log event format has not been updated since 7.2, so we are safe to update the log event known protocol versions to include FDB 7.3. There's not a great way of testing this without doing a more thorough job of updating our infrastructure to use a 7.3 server version and then run a few one off tests we have that try and parse these values. However, the Python script this is based on has been updated for 7.3 and it didn't need to make any changes from 7.2: https://github.com/apple/foundationdb/commit/321b77d8099f6ab3ec7c277139c0158abd823124

This resolves #2682.