### PR TITLE
Resolves #2689: Decompressing deserializer does not validate length of decompressed data

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -33,6 +33,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** The `TransformedRecordSerializer` now validates that compressed data decompresses to the expected size [(Issue #2689)](https://github.com/FoundationDB/fdb-record-layer/issues/2689)
+* **Feature** The `TransformedRecordSerializer` now includes checksums in compressed data that is validated during decompression [(Issue #2689)](https://github.com/FoundationDB/fdb-record-layer/issues/2691)
 * **Feature** Updated the set of known protocol versions for client log event parsing to include FDB 7.3 [(Issue #2682)](https://github.com/FoundationDB/fdb-record-layer/issues/2682)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -31,6 +31,8 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add logging information to the runner used when repartitioning [(Issue #2685)](https://github.com/FoundationDB/fdb-record-layer/issues/2685)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** The `TransformedRecordSerializer` now validates that compressed data decompresses to the expected size [(Issue #2689)](https://github.com/FoundationDB/fdb-record-layer/issues/2689)
 * **Feature** Updated the set of known protocol versions for client log event parsing to include FDB 7.3 [(Issue #2682)](https://github.com/FoundationDB/fdb-record-layer/issues/2682)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -175,6 +175,7 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
         int compressedLength;
         try {
             compressor.setInput(state.data, state.offset, state.length);
+            compressor.finish(); // necessary to include checksum
             compressedLength = compressor.deflate(compressed, 5, compressed.length - 5, Deflater.FULL_FLUSH);
         } finally {
             compressor.end();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -172,9 +172,13 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
         // return the uncompressed value because it's pointless to compress
         // if we actually increase the amount of data.
         Deflater compressor = new Deflater(compressionLevel);
-        compressor.setInput(state.data, state.offset, state.length);
-        int compressedLength = compressor.deflate(compressed, 5, compressed.length - 5, Deflater.FULL_FLUSH);
-        compressor.end();
+        int compressedLength;
+        try {
+            compressor.setInput(state.data, state.offset, state.length);
+            compressedLength = compressor.deflate(compressed, 5, compressed.length - 5, Deflater.FULL_FLUSH);
+        } finally {
+            compressor.end();
+        }
         if (compressedLength == compressed.length - 5) {
             increment(timer, Counts.RECORD_BYTES_AFTER_COMPRESSION, state.length);
             state.compressed = false;
@@ -272,9 +276,21 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
         byte[] decompressed = new byte[decompressedLength];
 
         Inflater decompressor = new Inflater();
-        decompressor.setInput(state.data, state.offset + 5, state.length - 5);
-        decompressor.inflate(decompressed);
-        decompressor.end();
+        try {
+            decompressor.setInput(state.data, state.offset + 5, state.length - 5);
+            int actualDecompressedSize = decompressor.inflate(decompressed);
+            if (actualDecompressedSize < decompressedLength) {
+                throw new RecordSerializationException("decompressed record too small")
+                        .addLogInfo(LogMessageKeys.EXPECTED, decompressedLength)
+                        .addLogInfo(LogMessageKeys.ACTUAL, actualDecompressedSize);
+            } else if (decompressor.getRemaining() > 0) {
+                throw new RecordSerializationException("decompressed record too large")
+                        .addLogInfo(LogMessageKeys.EXPECTED, decompressedLength);
+            }
+        } finally {
+            decompressor.end();
+        }
+
         state.setDataArray(decompressed);
 
         if (timer != null) {


### PR DESCRIPTION
This adds a check to the `decompress` method to validate that the decompressed data coming from a transformed record serializer exactly matches the size encoded in the serialized data frame. This ensures that if there is some kind of error that results in the compressed blob either deserializing into something bigger or smaller than the original size, we notice and get a error right away (rather than, say, a protobuf deserialization error).

This resolves #2689.