### PR TITLE
Fixes #2715: Error message for stores with missing header can be misleading

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Error messages reported when a store is missing a header now indicate whether the store has record or index data correctly [(Issue #2715)](https://github.com/FoundationDB/fdb-record-layer/issues/2715)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -2469,29 +2469,31 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                         LogMessageKeys.KEY, firstKey));
             }
             return false;
-        } else if (existenceCheck == StoreExistenceCheck.ERROR_IF_NO_INFO_AND_HAS_RECORDS_OR_INDEXES) {
-            final FDBRecordStoreKeyspace keyspace = determineRecordStoreKeyspace(firstKey, subspaceProvider, context);
-            // White list of acceptable key ranges for the first key. This may need to be updated as more keyspaces are added.
-            // Includes: INDEX_STATE_SPACE, INDEX_RANGE_SPACE, and INDEX_BUILD_SPACE as those contain only meta-data about the state of the
-            // index or index build but no "user data"
-            // Excludes: anything with records or data about records, i.e., RECORD (as it contains records), INDEX and INDEX_SECONDARY space (as
-            // they contains data from indexes), RECORD_COUNT (as that is/was effectively an index), INDEX_UNIQUENESS_VIOLATIONS_SPACE (as it
-            // contains data that should be consistent with the index), and RECORD_VERSION_SPACE (as it contains data that is effectively tied
-            // to the records). In a record store where the only corruption is the lack of a store header, then if the store has no records,
-            // INDEX_UNIQUENESS_VIOLATIONS_SPACE and RECORD_VERSION_SPACE should be empty as well, but this isn't validated. In theory, if the
-            // RECORD_COUNT keyspace was zero, that would be consistent, so it would be "safe" to only warn then as well.
-            if (FDBRecordStoreKeyspace.INDEX_STATE_SPACE.equals(keyspace) || FDBRecordStoreKeyspace.INDEX_RANGE_SPACE.equals(keyspace) || FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.equals(keyspace)) {
-                if (LOGGER.isWarnEnabled()) {
-                    LOGGER.warn(KeyValueLogMessage.of("Record store has no info or records but is not empty",
-                            subspaceProvider.logKey(), subspaceProvider.toString(context),
-                            LogMessageKeys.KEY, firstKey));
-                }
-                return false;
-            } else {
-                throw noInfoAndNotEmptyException("Record store has no info or records but is not empty", firstKey, subspaceProvider, context);
-            }
         } else {
-            throw noInfoAndNotEmptyException("Record store has no info but is not empty", firstKey, subspaceProvider, context);
+            final FDBRecordStoreKeyspace keyspace = determineRecordStoreKeyspace(firstKey, subspaceProvider, context);
+            if (FDBRecordStoreKeyspace.INDEX_STATE_SPACE.equals(keyspace) || FDBRecordStoreKeyspace.INDEX_RANGE_SPACE.equals(keyspace) || FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.equals(keyspace)) {
+                // Allow list of acceptable key ranges for the first key. This may need to be updated as more keyspaces are added.
+                // Includes: INDEX_STATE_SPACE, INDEX_RANGE_SPACE, and INDEX_BUILD_SPACE as those contain only meta-data about the state of the
+                // index or index build but no "user data"
+                // Excludes: anything with records or data about records, i.e., RECORD (as it contains records), INDEX and INDEX_SECONDARY space (as
+                // they contains data from indexes), RECORD_COUNT (as that is/was effectively an index), INDEX_UNIQUENESS_VIOLATIONS_SPACE (as it
+                // contains data that should be consistent with the index), and RECORD_VERSION_SPACE (as it contains data that is effectively tied
+                // to the records). In a record store where the only corruption is the lack of a store header, then if the store has no records,
+                // INDEX_UNIQUENESS_VIOLATIONS_SPACE and RECORD_VERSION_SPACE should be empty as well, but this isn't validated. In theory, if the
+                // RECORD_COUNT keyspace was zero, that would be consistent, so it would be "safe" to only warn then as well.
+                if (existenceCheck == StoreExistenceCheck.ERROR_IF_NO_INFO_AND_HAS_RECORDS_OR_INDEXES) {
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER.warn(KeyValueLogMessage.of("Record store has no info or records but is not empty",
+                                subspaceProvider.logKey(), subspaceProvider.toString(context),
+                                LogMessageKeys.KEY, firstKey));
+                    }
+                    return false;
+                } else {
+                    throw noInfoAndNotEmptyException("Record store has no info or records but is not empty", firstKey, subspaceProvider, context);
+                }
+            } else {
+                throw noInfoAndNotEmptyException("Record store has no info but is not empty", firstKey, subspaceProvider, context);
+            }
         }
     }
 
@@ -2508,8 +2510,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             return FDBRecordStoreKeyspace.fromKey(firstKey.get(0));
         } catch (RecordCoreException e) {
             // PMD doesn't like this line because it can't tell it's actually the same exception being rethrown
-            throw e.addLogInfo(subspaceProvider.logKey(), subspaceProvider.toString(context),
-                    LogMessageKeys.KEY, firstKey);
+            throw new RecordStoreNoInfoAndNotEmptyException("Record store has no info but is not empty with an unknown keyspace", e)
+                    .addLogInfo(subspaceProvider.logKey(), subspaceProvider.toString(context))
+                    .addLogInfo(LogMessageKeys.KEY, firstKey);
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordStoreNoInfoAndNotEmptyException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordStoreNoInfoAndNotEmptyException.java
@@ -34,6 +34,10 @@ import javax.annotation.Nullable;
 @SuppressWarnings("serial")
 @API(API.Status.STABLE)
 public class RecordStoreNoInfoAndNotEmptyException extends RecordCoreStorageException {
+    public RecordStoreNoInfoAndNotEmptyException(@Nonnull String msg, @Nullable Throwable cause) {
+        super(msg, cause);
+    }
+
     public RecordStoreNoInfoAndNotEmptyException(@Nonnull String msg, @Nullable Object ... keyValues) {
         super(msg, keyValues);
     }


### PR DESCRIPTION
The previous logic used to decide what error message to present based on the `storeExistenceCheck`. This is incorrect, because it means we would report that the store would have no record data if the existence check supported opening stores with no header and no recods, but we should instead only report that if the store actually has no records. So now the error message is based on the data we actually find.

This fixes #2715.