### PR TITLE
FIXES #2684: LuceneIndexTest.findStartingPartitionTest(false) false t…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** LuceneIndexTest.findStartingPartitionTest(false) false to decode tuple [(Issue #2684)](https://github.com/FoundationDB/fdb-record-layer/issues/2684)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -1111,7 +1111,7 @@ public class LucenePartitioner {
     }
 
     public static boolean isPrefixOlderThanPartition(@Nonnull final Tuple prefix, @Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
-        return getPartitionKey(partitionInfo).compareTo(Tuple.fromBytes(ByteArrayUtil.strinc(prefix.pack()))) >= 0;
+        return ByteArrayUtil.compareUnsigned(getPartitionKey(partitionInfo).pack(), ByteArrayUtil.strinc(prefix.pack())) >= 0;
     }
 
     /**


### PR DESCRIPTION
…o decode tuple

- if the value of `prefix` passed to `isPrefixOlderThanPartition(@Nonnull final Tuple prefix, @Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo)` ends with `0xff` when packed, the exception
```
java.lang.IllegalArgumentException: Invalid tuple (possible truncation)
```
 is thrown. Fixed by replacing the comparison call, so that we don't try to build a `Tuple` from the `strinc(prefix.pack())`.