### PR TITLE
Fixes #2741: Inverted range from tests that run non-overlapping parallel builds

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -221,13 +222,17 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                     assumeFalse(safeBuild);
                     buildFuture = indexBuilder.buildEndpoints().thenCompose(tupleRange -> {
                         if (tupleRange != null) {
-                            long start = Objects.requireNonNull(tupleRange.getLow()).getLong(0);
-                            long end = Objects.requireNonNull(tupleRange.getHigh()).getLong(0);
+                            // Divide the range so that each agent takes an equal amount of the integer range
+                            // Use BigIntegers for computing the boundaries because intermediate steps can exceed
+                            // 64-bit precision if, for example, start is near Long.MIN_VALUE and end is near Long.MAX_VALUE
+                            final BigInteger start = Objects.requireNonNull(tupleRange.getLow()).getBigInteger(0);
+                            final BigInteger end = Objects.requireNonNull(tupleRange.getHigh()).getBigInteger(0);
+                            final BigInteger rangePerAgent = end.subtract(start).divide(BigInteger.valueOf(agents));
 
                             CompletableFuture<?>[] futures = new CompletableFuture<?>[agents];
                             for (int i = 0; i < agents; i++) {
-                                long itrStart = start + (end - start) / agents * i;
-                                long itrEnd = (i == agents - 1) ? end : start + (end - start) / agents * (i + 1);
+                                long itrStart = start.add(rangePerAgent.multiply(BigInteger.valueOf(i))).longValue();
+                                long itrEnd = (i == agents - 1) ? end.longValue() : start.add(rangePerAgent.multiply(BigInteger.valueOf(i + 1))).longValue();
                                 LOGGER.info(KeyValueLogMessage.of("building range",
                                         TestLogMessageKeys.INDEX, index,
                                         TestLogMessageKeys.AGENT, i,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
@@ -378,12 +378,12 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     @Tag(Tags.Slow)
     public void updateRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
-        List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
                         .setNumValue2(r.nextInt(20))
                         .build()
-        ).collect(Collectors.toList());
+        ).limit(300).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = records.stream()
                 .filter(rec -> r.nextBoolean())
                 .map(rec -> rec.toBuilder().setNumValue2(r.nextInt(20)).build())
@@ -396,12 +396,12 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     @Tag(Tags.Slow)
     public void deleteRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
-        List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
                         .setNumValue2(r.nextInt(50))
                         .build()
-        ).collect(Collectors.toList());
+        ).limit(300).collect(Collectors.toList());
         List<Long> toDelete = records.stream()
                 .filter(rec -> r.nextBoolean())
                 .map(TestRecords1Proto.MySimpleRecord::getRecNo)
@@ -414,12 +414,12 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     @Tag(Tags.Slow)
     public void updateAndDeleteRecordsWhileBuildingSum(@Nullable Index sourceIndex, long seed) {
         Random r = new Random(seed);
-        List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 300).mapToObj(val ->
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
                         .setNumValue2(r.nextInt(50))
                         .build()
-        ).collect(Collectors.toList());
+        ).limit(300).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = records.stream()
                 .filter(rec -> r.nextBoolean())
                 .map(rec -> rec.toBuilder().setNumValue2(r.nextInt(20)).build())
@@ -451,13 +451,13 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
     @Tag(Tags.Slow)
     public void updateWhileBuildingFilteredSum(@Nullable Index sourceIndex, boolean filterSource, long seed) {
         Random r = new Random(seed);
-        List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 500).mapToObj(val ->
+        List<TestRecords1Proto.MySimpleRecord> records = Stream.generate(() ->
                 TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(r.nextLong())
                         .setNumValue2(r.nextInt(50) - 25)
                         .setNumValue3Indexed(r.nextInt(2))
                         .build()
-        ).collect(Collectors.toList());
+        ).limit(500).collect(Collectors.toList());
         List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding = records.stream()
                 .filter(rec -> r.nextBoolean())
                 .map(rec -> rec.toBuilder().setNumValue2(r.nextInt(50) - 25).setNumValue3Indexed(r.nextInt(2)).build())

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
@@ -588,8 +588,9 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
     @MethodSource("overlapAndRandomSeeds")
     void sumFiveHundredParallelBuild(boolean overlap, long seed) {
         final Random r = new Random(seed);
-        List<Message> records = LongStream.range(1L, 501L)
+        List<Message> records = LongStream.generate(r::nextLong)
                 .mapToObj(id -> randomOuterRecord(r, id))
+                .limit(500)
                 .collect(Collectors.toList());
         singleSumIndexRebuild(records, null, null, 5, overlap);
     }
@@ -615,8 +616,9 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
     @MethodSource("overlapAndRandomSeeds")
     void simpleParallelTwoHundredRebuild(boolean overlap, long seed) {
         final Random r = new Random(seed);
-        List<Message> records = LongStream.range(0L, 200L)
+        List<Message> records = LongStream.generate(r::nextLong)
                 .mapToObj(id -> randomOuterRecord(r, id))
+                .limit(200)
                 .collect(Collectors.toList());
         singleValueIndexRebuild(records, null, null, 5, overlap);
     }
@@ -626,8 +628,9 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
     @MethodSource("overlapAndRandomSeeds")
     void parallelBuildFiveHundredWithDeletesAndUpdates(boolean overlap, long seed) {
         final Random r = new Random(seed);
-        List<Message> records = LongStream.range(0L, 500L)
+        List<Message> records = LongStream.generate(r::nextLong)
                 .mapToObj(id -> randomOuterRecord(r, id))
+                .limit(500)
                 .collect(Collectors.toList());
 
         List<Message> recordsWhileBuilding = new ArrayList<>();
@@ -643,8 +646,9 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
     @MethodSource("randomSeeds")
     void parallelBuildSixHundredWithDeletesAndUpdatesFromIndex(long seed) {
         final Random r = new Random(seed);
-        List<Message> records = LongStream.range(0L, 600L)
+        List<Message> records = LongStream.generate(r::nextLong)
                 .mapToObj(id -> randomOuterRecord(r, id))
+                .limit(600)
                 .collect(Collectors.toList());
 
         List<Message> recordsWhileBuilding = new ArrayList<>();


### PR DESCRIPTION
This updates the logic within the index builder tests so that it uses `BigInteger`s when splitting up the range. This is necessary because we can sometimes get large enough ranges between the `start` and `end` that intermediate steps may not be handled using 64-bit precision. These tests may be unnecessary as we mature the other parallel index build infrastructure and tests, but for now, this should unblock those hitting these flaky tests.

This fixes #2741.