### PR TITLE
 Lucene: merges should run in default transaction priority

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Lucene: merges should run in default transaction priority [(Issue #2696)](https://github.com/FoundationDB/fdb-record-layer/issues/2696)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add logging information to the runner used when repartitioning [(Issue #2685)](https://github.com/FoundationDB/fdb-record-layer/issues/2685)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -112,4 +112,8 @@ public final class LuceneRecordContextProperties {
      * assume that merge will not be performed during IO but in a background process.
      */
     public static final RecordLayerPropertyKey<Boolean> LUCENE_USE_CONCURRENT_MERGE_SCHEDULER = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.useConcurrentMergeScheduler", false);
+    /**
+     * Use "default transaction priority" during merge. The default of this prop is "true" because merge over multiple transactions may be holding back user operations.
+     */
+    public static final RecordLayerPropertyKey<Boolean> LUCENE_USE_DEFAULT_PRIORITY_DURING_MERGE = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.useDefaultPriorityDuringMerge", false);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -113,7 +113,7 @@ public final class LuceneRecordContextProperties {
      */
     public static final RecordLayerPropertyKey<Boolean> LUCENE_USE_CONCURRENT_MERGE_SCHEDULER = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.useConcurrentMergeScheduler", false);
     /**
-     * Use "default transaction priority" during merge. The default of this prop is "true" because merge over multiple transactions may be holding back user operations.
+     * Use "default transaction priority" during merge. The default of this prop is {@code true} because merge over multiple transactions may be preventing user operations.
      */
-    public static final RecordLayerPropertyKey<Boolean> LUCENE_USE_DEFAULT_PRIORITY_DURING_MERGE = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.useDefaultPriorityDuringMerge", false);
+    public static final RecordLayerPropertyKey<Boolean> LUCENE_USE_DEFAULT_PRIORITY_DURING_MERGE = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.useDefaultPriorityDuringMerge", true);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -51,8 +51,12 @@ public interface AgilityContext {
         return new NonAgile(callerContext);
     }
 
+    static AgilityContext agile(FDBRecordContext callerContext, @Nullable FDBRecordContextConfig.Builder contextBuilder, final long timeQuotaMillis, final long sizeQuotaBytes) {
+        return new Agile(callerContext, contextBuilder, timeQuotaMillis, sizeQuotaBytes);
+    }
+
     static AgilityContext agile(FDBRecordContext callerContext, final long timeQuotaMillis, final long sizeQuotaBytes) {
-        return new Agile(callerContext, timeQuotaMillis, sizeQuotaBytes);
+        return agile(callerContext, null, timeQuotaMillis, sizeQuotaBytes);
     }
 
     /**
@@ -194,9 +198,9 @@ public interface AgilityContext {
         private long prevCommitCheckTime;
         private boolean closed = false;
 
-        protected Agile(FDBRecordContext callerContext, final long timeQuotaMillis, final long sizeQuotaBytes) {
+        protected Agile(FDBRecordContext callerContext, @Nullable FDBRecordContextConfig.Builder contextBuilder, final long timeQuotaMillis, final long sizeQuotaBytes) {
             this.callerContext = callerContext;
-            contextConfigBuilder = callerContext.getConfig().toBuilder();
+            contextConfigBuilder = contextBuilder != null ? contextBuilder : callerContext.getConfig().toBuilder();
             contextConfigBuilder.setWeakReadSemantics(null); // We don't want all the transactions to use the same read-version
             database = callerContext.getDatabase();
             this.timeQuotaMillis = timeQuotaMillis;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -40,6 +40,8 @@ import com.apple.foundationdb.record.lucene.LuceneRecordContextProperties;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
+import com.apple.foundationdb.record.provider.foundationdb.FDBTransactionPriority;
 import com.apple.foundationdb.record.provider.foundationdb.IndexDeferredMaintenanceControl;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.record.provider.foundationdb.KeyValueCursor;
@@ -319,7 +321,14 @@ public class FDBDirectoryManager implements AutoCloseable {
             sizeQuotaBytes =  Objects.requireNonNullElse(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_AGILE_COMMIT_SIZE_QUOTA), 900_000);
             deferredControl.setSizeQuotaBytes(sizeQuotaBytes);
         }
-        return AgilityContext.agile(state.context, timeQuotaMillis, sizeQuotaBytes);
+        boolean useDefaultPriorityDuringMerge =  Objects.requireNonNullElse(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_USE_DEFAULT_PRIORITY_DURING_MERGE), true);
+        if (useDefaultPriorityDuringMerge) {
+            final FDBRecordContextConfig.Builder contextBuilder = state.context.getConfig().toBuilder();
+            contextBuilder.setPriority(FDBTransactionPriority.DEFAULT);
+            return AgilityContext.agile(state.context, contextBuilder, timeQuotaMillis, sizeQuotaBytes);
+        } else {
+            return AgilityContext.agile(state.context, timeQuotaMillis, sizeQuotaBytes);
+        }
     }
 
     @Nonnull

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
@@ -356,12 +356,12 @@ public class LucenePrimaryKeySegmentIndexTest extends FDBRecordStoreTestBase {
     }
 
 
-    private class FailCommitsAgilityContext extends AgilityContext.Agile {
+    private static class FailCommitsAgilityContext extends AgilityContext.Agile {
         private final Object indexSubspaceKey;
         private int commitCount = 0;
 
         public FailCommitsAgilityContext(FDBRecordContext callerContext, final Object indexSubspaceKey) {
-            super(callerContext, 1L, 1L);
+            super(callerContext, null, 1L, 1L);
             this.indexSubspaceKey = indexSubspaceKey;
         }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
@@ -707,12 +707,13 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
     }
 
 
-    @Test
-    void luceneTransactionPriorityVerificationTest() {
+    @ParameterizedTest
+    @BooleanSource
+    void luceneTransactionPriorityVerificationTest(boolean usePriorityBatch) {
         // Assert the expected priorities for user context and agility context
         try (FDBRecordContext userContext = openContext()) {
             final FDBTransactionPriority userPriority = userContext.getPriority();
-            final FDBTransactionPriority agilePriority = userPriority == FDBTransactionPriority.DEFAULT ? FDBTransactionPriority.BATCH : FDBTransactionPriority.DEFAULT;
+            final FDBTransactionPriority agilePriority = usePriorityBatch ? FDBTransactionPriority.BATCH : FDBTransactionPriority.DEFAULT;
             final FDBRecordContextConfig.Builder contextBuilder = userContext.getConfig().toBuilder();
             contextBuilder.setPriority(agilePriority);
             final AgilityContext agilityContext = AgilityContext.agile(userContext, contextBuilder, 2, 10000);


### PR DESCRIPTION
   Since user operations are waiting for merge to finish over the “file lock” semaphore, the merge operation should not be running in BATCH priority but DEFAULT.