### PR TITLE
Resolve #2749: Allow Lucene block cache size to be configured.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Make Lucene block cache size configurable [(Issue #2749)](https://github.com/FoundationDB/fdb-record-layer/issues/2749)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -235,7 +235,7 @@ public class LuceneEvents {
         LUCENE_AGILE_COMMITS_TIME_QUOTA("lucene agile commits time quota", false),
         /** Count of times a rebalance was called. */
         LUCENE_REPARTITION_CALLS("Count of Lucene repartition calls", false),
-        /** Count of the number of times a block was removed from the block cache */
+        /** Count of the number of times a block was removed from the block cache. */
         LUCENE_BLOCK_CACHE_REMOVE("Count of blocks removed from cache", false);
 
         private final String title;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -234,8 +234,9 @@ public class LuceneEvents {
         /** Number of agile context commits after exceeding time quota. */
         LUCENE_AGILE_COMMITS_TIME_QUOTA("lucene agile commits time quota", false),
         /** Count of times a rebalance was called. */
-        LUCENE_REPARTITION_CALLS("Count of Lucene repartition calls", false)
-        ;
+        LUCENE_REPARTITION_CALLS("Count of Lucene repartition calls", false),
+        /** Count of the number of times a block was removed from the block cache */
+        LUCENE_BLOCK_CACHE_REMOVE("Count of blocks removed from cache", false);
 
         private final String title;
         private final boolean isSize;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene;
 
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyKey;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 
@@ -116,4 +117,8 @@ public final class LuceneRecordContextProperties {
      * Use "default transaction priority" during merge. The default of this prop is {@code true} because merge over multiple transactions may be preventing user operations.
      */
     public static final RecordLayerPropertyKey<Boolean> LUCENE_USE_DEFAULT_PRIORITY_DURING_MERGE = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.useDefaultPriorityDuringMerge", true);
+    /**
+     * Lucene block cache maximum size. At most these many blocks will be stored in cache.
+     */
+    public static final RecordLayerPropertyKey<Integer> LUCENE_BLOCK_CACHE_MAXIMUM_SIZE = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.block.cache.size", FDBDirectory.DEFAULT_BLOCK_CACHE_MAXIMUM_SIZE);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -484,6 +484,7 @@ public class FDBDirectory extends Directory  {
     }
 
     @Nonnull
+    @SuppressWarnings("PMD.PreserveStackTrace")
     private CompletableFuture<byte[]> readBlock(@Nonnull IndexInput requestingInput, @Nonnull String fileName,
                                                 @Nullable FDBLuceneFileReference reference, int block) {
         if (LOGGER.isTraceEnabled()) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -114,7 +115,7 @@ import static org.apache.lucene.codecs.lucene86.Lucene86SegmentInfoFormat.SI_EXT
 public class FDBDirectory extends Directory  {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDirectory.class);
     public static final int DEFAULT_BLOCK_SIZE = 1_024;
-    public static final int DEFAULT_MAXIMUM_SIZE = 1024;
+    public static final int DEFAULT_BLOCK_CACHE_MAXIMUM_SIZE = 1024;
     public static final int DEFAULT_CONCURRENCY_LEVEL = 16;
     public static final int DEFAULT_INITIAL_CAPACITY = 128;
     private static final int SEQUENCE_SUBSPACE = 0;
@@ -190,12 +191,19 @@ public class FDBDirectory extends Directory  {
                         @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey,
                         boolean deferDeleteToCompoundFile, AgilityContext agilityContext) {
         this(subspace, indexOptions, sharedCacheManager, sharedCacheKey, agilityContext,
-                DEFAULT_BLOCK_SIZE, DEFAULT_INITIAL_CAPACITY, DEFAULT_MAXIMUM_SIZE, DEFAULT_CONCURRENCY_LEVEL, deferDeleteToCompoundFile);
+                DEFAULT_BLOCK_SIZE, DEFAULT_INITIAL_CAPACITY, DEFAULT_BLOCK_CACHE_MAXIMUM_SIZE, DEFAULT_CONCURRENCY_LEVEL, deferDeleteToCompoundFile);
+    }
+
+    public FDBDirectory(@Nonnull Subspace subspace, @Nullable Map<String, String> indexOptions,
+                        @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey,
+                        boolean deferDeleteToCompoundFile, AgilityContext agilityContext, int blockCacheMaximumSize) {
+        this(subspace, indexOptions, sharedCacheManager, sharedCacheKey, agilityContext,
+                DEFAULT_BLOCK_SIZE, DEFAULT_INITIAL_CAPACITY, blockCacheMaximumSize, DEFAULT_CONCURRENCY_LEVEL, deferDeleteToCompoundFile);
     }
 
     private FDBDirectory(@Nonnull Subspace subspace, @Nullable Map<String, String> indexOptions,
                          @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey, AgilityContext agilityContext,
-                         int blockSize, final int initialCapacity, final int maximumSize, final int concurrencyLevel,
+                         int blockSize, final int initialCapacity, final int blockCacheMaximumSize, final int concurrencyLevel,
                          boolean deferDeleteToCompoundFile) {
         this.agilityContext = agilityContext;
         this.indexOptions = indexOptions == null ? Collections.emptyMap() : indexOptions;
@@ -213,8 +221,9 @@ public class FDBDirectory extends Directory  {
         this.blockCache = CacheBuilder.newBuilder()
                 .concurrencyLevel(concurrencyLevel)
                 .initialCapacity(initialCapacity)
-                .maximumSize(maximumSize)
+                .maximumSize(blockCacheMaximumSize)
                 .recordStats()
+                .removalListener(notification -> cacheRemovalCallback())
                 .build();
         this.fileSequenceCounter = new AtomicLong(-1);
         this.compressionEnabled = Objects.requireNonNullElse(agilityContext.getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_COMPRESSION_ENABLED), false);
@@ -225,6 +234,10 @@ public class FDBDirectory extends Directory  {
         this.sharedCachePending = sharedCacheManager != null && sharedCacheKey != null;
         this.fieldInfosStorage = new FieldInfosStorage(this);
         this.deferDeleteToCompoundFile = deferDeleteToCompoundFile;
+    }
+
+    private void cacheRemovalCallback() {
+        agilityContext.increment(LuceneEvents.Counts.LUCENE_BLOCK_CACHE_REMOVE);
     }
 
     private long deserializeFileSequenceCounter(@Nullable byte[] value) {
@@ -485,23 +498,28 @@ public class FDBDirectory extends Directory  {
             return exceptionalFuture;
         }
         final long id = reference.getId();
-        return agilityContext.instrument(LuceneEvents.Events.LUCENE_READ_BLOCK, blockCache.asMap().computeIfAbsent(ComparablePair.of(id, block), ignore -> {
-                    if (sharedCache == null) {
-                        return readData(id, block);
-                    }
-                    final byte[] fromShared = sharedCache.getBlockIfPresent(id, block);
-                    if (fromShared != null) {
-                        agilityContext.increment(LuceneEvents.Counts.LUCENE_SHARED_CACHE_HITS);
-                        return CompletableFuture.completedFuture(fromShared);
-                    } else {
-                        agilityContext.increment(LuceneEvents.Counts.LUCENE_SHARED_CACHE_MISSES);
-                        return readData(id, block).thenApply(data -> {
-                            sharedCache.putBlockIfAbsent(id, block, data);
-                            return data;
-                        });
-                    }
+        try {
+            return agilityContext.instrument(LuceneEvents.Events.LUCENE_READ_BLOCK, blockCache.get(ComparablePair.of(id, block), () -> {
+                if (sharedCache == null) {
+                    return readData(id, block);
                 }
-                ));
+                final byte[] fromShared = sharedCache.getBlockIfPresent(id, block);
+                if (fromShared != null) {
+                    agilityContext.increment(LuceneEvents.Counts.LUCENE_SHARED_CACHE_HITS);
+                    return CompletableFuture.completedFuture(fromShared);
+                } else {
+                    agilityContext.increment(LuceneEvents.Counts.LUCENE_SHARED_CACHE_MISSES);
+                    return readData(id, block).thenApply(data -> {
+                        sharedCache.putBlockIfAbsent(id, block, data);
+                        return data;
+                    });
+                }
+                    }
+            ));
+        } catch (ExecutionException e) {
+            // This would happen when the cache.get() fails to execute the lambda (not when the block's future is joined)
+            throw new RecordCoreException(e.getCause());
+        }
     }
 
     private CompletableFuture<byte[]> readData(long id, int block) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -287,12 +287,16 @@ public class FDBDirectoryManager implements AutoCloseable {
 
     private FDBDirectoryWrapper getDirectoryWrapper(@Nullable Tuple groupingKey, @Nullable Integer partitionId, final AgilityContext agilityContext) {
         final Tuple mapKey = getDirectoryKey(groupingKey, partitionId);
-        return createdDirectories.computeIfAbsent(mapKey, key -> new FDBDirectoryWrapper(state, key, mergeDirectoryCount, agilityContext));
+        return createdDirectories.computeIfAbsent(mapKey, key -> new FDBDirectoryWrapper(state, key, mergeDirectoryCount, agilityContext, getBlockCacheMaximumSize()));
     }
 
     public FDBDirectoryWrapper createDirectoryWrapper(@Nullable Tuple groupingKey, @Nullable Integer partitionId,
                                                       final AgilityContext agilityContext) {
-        return new FDBDirectoryWrapper(state, getDirectoryKey(groupingKey, partitionId), mergeDirectoryCount, agilityContext);
+        return new FDBDirectoryWrapper(state, getDirectoryKey(groupingKey, partitionId), mergeDirectoryCount, agilityContext, getBlockCacheMaximumSize());
+    }
+
+    private int getBlockCacheMaximumSize() {
+        return state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_BLOCK_CACHE_MAXIMUM_SIZE);
     }
 
     private static Tuple getDirectoryKey(final @Nullable Tuple groupingKey, final @Nullable Integer partitionId) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -76,14 +76,14 @@ public class FDBDirectoryWrapper implements AutoCloseable {
     @SuppressWarnings({"squid:S3077"}) // object is thread safe, so use of volatile to control instance creation is correct
     private volatile DirectoryReader writerReader;
 
-    FDBDirectoryWrapper(IndexMaintainerState state, Tuple key, int mergeDirectoryCount, final AgilityContext agilityContext) {
+    FDBDirectoryWrapper(IndexMaintainerState state, Tuple key, int mergeDirectoryCount, final AgilityContext agilityContext, final int blockCacheMaximumSize) {
         final Subspace subspace = state.indexSubspace.subspace(key);
         final FDBDirectorySharedCacheManager sharedCacheManager = FDBDirectorySharedCacheManager.forContext(state.context);
         final Tuple sharedCacheKey = sharedCacheManager == null ? null :
                                      (sharedCacheManager.getSubspace() == null ? state.store.getSubspace() : sharedCacheManager.getSubspace()).unpack(subspace.pack());
         this.state = state;
         this.key = key;
-        this.directory = new FDBDirectory(subspace, state.index.getOptions(), sharedCacheManager, sharedCacheKey, USE_COMPOUND_FILE, agilityContext);
+        this.directory = new FDBDirectory(subspace, state.index.getOptions(), sharedCacheManager, sharedCacheKey, USE_COMPOUND_FILE, agilityContext, blockCacheMaximumSize);
         this.agilityContext = agilityContext;
         this.mergeDirectoryCount = mergeDirectoryCount;
     }


### PR DESCRIPTION
Allow Lucene block cache size to be configured.
Use the cache's native get(provider) to allow stats.
Add cache removal counter.