### PR TITLE
Resolves #2754: FDBDirectoryLock won't fail if flushed in close

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 
 * **Bug fix** The `ArithmeticValue` and `NumericAggregationValue` classes now uses a fixed `Locale` with `toUpperCase` when encapsulating a specified function by name to avoid mismatches when running in the Turkish locale [(Issue #2750)](https://github.com/FoundationDB/fdb-record-layer/issues/2750)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** FDBDirectoryLock won't fail if AgilityContext is flushed while closing [(Issue #2754)](https://github.com/FoundationDB/fdb-record-layer/issues/2754)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Inconsistent nullability status for Array's element type [(Issue #2732)](https://github.com/FoundationDB/fdb-record-layer/issues/2737)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -145,7 +145,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             return aContext.ensureActive().get(fileLockKey)
                     .thenAccept(val -> {
                         synchronized (fileLockSetLock) {
-                            if (isHeartbeat && aContext == closingContext) {
+                            if (isHeartbeat && aContext.equals(closingContext)) {
                                 // we are in a context which has already cleared this lock, the value should be null
                                 if (val != null) {
                                     long existingTimeStamp = fileLockValueToTimestamp(val);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -294,26 +294,31 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
 
 
     static Stream<Arguments> flakyMergeArguments() {
+        // because some of these require @SuperSlow, flakyMerge quick covers an example that we can comfortably put in
+        // PRB
         return Stream.concat(
-                Stream.of(
-                        Arguments.of(true, true, true, 31, -644766138635622644L, true)),
-                Stream.concat(
-                        // all of these permutations take multiple minutes, but probably are not all needed as part of
-                        // PRB, so put 3 fixed configuration that we know will fail merges in a variety of places into
-                        // the nightly build
-                        TestConfigurationUtils.onlyNightly(
-                                Stream.of(
-                                        Arguments.of(true, false, false, 50, 9237590782644L, true),
-                                        Arguments.of(false, true, true, 33, -1089113174774589435L, true),
-                                        Arguments.of(false, false, false, 35, 6223372946177329440L, true))
-                        ),
-                        RandomizedTestUtils.randomArguments(random ->
-                                Arguments.of(random.nextBoolean(), // isGrouped
-                                        random.nextBoolean(), // isSynthetic
-                                        random.nextBoolean(), // primaryKeySegmentIndexEnabled
-                                        random.nextInt(40) + 2, // minDocumentCount
-                                        random.nextLong(), // seed for other randomness
-                                        false)))); // require failure
+                // all of these permutations take multiple minutes, but probably are not all needed as part of
+                // PRB, so put 3 fixed configuration that we know will fail merges in a variety of places into
+                // the nightly build
+                TestConfigurationUtils.onlyNightly(
+                        Stream.of(
+                                Arguments.of(true, false, false, 50, 9237590782644L, true),
+                                Arguments.of(false, true, true, 33, -1089113174774589435L, true),
+                                Arguments.of(false, false, false, 35, 6223372946177329440L, true))
+                ),
+                RandomizedTestUtils.randomArguments(random ->
+                        Arguments.of(random.nextBoolean(), // isGrouped
+                                random.nextBoolean(), // isSynthetic
+                                random.nextBoolean(), // primaryKeySegmentIndexEnabled
+                                random.nextInt(40) + 2, // minDocumentCount
+                                random.nextLong(), // seed for other randomness
+                                false))); // require failure
+    }
+
+    @Test
+    @Tag(Tags.Slow)
+    void flakyMergeQuick() throws IOException {
+        flakyMerge(true, true, true, 31, -644766138635622644L, true);
     }
 
     /**
@@ -329,7 +334,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
      */
     @ParameterizedTest(name = "flakyMerge({argumentsWithNames})")
     @MethodSource("flakyMergeArguments")
-    @Tag(Tags.Slow)
+    @SuperSlow
     void flakyMerge(boolean isGrouped,
                     boolean isSynthetic,
                     boolean primaryKeySegmentIndexEnabled,

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
@@ -153,7 +153,7 @@ class FDBDirectoryLockTest {
         // This test simulates the situation where the AgilityContext flushes as part of the call to clear
         final String lockName = "file.lock";
         try (FDBRecordContext context = fdb.openContext()) {
-            AgilityContext agilityContext = AgilityContext.agile(context, 0, 0);
+            AgilityContext agilityContext = AgilityContext.agile(context, -5, 0);
             FDBDirectory directory = createDirectory(agilityContext);
             try {
                 final Lock lock1 = directory.obtainLock(lockName);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -75,7 +76,7 @@ class FDBDirectoryLockTest {
                     AgilityContext.agile(context, 1000, 100_0000) :
                     AgilityContext.nonAgile(context);
 
-            FDBDirectory directory = new FDBDirectory(subspace, null, null, null, true, agilityContext);
+            FDBDirectory directory = createDirectory(agilityContext);
             String lockName = "file.lock";
             String alreadyLockedMessage = "FileLock: Lock failed: already locked by another entity";
             final Lock lock1 = directory.obtainLock(lockName);
@@ -100,7 +101,7 @@ class FDBDirectoryLockTest {
         try (FDBRecordContext context = fdb.openContext()) {
             AgilityContext agilityContext = AgilityContext.agile(context, 1000, 100_0000);
 
-            FDBDirectory directory = new FDBDirectory(subspace, null, null, null, true, agilityContext);
+            FDBDirectory directory = createDirectory(agilityContext);
             final String lockName = "file.lock";
             final Lock lock1 = directory.obtainLock(lockName);
             final String string1 = lock1.toString();
@@ -130,6 +131,46 @@ class FDBDirectoryLockTest {
         }
     }
 
+    @Test
+    void testFileLockCallbackFrequently() throws IOException {
+        // This test simulates the situation where the AgilityContext flushes as part of the call to clear
+        final String lockName = "file.lock";
+        try (FDBRecordContext context = fdb.openContext()) {
+            AgilityContext agilityContext = AgilityContext.agile(context, 0, 0);
+            try (FDBDirectory directory = createDirectory(agilityContext)) {
+                final Lock lock1 = directory.obtainLock(lockName);
+                lock1.close();
+            }
+            agilityContext.flushAndClose();
+        }
+
+        assertCanObtainLock(lockName);
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    void testFileLockCallbackFrequentlyLost(boolean clearLock) throws IOException {
+        // This test simulates the situation where the AgilityContext flushes as part of the call to clear
+        final String lockName = "file.lock";
+        try (FDBRecordContext context = fdb.openContext()) {
+            AgilityContext agilityContext = AgilityContext.agile(context, 0, 0);
+            FDBDirectory directory = createDirectory(agilityContext);
+            try {
+                final Lock lock1 = directory.obtainLock(lockName);
+                if (clearLock) {
+                    forceClearLock(lockName);
+                } else {
+                    forceStealLock(lockName);
+                }
+                assertThrows(AlreadyClosedException.class, lock1::close);
+            } finally {
+                assertThrows(AlreadyClosedException.class, directory::close);
+            }
+            agilityContext.abortAndClose();
+        }
+        assertCanObtainLock(lockName);
+    }
+
     @ParameterizedTest
     @CsvSource({"true,true", "true,false", "false,true", "false,false"})
     void testFileLockClose(boolean useAgile, boolean abortAgilityContext) throws IOException {
@@ -141,7 +182,7 @@ class FDBDirectoryLockTest {
                         AgilityContext.agile(context, 1000, 100_0000) :
                         AgilityContext.nonAgile(context);
 
-                FDBDirectory directory = new FDBDirectory(subspace, null, null, null, true, agilityContext);
+                FDBDirectory directory = createDirectory(agilityContext);
                 String lockName = "file.lock";
                 final Lock lock1 = directory.obtainLock(lockName);
                 lock1.ensureValid();
@@ -157,5 +198,44 @@ class FDBDirectoryLockTest {
                 context.commit();
             }
         }
+    }
+
+    private void assertCanObtainLock(final String lockName) throws IOException {
+        try (FDBRecordContext context = fdb.openContext()) {
+            AgilityContext agilityContext = AgilityContext.nonAgile(context);
+            try (FDBDirectory directory = createDirectory(agilityContext)) {
+                directory.obtainLock(lockName).close(); // should be able to obtain the lock
+            }
+            agilityContext.abortAndClose();
+        }
+    }
+
+    private void forceClearLock(final String lockName) {
+        try (FDBRecordContext context = fdb.openContext()) {
+            final AgilityContext agilityContext = AgilityContext.nonAgile(context);
+            try (FDBDirectory directory2 = createDirectory(agilityContext)) {
+                agilityContext.accept(context2 -> {
+                    context2.ensureActive().clear(directory2.fileLockKey(lockName));
+                });
+            }
+            context.commit();
+        }
+    }
+
+    private void forceStealLock(final String lockName) throws IOException {
+        try (FDBRecordContext context = fdb.openContext()) {
+            final AgilityContext agilityContext = AgilityContext.nonAgile(context);
+            try (FDBDirectory directory = createDirectory(agilityContext)) {
+                agilityContext.accept(context2 -> {
+                    context2.ensureActive().clear(directory.fileLockKey(lockName));
+                });
+                directory.obtainLock(lockName);
+            }
+            context.commit();
+        }
+    }
+
+    private @Nonnull FDBDirectory createDirectory(final AgilityContext agilityContext) {
+        return new FDBDirectory(subspace, null, null, null, true, agilityContext);
     }
 }


### PR DESCRIPTION
Previously, if the context that was clearing the lock was flushed, the commit check would fail because the lock is missing. It now protects against this.
This also means that LuceneIndexMaintenanceTest.flakyMerge is no longer flaky.