### PR TITLE
Properly handle autocompletion with CJK using CJKUnigram filter #2712

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AlphanumericCjkAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AlphanumericCjkAnalyzer.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.record.lucene;
 
+import com.apple.foundationdb.record.lucene.filter.AlphanumericLengthFilter;
+import com.apple.foundationdb.record.lucene.filter.CjkUnigramFilter;
 import com.apple.foundationdb.record.lucene.synonym.SynonymMapRegistryImpl;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -127,6 +129,7 @@ public class AlphanumericCjkAnalyzer extends StopwordAnalyzerBase {
         TokenStream result = new CJKWidthFilter(src);
         result = new LowerCaseFilter(result);
         result = new ASCIIFoldingFilter(result);
+        result = new CjkUnigramFilter(result);
         result = new AlphanumericLengthFilter(result, minTokenLength, getMaxTokenLength());
         result = new StopFilter(result, stopwords);
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AlphanumericLengthFilterFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AlphanumericLengthFilterFactory.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene;
 
+import com.apple.foundationdb.record.lucene.filter.AlphanumericLengthFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AutoCompleteAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AutoCompleteAnalyzer.java
@@ -1,0 +1,62 @@
+/*
+ * AutoCompleteAnalyzer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.lucene.filter.CjkUnigramFilter;
+import org.apache.lucene.analysis.StopwordAnalyzerBase;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.cjk.CJKWidthFilter;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter;
+import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizer;
+
+/**
+ * An analyzer that is used to analyze the auto_complete input.
+ * Essentially, this analyzer combines {@link org.apache.lucene.analysis.standard.UAX29URLEmailAnalyzer} and {@link CjkUnigramFilter}
+ * to apply relatively minimal transformation on the text.
+ * */
+public class AutoCompleteAnalyzer extends StopwordAnalyzerBase {
+
+    public static final String UNIQUE_IDENTIFIER = "AUTO_COMPLETE";
+
+    public AutoCompleteAnalyzer() {
+        super(null);
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CloseResource") //intentional pattern of lucene
+    protected TokenStreamComponents createComponents(final String fieldName) {
+        final Tokenizer src;
+        TokenStream result;
+        src = new UAX29URLEmailTokenizer();
+        result = new CJKWidthFilter(src);
+        result = new CjkUnigramFilter(result);
+        result = new LowerCaseFilter(result);
+        result = new ASCIIFoldingFilter(result);
+        return new TokenStreamComponents(src, result);
+    }
+
+    @Override
+    protected TokenStream normalize(final String fieldName, final TokenStream in) {
+        return new LowerCaseFilter(new CJKWidthFilter(in));
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzer.java
@@ -1,0 +1,129 @@
+/*
+ * EmailCjkSynonymAnalyzer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.lucene.filter.AlphanumericLengthFilter;
+import com.apple.foundationdb.record.lucene.filter.CjkUnigramFilter;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.LowerCaseFilter;
+import org.apache.lucene.analysis.StopFilter;
+import org.apache.lucene.analysis.StopwordAnalyzerBase;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.cjk.CJKWidthFilter;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter;
+import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizerFactory;
+import org.apache.lucene.analysis.synonym.SynonymGraphFilter;
+import org.apache.lucene.analysis.synonym.SynonymMap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+
+/**
+ * An analyzer that can handle emails, CJK, and synonyms. It essentially combines UAX29URLEmailAnalyzer, CJKUnigramFilter,
+ * and SynonymGraphFilter.
+ */
+
+public class EmailCjkSynonymAnalyzer extends StopwordAnalyzerBase {
+
+    public static final String UNIQUE_IDENTIFIER = "SYNONYM_EMAIL";
+
+    private final int minAlphanumericTokenLength;
+    private int minTokenLength;
+    private int maxTokenLength;
+    private final boolean withEmailTokenizer;
+    private final boolean withSynonymGraphFilter;
+    @Nullable
+    private final SynonymMap synonymMap;
+
+    public EmailCjkSynonymAnalyzer(@Nonnull CharArraySet stopwords, int minTokenLength, int minAlphanumericTokenLength, int maxTokenLength,
+                                   boolean withEmailTokenizer,
+                                   boolean withSynonymGraphFilter, @Nullable SynonymMap synonymMap) {
+        super(stopwords);
+        this.minTokenLength = minTokenLength;
+        this.maxTokenLength = maxTokenLength;
+        this.withEmailTokenizer = withEmailTokenizer;
+        this.withSynonymGraphFilter = withSynonymGraphFilter;
+        this.minAlphanumericTokenLength = minAlphanumericTokenLength;
+        this.synonymMap = synonymMap;
+    }
+
+    @Deprecated // due to the use of deprecated WordDelimiterFilter
+    @Override
+    @SuppressWarnings("PMD.CloseResource") //intentional pattern of lucene
+    protected TokenStreamComponents createComponents(final String fieldName) {
+        final Tokenizer src;
+        TokenStream result;
+        if (withEmailTokenizer()) {
+            src = new UAX29URLEmailTokenizerFactory(Collections.emptyMap()).create(attributeFactory(fieldName));
+            result = new CJKWidthFilter(src);
+            result = new CjkUnigramFilter(result);
+            result = new WordDelimiterFilter(result, WordDelimiterFilter.GENERATE_WORD_PARTS | WordDelimiterFilter.PRESERVE_ORIGINAL, null);
+            result = new org.apache.lucene.analysis.core.LowerCaseFilter(result);
+            result = new ASCIIFoldingFilter(result);
+        } else {
+            src = new StandardTokenizer();
+            result = new CJKWidthFilter(src);
+            result = new org.apache.lucene.analysis.core.LowerCaseFilter(result);
+            result = new ASCIIFoldingFilter(result);
+            result = new CjkUnigramFilter(result);
+        }
+        result = new AlphanumericLengthFilter(result, minAlphanumericTokenLength, getMaxTokenLength());
+        if (withSynonymGraphFilter()) {
+            result = new SynonymGraphFilter(result, getSynonymMap(), true);
+        }
+        result = new StopFilter(result, stopwords);
+        return new TokenStreamComponents(src, result);
+    }
+
+    @Override
+    protected TokenStream normalize(final String fieldName, final TokenStream in) {
+        return new LowerCaseFilter(new CJKWidthFilter(in));
+    }
+
+    public int getMinTokenLength() {
+        return minTokenLength;
+    }
+
+    public int getMaxTokenLength() {
+        return maxTokenLength;
+    }
+
+    protected boolean withSynonymGraphFilter() {
+        return withSynonymGraphFilter;
+    }
+
+    protected boolean withEmailTokenizer() {
+        return withEmailTokenizer;
+    }
+
+    @Nonnull
+    protected SynonymMap getSynonymMap() {
+        if (!withSynonymGraphFilter || synonymMap == null) {
+            throw new RecordCoreException("Invalid call to get synonym map for EmailCjkSynonymAnalyzer, which is not enabled with synonym and valid map");
+        }
+        return synonymMap;
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzerFactory.java
@@ -1,0 +1,91 @@
+/*
+ * EmailCjkSynonymAnalyzerFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.lucene.synonym.SynonymMapRegistryImpl;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.google.auto.service.AutoService;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.standard.UAX29URLEmailAnalyzer;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Factory to build index and query {@link org.apache.lucene.analysis.Analyzer} for {@link EmailCjkSynonymAnalyzer}.
+ */
+@AutoService(LuceneAnalyzerFactory.class)
+public class EmailCjkSynonymAnalyzerFactory implements LuceneAnalyzerFactory {
+    public static final String ANALYZER_FACTORY_NAME = "SYNONYM_EMAIL";
+    public static final String UNIQUE_IDENTIFIER = "synonym_email";
+
+    private static final String DEFAULT_MINIMUM_TOKEN_LENGTH = "3";
+    private static final String DEFAULT_MAXIMUM_TOKEN_LENGTH = "30";
+
+    public static final CharArraySet MINIMAL_STOP_WORDS = new CharArraySet(List.of("into", "onto", "the"), true);
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return ANALYZER_FACTORY_NAME;
+    }
+
+    @Nonnull
+    @Override
+    public LuceneAnalyzerType getType() {
+        return LuceneAnalyzerType.FULL_TEXT;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Nonnull
+    @Override
+    public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index index) {
+        try {
+            final String minLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MIN_SIZE)).orElse(DEFAULT_MINIMUM_TOKEN_LENGTH);
+            final String maxLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MAX_SIZE)).orElse(Integer.toString(UAX29URLEmailAnalyzer.DEFAULT_MAX_TOKEN_LENGTH));
+
+            return t -> new LuceneAnalyzerWrapper(UNIQUE_IDENTIFIER,
+                    new EmailCjkSynonymAnalyzer(MINIMAL_STOP_WORDS, 1, Integer.parseInt(minLengthString), Integer.parseInt(maxLengthString), true,
+                            false, null));
+        } catch (NumberFormatException ex) {
+            throw new RecordCoreException("Invalid parameter for Lucene analyzer's token length", ex);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Nonnull
+    @Override
+    public AnalyzerChooser getQueryAnalyzerChooser(@Nonnull Index index, @Nonnull AnalyzerChooser indexAnalyzerChooser) {
+        try {
+            final String minLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MIN_SIZE)).orElse(DEFAULT_MINIMUM_TOKEN_LENGTH);
+            final String maxLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MAX_SIZE)).orElse(DEFAULT_MAXIMUM_TOKEN_LENGTH);
+            final String synonymConfigName = index.getOption(LuceneIndexOptions.TEXT_SYNONYM_SET_NAME_OPTION);
+            return t -> new LuceneAnalyzerWrapper(UNIQUE_IDENTIFIER,
+                    new EmailCjkSynonymAnalyzer(MINIMAL_STOP_WORDS, 1, Integer.parseInt(minLengthString), Integer.parseInt(maxLengthString), true,
+                            synonymConfigName != null, synonymConfigName != null ? SynonymMapRegistryImpl.instance().getSynonymMap(synonymConfigName) : null));
+        } catch (NumberFormatException ex) {
+            throw new RecordCoreException("Invalid parameter for Lucene analyzer's token length", ex);
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteHelpers.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteHelpers.java
@@ -382,6 +382,23 @@ public class LuceneAutoCompleteHelpers {
         return isPhraseSearch ? search.substring(1, search.length() - 1) : search;
     }
 
+    /*
+     * For auto-complete matches, use the index analyzer selector
+     * Returns an analyzerSelector for full text
+     */
+    @Nullable
+    public static <M extends Message> LuceneAnalyzerCombinationProvider getAutoCompletedMatchesAnalyzerSelector(@Nullable FDBQueriedRecord<M> queriedRecord) {
+        if (queriedRecord == null) {
+            return null;
+        }
+        final var indexEntry = queriedRecord.getIndexEntry();
+        if (!(indexEntry instanceof LuceneRecordCursor.ScoreDocIndexEntry)) {
+            return null;
+        }
+        final var docIndexEntry = (LuceneRecordCursor.ScoreDocIndexEntry)indexEntry;
+        return docIndexEntry.getAnalyzerSelector();
+    }
+
     @Nullable
     public static <M extends Message> LuceneAnalyzerCombinationProvider getAutoCompleteAnalyzerSelector(@Nullable FDBQueriedRecord<M> queriedRecord) {
         if (queriedRecord == null) {
@@ -392,11 +409,7 @@ public class LuceneAutoCompleteHelpers {
             return null;
         }
         final var docIndexEntry = (LuceneRecordCursor.ScoreDocIndexEntry)indexEntry;
-        final var autoCompleteAnalyzerSelector = docIndexEntry.getAutoCompleteAnalyzerSelector();
-        if (autoCompleteAnalyzerSelector == null) {
-            return null;
-        }
-        return autoCompleteAnalyzerSelector;
+        return docIndexEntry.getAutoCompleteAnalyzerSelector();
     }
 
     /**

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/CjkUnigramFilter.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/CjkUnigramFilter.java
@@ -1,0 +1,236 @@
+/*
+ * CjkUnigramFilter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene.filter;
+
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.ArrayUtil;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * An analyzer that forms unigrams of CJK terms.
+ * NOTICE:
+ * This analyzer contains code that was
+ * taken from {@link org.apache.lucene.analysis.cjk.CJKBigramFilter} and modified
+ */
+public final class CjkUnigramFilter extends TokenFilter {
+    // when we emit a unigram, it's then marked as this type
+    public static final String SINGLE_TYPE = "<SINGLE>";
+
+    // the types from standardtokenizer
+    private static final String HAN_TYPE = StandardTokenizer.TOKEN_TYPES[StandardTokenizer.IDEOGRAPHIC];
+    private static final String HIRAGANA_TYPE = StandardTokenizer.TOKEN_TYPES[StandardTokenizer.HIRAGANA];
+    private static final String KATAKANA_TYPE = StandardTokenizer.TOKEN_TYPES[StandardTokenizer.KATAKANA];
+    private static final String HANGUL_TYPE = StandardTokenizer.TOKEN_TYPES[StandardTokenizer.HANGUL];
+
+    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    private final TypeAttribute typeAtt = addAttribute(TypeAttribute.class);
+    private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+
+    // buffers containing codepoint and offsets in parallel
+    int[] buffer = new int[8];
+    int[] startOffset = new int[8];
+    int[] endOffset = new int[8];
+    // length of valid buffer
+    int bufferLen;
+    // current buffer index
+    int index;
+
+    // the last end offset
+    int lastEndOffset;
+
+    private boolean exhausted;
+
+    public CjkUnigramFilter(TokenStream in) {
+        super(in);
+    }
+
+    /*
+     * much of this complexity revolves around handling the special case of a
+     * "lone cjk character" where cjktokenizer would output a unigram. this
+     * is also the only time we ever have to captureState.
+     */
+    @Override
+    public boolean incrementToken() throws IOException {
+        while (true) {
+            if (hasBufferedUnigram()) {
+                flushUnigram();
+                return true;
+            }
+
+            if (!doNext()) { // read next token from stream
+                return false;
+            }
+
+            if (!isCjkType(typeAtt.type())) {
+                return true;  // not a CJK type; just return token as-is.
+            }
+
+            refill();
+        }
+    }
+
+    private boolean isCjkType(final String type) {
+        return HAN_TYPE.equals(type) || HIRAGANA_TYPE.equals(type) ||
+                KATAKANA_TYPE.equals(type) || HANGUL_TYPE.equals(type);
+    }
+
+    /**
+     * looks at next input token, returning false is none is available.
+     */
+    private boolean doNext() throws IOException {
+        if (exhausted) {
+            return false;
+        } else if (input.incrementToken()) {
+            return true;
+        } else {
+            exhausted = true;
+            return false;
+        }
+    }
+
+    /**
+     * refills buffers with new data from the current token.
+     */
+    private void refill() {
+        // compact buffers to keep them smallish if they become large
+        // just a safety check, but technically we only need the last codepoint
+        if (bufferLen > 64) {
+            int last = bufferLen - 1;
+            buffer[0] = buffer[last];
+            startOffset[0] = startOffset[last];
+            endOffset[0] = endOffset[last];
+            bufferLen = 1;
+            index -= last;
+        }
+
+        char[] termBuffer = termAtt.buffer();
+        int len = termAtt.length();
+
+        int newSize = bufferLen + len;
+        buffer = ArrayUtil.grow(buffer, newSize);
+        startOffset = ArrayUtil.grow(startOffset, newSize);
+        endOffset = ArrayUtil.grow(endOffset, newSize);
+
+        int start = offsetAtt.startOffset();
+        int end = offsetAtt.endOffset();
+        lastEndOffset = end;
+
+        if (end - start != len) {
+            // crazy offsets (modified by synonym or charfilter): just preserve
+            int cp;
+            for (int i = 0; i < len; i += Character.charCount(cp)) {
+                cp = buffer[bufferLen] = Character.codePointAt(termBuffer, i, len);
+                startOffset[bufferLen] = start;
+                endOffset[bufferLen] = end;
+                bufferLen++;
+            }
+        } else {
+            // normal offsets
+            int cp;
+            int cpLen;
+            for (int i = 0; i < len; i += cpLen) {
+                cp = buffer[bufferLen] = Character.codePointAt(termBuffer, i, len);
+                cpLen = Character.charCount(cp);
+                startOffset[bufferLen] = start;
+                start = endOffset[bufferLen] = start + cpLen;
+                bufferLen++;
+            }
+        }
+    }
+
+    /**
+     * Flushes a unigram token to output from our buffer.
+     * This happens when we encounter isolated CJK characters, either the whole
+     * CJK string is a single character, or we encounter a CJK character surrounded
+     * by space, punctuation, english, etc, but not beside any other CJK.
+     */
+    private void flushUnigram() {
+        clearAttributes();
+        char[] termBuffer = termAtt.resizeBuffer(2); // maximum unigram length (2 surrogates)
+        int len = Character.toChars(buffer[index], termBuffer, 0);
+        termAtt.setLength(len);
+        offsetAtt.setOffset(startOffset[index], endOffset[index]);
+        typeAtt.setType(SINGLE_TYPE);
+        index++;
+    }
+
+    /**
+     * True if we have a single codepoint sitting in our buffer, where its future
+     * depends upon not-yet-seen inputs.
+     */
+    private boolean hasBufferedUnigram() {
+        return (bufferLen - index) > 0;
+    }
+
+    @Override
+    public void reset() throws IOException {
+        super.reset();
+        bufferLen = 0;
+        index = 0;
+        lastEndOffset = 0;
+        exhausted = false;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CloseResource") //nothing to actually close
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        CjkUnigramFilter that = (CjkUnigramFilter) o;
+        return bufferLen == that.bufferLen &&
+                index == that.index &&
+                lastEndOffset == that.lastEndOffset &&
+                exhausted == that.exhausted &&
+                termAtt.equals(that.termAtt) &&
+                typeAtt.equals(that.typeAtt) &&
+                offsetAtt.equals(that.offsetAtt) &&
+                Arrays.equals(buffer, that.buffer) &&
+                Arrays.equals(startOffset, that.startOffset) &&
+                Arrays.equals(endOffset, that.endOffset);
+    }
+
+    static boolean isUnigramTokenType(final String type) {
+        return CjkUnigramFilter.SINGLE_TYPE.equals(type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), Arrays.hashCode(buffer), Arrays.hashCode(startOffset), Arrays.hashCode(endOffset), termAtt, typeAtt, offsetAtt, bufferLen, index, lastEndOffset, exhausted);
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains filter classes.
+ */
+package com.apple.foundationdb.record.lucene.filter;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
@@ -91,6 +91,7 @@ public class LuceneIndexTestUtils {
     protected static final String TEXT_AND_BOOLEAN_INDEX_KEY = "text_and_boolean_index_key";
     protected static final String TEXT_AND_NUMBER_INDEX_KEY = "text_and_number_index_key";
     protected static final String SIMPLE_TEXT_WITH_AUTO_COMPLETE_KEY = "simple_text_with_auto_complete_key";
+    protected static final String EMAIL_CJK_SYM_TEXT_WITH_AUTO_COMPLETE_KEY = "email_cjk_sym_text_with_auto_complete_key";
     protected static final String MAP_ON_VALUE_INDEX_KEY = "map_on_value_index_key";
     protected static final String SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY = "simple_text_suffixes_with_primary_key_segment_index_key";
     protected static final String COMPLEX_GROUPED_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY = "complex_grouped_with_primary_key_segment_index_key";
@@ -214,6 +215,11 @@ public class LuceneIndexTestUtils {
             SIMPLE_TEXT_WITH_AUTO_COMPLETE_STORED_FIELD,
             LuceneIndexTypes.LUCENE,
             ImmutableMap.of());
+
+    protected static final Index EMAIL_CJK_SYM_TEXT_WITH_AUTO_COMPLETE = new Index("Email_cjk_sym_with_auto_complete",
+            SIMPLE_TEXT_WITH_AUTO_COMPLETE_STORED_FIELD,
+            LuceneIndexTypes.LUCENE,
+            ImmutableMap.of(LuceneIndexOptions.LUCENE_ANALYZER_NAME_OPTION, EmailCjkSynonymAnalyzer.UNIQUE_IDENTIFIER));
 
     protected static final Index MAP_ON_VALUE_INDEX = getMapOnValueIndexWithOption("Map$entry-value", ImmutableMap.of());
 
@@ -355,6 +361,21 @@ public class LuceneIndexTestUtils {
                             field("complex").nest(function(LuceneFunctionNames.LUCENE_SORTED, field("timestamp")))
                     ), LuceneIndexTypes.LUCENE,
                     ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME,
+                            LuceneIndexOptions.TEXT_SYNONYM_SET_NAME_OPTION, EnglishSynonymMapConfig.ExpandedEnglishSynonymMapConfig.CONFIG_NAME,
+                            LuceneIndexOptions.OPTIMIZED_STORED_FIELDS_FORMAT_ENABLED, "true"));
+
+    protected static final Index JOINED_COMPLEX_MULTIPLE_EMAIL_CJK_SYM_INDEXES =
+            new Index("JoinedComplex$text_multipleEmailCJKSymIndexes",
+                    concat(
+                            field("complex").nest(function(LuceneFunctionNames.LUCENE_STORED, field("is_seen"))),
+                            field("simple").nest(function(LuceneFunctionNames.LUCENE_TEXT, field("text"))),
+                            field("complex").nest(function(LuceneFunctionNames.LUCENE_TEXT, field("text2"))),
+                            field("complex").nest(function(LuceneFunctionNames.LUCENE_STORED, field("score"))),
+                            field("complex").nest(function(LuceneFunctionNames.LUCENE_STORED, field("group"))),
+                            field("complex").nest(function(LuceneFunctionNames.LUCENE_SORTED, field("timestamp")))
+                    ), LuceneIndexTypes.LUCENE,
+                    ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME,
+                            LuceneIndexOptions.LUCENE_ANALYZER_NAME_OPTION, EmailCjkSynonymAnalyzer.UNIQUE_IDENTIFIER,
                             LuceneIndexOptions.TEXT_SYNONYM_SET_NAME_OPTION, EnglishSynonymMapConfig.ExpandedEnglishSynonymMapConfig.CONFIG_NAME,
                             LuceneIndexOptions.OPTIMIZED_STORED_FIELDS_FORMAT_ENABLED, "true"));
 
@@ -830,6 +851,7 @@ public class LuceneIndexTestUtils {
                 Map.entry(TEXT_AND_BOOLEAN_INDEX_KEY, JOINED_COMPLEX_MULTIPLE_TEXT_INDEXES),
                 Map.entry(TEXT_AND_NUMBER_INDEX_KEY, JOINED_COMPLEX_MULTIPLE_TEXT_INDEXES),
                 Map.entry(SIMPLE_TEXT_WITH_AUTO_COMPLETE_KEY, JOINED_COMPLEX_MULTIPLE_TEXT_INDEXES),
+                Map.entry(EMAIL_CJK_SYM_TEXT_WITH_AUTO_COMPLETE_KEY, JOINED_COMPLEX_MULTIPLE_EMAIL_CJK_SYM_INDEXES),
                 Map.entry(MAP_ON_VALUE_INDEX_KEY, JOINED_COMPLEX_MAP_TEXT_INDEXES),
                 Map.entry(SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY, JOINED_COMPLEX_MULTIPLE_TEXT_PRIMARY_KEY_SEGMENT_INDEXES),
                 Map.entry(COMPLEX_MULTIPLE_TEXT_INDEXES_KEY, JOINED_COMPLEX_MULTIPLE_TEXT_INDEXES),
@@ -855,6 +877,7 @@ public class LuceneIndexTestUtils {
                 Map.entry(TEXT_AND_BOOLEAN_INDEX_KEY, TEXT_AND_BOOLEAN_INDEX),
                 Map.entry(TEXT_AND_NUMBER_INDEX_KEY, TEXT_AND_NUMBER_INDEX),
                 Map.entry(SIMPLE_TEXT_WITH_AUTO_COMPLETE_KEY, SIMPLE_TEXT_WITH_AUTO_COMPLETE),
+                Map.entry(EMAIL_CJK_SYM_TEXT_WITH_AUTO_COMPLETE_KEY, EMAIL_CJK_SYM_TEXT_WITH_AUTO_COMPLETE),
                 Map.entry(MAP_ON_VALUE_INDEX_KEY, MAP_ON_VALUE_INDEX),
                 Map.entry(SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY, SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX),
                 Map.entry(COMPLEX_MULTIPLE_TEXT_INDEXES_KEY, COMPLEX_MULTIPLE_TEXT_INDEXES),


### PR DESCRIPTION
**Motivation**
Fix handling of CJK autocomplete. 

**Modifications**
- Make a new autocomplete analyzer that can understand CJK to analyze the input for phrase construction, and also for matching of autocompleted text.
- Added more tests around CJK autocomplete and CJK autocomplete matching
- Created `CJKUnigramFilter` and a new `AlphanumericLengthFilter` that works with the `CJKUnigramFilter`
- Added a new `EmailCjkSynonymAnalyzer`, mostly for testing
