### PR TITLE
Test for #2691: Compressing serializer does not include checksum

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
We addressed #2691 with #2690. One thing that was left untested was making sure that we could deserialize older data that was written without the checksum. This adds a backwards compatibility test that constructs serialized data that is purposefully written without a checksum, and it validates that it can still deserialize that data into the original record. So, this data won't have the benefit of the checksum, but our current deserializer won't hit problems if we run it against older data.