### PR TITLE
Fixes #2750: Some calls to toUpperCase and toLowerCase are missing fixed Locale

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** The `ArithmeticValue` and `NumericAggregationValue` classes now uses a fixed `Locale` with `toUpperCase` when encapsulating a specified function by name to avoid mismatches when running in the Turkish locale [(Issue #2750)](https://github.com/FoundationDB/fdb-record-layer/issues/2750)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CorrelationIdentifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CorrelationIdentifier.java
@@ -74,7 +74,7 @@ public class CorrelationIdentifier {
      */
     @Nonnull
     public static CorrelationIdentifier uniqueID(@Nonnull final Class<?> clazz) {
-        return uniqueID(clazz, clazz.getSimpleName().substring(0, 1).toLowerCase(Locale.getDefault()));
+        return uniqueID(clazz, clazz.getSimpleName().substring(0, 1).toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -145,7 +145,7 @@ public class ArithmeticValue extends AbstractValue {
 
     @Override
     public String toString() {
-        return operator.name().toLowerCase(Locale.getDefault()) + "(" + leftChild + ", " + rightChild + ")";
+        return operator.name().toLowerCase(Locale.ROOT) + "(" + leftChild + ", " + rightChild + ")";
     }
 
     @Override
@@ -205,7 +205,7 @@ public class ArithmeticValue extends AbstractValue {
         final Type type1 = arg1.getResultType();
         SemanticException.check(type1.isPrimitive(), SemanticException.ErrorCode.ARGUMENT_TO_ARITHMETIC_OPERATOR_IS_OF_COMPLEX_TYPE);
 
-        final Optional<LogicalOperator> logicalOperatorOptional = Enums.getIfPresent(LogicalOperator.class, functionName.toUpperCase(Locale.getDefault())).toJavaUtil();
+        final Optional<LogicalOperator> logicalOperatorOptional = Enums.getIfPresent(LogicalOperator.class, functionName.toUpperCase(Locale.ROOT)).toJavaUtil();
         Verify.verify(logicalOperatorOptional.isPresent());
         final LogicalOperator logicalOperator = logicalOperatorOptional.get();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CountValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CountValue.java
@@ -122,9 +122,9 @@ public class CountValue extends AbstractValue implements AggregateValue, Streama
     @Override
     public String explain(@Nonnull final Formatter formatter) {
         if (child != null) {
-            return operator.name().toLowerCase(Locale.getDefault()) + "(" + child.explain(formatter) + ")";
+            return operator.name().toLowerCase(Locale.ROOT) + "(" + child.explain(formatter) + ")";
         } else {
-            return operator.name().toLowerCase(Locale.getDefault()) + "()";
+            return operator.name().toLowerCase(Locale.ROOT) + "()";
         }
     }
 
@@ -163,7 +163,7 @@ public class CountValue extends AbstractValue implements AggregateValue, Streama
 
     @Override
     public String toString() {
-        return operator.name().toLowerCase(Locale.getDefault()) + "(" + child + ")";
+        return operator.name().toLowerCase(Locale.ROOT) + "(" + child + ")";
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
@@ -153,7 +153,7 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
 
     @Override
     public String toString() {
-        return operator.name().toLowerCase(Locale.getDefault()) + "(" + child + ")";
+        return operator.name().toLowerCase(Locale.ROOT) + "(" + child + ")";
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NumericAggregationValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NumericAggregationValue.java
@@ -117,7 +117,7 @@ public abstract class NumericAggregationValue extends AbstractValue implements V
     @Nonnull
     @Override
     public String explain(@Nonnull final Formatter formatter) {
-        return operator.name().toLowerCase(Locale.getDefault()) + child.explain(formatter) + ")";
+        return operator.name().toLowerCase(Locale.ROOT) + child.explain(formatter) + ")";
     }
 
     @Nonnull
@@ -150,7 +150,7 @@ public abstract class NumericAggregationValue extends AbstractValue implements V
 
     @Override
     public String toString() {
-        return operator.name().toLowerCase(Locale.getDefault()) + "(" + child + ")";
+        return operator.name().toLowerCase(Locale.ROOT) + "(" + child + ")";
     }
 
     @Override
@@ -187,7 +187,7 @@ public abstract class NumericAggregationValue extends AbstractValue implements V
         final Type type0 = arg0.getResultType();
         SemanticException.check(type0.isPrimitive(), SemanticException.ErrorCode.ARGUMENT_TO_ARITHMETIC_OPERATOR_IS_OF_COMPLEX_TYPE);
 
-        final Optional<LogicalOperator> logicalOperatorOptional = Enums.getIfPresent(LogicalOperator.class, functionName.toUpperCase(Locale.getDefault())).toJavaUtil();
+        final Optional<LogicalOperator> logicalOperatorOptional = Enums.getIfPresent(LogicalOperator.class, functionName.toUpperCase(Locale.ROOT)).toJavaUtil();
         Verify.verify(logicalOperatorOptional.isPresent());
         final LogicalOperator logicalOperator = logicalOperatorOptional.get();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
@@ -98,7 +98,7 @@ public class VariadicFunctionValue extends AbstractValue {
     @Nonnull
     @Override
     public String explain(@Nonnull final Formatter formatter) {
-        return operator.name().toLowerCase(Locale.getDefault()) + "(" + children.stream().map(c -> c.explain(formatter)).collect(Collectors.joining(",")) + ")";
+        return operator.name().toLowerCase(Locale.ROOT) + "(" + children.stream().map(c -> c.explain(formatter)).collect(Collectors.joining(",")) + ")";
     }
 
     @Nonnull
@@ -132,7 +132,7 @@ public class VariadicFunctionValue extends AbstractValue {
 
     @Override
     public String toString() {
-        return operator.name().toLowerCase(Locale.getDefault()) + "(" + children.stream().map(Object::toString).collect(Collectors.joining(",")) + ")";
+        return operator.name().toLowerCase(Locale.ROOT) + "(" + children.stream().map(Object::toString).collect(Collectors.joining(",")) + ")";
     }
 
     @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -857,7 +858,7 @@ public class MetaDataEvolutionValidatorTest {
         for (int i = 0; i < labels.size(); i++) {
             final int itr = i;
             final DescriptorProtos.FieldDescriptorProto.Label label = labels.get(itr);
-            final String labelText = label.name().substring(label.name().indexOf('_') + 1).toLowerCase();
+            final String labelText = label.name().substring(label.name().indexOf('_') + 1).toLowerCase(Locale.ROOT);
             final String errMsg = String.format("%s field is no longer %s", labelText, labelText);
             FileDescriptor updatedFile = mutateField("MySimpleRecord", "str_value_indexed", oldFile,
                     field -> field.setLabel(labels.get((itr + 1) % labels.size())));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/Commands.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/Commands.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -148,7 +149,7 @@ public class Commands {
                         final String transformName = words.get(2);
                         final Location location =
                                 words.size() == 4
-                                ? Enums.getIfPresent(Location.class, words.get(3).toUpperCase()).or(Location.BEGIN)
+                                ? Enums.getIfPresent(Location.class, words.get(3).toUpperCase(Locale.ROOT)).or(Location.BEGIN)
                                 : Location.BEGIN;
                         plannerRepl.addBreakPoint(new PlannerRepl.OnRuleBreakPoint(transformName, location));
                         return false;
@@ -162,7 +163,7 @@ public class Commands {
                         final String candidateMatchPrefix = words.get(2);
                         final Location location =
                                 words.size() == 4
-                                ? Enums.getIfPresent(Location.class, words.get(3).toUpperCase()).or(Location.BEGIN)
+                                ? Enums.getIfPresent(Location.class, words.get(3).toUpperCase(Locale.ROOT)).or(Location.BEGIN)
                                 : Location.BEGIN;
                         plannerRepl.addBreakPoint(new PlannerRepl.OnRuleCallBreakPoint(candidateMatchPrefix, location));
                         return false;
@@ -173,7 +174,7 @@ public class Commands {
 
                 if ("YIELD".equals(word1)) {
                     if (words.size() == 4) {
-                        final String word2 = words.get(2).toUpperCase();
+                        final String word2 = words.get(2).toUpperCase(Locale.ROOT);
 
                         if ("EXP".equals(word2)) {
                             final String word3 = words.get(3);
@@ -181,7 +182,7 @@ public class Commands {
                                 plannerRepl.printlnError("invalid identifier");
                                 return false;
                             }
-                            plannerRepl.addBreakPoint(new PlannerRepl.OnYieldExpressionBreakPoint(word3.toLowerCase()));
+                            plannerRepl.addBreakPoint(new PlannerRepl.OnYieldExpressionBreakPoint(word3.toLowerCase(Locale.ROOT)));
                             return false;
                         }
 
@@ -223,7 +224,7 @@ public class Commands {
 
                 if (words.size() >= 3) {
                     // "break event_type [location | refId [location]]"
-                    final String word2 = words.get(2).toUpperCase();
+                    final String word2 = words.get(2).toUpperCase(Locale.ROOT);
 
                     Optional<Location> locationOptional = Enums.getIfPresent(Location.class, word2).toJavaUtil();
                     if (words.size() == 3 && locationOptional.isPresent()) {
@@ -237,8 +238,8 @@ public class Commands {
                         // "break event_type refId [location]"
                         if (words.size() >= 4) {
                             // "break event_type refId location"
-                            final String word3 = words.get(3).toUpperCase();
-                            locationOptional = Enums.getIfPresent(Location.class, word3.toUpperCase()).toJavaUtil();
+                            final String word3 = words.get(3).toUpperCase(Locale.ROOT);
+                            locationOptional = Enums.getIfPresent(Location.class, word3.toUpperCase(Locale.ROOT)).toJavaUtil();
                         } else {
                             // "break event_type refId"
                             locationOptional = Optional.empty();
@@ -523,7 +524,7 @@ public class Commands {
                 return false;
             }
 
-            final String word1 = words.get(1).toUpperCase();
+            final String word1 = words.get(1).toUpperCase(Locale.ROOT);
             final boolean identifiersProcessed = plannerRepl.processIdentifiers(word1,
                     expression -> expression.show(true),
                     reference -> reference.show(true),

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/DebuggerWithSymbolTables.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/DebuggerWithSymbolTables.java
@@ -37,6 +37,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -192,7 +193,7 @@ public class DebuggerWithSymbolTables implements Debugger {
     }
 
     boolean isValidEntityName(@Nonnull final String identifier) {
-        final String lowerCase = identifier.toLowerCase();
+        final String lowerCase = identifier.toLowerCase(Locale.ROOT);
         if (!lowerCase.startsWith("exp") &&
                 !lowerCase.startsWith("ref") &&
                 !lowerCase.startsWith("qun")) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
@@ -56,6 +56,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -330,7 +331,7 @@ public class PlannerRepl implements Debugger {
                                final Consumer<Reference> referenceConsumer,
                                final Consumer<Quantifier> quantifierConsumer) {
         final State state = getCurrentState();
-        final String upperCasePotentialIdentifier = potentialIdentifier.toUpperCase();
+        final String upperCasePotentialIdentifier = potentialIdentifier.toUpperCase(Locale.ROOT);
         if (upperCasePotentialIdentifier.startsWith("EXP")) {
             @Nullable final RelationalExpression expression = lookupInCache(state.getExpressionCache(), upperCasePotentialIdentifier, "EXP");
             if (expression == null) {
@@ -382,7 +383,7 @@ public class PlannerRepl implements Debugger {
     }
 
     boolean isValidEntityName(@Nonnull final String identifier) {
-        final String lowerCase = identifier.toLowerCase();
+        final String lowerCase = identifier.toLowerCase(Locale.ROOT);
         if (!lowerCase.startsWith("exp") &&
                 !lowerCase.startsWith("ref") &&
                 !lowerCase.startsWith("qun")) {
@@ -640,7 +641,7 @@ public class PlannerRepl implements Debugger {
         if (words.size() <= wordIndex) {
             return Optional.empty();
         }
-        final String commandToken = words.get(wordIndex).toUpperCase();
+        final String commandToken = words.get(wordIndex).toUpperCase(Locale.ROOT);
         return Optional.ofNullable(commandsMap.get(commandToken));
     }
 
@@ -756,7 +757,7 @@ public class PlannerRepl implements Debugger {
                                      @Nonnull final Location location) {
             super(event -> event.getShorthand() == shorthand && (location == Location.ANY || event.getLocation() == location));
             this.shorthand = shorthand;
-            this.referenceName = referenceName == null ? null : referenceName.toLowerCase();
+            this.referenceName = referenceName == null ? null : referenceName.toLowerCase(Locale.ROOT);
             this.location = location;
         }
 
@@ -792,11 +793,11 @@ public class PlannerRepl implements Debugger {
         public void onList(final PlannerRepl plannerRepl) {
             super.onList(plannerRepl);
             plannerRepl.print("; ");
-            plannerRepl.printKeyValue("shorthand", getShorthand().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
             if (getReferenceName() != null) {
-                plannerRepl.printKeyValue("reference", getReferenceName().toLowerCase() + "; ");
+                plannerRepl.printKeyValue("reference", getReferenceName().toLowerCase(Locale.ROOT) + "; ");
             }
-            plannerRepl.printKeyValue("location", getLocation().name().toLowerCase());
+            plannerRepl.printKeyValue("location", getLocation().name().toLowerCase(Locale.ROOT));
         }
 
         @Override
@@ -851,7 +852,7 @@ public class PlannerRepl implements Debugger {
             super.onList(plannerRepl);
             plannerRepl.print("; ");
             plannerRepl.printKeyValue("shorthand", Shorthand.RULECALL + "; ");
-            plannerRepl.printKeyValue("location", Location.END.name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("location", Location.END.name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("expression", expressionName);
         }
 
@@ -904,7 +905,7 @@ public class PlannerRepl implements Debugger {
             super.onList(plannerRepl);
             plannerRepl.print("; ");
             plannerRepl.printKeyValue("shorthand", Shorthand.RULECALL + "; ");
-            plannerRepl.printKeyValue("location", Location.END.name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("location", Location.END.name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("candidate", candidateName);
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/Processors.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/Processors.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import org.jline.reader.ParsedLine;
 
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -74,8 +75,8 @@ public class Processors {
     public static class ExecutingTaskProcessor implements Processor<ExecutingTaskEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final ExecutingTaskEvent event) {
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
-            plannerRepl.printlnKeyValue("shorthand", event.getShorthand().name().toLowerCase());
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("kind", event.getTask().getClass().getSimpleName());
             plannerRepl.printlnKeyValue("current root reference", "");
@@ -84,8 +85,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final ExecutingTaskEvent event) {
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("kind", event.getTask().getClass().getSimpleName() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()));
@@ -104,8 +105,8 @@ public class Processors {
     public static class OptimizeGroupProcessor implements Processor<OptimizeGroupEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final OptimizeGroupEvent event) {
-            plannerRepl.printlnKeyValue("shorthand", event.getShorthand().name().toLowerCase());
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
+            plannerRepl.printlnKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("current root reference", "");
             plannerRepl.printlnReference(event.getRootReference(), "  ");
@@ -115,8 +116,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final OptimizeGroupEvent event) {
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()) + "; ");
             plannerRepl.printKeyValue("group", plannerRepl.nameForObjectOrNotInCache(event.getCurrentReference()));
@@ -135,8 +136,8 @@ public class Processors {
     public static class ExploreExpressionProcessor implements Processor<ExploreExpressionEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final ExploreExpressionEvent event) {
-            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase());
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
+            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("current root reference", "");
             plannerRepl.printlnReference(event.getRootReference(), "  ");
@@ -147,8 +148,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final ExploreExpressionEvent event) {
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()) + "; ");
             plannerRepl.printKeyValue("group", plannerRepl.nameForObjectOrNotInCache(event.getCurrentReference()) + "; ");
@@ -168,8 +169,8 @@ public class Processors {
     public static class ExploreGroupProcessor implements Processor<ExploreGroupEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final ExploreGroupEvent event) {
-            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase());
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
+            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("current root reference", "");
             plannerRepl.printlnReference(event.getRootReference(), "  ");
@@ -179,8 +180,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final ExploreGroupEvent event) {
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()) + "; ");
             plannerRepl.printKeyValue("group", plannerRepl.nameForObjectOrNotInCache(event.getCurrentReference()));
@@ -199,8 +200,8 @@ public class Processors {
     public static class TransformProcessor implements Processor<TransformEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final TransformEvent event) {
-            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase());
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
+            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("current root reference", "");
             plannerRepl.printlnReference(event.getRootReference(), "  ");
@@ -217,8 +218,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final TransformEvent event) {
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()) + "; ");
             plannerRepl.printKeyValue("group", plannerRepl.nameForObjectOrNotInCache(event.getCurrentReference()) + "; ");
@@ -244,8 +245,8 @@ public class Processors {
     public static class TransformRuleCallProcessor implements Processor<TransformRuleCallEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final TransformRuleCallEvent event) {
-            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase());
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
+            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("current root reference", "");
             plannerRepl.printlnReference(event.getRootReference(), "  ");
@@ -273,8 +274,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final TransformRuleCallEvent event) {
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()) + "; ");
             plannerRepl.printKeyValue("group", plannerRepl.nameForObjectOrNotInCache(event.getCurrentReference()) + "; ");
@@ -300,8 +301,8 @@ public class Processors {
     public static class AdjustMatchProcessor implements Processor<AdjustMatchEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final AdjustMatchEvent event) {
-            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase());
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
+            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("current root reference", "");
             plannerRepl.printlnReference(event.getRootReference(), "  ");
@@ -313,8 +314,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final AdjustMatchEvent event) {
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()) + "; ");
             plannerRepl.printKeyValue("group", plannerRepl.nameForObjectOrNotInCache(event.getCurrentReference()) + "; ");
@@ -334,8 +335,8 @@ public class Processors {
     public static class OptimizeInputsProcessor implements Processor<OptimizeInputsEvent> {
         @Override
         public void onDetail(final PlannerRepl plannerRepl, final OptimizeInputsEvent event) {
-            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase());
-            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase());
+            plannerRepl.printlnKeyValue("event", event.getShorthand().name().toLowerCase(Locale.ROOT));
+            plannerRepl.printlnKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT));
             plannerRepl.printlnKeyValue("description", event.getDescription());
             plannerRepl.printlnKeyValue("current root reference", "");
             plannerRepl.printlnReference(event.getRootReference(), "  ");
@@ -346,8 +347,8 @@ public class Processors {
 
         @Override
         public void onList(final PlannerRepl plannerRepl, final OptimizeInputsEvent event) {
-            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase() + "; ");
-            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase() + "; ");
+            plannerRepl.printKeyValue("shorthand", event.getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
+            plannerRepl.printKeyValue("location", event.getLocation().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("description", event.getDescription() + "; ");
             plannerRepl.printKeyValue("root", plannerRepl.nameForObjectOrNotInCache(event.getRootReference()) + "; ");
             plannerRepl.printKeyValue("group", plannerRepl.nameForObjectOrNotInCache(event.getCurrentReference()) + "; ");

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighterTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighterTest.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -366,7 +367,7 @@ public class LuceneHighlighterTest {
     void highlightsSpecialCharacterPrefixSearch(String ignored, Analyzer queryAnalyzer, Analyzer indexAnalyzer, String specialCharacter) throws Exception {
         String text = String.format("Do we match special characters like %1$s even when its mashed together like %1$snoSpaces?", specialCharacter);
 
-        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", specialCharacter.toLowerCase()), 1);
+        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", specialCharacter.toLowerCase(Locale.ROOT)), 1);
         Assertions.assertEquals(2, result.getNumHighlights(), "Incorrect number of highlights!");
         Assertions.assertEquals("...like " + specialCharacter + " even...like " + specialCharacter + "noSpaces?", result.getSummarizedText(), "Incorrect summary string!");
         for (int i = 0; i < result.getNumHighlights(); i++) {
@@ -384,7 +385,7 @@ public class LuceneHighlighterTest {
     void highlightsSpecialCharacterTerm(String ignored, Analyzer queryAnalyzer, Analyzer indexAnalyzer, String specialCharacter) throws Exception {
         String text = String.format("Do we match special characters like %1$s even when its mashed together like %1$snoSpaces?", specialCharacter);
 
-        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s", specialCharacter.toLowerCase()), 1);
+        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s", specialCharacter.toLowerCase(Locale.ROOT)), 1);
         Assertions.assertEquals(1, result.getNumHighlights(), "Incorrect number of highlights!");
         Assertions.assertEquals("...like " + specialCharacter + " even...", result.getSummarizedText(), "Incorrect summary string!");
         for (int i = 0; i < result.getNumHighlights(); i++) {
@@ -405,7 +406,7 @@ public class LuceneHighlighterTest {
         String text = "This is a " + longTerm + "  I think, but maybe not also because things are weird";
 
         int maxTokenSize = getMaxTokenSize(queryAnalyzer);
-        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", longTerm.toLowerCase().substring(0, maxTokenSize - 1)), 1);
+        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", longTerm.toLowerCase(Locale.ROOT).substring(0, maxTokenSize - 1)), 1);
         Assertions.assertEquals(1, result.getNumHighlights(), "Incorrect number of highlights!");
         if ("Ngram".equals(name)) {
             Assertions.assertEquals("...a " + longTerm + "  ...", result.getSummarizedText(), "Incorrect summary string!");
@@ -439,7 +440,7 @@ public class LuceneHighlighterTest {
 
 
         final String prefix = longTerm.substring(0, 25);
-        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", prefix.toLowerCase()), 1);
+        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", prefix.toLowerCase(Locale.ROOT)), 1);
         Assertions.assertEquals(1, result.getNumHighlights(), "Incorrect number of highlights!");
 
 
@@ -473,7 +474,7 @@ public class LuceneHighlighterTest {
         String longTerm = "reallyLongTermWhichTakesHundredsAndHundredsNoIMeanItLotsAndLotsOfCharactersSoItWillExceedTheLimitOfOurConfigurations";
         String text = "This is a " + longTerm + "  I think, but maybe not also because things are weird";
 
-        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", longTerm.toLowerCase()), 1);
+        HighlightedTerm result = doHighlight(queryAnalyzer, indexAnalyzer, text, String.format("text:%s*", longTerm.toLowerCase(Locale.ROOT)), 1);
 
         int maxTokenSize = getMaxTokenSize(indexAnalyzer);
         if (maxTokenSize > 0) {


### PR DESCRIPTION
This updates a few calls to `toUpperCase()` and `toLowerCase()` to specify `Locale.ROOT` instead of `Locale.getDefault()`. This fixes an issue where different handling of `"i".toUpperCase()` or `"I".toLowerCase()` were resulting in the `ArithmeticValue` to not successfully encapsulate multiplication. For the record, it turns out we're already using a PMD rule that forces the user to specify a `Locale`, but it only checks that a locale was specified, not that the `Locale` is a specific value. Also, the PMD checks don't run on test code, which is why those classes in test logic were not specifying a locale at all.

This fixes #2750.