### PR TITLE
Lucene lock: treat close as a potential recovery path

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Lucene: FileLock should handle close as a possible recovery path [(Issue #2692)](https://github.com/FoundationDB/fdb-record-layer/issues/2692)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -178,7 +178,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
                                         aContext.ensureActive().clear(fileLockKey);
                                         logSelf(isRecovery ? "FileLock: Cleared in Recovery path" : "FileLock: Cleared");
                                     } else if (! isRecovery) {
-                                        throw new AlreadyClosedException("FileLock: Expected lock during close.This=" + this + " existingUuid=" + existingUuid); // The string append methods should handle null arguments.
+                                        throw new AlreadyClosedException("FileLock: Expected to be locked during close.This=" + this + " existingUuid=" + existingUuid); // The string append methods should handle null arguments.
                                     }
                                 }
                             });

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -82,18 +82,6 @@ public final class FDBDirectoryLockFactory extends LockFactory {
         }
 
         @Override
-        public void close() {
-            fileLockClear();
-            flushAndClose();
-        }
-
-        private void flushAndClose() {
-            // always flush before declaring this object as closed. Else agilityContext may fail to commit, while this lock may skip retry
-            agilityContext.flush();
-            closed = true;
-        }
-
-        @Override
         public void ensureValid() {
             // ... and implement heartbeat
             if (closed) {
@@ -179,36 +167,18 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             }
         }
 
-
-        private void fileLockClear() {
-            agilityContext.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK_CLEAR,
-                    agilityContext.apply(aContext ->
-                            aContext.ensureActive().get(fileLockKey)
-                                    .thenAccept(val -> {
-                                        synchronized (fileLockSetLock) {
-                                            fileLockCheckHeartBeat(val); // ensure valid
-                                            aContext.ensureActive().clear(fileLockKey);
-                                            logSelf("FileLock: Cleared");
-                                        }
-                                    })
-                    ));
-        }
-
-        protected void fileLockClearIfLocked() {
-            if (closed) {
-                // Here: the lock was already cleared and closed.
-                return;
-            }
-            // Here: the lock was not cleared in the regular path while the wrapping resource is being closed -
-            // clear the lock unconditionally if locked and matches uuid
+        private void fileLockClearFlushAndClose(boolean isRecovery) {
             Function<FDBRecordContext, CompletableFuture<Void>> fileLockFunc = aContext ->
                     aContext.ensureActive().get(fileLockKey)
                             .thenAccept(val -> {
                                 synchronized (fileLockSetLock) {
                                     UUID existingUuid = fileLockValueToUuid(val);
                                     if (existingUuid != null && existingUuid.compareTo(selfStampUuid) == 0) {
+                                        // clear the lock if locked and matches uuid
                                         aContext.ensureActive().clear(fileLockKey);
-                                        logSelf("FileLock: Cleared in Recovery path");
+                                        logSelf(isRecovery ? "FileLock: Cleared in Recovery path" : "FileLock: Cleared");
+                                    } else if (! isRecovery) {
+                                        throw new AlreadyClosedException("FileLock: Expected lock during close.This=" + this + " existingUuid=" + existingUuid); // The string append methods should handle null arguments.
                                     }
                                 }
                             });
@@ -222,7 +192,26 @@ public final class FDBDirectoryLockFactory extends LockFactory {
                 agilityContext.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FILE_LOCK_CLEAR,
                         agilityContext.apply(fileLockFunc));
             }
-            flushAndClose();
+            // always flush before declaring this object as closed. Else agilityContext may fail to commit, while this lock may skip retry
+            agilityContext.flush();
+            closed = true;
+        }
+
+        protected void fileLockClearIfLocked() {
+            if (closed) {
+                // Here: the lock was already cleared and closed.
+                return;
+            }
+            // Here: the lock was not cleared in the regular path while the wrapping resource is being closed -
+            fileLockClearFlushAndClose(true);
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                throw new AlreadyClosedException("Lock file is already closed. This=" + this);
+            }
+            fileLockClearFlushAndClose(false);
         }
 
         @Override

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
@@ -110,6 +110,7 @@ class FDBDirectoryLockTest {
                 assertFalse(agilityContext.isClosed());
             }
             lock1.close();
+            directory.close();
             agilityContext.flushAndClose();
             context.commit();
         }


### PR DESCRIPTION
Do not assume that the agility context is still active. 