### PR TITLE
Resolve #2765: Index Scrubbing: support cleanup when dangling index entries are expected

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -31,7 +31,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
++* **Feature** Index Scrubbing: support cleanup when dangling index entries are expected [(Issue #2765)](https://github.com/FoundationDB/fdb-record-layer/issues/2765)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -67,6 +67,7 @@ public class IndexingCommon {
 
     @Nonnull private Collection<RecordType> allRecordTypes;
     @Nonnull private final List<IndexContext> targetIndexContexts;
+    private int enforcedDelayMilliseconds = 0;
     /**
      * Constant indicating that there should be no limit to some usually limited operation.
      */
@@ -304,5 +305,19 @@ public class IndexingCommon {
         if (synchronizedSessionRunner != null) {
             synchronizedSessionRunner.close();
         }
+    }
+
+    public void enforceThrottleDelayMilliseconds(int delay, int estimatedTimeSpentMillis) {
+        if (useSynchronizedSession && delay > (leaseLengthMillis - estimatedTimeSpentMillis)) {
+            // Prefer disobeying the delay over loosing the sync lock
+            delay = (int) (leaseLengthMillis - estimatedTimeSpentMillis);
+        }
+        enforcedDelayMilliseconds = delay;
+    }
+
+    public int getResetEnforcedDelayMilliseconds() {
+        final int delay = enforcedDelayMilliseconds;
+        enforcedDelayMilliseconds = 0;
+        return delay;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -106,6 +106,7 @@ public class IndexingScrubMissing extends IndexingBase {
                         .build();
     }
 
+    @Override
     protected boolean shouldResetRecordScrubbingRange() {
         return scrubbingPolicy.isFullScan();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -106,6 +106,11 @@ public class IndexingScrubMissing extends IndexingBase {
                         .build();
     }
 
+    protected boolean shouldResetRecordScrubbingRange() {
+        return scrubbingPolicy.isFullScan();
+    }
+
+
     @Override
     CompletableFuture<Void> buildIndexInternalAsync() {
         return getRunner().runAsync(context ->

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -103,6 +103,13 @@ public class IndexingThrottle {
             // - For simplicity and locality, assume that the next chunk starts at nowMillis+waitMillis
             // - Avoiding negative delta and restricting toWait's range implies self initialization
             // - Ignore failed transactions (they should be rare, and limited in number)
+            final int enforcedDelay = common.getResetEnforcedDelayMilliseconds();
+            if (enforcedDelay > 0) {
+                // Here: The end module decided to override potential throttle delay. Respect it.
+                recordsScannedSinceForcedDelayMilliSeconds = 0;
+                forcedDelayTimestampMilliSeconds = 0;
+                return enforcedDelay;
+            }
             int recordsPerSecond = common.config.getRecordsPerSecond();
             if (recordsPerSecond == IndexingCommon.UNLIMITED) {
                 // in case config loader changes this value from UNLIMITED to limit

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -142,19 +142,23 @@ public class OnlineIndexScrubber implements AutoCloseable {
      * A builder for the scrubbing policy.
      */
     public static class ScrubbingPolicy {
-        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, true, 0, false);
+        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, true, 0, false, false, 0);
         private final int logWarningsLimit;
         private final boolean allowRepair;
         private final long entriesScanLimit;
         private final boolean ignoreIndexTypeCheck;
+        private final boolean fullScan;
+        private final int maxDeletesPerSecond;
 
         public ScrubbingPolicy(int logWarningsLimit, boolean allowRepair, long entriesScanLimit,
-                               boolean ignoreIndexTypeCheck) {
+                               boolean ignoreIndexTypeCheck, boolean fullScan, int maxDeletesPerSecond) {
 
             this.logWarningsLimit = logWarningsLimit;
             this.allowRepair = allowRepair;
             this.entriesScanLimit = entriesScanLimit;
             this.ignoreIndexTypeCheck = ignoreIndexTypeCheck;
+            this.fullScan = fullScan;
+            this.maxDeletesPerSecond = maxDeletesPerSecond;
         }
 
         boolean allowRepair() {
@@ -171,6 +175,14 @@ public class OnlineIndexScrubber implements AutoCloseable {
 
         public int getLogWarningsLimit() {
             return logWarningsLimit;
+        }
+
+        public boolean isFullScan() {
+            return fullScan;
+        }
+
+        public int getMaxDeletesPerSecond() {
+            return maxDeletesPerSecond;
         }
 
         /**
@@ -196,6 +208,8 @@ public class OnlineIndexScrubber implements AutoCloseable {
             boolean allowRepair = true;
             long entriesScanLimit = 0;
             boolean ignoreIndexTypeCheck = false;
+            boolean fullScan = false;
+            int maxDeletesPerSecond = 0;
 
             protected Builder() {
             }
@@ -254,8 +268,18 @@ public class OnlineIndexScrubber implements AutoCloseable {
                 return this;
             }
 
+            public Builder setFullScan(final boolean fullScan) {
+                this.fullScan = fullScan;
+                return this;
+            }
+
+            public Builder setMaxDeletesPerSecond(final int maxDeletesPerSecond) {
+                this.maxDeletesPerSecond = maxDeletesPerSecond;
+                return this;
+            }
+
             public ScrubbingPolicy build() {
-                return new ScrubbingPolicy(logWarningsLimit, allowRepair, entriesScanLimit, ignoreIndexTypeCheck);
+                return new ScrubbingPolicy(logWarningsLimit, allowRepair, entriesScanLimit, ignoreIndexTypeCheck, fullScan, maxDeletesPerSecond);
             }
         }
     }


### PR DESCRIPTION
Support users who wish to use a "lazy delete" - which clears the record in foreground, then let a background index scrubbing task clear the dangling index entries. This requires: 
1. Set full scan (new API) 
2. Set deletes/second limit (new API - required to avoid flooding the DB) 
3. Avoid warning (existing API) 