### PR TITLE
improvements to semantic equals

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexPredicate.java
@@ -217,7 +217,7 @@ public abstract class IndexPredicate {
         @Nonnull
         @Override
         public QueryPredicate toPredicate(@Nonnull final Value value) {
-            return com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate.andOrTrue(children.stream().map(c -> c.toPredicate(value)).collect(Collectors.toList()));
+            return com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate.and(children.stream().map(c -> c.toPredicate(value)).collect(Collectors.toList()));
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -1235,7 +1235,7 @@ public class Comparisons {
             // graph.
             //
             if (isCorrelation() && that.isCorrelation()) {
-                return aliasMap.containsMapping(getAlias(), that.getAlias());
+                return getAlias().equals(that.getAlias()) || aliasMap.containsMapping(getAlias(), that.getAlias());
             }
 
             if (!getParameter().equals(that.getParameter())) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
@@ -111,7 +111,7 @@ public class QueryPlanConstraint implements PlanHashable, PlanSerializable {
 
     @Nonnull
     public static QueryPlanConstraint composeConstraints(@Nonnull final Collection<QueryPlanConstraint> constraints) {
-        return new QueryPlanConstraint(AndPredicate.andOrTrue(constraints.stream().map(QueryPlanConstraint::getPredicate).collect(Collectors.toList())));
+        return new QueryPlanConstraint(AndPredicate.and(constraints.stream().map(QueryPlanConstraint::getPredicate).collect(Collectors.toList())));
     }
 
     @Nonnull
@@ -121,7 +121,7 @@ public class QueryPlanConstraint implements PlanHashable, PlanSerializable {
 
     @Nonnull
     public static QueryPlanConstraint ofPredicates(@Nonnull final Collection<QueryPredicate> predicates) {
-        return new QueryPlanConstraint(AndPredicate.andOrTrue(predicates));
+        return new QueryPlanConstraint(AndPredicate.and(predicates));
     }
 
     @Nonnull
@@ -167,7 +167,7 @@ public class QueryPlanConstraint implements PlanHashable, PlanSerializable {
         public QueryPlanConstraint getConstraint(@Nonnull final RecordQueryPlan plan) {
             visit(plan);
             final var constraints = builder.build();
-            return QueryPlanConstraint.ofPredicate(AndPredicate.andOrTrue(constraints.stream().map(QueryPlanConstraint::getPredicate).collect(Collectors.toList())));
+            return QueryPlanConstraint.ofPredicate(AndPredicate.and(constraints.stream().map(QueryPlanConstraint::getPredicate).collect(Collectors.toList())));
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
@@ -92,6 +92,11 @@ public class QueryPlanConstraint implements PlanHashable, PlanSerializable {
     }
 
     @Nonnull
+    public QueryPlanConstraint compose(@Nonnull final QueryPlanConstraint otherQueryPlanConstraint) {
+        return compose(ImmutableList.of(this, otherQueryPlanConstraint));
+    }
+
+    @Nonnull
     @Override
     public PQueryPlanConstraint toProto(@Nonnull final PlanSerializationContext serializationContext) {
         return PQueryPlanConstraint.newBuilder().setPredicate(predicate.toQueryPredicateProto(serializationContext)).build();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanConstraint.java
@@ -93,7 +93,7 @@ public class QueryPlanConstraint implements PlanHashable, PlanSerializable {
 
     @Nonnull
     public QueryPlanConstraint compose(@Nonnull final QueryPlanConstraint otherQueryPlanConstraint) {
-        return compose(ImmutableList.of(this, otherQueryPlanConstraint));
+        return composeConstraints(ImmutableList.of(this, otherQueryPlanConstraint));
     }
 
     @Nonnull
@@ -110,7 +110,7 @@ public class QueryPlanConstraint implements PlanHashable, PlanSerializable {
     }
 
     @Nonnull
-    public static QueryPlanConstraint compose(@Nonnull final Collection<QueryPlanConstraint> constraints) {
+    public static QueryPlanConstraint composeConstraints(@Nonnull final Collection<QueryPlanConstraint> constraints) {
         return new QueryPlanConstraint(AndPredicate.andOrTrue(constraints.stream().map(QueryPlanConstraint::getPredicate).collect(Collectors.toList())));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/BooleanWithConstraint.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/BooleanWithConstraint.java
@@ -1,0 +1,217 @@
+/*
+ * BooleanWithConstraint.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A boolean container that can if the boolean is true carry a {@link QueryPlanConstraint}.
+ * <br>
+ * The meaning of an object of this class is:
+ * <ul>
+ *     <li>The boolean is {@code false} (there is no constraint).</li>
+ *     <li>
+ *         The boolean is {@code true} under the condition that the recorded {@link QueryPlanConstraint}
+ *         evaluates to {@code true}.
+ *     </li>
+ * </ul>
+ * Note that the {@link QueryPlanConstraint} can be {@link QueryPlanConstraint#tautology()} which means that this
+ * boolean is effectively unconditionally true. {@link QueryPlanConstraint}s are usually proven to be true for this
+ * invocation of the planner but refer to an external environment that may change if a plan were to be re-executed in
+ * a different environment.
+ * <br>
+ * This class is a monad which conceptually wraps around a boolean and a {@link QueryPlanConstraint}. There are two
+ * combinators {@link #composeWithOther(BooleanWithConstraint)} and {@link #filter(Predicate)}.
+ */
+public class BooleanWithConstraint {
+    private static final BooleanWithConstraint FALSE = new BooleanWithConstraint(null);
+    private static final BooleanWithConstraint ALWAYS_TRUE = new BooleanWithConstraint(QueryPlanConstraint.tautology());
+
+    /**
+     * The query plan constraint recorded for this boolean. By convention, if this field is equal to {@code null} this
+     * boolean is considered to be {@code false}, it is {@code true} otherwise.
+     */
+    @Nullable
+    private final QueryPlanConstraint queryPlanConstraint;
+
+    private BooleanWithConstraint(@Nullable final QueryPlanConstraint queryPlanConstraint) {
+        this.queryPlanConstraint = queryPlanConstraint;
+    }
+
+    /**
+     * Returns iff this boolean is considered to be true.
+     *
+     * @return {@code true} if this boolean is true, {@code false} otherwise.
+     */
+    public boolean isTrue() {
+        return queryPlanConstraint != null;
+    }
+
+    /**
+     * Returns iff this boolean is considered to be false. This method is just provided to avoid {@code !isTrue()} in
+     * client code.
+     *
+     * @return {@code true} if this boolean is false, {@code false} otherwise.
+     */
+    public boolean isFalse() {
+        return !isTrue();
+    }
+
+    @Nonnull
+    public QueryPlanConstraint getConstraint() {
+        return Objects.requireNonNull(queryPlanConstraint);
+    }
+
+    /**
+     * Method to compose this boolean with another {@link BooleanWithConstraint}.
+     * @param other another {@link BooleanWithConstraint}
+     * @return a new {@link BooleanWithConstraint} that is {@code false} if {@code this} or {@code other} is false,
+     *         and that is {@code true} otherwise under the composed constraint from the constraint of {@code this} and
+     *         the constraint of {@code other}
+     */
+    @Nonnull
+    public BooleanWithConstraint composeWithOther(@Nonnull final BooleanWithConstraint other) {
+        if (other.isFalse()) {
+            return falseValue();
+        }
+
+        return composeWithConstraint(other.getConstraint());
+    }
+
+    /**
+     * Method to compose this boolean with a {@link QueryPlanConstraint}. It is assumed that the caller just wants to
+     * strengthen the constraint already recorded in {@code this}.
+     * @param constraint a {@link QueryPlanConstraint}
+     * @return a new {@link BooleanWithConstraint} that is {@code false} if {@code this} is false,
+     *         and that is {@code true} otherwise under the composed constraint from the constraint of {@code this} and
+     *         the {@code constraint}
+     */
+    @Nonnull
+    public BooleanWithConstraint composeWithConstraint(@Nonnull final QueryPlanConstraint constraint) {
+        if (!this.isTrue()) {
+            return falseValue();
+        }
+
+        return trueWithConstraint(Objects.requireNonNull(queryPlanConstraint).compose(constraint));
+    }
+
+    /**
+     * Monadic method to filter {@code this} by applying a {@link Predicate} to the recorded plan constraint if
+     * applicable.
+     * @param predicate to be applied as filter
+     * @return {@link BooleanWithConstraint#falseValue()} if {@link #isFalse()} is true or the {@link Predicate}
+     *         evaluates to {@code false}, {@code this} otherwise
+     */
+    @Nonnull
+    public BooleanWithConstraint filter(@Nonnull final Predicate<? super QueryPlanConstraint> predicate) {
+        if (isFalse() || !predicate.test(getConstraint())) {
+            return falseValue();
+        }
+        return this;
+    }
+
+    /**
+     * Helper method to interface with {@link Optional}s. A mapper that is passed in by the client to map the
+     * recorded {@link QueryPlanConstraint} to an object of a type {@code U} which is applied when {@code this} object
+     * is transformed to an {@link Optional}.
+     * @param mapper a function to map from {@link QueryPlanConstraint} to type {@code U}
+     * @param <U> type parameter of the resulting {@link Optional}
+     * @return an {@link Optional} of type {@code U} that is {@link Optional#empty()} if {@code this} is false; it is
+     *         {@code Optional.of(mapper.apply(getConstraint))} otherwise.
+     */
+    @Nonnull
+    public <U> Optional<U> mapToOptional(@Nonnull final Function<? super QueryPlanConstraint, ? extends U> mapper) {
+        if (isFalse()) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(mapper.apply(getConstraint()));
+        }
+    }
+
+    /**
+     * Monadic method to compose {@code this} by applying a {@link Function} to the recorded plan constraint if
+     * applicable.
+     * @param composeFunction function that maps the current {@link QueryPlanConstraint} to a new
+     *        {@link BooleanWithConstraint}
+     * @return {@link BooleanWithConstraint#falseValue()} if {@link #isFalse()} is true or the
+     *         {@link BooleanWithConstraint} that the {@code composeFunction} returned
+     */
+    @Nonnull
+    public BooleanWithConstraint compose(@Nonnull final Function<? super QueryPlanConstraint, ? extends BooleanWithConstraint> composeFunction) {
+        if (isFalse()) {
+            return BooleanWithConstraint.falseValue();
+        } else {
+            final var result = composeFunction.apply(getConstraint());
+            if (result.isFalse()) {
+                return BooleanWithConstraint.falseValue();
+            }
+            return composeWithOther(result);
+        }
+    }
+
+    /**
+     * Factory method to return a {@code false}.
+     * @return {@code false}
+     */
+    @Nonnull
+    public static BooleanWithConstraint falseValue() {
+        return FALSE;
+    }
+
+    /**
+     * Factory method to create an unconditional {@code true}.
+     * @return a {@link BooleanWithConstraint} that is unconditionally {@code true}, i.e. that is {@code true} using
+     *         a {@link QueryPlanConstraint#tautology()}
+     */
+    @Nonnull
+    public static BooleanWithConstraint alwaysTrue() {
+        return ALWAYS_TRUE;
+    }
+
+    /**
+     * Helper method to dispatch to {@link #falseValue()} or {@link #alwaysTrue()} based on a boolean value handed in.
+     * @param isTrue {@code true} or {@code false}
+     * @return the appropriate unconditional {@link BooleanWithConstraint}
+     */
+    @Nonnull
+    public static BooleanWithConstraint fromBoolean(final boolean isTrue) {
+        return isTrue ? alwaysTrue() : falseValue();
+    }
+
+    /**
+     * Factory method to create a conditional {@code true} based on a {@link QueryPlanConstraint} that is also passed
+     * in.
+     * @param constraint the {@link QueryPlanConstraint} that this {@link BooleanWithConstraint} is constraint on.
+     * @return a {@link BooleanWithConstraint} that is conditionally {@code true} under the constraint
+     *         {@code constraint}.
+     */
+    @Nonnull
+    public static BooleanWithConstraint trueWithConstraint(@Nonnull final QueryPlanConstraint constraint) {
+        return new BooleanWithConstraint(constraint);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
@@ -73,11 +73,11 @@ public class CascadesRuleCall implements PlannerRuleCall<Reference>, Memoizer {
     @Nonnull
     private final EvaluationContext evaluationContext;
 
-    public CascadesRuleCall(@Nonnull PlanContext context,
-                            @Nonnull CascadesRule<?> rule,
-                            @Nonnull Reference root,
-                            @Nonnull Traversal traversal,
-                            @Nonnull PlannerBindings bindings,
+    public CascadesRuleCall(@Nonnull final PlanContext context,
+                            @Nonnull final CascadesRule<?> rule,
+                            @Nonnull final Reference root,
+                            @Nonnull final Traversal traversal,
+                            @Nonnull final PlannerBindings bindings,
                             @Nonnull final EvaluationContext evaluationContext) {
         this.context = context;
         this.rule = rule;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
@@ -122,7 +122,7 @@ public class GraphExpansion {
 
     @Nonnull
     public QueryPredicate asAndPredicate() {
-        return AndPredicate.andOrTrue(getPredicates());
+        return AndPredicate.and(getPredicates());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
@@ -202,7 +202,7 @@ public class MatchInfo {
             return Optional.empty();
         }
         final var allConstraints = ImmutableList.<QueryPlanConstraint>builder().addAll(constraints).addAll(childConstraints).build();
-        return Optional.of(QueryPlanConstraint.compose(allConstraints));
+        return Optional.of(QueryPlanConstraint.composeConstraints(allConstraints));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
@@ -196,7 +196,7 @@ public class MatchInfo {
         final var constraints = predicateMap.getMap()
                 .values()
                 .stream()
-                .flatMap(predicate -> predicate.getConstraint().stream())
+                .map(PredicateMultiMap.PredicateMapping::getConstraint)
                 .collect(Collectors.toUnmodifiableList());
         if (constraints.isEmpty() && childConstraints.isEmpty()) {
             return Optional.empty();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PredicateMultiMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PredicateMultiMap.java
@@ -93,7 +93,7 @@ public class PredicateMultiMap {
          */
         public enum MappingKind {
             REGULAR_IMPLIES_CANDIDATE,
-            OR_TERM_IMPLIES_CANDIDATE;
+            OR_TERM_IMPLIES_CANDIDATE
         }
 
         @Nonnull
@@ -103,7 +103,7 @@ public class PredicateMultiMap {
         @Nonnull
         private final Optional<CorrelationIdentifier> parameterAliasOptional;
         @Nonnull
-        private final Optional<QueryPlanConstraint> constraintOptional;
+        private final QueryPlanConstraint constraint;
 
         @Nonnull
         private final Optional<QueryPredicate> translatedQueryPredicateOptional;
@@ -113,12 +113,12 @@ public class PredicateMultiMap {
                                  @Nonnull final MappingKind mappingKind,
                                  @Nonnull final CompensatePredicateFunction compensatePredicateFunction,
                                  @Nonnull final Optional<CorrelationIdentifier> parameterAlias,
-                                 @Nonnull final Optional<QueryPlanConstraint> constraintOptional,
+                                 @Nonnull final QueryPlanConstraint constraint,
                                  @Nonnull final Optional<QueryPredicate> translatedQueryPredicateOptional) {
             this.mappingKey = new MappingKey(queryPredicate, candidatePredicate, mappingKind);
             this.compensatePredicateFunction = compensatePredicateFunction;
             this.parameterAliasOptional = parameterAlias;
-            this.constraintOptional = constraintOptional;
+            this.constraint = constraint;
             this.translatedQueryPredicateOptional = translatedQueryPredicateOptional;
         }
 
@@ -163,8 +163,8 @@ public class PredicateMultiMap {
         }
 
         @Nonnull
-        public Optional<QueryPlanConstraint> getConstraint() {
-            return constraintOptional;
+        public QueryPlanConstraint getConstraint() {
+            return constraint;
         }
 
         @Nonnull
@@ -174,14 +174,15 @@ public class PredicateMultiMap {
 
         @Nonnull
         public PredicateMapping withTranslatedQueryPredicate(@Nonnull final Optional<QueryPredicate> translatedCandidatePredicate) {
-            return new PredicateMapping(getQueryPredicate(), getCandidatePredicate(), getMappingKind(), compensatePredicateFunction, parameterAliasOptional, constraintOptional, translatedCandidatePredicate);
+            return new PredicateMapping(getQueryPredicate(), getCandidatePredicate(), getMappingKind(), compensatePredicateFunction, parameterAliasOptional, constraint, translatedCandidatePredicate);
         }
 
         @Nonnull
         public static PredicateMapping regularMappingWithoutCompensation(@Nonnull final QueryPredicate queryPredicate,
                                                                          @Nonnull final QueryPredicate candidatePredicate,
-                                                                         @Nonnull final QueryPlanConstraint queryPlanConstraint) {
-            return regularMapping(queryPredicate, candidatePredicate, CompensatePredicateFunction.noCompensationNeeded(), Optional.empty(), Optional.of(queryPlanConstraint), Optional.empty());
+                                                                         @Nonnull final QueryPlanConstraint constraint) {
+            return regularMapping(queryPredicate, candidatePredicate, CompensatePredicateFunction.noCompensationNeeded(),
+                    Optional.empty(), constraint, Optional.empty());
         }
 
         @Nonnull
@@ -189,7 +190,8 @@ public class PredicateMultiMap {
                                                       @Nonnull final QueryPredicate candidatePredicate,
                                                       @Nonnull final CompensatePredicateFunction compensatePredicateFunction,
                                                       @Nonnull final Optional<QueryPredicate> translatedQueryPredicate) {
-            return regularMapping(queryPredicate, candidatePredicate, compensatePredicateFunction, Optional.empty(), Optional.empty(), translatedQueryPredicate);
+            return regularMapping(queryPredicate, candidatePredicate, compensatePredicateFunction,
+                    Optional.empty(), QueryPlanConstraint.tautology(), translatedQueryPredicate);
         }
 
         @Nonnull
@@ -197,9 +199,10 @@ public class PredicateMultiMap {
                                                       @Nonnull final QueryPredicate candidatePredicate,
                                                       @Nonnull final CompensatePredicateFunction compensatePredicateFunction,
                                                       @Nonnull final Optional<CorrelationIdentifier> parameterAliasOptional,
-                                                      @Nonnull final Optional<QueryPlanConstraint> constraintOptional,
+                                                      @Nonnull final QueryPlanConstraint constraint,
                                                       @Nonnull final Optional<QueryPredicate> translatedQueryPredicate) {
-            return new PredicateMapping(queryPredicate, candidatePredicate, MappingKind.REGULAR_IMPLIES_CANDIDATE, compensatePredicateFunction, parameterAliasOptional, constraintOptional, translatedQueryPredicate);
+            return new PredicateMapping(queryPredicate, candidatePredicate, MappingKind.REGULAR_IMPLIES_CANDIDATE,
+                    compensatePredicateFunction, parameterAliasOptional, constraint, translatedQueryPredicate);
         }
 
         @Nonnull
@@ -207,7 +210,8 @@ public class PredicateMultiMap {
                                                      @Nonnull final QueryPredicate candidatePredicate,
                                                      @Nonnull final CompensatePredicateFunction compensatePredicateFunction,
                                                      @Nonnull final Optional<QueryPredicate> translatedQueryPredicate) {
-            return orTermMapping(queryPredicate, candidatePredicate, compensatePredicateFunction, Optional.empty(), Optional.empty(), translatedQueryPredicate);
+            return orTermMapping(queryPredicate, candidatePredicate, compensatePredicateFunction,
+                    Optional.empty(), QueryPlanConstraint.tautology(), translatedQueryPredicate);
         }
 
         @Nonnull
@@ -215,9 +219,10 @@ public class PredicateMultiMap {
                                                      @Nonnull final QueryPredicate candidatePredicate,
                                                      @Nonnull final CompensatePredicateFunction compensatePredicateFunction,
                                                      @Nonnull final Optional<CorrelationIdentifier> parameterAliasOptional,
-                                                     @Nonnull final Optional<QueryPlanConstraint> constraintOptional,
+                                                     @Nonnull final QueryPlanConstraint constraint,
                                                      @Nonnull final Optional<QueryPredicate> translatedQueryPredicate) {
-            return new PredicateMapping(queryPredicate, candidatePredicate, MappingKind.OR_TERM_IMPLIES_CANDIDATE, compensatePredicateFunction, parameterAliasOptional, constraintOptional, translatedQueryPredicate);
+            return new PredicateMapping(queryPredicate, candidatePredicate, MappingKind.OR_TERM_IMPLIES_CANDIDATE,
+                    compensatePredicateFunction, parameterAliasOptional, constraint, translatedQueryPredicate);
         }
 
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PredicateMultiMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PredicateMultiMap.java
@@ -179,8 +179,9 @@ public class PredicateMultiMap {
 
         @Nonnull
         public static PredicateMapping regularMappingWithoutCompensation(@Nonnull final QueryPredicate queryPredicate,
-                                                                         @Nonnull final QueryPredicate candidatePredicate) {
-            return regularMapping(queryPredicate, candidatePredicate, CompensatePredicateFunction.noCompensationNeeded(), Optional.empty(), Optional.empty(), Optional.empty());
+                                                                         @Nonnull final QueryPredicate candidatePredicate,
+                                                                         @Nonnull final QueryPlanConstraint queryPlanConstraint) {
+            return regularMapping(queryPredicate, candidatePredicate, CompensatePredicateFunction.noCompensationNeeded(), Optional.empty(), Optional.of(queryPlanConstraint), Optional.empty());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/UsesValueEquivalence.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/UsesValueEquivalence.java
@@ -1,0 +1,54 @@
+/*
+ * AliasMap.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * Tag interface to provide a common base for all classes implementing a semantic equals using a
+ * {@link ValueEquivalence}.
+ * @param <T> type parameter that {@link #semanticEquals} operates on.
+ */
+public interface UsesValueEquivalence<T extends UsesValueEquivalence<T>> {
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    default Optional<QueryPlanConstraint> semanticEquals(@Nullable final Object other, @Nonnull final ValueEquivalence valueEquivalence) {
+        if (this == other) {
+            return ValueEquivalence.alwaysEqual();
+        }
+
+        final var thisClass = this.getClass();
+        if (other == null || thisClass != other.getClass()) {
+            return Optional.empty();
+        }
+
+        // This cast is safe!
+        return semanticEqualsTyped((T)thisClass.cast(other), valueEquivalence);
+    }
+
+    @Nonnull
+    Optional<QueryPlanConstraint> semanticEqualsTyped(@Nonnull T other, @Nonnull final ValueEquivalence valueEquivalence);
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/UsesValueEquivalence.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/UsesValueEquivalence.java
@@ -1,5 +1,5 @@
 /*
- * AliasMap.java
+ * UsesValueEquivalence.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueEquivalence.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueEquivalence.java
@@ -35,7 +35,15 @@ import java.util.function.Supplier;
 /**
  * TODO.
  */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public interface ValueEquivalence {
+    @Nonnull
+    Optional<QueryPlanConstraint> ALWAYS_EQUAL = Optional.of(QueryPlanConstraint.tautology());
+
+    static Optional<QueryPlanConstraint> alwaysEqual() {
+        return ALWAYS_EQUAL;
+    }
+
     @Nonnull
     Optional<QueryPlanConstraint> equivalence(@Nonnull final Value left,
                                               @Nonnull final Value right);
@@ -170,7 +178,7 @@ public interface ValueEquivalence {
             final var rightAlias = ((QuantifiedValue)right).getAlias();
 
             if (leftAlias.equals(rightAlias) || aliasMap.containsMapping(leftAlias, rightAlias)) {
-                return Value.alwaysEqual();
+                return alwaysEqual();
             }
 
             return Optional.empty();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueEquivalence.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueEquivalence.java
@@ -1,5 +1,5 @@
 /*
- * AliasMap.java
+ * ValueEquivalence.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueEquivalence.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueEquivalence.java
@@ -1,0 +1,179 @@
+/*
+ * AliasMap.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.Nonnull;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * TODO.
+ */
+public interface ValueEquivalence {
+    @Nonnull
+    Optional<QueryPlanConstraint> equivalence(@Nonnull final Value left,
+                                              @Nonnull final Value right);
+
+    default ValueEquivalence then(@Nonnull final ValueEquivalence thenEquivalence) {
+        return new ThenEquivalence(this, thenEquivalence);
+    }
+
+    /**
+     * Helper equivalence to compose to equivalences.
+     */
+    class ThenEquivalence implements ValueEquivalence {
+        @Nonnull
+        private final ValueEquivalence first;
+        @Nonnull
+        private final ValueEquivalence then;
+
+        public ThenEquivalence(@Nonnull final ValueEquivalence first, @Nonnull final ValueEquivalence then) {
+            this.first = first;
+            this.then = then;
+        }
+
+        @Nonnull
+        @Override
+        public Optional<QueryPlanConstraint> equivalence(@Nonnull final Value left, @Nonnull final Value right) {
+            final var firstEquivalence = first.equivalence(left, right);
+            if (firstEquivalence.isPresent()) {
+                return firstEquivalence;
+            }
+            return then.equivalence(left, right);
+        }
+    }
+
+    @Nonnull
+    static ValueMap.Builder valueMapBuilder() {
+        return new ValueMap.Builder();
+    }
+
+    /**
+     * Value equivalence based on a map of values. Note that we do not enforce {@code a R a} (reflexivity),
+     * nor {@code a R b => b R a} (symmetry). While reflexivity is naturally enforced even when the corresponding
+     * pairs are not in the equivalence map, symmetry needs to be added (and enforced) by the client of this class
+     */
+    class ValueMap implements ValueEquivalence {
+        @Nonnull
+        private final Map<Value, Value> valueEquivalenceMap;
+
+        @Nonnull
+        private final Map<Value, Supplier<QueryPlanConstraint>> valueConstraintSupplierMap;
+
+        private ValueMap(@Nonnull final Map<Value, Value> valueEquivalenceMap,
+                         @Nonnull final Map<Value, Supplier<QueryPlanConstraint>> valueConstraintSupplierMap) {
+            this.valueEquivalenceMap = ImmutableMap.copyOf(valueEquivalenceMap);
+            this.valueConstraintSupplierMap = ImmutableMap.copyOf(valueConstraintSupplierMap);
+        }
+
+        @Nonnull
+        @Override
+        public Optional<QueryPlanConstraint> equivalence(@Nonnull final Value left, @Nonnull final Value right) {
+            final var rightFromMap = valueEquivalenceMap.get(left);
+            if (rightFromMap == null || !rightFromMap.equals(right)) {
+                return Optional.empty();
+            }
+            return Optional.of(Objects.requireNonNull(valueConstraintSupplierMap.get(left)).get());
+        }
+
+        /**
+         * Builder.
+         */
+        public static class Builder {
+            @Nonnull
+            private final Map<Value, Value> valueEquivalenceMap;
+            @Nonnull
+            private final Map<Value, Supplier<QueryPlanConstraint>> valueConstraintSupplierMap;
+
+            private Builder() {
+                this(new LinkedHashMap<>(), new LinkedHashMap<>());
+            }
+
+            private Builder(@Nonnull final Map<Value, Value> valueEquivalenceMap,
+                            @Nonnull final Map<Value, Supplier<QueryPlanConstraint>> valueConstraintSupplierMap) {
+                this.valueEquivalenceMap = valueEquivalenceMap;
+                this.valueConstraintSupplierMap = valueConstraintSupplierMap;
+            }
+
+            @Nonnull
+            public Builder add(@Nonnull final Value left, @Nonnull final Value right,
+                               @Nonnull final Supplier<QueryPlanConstraint> planConstraintSupplier) {
+                valueEquivalenceMap.put(left, right);
+                valueConstraintSupplierMap.put(left, planConstraintSupplier);
+                return this;
+            }
+
+            @Nonnull
+            public ValueMap build() {
+                return new ValueMap(valueEquivalenceMap, valueConstraintSupplierMap);
+            }
+        }
+    }
+
+    @Nonnull
+    static AliasMapBackedValueEquivalence fromAliasMap(@Nonnull final AliasMap aliasMap) {
+        return new AliasMapBackedValueEquivalence(aliasMap);
+    }
+
+    /**
+     * Equivalence that is being backed by an {@link AliasMap}.
+     */
+    class AliasMapBackedValueEquivalence implements ValueEquivalence {
+        @Nonnull
+        private final AliasMap aliasMap;
+
+        public AliasMapBackedValueEquivalence(@Nonnull final AliasMap aliasMap) {
+            this.aliasMap = aliasMap;
+        }
+
+        @Nonnull
+        @Override
+        public Optional<QueryPlanConstraint> equivalence(@Nonnull final Value left, @Nonnull final Value right) {
+            //
+            // If any of the participants is not a quantified value, left is not equal to right.
+            //
+            if (!(left instanceof QuantifiedValue) || !(right instanceof QuantifiedValue)) {
+                return Optional.empty();
+            }
+
+            if (left.getClass() != right.getClass()) {
+                return Optional.empty();
+            }
+
+            final var leftAlias = ((QuantifiedValue)left).getAlias();
+            final var rightAlias = ((QuantifiedValue)right).getAlias();
+
+            if (leftAlias.equals(rightAlias) || aliasMap.containsMapping(leftAlias, rightAlias)) {
+                return Value.alwaysEqual();
+            }
+
+            return Optional.empty();
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalFilterExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalFilterExpression.java
@@ -155,7 +155,7 @@ public class LogicalFilterExpression implements RelationalExpressionWithChildren
                         this,
                         NodeInfo.PREDICATE_FILTER_OPERATOR,
                         ImmutableList.of("WHERE {{pred}}"),
-                        ImmutableMap.of("pred", Attribute.gml(AndPredicate.andOrTrue(getPredicates()).toString()))),
+                        ImmutableMap.of("pred", Attribute.gml(AndPredicate.and(getPredicates()).toString()))),
                 childGraphs);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndOrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndOrPredicate.java
@@ -59,13 +59,13 @@ public abstract class AndOrPredicate extends AbstractQueryPredicate {
         this.children = childrenBuilder.build();
     }
 
-    protected AndOrPredicate(@Nonnull final List<QueryPredicate> children, final boolean isAtomic) {
+    protected AndOrPredicate(@Nonnull final List<? extends QueryPredicate> children, final boolean isAtomic) {
         super(isAtomic);
         if (children.size() < 2) {
             throw new RecordCoreException(getClass().getSimpleName() + " must have at least two children");
         }
 
-        this.children = children;
+        this.children = ImmutableList.copyOf(children);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndOrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndOrPredicate.java
@@ -94,7 +94,7 @@ public abstract class AndOrPredicate extends AbstractQueryPredicate {
         }
         final var andOrPredicate = andOrPredicateOptional.get();
 
-        if (aliasMap.definesOnlyIdentities() && getCorrelatedTo().containsAll(aliasMap.sources())) {
+        if (getCorrelatedTo().equals(otherPred.getCorrelatedTo())) {
             return getChildrenAsSet().equals(andOrPredicate.getChildrenAsSet());
         }
         return super.equalsForChildren(otherPred, aliasMap);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndPredicate.java
@@ -67,7 +67,7 @@ public class AndPredicate extends AndOrPredicate {
         super(serializationContext, Objects.requireNonNull(andPredicateProto.getSuper()));
     }
 
-    private AndPredicate(@Nonnull final List<QueryPredicate> children, final boolean isAtomic) {
+    private AndPredicate(@Nonnull final List<? extends QueryPredicate> children, final boolean isAtomic) {
         super(children, isAtomic);
     }
 
@@ -187,7 +187,12 @@ public class AndPredicate extends AndOrPredicate {
             return Iterables.getOnlyElement(conjuncts);
         }
 
-        return new AndPredicate(ImmutableList.copyOf(conjuncts), isAtomic);
+        final var filteredConjuncts =
+                conjuncts.stream()
+                        .filter(queryPredicate -> !queryPredicate.isTautology())
+                        .collect(ImmutableList.toImmutableList());
+
+        return new AndPredicate(filteredConjuncts, isAtomic);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndPredicate.java
@@ -34,7 +34,6 @@ import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
 import com.apple.foundationdb.record.query.plan.cascades.PredicateMultiMap.ExpandCompensationFunction;
 import com.google.auto.service.AutoService;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Message;
@@ -164,33 +163,28 @@ public class AndPredicate extends AndOrPredicate {
 
     public static QueryPredicate and(@Nonnull QueryPredicate first, @Nonnull QueryPredicate second,
                                      @Nonnull QueryPredicate... operands) {
-        return of(toList(first, second, operands), false);
+        return and(toList(first, second, operands), false);
     }
 
     @Nonnull
     public static QueryPredicate and(@Nonnull final Collection<? extends QueryPredicate> conjuncts) {
-        return of(conjuncts, false);
+        return and(conjuncts, false);
     }
 
     @Nonnull
-    public static QueryPredicate andOrTrue(@Nonnull final Collection<? extends QueryPredicate> conjuncts) {
-        if (conjuncts.isEmpty()) {
-            return ConstantPredicate.TRUE;
-        }
-        return of(conjuncts, false);
-    }
-
-    @Nonnull
-    public static QueryPredicate of(@Nonnull final Collection<? extends QueryPredicate> conjuncts, final boolean isAtomic) {
-        Verify.verify(!conjuncts.isEmpty());
-        if (conjuncts.size() == 1) {
-            return Iterables.getOnlyElement(conjuncts);
-        }
-
+    public static QueryPredicate and(@Nonnull final Collection<? extends QueryPredicate> conjuncts, final boolean isAtomic) {
         final var filteredConjuncts =
                 conjuncts.stream()
                         .filter(queryPredicate -> !queryPredicate.isTautology())
                         .collect(ImmutableList.toImmutableList());
+
+        if (filteredConjuncts.isEmpty()) {
+            return ConstantPredicate.TRUE;
+        }
+
+        if (filteredConjuncts.size() == 1) {
+            return Iterables.getOnlyElement(filteredConjuncts);
+        }
 
         return new AndPredicate(filteredConjuncts, isAtomic);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/CompatibleTypeEvolutionPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/CompatibleTypeEvolutionPredicate.java
@@ -35,8 +35,8 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PCompatibleTypeEvoluti
 import com.apple.foundationdb.record.RecordQueryPlanProto.PFieldAccessTrieNode;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.properties.DerivationsProperty;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
@@ -60,7 +60,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -170,16 +169,14 @@ public class CompatibleTypeEvolutionPredicate extends AbstractQueryPredicate imp
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
-                                                               @Nonnull final ValueEquivalence valueEquivalence) {
-        final var equalsWithoutChildren = super.equalsWithoutChildren(other, valueEquivalence);
-        if (equalsWithoutChildren.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final CompatibleTypeEvolutionPredicate otherCompatibleTypeEvolutionPredicate = (CompatibleTypeEvolutionPredicate)other;
-        return recordTypeNameFieldAccessMap.equals(otherCompatibleTypeEvolutionPredicate.recordTypeNameFieldAccessMap)
-                ? equalsWithoutChildren : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                       @Nonnull final ValueEquivalence valueEquivalence) {
+        return super.equalsWithoutChildren(other, valueEquivalence)
+                .filter(ignored -> {
+                    final CompatibleTypeEvolutionPredicate otherCompatibleTypeEvolutionPredicate = (CompatibleTypeEvolutionPredicate)other;
+                    return recordTypeNameFieldAccessMap.equals(
+                            otherCompatibleTypeEvolutionPredicate.recordTypeNameFieldAccessMap);
+                });
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/CompatibleTypeEvolutionPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/CompatibleTypeEvolutionPredicate.java
@@ -35,7 +35,9 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PCompatibleTypeEvoluti
 import com.apple.foundationdb.record.RecordQueryPlanProto.PFieldAccessTrieNode;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.properties.DerivationsProperty;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
@@ -58,6 +60,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -165,14 +168,18 @@ public class CompatibleTypeEvolutionPredicate extends AbstractQueryPredicate imp
         return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final QueryPredicate other, @Nonnull final AliasMap aliasMap) {
-        if (!super.equalsWithoutChildren(other, aliasMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                               @Nonnull final ValueEquivalence valueEquivalence) {
+        final var equalsWithoutChildren = super.equalsWithoutChildren(other, valueEquivalence);
+        if (equalsWithoutChildren.isEmpty()) {
+            return Optional.empty();
         }
 
         final CompatibleTypeEvolutionPredicate otherCompatibleTypeEvolutionPredicate = (CompatibleTypeEvolutionPredicate)other;
-        return recordTypeNameFieldAccessMap.equals(otherCompatibleTypeEvolutionPredicate.recordTypeNameFieldAccessMap);
+        return recordTypeNameFieldAccessMap.equals(otherCompatibleTypeEvolutionPredicate.recordTypeNameFieldAccessMap)
+                ? equalsWithoutChildren : Optional.empty();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ConstantPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ConstantPredicate.java
@@ -30,8 +30,10 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PConstantPredicate;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
 import com.google.auto.service.AutoService;
 import com.google.protobuf.Message;
@@ -40,6 +42,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -109,13 +112,16 @@ public class ConstantPredicate extends AbstractQueryPredicate implements LeafQue
         return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final QueryPredicate other, @Nonnull final AliasMap aliasMap) {
-        if (!LeafQueryPredicate.super.equalsWithoutChildren(other, aliasMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                               @Nonnull final ValueEquivalence valueEquivalence) {
+        final var superEqualsWithoutChildren = LeafQueryPredicate.super.equalsWithoutChildren(other, valueEquivalence);
+        if (superEqualsWithoutChildren.isEmpty()) {
+            return Optional.empty();
         }
         final ConstantPredicate that = (ConstantPredicate)other;
-        return Objects.equals(value, that.value);
+        return Objects.equals(value, that.value) ? superEqualsWithoutChildren : Optional.empty();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ConstantPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ConstantPredicate.java
@@ -30,8 +30,8 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PConstantPredicate;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
@@ -42,7 +42,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -114,14 +113,13 @@ public class ConstantPredicate extends AbstractQueryPredicate implements LeafQue
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
-                                                               @Nonnull final ValueEquivalence valueEquivalence) {
-        final var superEqualsWithoutChildren = LeafQueryPredicate.super.equalsWithoutChildren(other, valueEquivalence);
-        if (superEqualsWithoutChildren.isEmpty()) {
-            return Optional.empty();
-        }
-        final ConstantPredicate that = (ConstantPredicate)other;
-        return Objects.equals(value, that.value) ? superEqualsWithoutChildren : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                       @Nonnull final ValueEquivalence valueEquivalence) {
+        return LeafQueryPredicate.super.equalsWithoutChildren(other, valueEquivalence)
+                .filter(ignored -> {
+                    final ConstantPredicate that = (ConstantPredicate)other;
+                    return Objects.equals(value, that.value);
+                });
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
@@ -35,8 +35,8 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PDatabaseObjectDepende
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.auto.service.AutoService;
@@ -49,7 +49,6 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -134,17 +133,14 @@ public class DatabaseObjectDependenciesPredicate extends AbstractQueryPredicate 
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
-                                                               @Nonnull final ValueEquivalence valueEquivalence) {
-        final var superEqualsWithoutChildren = super.equalsWithoutChildren(other, valueEquivalence);
-        if (superEqualsWithoutChildren.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final DatabaseObjectDependenciesPredicate otherDatabaseObjectDependenciesPredicate =
-                (DatabaseObjectDependenciesPredicate)other;
-        return usedIndexes.equals(otherDatabaseObjectDependenciesPredicate.usedIndexes)
-               ? superEqualsWithoutChildren : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                       @Nonnull final ValueEquivalence valueEquivalence) {
+        return super.equalsWithoutChildren(other, valueEquivalence)
+                .filter(ignored -> {
+                    final DatabaseObjectDependenciesPredicate otherDatabaseObjectDependenciesPredicate =
+                            (DatabaseObjectDependenciesPredicate)other;
+                    return usedIndexes.equals(otherDatabaseObjectDependenciesPredicate.usedIndexes);
+                });
     }
 
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
@@ -35,7 +35,9 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PDatabaseObjectDepende
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
@@ -47,6 +49,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -129,15 +132,19 @@ public class DatabaseObjectDependenciesPredicate extends AbstractQueryPredicate 
         return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final QueryPredicate other, @Nonnull final AliasMap aliasMap) {
-        if (!super.equalsWithoutChildren(other, aliasMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                               @Nonnull final ValueEquivalence valueEquivalence) {
+        final var superEqualsWithoutChildren = super.equalsWithoutChildren(other, valueEquivalence);
+        if (superEqualsWithoutChildren.isEmpty()) {
+            return Optional.empty();
         }
 
         final DatabaseObjectDependenciesPredicate otherDatabaseObjectDependenciesPredicate =
                 (DatabaseObjectDependenciesPredicate)other;
-        return usedIndexes.equals(otherDatabaseObjectDependenciesPredicate.usedIndexes);
+        return usedIndexes.equals(otherDatabaseObjectDependenciesPredicate.usedIndexes)
+               ? superEqualsWithoutChildren : Optional.empty();
     }
 
 
@@ -169,8 +176,8 @@ public class DatabaseObjectDependenciesPredicate extends AbstractQueryPredicate 
     }
 
     @Nonnull
-    public static <M extends Message> DatabaseObjectDependenciesPredicate fromPlan(@Nonnull final RecordMetaData recordMetaData,
-                                                                                   @Nonnull final RecordQueryPlan plan) {
+    public static DatabaseObjectDependenciesPredicate fromPlan(@Nonnull final RecordMetaData recordMetaData,
+                                                               @Nonnull final RecordQueryPlan plan) {
         final List<String> usedIndexesNamesList = Lists.newArrayList(plan.getUsedIndexes());
         // we have to do this to get a proper stable order
         Collections.sort(usedIndexesNamesList);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
@@ -135,7 +135,8 @@ public class ExistsPredicate extends AbstractQueryPredicate implements LeafQuery
             return false;
         }
         final ExistsPredicate that = (ExistsPredicate)other;
-        return aliasMap.containsMapping(existentialAlias, that.existentialAlias);
+        return existentialAlias.equals(that.existentialAlias) ||
+                aliasMap.containsMapping(existentialAlias, that.existentialAlias);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/NotPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/NotPredicate.java
@@ -151,7 +151,7 @@ public class NotPredicate extends AbstractQueryPredicate implements QueryPredica
 
         return Optional.of(translationMap -> {
             final var childPredicates = childInjectCompensationFunction.applyCompensationForPredicate(translationMap);
-            return LinkedIdentitySet.of(not(AndPredicate.andOrTrue(childPredicates)));
+            return LinkedIdentitySet.of(not(AndPredicate.and(childPredicates)));
         });
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
@@ -29,12 +29,13 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.POrPredicate;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
 import com.apple.foundationdb.record.query.plan.cascades.PredicateMultiMap;
+import com.apple.foundationdb.record.query.plan.cascades.PredicateMultiMap.PredicateMapping;
 import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
@@ -54,6 +55,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A {@link QueryPredicate} that is satisfied when any of its child components is satisfied.
@@ -138,7 +140,6 @@ public class OrPredicate extends AndOrPredicate {
             return Optional.empty();
         }
 
-        final var value = ((PredicateWithValue)getChildren().stream().findFirst().orElseThrow()).getValue();
         final ImmutableSet.Builder<RangeConstraints> rangesSet = ImmutableSet.builder();
 
         for (final var child : getChildren()) {
@@ -162,6 +163,7 @@ public class OrPredicate extends AndOrPredicate {
             rangesSet.add(range.get());
         }
 
+        final var value = Objects.requireNonNull(((PredicateWithValue)Iterables.getFirst(getChildren(), null)).getValue());
         return Optional.of(PredicateWithValueAndRanges.ofRanges(value, rangesSet.build()));
     }
 
@@ -198,7 +200,7 @@ public class OrPredicate extends AndOrPredicate {
      * result:
      * - no match.
      *
-     * @param aliasMap the current alias map.
+     * @param valueEquivalence the current values equivalence.
      * @param candidatePredicate another predicate to match.
      * @param evaluationContext the evaluation context used to evaluate any compile-time constants when examining predicate
      * implication.
@@ -207,10 +209,10 @@ public class OrPredicate extends AndOrPredicate {
      */
     @Nonnull
     @Override
-    public Optional<PredicateMultiMap.PredicateMapping> impliesCandidatePredicate(@NonNull final ValueEquivalence aliasMap,
-                                                                                  @Nonnull final QueryPredicate candidatePredicate,
-                                                                                  @Nonnull final EvaluationContext evaluationContext) {
-        Optional<PredicateMultiMap.PredicateMapping> mappingsOptional = super.impliesCandidatePredicate(aliasMap, candidatePredicate, evaluationContext);
+    public Optional<PredicateMapping> impliesCandidatePredicate(@NonNull final ValueEquivalence valueEquivalence,
+                                                                @Nonnull final QueryPredicate candidatePredicate,
+                                                                @Nonnull final EvaluationContext evaluationContext) {
+        Optional<PredicateMapping> mappingsOptional = super.impliesCandidatePredicate(valueEquivalence, candidatePredicate, evaluationContext);
         if (mappingsOptional.isPresent()) {
             return mappingsOptional;
         }
@@ -222,7 +224,7 @@ public class OrPredicate extends AndOrPredicate {
             final var candidateValueWithRangesOptional = candidatePredicate.toValueWithRangesMaybe(evaluationContext);
             if (candidateValueWithRangesOptional.isPresent()) {
                 final var rightValueWithRanges = candidateValueWithRangesOptional.get();
-                mappingsOptional = impliesWithValuesAndRanges(aliasMap, candidatePredicate, evaluationContext, leftValueWithRanges, rightValueWithRanges);
+                mappingsOptional = impliesWithValuesAndRanges(valueEquivalence, candidatePredicate, evaluationContext, leftValueWithRanges, rightValueWithRanges);
             }
         }
 
@@ -230,21 +232,24 @@ public class OrPredicate extends AndOrPredicate {
             final var candidateValue = ((Placeholder)candidatePredicate).getValue();
             final var anyMatchingLeafPredicate = preOrderStream()
                     .filter(LeafQueryPredicate.class::isInstance)
-                    .anyMatch(predicate -> {
+                    .flatMap(predicate -> {
                         if (predicate instanceof PredicateWithValue) {
                             final var queryValue = ((ValuePredicate)predicate).getValue();
-                            return queryValue.semanticEquals(candidateValue, aliasMap);
+                            return queryValue.semanticEquals(candidateValue, valueEquivalence).stream();
                         }
-                        return false;
-                    });
-            if (anyMatchingLeafPredicate) {
+                        return Stream.empty();
+                    })
+                    .findFirst();
+            if (anyMatchingLeafPredicate.isPresent()) {
                 //
                 // There is a sub-term that could be matched if the OR was broken into a UNION. Mark this as a
                 // special mapping.
                 //
-                return Optional.of(PredicateMultiMap.PredicateMapping.orTermMapping(this,
+                return Optional.of(PredicateMapping.orTermMapping(this,
                         new ConstantPredicate(true),
                         getDefaultCompensatePredicateFunction(),
+                        Optional.empty(),
+                        anyMatchingLeafPredicate.get(),
                         Optional.empty())); // TODO: provide a translated predicate value here.
             }
         }
@@ -253,12 +258,14 @@ public class OrPredicate extends AndOrPredicate {
     }
 
     @Nonnull
-    private Optional<PredicateMultiMap.PredicateMapping> impliesWithValuesAndRanges(@Nonnull final ValueEquivalence valueEquivalence,
-                                                                                    @Nonnull final QueryPredicate candidatePredicate,
-                                                                                    @Nonnull final EvaluationContext evaluationContext,
-                                                                                    @Nonnull final PredicateWithValueAndRanges leftValueWithRanges,
-                                                                                    @Nonnull final PredicateWithValueAndRanges rightValueWithRanges) {
-        if (!leftValueWithRanges.getValue().semanticEquals(rightValueWithRanges.getValue(), valueEquivalence)) {
+    private Optional<PredicateMapping> impliesWithValuesAndRanges(@Nonnull final ValueEquivalence valueEquivalence,
+                                                                  @Nonnull final QueryPredicate candidatePredicate,
+                                                                  @Nonnull final EvaluationContext evaluationContext,
+                                                                  @Nonnull final PredicateWithValueAndRanges leftValueWithRanges,
+                                                                  @Nonnull final PredicateWithValueAndRanges rightValueWithRanges) {
+        final var semanticEqualsLeftRight =
+                leftValueWithRanges.getValue().semanticEquals(rightValueWithRanges.getValue(), valueEquivalence);
+        if (semanticEqualsLeftRight.isEmpty()) {
             return Optional.empty();
         }
 
@@ -269,10 +276,10 @@ public class OrPredicate extends AndOrPredicate {
             boolean termRequiresCompensation = true;
             boolean foundMatch = false;
             for (final var rightRange : rightValueWithRanges.getRanges()) {
-                final var evaledLeft = leftRange.compileTimeEval(evaluationContext);
-                if (rightRange.encloses(evaledLeft, evaluationContext) == Proposition.TRUE) {
+                final var evaluatedLeft = leftRange.compileTimeEval(evaluationContext);
+                if (rightRange.encloses(evaluatedLeft, evaluationContext) == Proposition.TRUE) {
                     foundMatch = true;
-                    if (evaledLeft.encloses(rightRange, evaluationContext) == Proposition.TRUE) {
+                    if (evaluatedLeft.encloses(rightRange, evaluationContext) == Proposition.TRUE) {
                         termRequiresCompensation = false;
                         break;
                     }
@@ -287,16 +294,19 @@ public class OrPredicate extends AndOrPredicate {
         // need a compensation, because at least one leg did not find an exactly-matching companion, in this case,
         // add this predicate as a residual on top.
         if (requiresCompensation) {
-            return Optional.of(PredicateMultiMap.PredicateMapping.regularMapping(this,
+            return Optional.of(PredicateMapping.regularMapping(this,
                     candidatePredicate,
-                    ((partialMatch, boundParameterPrefixMap) ->
-                             Objects.requireNonNull(foldNullable(Function.identity(),
-                                     (queryPredicate, childFunctions) -> queryPredicate.injectCompensationFunctionMaybe(partialMatch,
-                                             boundParameterPrefixMap,
-                                             ImmutableList.copyOf(childFunctions))))),
+                    (partialMatch, boundParameterPrefixMap) ->
+                            Objects.requireNonNull(foldNullable(Function.identity(),
+                                    (queryPredicate, childFunctions) -> queryPredicate.injectCompensationFunctionMaybe(partialMatch,
+                                            boundParameterPrefixMap,
+                                            ImmutableList.copyOf(childFunctions)))),
+                    Optional.empty(),
+                    QueryPlanConstraint.tautology(),
                     Optional.empty()));  // TODO: provide a translated predicate value here.
         } else {
-            return Optional.of(PredicateMultiMap.PredicateMapping.regularMappingWithoutCompensation(this, candidatePredicate));
+            return Optional.of(PredicateMapping.regularMappingWithoutCompensation(this,
+                    candidatePredicate, semanticEqualsLeftRight.get()));
         }
     }
 
@@ -321,7 +331,7 @@ public class OrPredicate extends AndOrPredicate {
             // take the predicates from each individual expansion, "and" them, and then "or" them
             final var predicates = LinkedIdentitySet.<QueryPredicate>of();
             for (final var childPredicates : childPredicatesList) {
-                predicates.add(AndPredicate.andOrTrue(childPredicates));
+                predicates.add(AndPredicate.and(childPredicates));
             }
             return LinkedIdentitySet.of(OrPredicate.or(predicates));
         });

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
 import com.apple.foundationdb.record.query.plan.cascades.PredicateMultiMap;
+import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -206,7 +207,7 @@ public class OrPredicate extends AndOrPredicate {
      */
     @Nonnull
     @Override
-    public Optional<PredicateMultiMap.PredicateMapping> impliesCandidatePredicate(@NonNull final AliasMap aliasMap,
+    public Optional<PredicateMultiMap.PredicateMapping> impliesCandidatePredicate(@NonNull final ValueEquivalence aliasMap,
                                                                                   @Nonnull final QueryPredicate candidatePredicate,
                                                                                   @Nonnull final EvaluationContext evaluationContext) {
         Optional<PredicateMultiMap.PredicateMapping> mappingsOptional = super.impliesCandidatePredicate(aliasMap, candidatePredicate, evaluationContext);
@@ -252,12 +253,12 @@ public class OrPredicate extends AndOrPredicate {
     }
 
     @Nonnull
-    private Optional<PredicateMultiMap.PredicateMapping> impliesWithValuesAndRanges(@Nonnull final AliasMap aliasMap,
+    private Optional<PredicateMultiMap.PredicateMapping> impliesWithValuesAndRanges(@Nonnull final ValueEquivalence valueEquivalence,
                                                                                     @Nonnull final QueryPredicate candidatePredicate,
                                                                                     @Nonnull final EvaluationContext evaluationContext,
                                                                                     @Nonnull final PredicateWithValueAndRanges leftValueWithRanges,
                                                                                     @Nonnull final PredicateWithValueAndRanges rightValueWithRanges) {
-        if (!leftValueWithRanges.getValue().semanticEquals(rightValueWithRanges.getValue(), aliasMap)) {
+        if (!leftValueWithRanges.getValue().semanticEquals(rightValueWithRanges.getValue(), valueEquivalence)) {
             return Optional.empty();
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
@@ -235,7 +235,8 @@ public class OrPredicate extends AndOrPredicate {
                     .flatMap(predicate -> {
                         if (predicate instanceof PredicateWithValue) {
                             final var queryValue = ((ValuePredicate)predicate).getValue();
-                            return queryValue.semanticEquals(candidateValue, valueEquivalence).stream();
+                            return queryValue.semanticEquals(candidateValue, valueEquivalence)
+                                    .mapToOptional(Function.identity()).stream();
                         }
                         return Stream.empty();
                     })
@@ -265,7 +266,7 @@ public class OrPredicate extends AndOrPredicate {
                                                                   @Nonnull final PredicateWithValueAndRanges rightValueWithRanges) {
         final var semanticEqualsLeftRight =
                 leftValueWithRanges.getValue().semanticEquals(rightValueWithRanges.getValue(), valueEquivalence);
-        if (semanticEqualsLeftRight.isEmpty()) {
+        if (semanticEqualsLeftRight.isFalse()) {
             return Optional.empty();
         }
 
@@ -306,7 +307,7 @@ public class OrPredicate extends AndOrPredicate {
                     Optional.empty()));  // TODO: provide a translated predicate value here.
         } else {
             return Optional.of(PredicateMapping.regularMappingWithoutCompensation(this,
-                    candidatePredicate, semanticEqualsLeftRight.get()));
+                    candidatePredicate, semanticEqualsLeftRight.getConstraint()));
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
@@ -73,7 +73,7 @@ public class OrPredicate extends AndOrPredicate {
         super(serializationContext, Objects.requireNonNull(orPredicateProto.getSuper()));
     }
 
-    private OrPredicate(@Nonnull final List<QueryPredicate> operands, final boolean isAtomic) {
+    private OrPredicate(@Nonnull final List<? extends QueryPredicate> operands, final boolean isAtomic) {
         super(operands, isAtomic);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
@@ -24,14 +24,17 @@ import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -99,13 +102,16 @@ public class Placeholder extends PredicateWithValueAndRanges implements WithAlia
         return parameterAlias;
     }
 
-
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final QueryPredicate other, @Nonnull final AliasMap aliasMap) {
-        if (!super.equalsWithoutChildren(other, aliasMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                               @Nonnull final ValueEquivalence valueEquivalence) {
+        final var equalsWithoutChildren =
+                super.equalsWithoutChildren(other, valueEquivalence);
+        if (equalsWithoutChildren.isEmpty()) {
+            return Optional.empty();
         }
-        return Objects.equals(parameterAlias, ((Placeholder)other).parameterAlias);
+        return Objects.equals(parameterAlias, ((Placeholder)other).parameterAlias) ? equalsWithoutChildren : Optional.empty();
     }
 
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
@@ -24,8 +24,8 @@ import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -104,14 +103,10 @@ public class Placeholder extends PredicateWithValueAndRanges implements WithAlia
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final QueryPredicate other,
-                                                               @Nonnull final ValueEquivalence valueEquivalence) {
-        final var equalsWithoutChildren =
-                super.equalsWithoutChildren(other, valueEquivalence);
-        if (equalsWithoutChildren.isEmpty()) {
-            return Optional.empty();
-        }
-        return Objects.equals(parameterAlias, ((Placeholder)other).parameterAlias) ? equalsWithoutChildren : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final QueryPredicate other,
+                                                       @Nonnull final ValueEquivalence valueEquivalence) {
+        return super.equalsWithoutChildren(other, valueEquivalence)
+                .filter(ignored -> Objects.equals(parameterAlias, ((Placeholder)other).parameterAlias));
     }
 
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/WithAlias.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/WithAlias.java
@@ -35,5 +35,4 @@ public interface WithAlias {
      */
     @Nonnull
     CorrelationIdentifier getParameterAlias();
-
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/IdentityAndRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/IdentityAndRule.java
@@ -78,7 +78,7 @@ public class IdentityAndRule extends QueryPredicateComputationRule<EvaluationCon
             }
         }
         final var resultTerms = resultTermsBuilder.build();
-        final var simplifiedPredicate = AndPredicate.andOrTrue(resultTerms);
+        final var simplifiedPredicate = AndPredicate.and(resultTerms);
         call.yieldPredicate(simplifiedPredicate, ImmutableList.of());
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/NormalizedResidualPredicateProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/NormalizedResidualPredicateProperty.java
@@ -80,7 +80,7 @@ public class NormalizedResidualPredicateProperty implements ExpressionProperty<Q
                     .forEach(resultPredicatesBuilder::add);
         }
 
-        return AndPredicate.andOrTrue(resultPredicatesBuilder.build());
+        return AndPredicate.and(resultPredicatesBuilder.build());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/NormalizePredicatesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/NormalizePredicatesRule.java
@@ -70,7 +70,7 @@ public class NormalizePredicatesRule extends CascadesRule<SelectExpression> {
         final Collection<? extends Quantifier> quantifiers = bindings.get(innerQuantifiersMatcher);
 
         // create one big conjuncted predicate
-        final QueryPredicate conjunctedPredicate = AndPredicate.andOrTrue(predicates);
+        final QueryPredicate conjunctedPredicate = AndPredicate.and(predicates);
 
         final BooleanPredicateNormalizer cnfNormalizer = BooleanPredicateNormalizer.forConfiguration(
                 BooleanPredicateNormalizer.Mode.CNF,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicateToLogicalUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicateToLogicalUnionRule.java
@@ -211,7 +211,8 @@ public class PredicateToLogicalUnionRule extends CascadesRule<MatchPartition> {
         }
         
         final var conjunctedPredicate = AndPredicate.and(toBeDnfPredicates);
-        final var constantAliases = Sets.difference(conjunctedPredicate.getCorrelatedTo(), Quantifiers.aliases(selectExpression.getQuantifiers()));
+        final var constantAliases = Sets.difference(conjunctedPredicate.getCorrelatedTo(),
+                Quantifiers.aliases(selectExpression.getQuantifiers()));
 
         final var dnfPredicate =
                 Simplification.optimize(conjunctedPredicate, EvaluationContext.empty(), AliasMap.emptyMap(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
@@ -30,8 +30,8 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PConstantObjectValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
@@ -45,7 +45,6 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -108,14 +107,9 @@ public class ConstantObjectValue extends AbstractValue implements LeafValue, Val
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraint = super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraint.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final var otherConstantObjectValue = (ConstantObjectValue)other;
-        return constantId.equals(otherConstantObjectValue.constantId) ? superQueryPlanConstraint : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> constantId.equals(((ConstantObjectValue)other).constantId));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PConstantObjectValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
@@ -44,6 +45,7 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -104,15 +106,16 @@ public class ConstantObjectValue extends AbstractValue implements LeafValue, Val
         return semanticHashCode();
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap aliasMap) {
-        if (!super.equalsWithoutChildren(other, aliasMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraint = super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraint.isEmpty()) {
+            return Optional.empty();
         }
 
         final var otherConstantObjectValue = (ConstantObjectValue)other;
-        return constantId.equals(otherConstantObjectValue.constantId);
+        return constantId.equals(otherConstantObjectValue.constantId) ? superQueryPlanConstraint : Optional.empty();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantValue.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PConstantValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
@@ -41,6 +42,7 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -98,14 +100,16 @@ public class ConstantValue extends AbstractValue implements LeafValue {
         return false;
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!LeafValue.super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraintOptional = LeafValue.super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraintOptional.isEmpty()) {
+            return Optional.empty();
         }
 
         final ConstantValue that = (ConstantValue)other;
-        return value.equals(that.value);
+        return value.equals(that.value) ? superQueryPlanConstraintOptional : Optional.empty();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantValue.java
@@ -30,8 +30,8 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PConstantValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
@@ -42,7 +42,6 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -102,14 +101,9 @@ public class ConstantValue extends AbstractValue implements LeafValue {
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraintOptional = LeafValue.super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraintOptional.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final ConstantValue that = (ConstantValue)other;
-        return value.equals(that.value) ? superQueryPlanConstraintOptional : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return LeafValue.super.equalsWithoutChildren(other)
+                .filter(ignored -> value.equals(((ConstantValue)other).value));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ExistsValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ExistsValue.java
@@ -54,13 +54,13 @@ import java.util.Optional;
  * A {@link Value} that checks whether an item exists in its child quantifier expression or not.
  */
 @API(API.Status.EXPERIMENTAL)
-public class ExistsValue extends AbstractValue implements BooleanValue, ValueWithChild, Value.CompileTimeValue {
+public class ExistsValue extends AbstractValue implements BooleanValue, QuantifiedValue, Value.CompileTimeValue {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Exists-Value");
     @Nonnull
-    private final QuantifiedObjectValue child;
+    private final CorrelationIdentifier alias;
 
-    public ExistsValue(@Nonnull QuantifiedObjectValue child) {
-        this.child = child;
+    public ExistsValue(@Nonnull CorrelationIdentifier alias) {
+        this.alias = alias;
     }
 
     @Override
@@ -68,20 +68,13 @@ public class ExistsValue extends AbstractValue implements BooleanValue, ValueWit
     @SpotBugsSuppressWarnings("NP_NONNULL_PARAM_VIOLATION")
     public Optional<QueryPredicate> toQueryPredicate(@Nullable final TypeRepository typeRepository,
                                                      @Nonnull final CorrelationIdentifier innermostAlias) {
-        return Optional.of(new ExistsPredicate(child.getAlias()));
+        return Optional.of(new ExistsPredicate(alias));
     }
 
     @Nonnull
     @Override
-    public Value getChild() {
-        return child;
-    }
-
-    @Nonnull
-    @Override
-    public ValueWithChild withNewChild(@Nonnull final Value newChild) {
-        Verify.verify(newChild instanceof QuantifiedObjectValue);
-        return new ExistsValue((QuantifiedObjectValue)newChild);
+    public CorrelationIdentifier getAlias() {
+        return alias;
     }
 
     @Override
@@ -91,18 +84,18 @@ public class ExistsValue extends AbstractValue implements BooleanValue, ValueWit
 
     @Override
     public int planHash(@Nonnull final PlanHashMode mode) {
-        return PlanHashable.objectsPlanHash(mode, BASE_HASH, child);
+        return PlanHashable.objectsPlanHash(mode, BASE_HASH, alias);
     }
 
     @Nonnull
     @Override
     public String explain(@Nonnull final Formatter formatter) {
-        return "exists(" + child.explain(formatter) + ")";
+        return "exists(" + alias + ")";
     }
 
     @Override
     public String toString() {
-        return "exists(" + child + ")";
+        return "exists(" + alias + ")";
     }
 
     @Override
@@ -121,7 +114,7 @@ public class ExistsValue extends AbstractValue implements BooleanValue, ValueWit
     @Override
     public PExistsValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
         return PExistsValue.newBuilder()
-                .setChild(child.toProto(serializationContext))
+                .setAlias(alias.getId())
                 .build();
     }
 
@@ -134,14 +127,18 @@ public class ExistsValue extends AbstractValue implements BooleanValue, ValueWit
     @Nonnull
     public static ExistsValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
                                         @Nonnull final PExistsValue existsValueProto) {
+        if (existsValueProto.hasAlias()) {
+            return new ExistsValue(CorrelationIdentifier.of(Objects.requireNonNull(existsValueProto.getAlias())));
+        }
+        // TODO deprecated -- remove this
         return new ExistsValue(QuantifiedObjectValue.fromProto(serializationContext,
-                Objects.requireNonNull(existsValueProto.getChild())));
+                Objects.requireNonNull(existsValueProto.getChild())).getAlias());
     }
 
     @Nonnull
     @Override
     protected Iterable<? extends Value> computeChildren() {
-        return ImmutableList.of(getChild());
+        return ImmutableList.of();
     }
 
     /**
@@ -163,7 +160,7 @@ public class ExistsValue extends AbstractValue implements BooleanValue, ValueWit
             // create an existential quantifier
             final Quantifier.Existential existsQuantifier = Quantifier.existential(Reference.of((RelationalExpression)in));
 
-            return new ExistsValue(existsQuantifier.getFlowedObjectValue());
+            return new ExistsValue(existsQuantifier.getAlias());
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PFieldPath.PResolvedAc
 import com.apple.foundationdb.record.RecordQueryPlanProto.PFieldValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.NullableArrayTypeUtils;
@@ -176,15 +177,16 @@ public class FieldValue extends AbstractValue implements ValueWithChild {
         }
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!ValueWithChild.super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraint = ValueWithChild.super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraint.isEmpty()) {
+            return Optional.empty();
         }
 
         final var that = (FieldValue)other;
-        return fieldPath.equals(that.fieldPath) &&
-                childValue.semanticEquals(that.childValue, equivalenceMap);
+        return fieldPath.equals(that.fieldPath) ? superQueryPlanConstraint : Optional.empty();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
@@ -35,8 +35,8 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PFieldPath.PResolvedAc
 import com.apple.foundationdb.record.RecordQueryPlanProto.PFieldValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordVersion;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.NullableArrayTypeUtils;
 import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
@@ -179,14 +179,9 @@ public class FieldValue extends AbstractValue implements ValueWithChild {
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraint = ValueWithChild.super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraint.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final var that = (FieldValue)other;
-        return fieldPath.equals(that.fieldPath) ? superQueryPlanConstraint : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return ValueWithChild.super.equalsWithoutChildren(other)
+                .filter(ignored -> fieldPath.equals(((FieldValue)other).getFieldPath()));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FirstOrDefaultValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FirstOrDefaultValue.java
@@ -111,17 +111,6 @@ public class FirstOrDefaultValue extends AbstractValue {
     }
 
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
-        }
-
-        final var that = (FirstOrDefaultValue)other;
-        return childValue.semanticEquals(that.childValue, equivalenceMap) &&
-                onEmptyResultValue.semanticEquals(that.onEmptyResultValue, equivalenceMap);
-    }
-
-    @Override
     public int hashCodeWithoutChildren() {
         return PlanHashable.objectsPlanHash(PlanHashable.CURRENT_FOR_CONTINUATION, BASE_HASH);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PMaxEverLongValue;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PMinEverLongValue;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
 import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
@@ -51,6 +52,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents a compile-time aggregation value that must be backed by an aggregation index, and can not be evaluated
@@ -167,13 +169,16 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
     }
 
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (this == other) {
-            return true;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraintOptional = super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraintOptional.isEmpty()) {
+            return Optional.empty();
         }
 
-        return other.getClass() == getClass() && ((IndexOnlyAggregateValue)other).operator.equals(operator);
+        final var that = (IndexOnlyAggregateValue)other;
+        return operator.equals(that.operator) ? superQueryPlanConstraintOptional : Optional.empty();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
@@ -35,8 +35,8 @@ import com.apple.foundationdb.record.RecordQueryPlanProto.PMaxEverLongValue;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PMinEverLongValue;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
 import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Represents a compile-time aggregation value that must be backed by an aggregation index, and can not be evaluated
@@ -168,17 +167,11 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
         return semanticHashCode();
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraintOptional = super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraintOptional.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final var that = (IndexOnlyAggregateValue)other;
-        return operator.equals(that.operator) ? superQueryPlanConstraintOptional : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> operator.equals(((IndexOnlyAggregateValue)other).operator));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LiteralValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LiteralValue.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PLiteralValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
@@ -46,6 +47,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A wrapper around a literal of the given type.
@@ -100,17 +102,20 @@ public class LiteralValue<T> extends AbstractValue implements LeafValue, Value.R
         return false;
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!LeafValue.super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraintOptional = LeafValue.super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraintOptional.isEmpty()) {
+            return Optional.empty();
         }
 
         final LiteralValue<?> that = (LiteralValue<?>)other;
         if (value == null && that.value == null) {
-            return true;
+            return superQueryPlanConstraintOptional;
         }
-        return Boolean.TRUE.equals(Comparisons.evalComparison(Comparisons.Type.EQUALS, value, that.value));
+        return Boolean.TRUE.equals(Comparisons.evalComparison(Comparisons.Type.EQUALS, value, that.value))
+               ? superQueryPlanConstraintOptional : Optional.empty();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NullValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NullValue.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PNullValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.google.auto.service.AutoService;
@@ -40,6 +41,7 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A value that evaluates to empty.
@@ -78,13 +80,15 @@ public class NullValue extends AbstractValue implements LeafValue {
         return false;
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!LeafValue.super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraintOptional = LeafValue.super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraintOptional.isEmpty()) {
+            return Optional.empty();
         }
 
-        return resultType.equals(other.getResultType());
+        return resultType.equals(other.getResultType()) ? superQueryPlanConstraintOptional : Optional.empty();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NullValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NullValue.java
@@ -30,8 +30,8 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PNullValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
@@ -41,7 +41,6 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A value that evaluates to empty.
@@ -82,13 +81,9 @@ public class NullValue extends AbstractValue implements LeafValue {
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraintOptional = LeafValue.super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraintOptional.isEmpty()) {
-            return Optional.empty();
-        }
-
-        return resultType.equals(other.getResultType()) ? superQueryPlanConstraintOptional : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> resultType.equals(other.getResultType()));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OfTypeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OfTypeValue.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.POfTypeValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
@@ -48,7 +49,7 @@ public class OfTypeValue extends AbstractValue implements Value.RangeMatchableVa
 
     @Nonnull
     private final Value child;
-
+    @Nonnull
     private final Type expectedType;
 
     private OfTypeValue(@Nonnull final Value child, @Nonnull final Type expectedType) {
@@ -65,6 +66,11 @@ public class OfTypeValue extends AbstractValue implements Value.RangeMatchableVa
     @Override
     public Value getChild() {
         return child;
+    }
+
+    @Nonnull
+    public Type getExpectedType() {
+        return expectedType;
     }
 
     @Nonnull
@@ -104,6 +110,13 @@ public class OfTypeValue extends AbstractValue implements Value.RangeMatchableVa
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
         return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+    }
+
+    @Nonnull
+    @Override
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> expectedType.equals(((OfTypeValue)other).getExpectedType()));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/QuantifiedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/QuantifiedValue.java
@@ -21,12 +21,11 @@
 package com.apple.foundationdb.record.query.plan.cascades.values;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -46,13 +45,8 @@ public interface QuantifiedValue extends LeafValue {
 
     @Nonnull
     @Override
-    default Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraint = LeafValue.super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraint.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final QuantifiedValue that = (QuantifiedValue)other;
-        return getAlias().equals(that.getAlias()) ? superQueryPlanConstraint : Optional.empty();
+    default BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return LeafValue.super.equalsWithoutChildren(other)
+                .filter(ignored -> getAlias().equals(((QuantifiedValue)other).getAlias()));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/QuantifiedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/QuantifiedValue.java
@@ -21,11 +21,12 @@
 package com.apple.foundationdb.record.query.plan.cascades.values;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -34,6 +35,7 @@ import java.util.Set;
 @API(API.Status.EXPERIMENTAL)
 public interface QuantifiedValue extends LeafValue {
 
+    @Nonnull
     CorrelationIdentifier getAlias();
 
     @Nonnull
@@ -42,13 +44,15 @@ public interface QuantifiedValue extends LeafValue {
         return ImmutableSet.of(getAlias());
     }
 
+    @Nonnull
     @Override
-    default boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!LeafValue.super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
+    default Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraint = LeafValue.super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraint.isEmpty()) {
+            return Optional.empty();
         }
 
         final QuantifiedValue that = (QuantifiedValue)other;
-        return equivalenceMap.containsMapping(getAlias(), that.getAlias());
+        return getAlias().equals(that.getAlias()) ? superQueryPlanConstraint : Optional.empty();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ThrowsValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ThrowsValue.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PThrowsValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
@@ -40,6 +41,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A value that throws an exception if it gets executed.
@@ -72,13 +74,14 @@ public class ThrowsValue extends AbstractValue implements LeafValue {
     }
 
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraint = super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraint.isEmpty()) {
+            return Optional.empty();
         }
 
         final var that = (ThrowsValue)other;
-        return resultType.equals(that.resultType);
+        return resultType.equals(that.resultType) ? superQueryPlanConstraint : Optional.empty();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ThrowsValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ThrowsValue.java
@@ -31,8 +31,8 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordQueryPlanProto;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PThrowsValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.google.auto.service.AutoService;
@@ -41,7 +41,6 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * A value that throws an exception if it gets executed.
@@ -73,15 +72,11 @@ public class ThrowsValue extends AbstractValue implements LeafValue {
         throw new RecordCoreException("evaluation of throws()");
     }
 
+    @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraint = super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraint.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final var that = (ThrowsValue)other;
-        return resultType.equals(that.resultType) ? superQueryPlanConstraint : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> resultType.equals(((ThrowsValue)other).resultType));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
@@ -59,6 +59,7 @@ public class VersionValue extends AbstractValue implements QuantifiedValue {
         this.baseAlias = baseAlias;
     }
 
+    @Nonnull
     @Override
     public CorrelationIdentifier getAlias() {
         return baseAlias;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PWindowedValue;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
@@ -37,6 +38,7 @@ import com.google.common.collect.Iterators;
 import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -149,14 +151,16 @@ public abstract class WindowedValue extends AbstractValue {
         return semanticHashCode();
     }
 
+    @Nonnull
     @Override
-    public boolean equalsWithoutChildren(@Nonnull final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (!super.equalsWithoutChildren(other, equivalenceMap)) {
-            return false;
+    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
+        final var superQueryPlanConstraintOptional = super.equalsWithoutChildren(other);
+        if (superQueryPlanConstraintOptional.isEmpty()) {
+            return Optional.empty();
         }
 
         final var otherWindowedValue = (WindowedValue)other;
-        return getName().equals(otherWindowedValue.getName());
+        return getName().equals(otherWindowedValue.getName()) ? superQueryPlanConstraintOptional : Optional.empty();
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
@@ -26,8 +26,8 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordQueryPlanProto.PWindowedValue;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.google.common.base.Preconditions;
@@ -38,7 +38,6 @@ import com.google.common.collect.Iterators;
 import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -153,14 +152,9 @@ public abstract class WindowedValue extends AbstractValue {
 
     @Nonnull
     @Override
-    public Optional<QueryPlanConstraint> equalsWithoutChildren(@Nonnull final Value other) {
-        final var superQueryPlanConstraintOptional = super.equalsWithoutChildren(other);
-        if (superQueryPlanConstraintOptional.isEmpty()) {
-            return Optional.empty();
-        }
-
-        final var otherWindowedValue = (WindowedValue)other;
-        return getName().equals(otherWindowedValue.getName()) ? superQueryPlanConstraintOptional : Optional.empty();
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> getName().equals(((WindowedValue)other).getName()));
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/Simplification.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/Simplification.java
@@ -290,11 +290,12 @@ public class Simplification {
                                                                                       @Nonnull final Set<CorrelationIdentifier> constantAliases,
                                                                                       @Nonnull final QueryPredicateComputationRuleSet<ARGUMENT, List<QueryPlanConstraint>> ruleSet) {
         final var resultsMap = new LinkedIdentityMap<QueryPredicate, Pair<QueryPredicate, List<QueryPlanConstraint>>>();
-        final var simplifiedPredicate = simplifyWithReExploration(root,
-                root,
-                resultsMap,
-                ruleSet,
-                (rule, r, c, plannerBindings) -> new QueryPredicateComputationRuleCall<>(rule, r, c, argument, plannerBindings, aliasMap, constantAliases, resultsMap::get));
+        final var simplifiedPredicate =
+                simplifyWithReExploration(root,
+                        root,
+                        resultsMap,
+                        ruleSet,
+                        (rule, r, c, plannerBindings) -> new QueryPredicateComputationRuleCall<>(rule, r, c, argument, plannerBindings, aliasMap, constantAliases, resultsMap::get));
         return simplifiedPredicate == root
                ? Pair.of(root, ImmutableList.of(QueryPlanConstraint.tautology()))
                : Verify.verifyNotNull(resultsMap.get(simplifiedPredicate));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
@@ -80,14 +80,14 @@ public class RecordQueryPredicatesFilterPlan extends RecordQueryFilterPlanBase i
             predicatesBuilder.add(QueryPredicate.fromQueryPredicateProto(serializationContext, recordQueryPredicatesFilterPlanProto.getPredicates(i)));
         }
         this.predicates = predicatesBuilder.build();
-        this.conjunctedPredicate = AndPredicate.andOrTrue(this.predicates);
+        this.conjunctedPredicate = AndPredicate.and(this.predicates);
     }
 
     public RecordQueryPredicatesFilterPlan(@Nonnull Quantifier.Physical inner,
                                            @Nonnull Iterable<? extends QueryPredicate> predicates) {
         super(inner);
         this.predicates = ImmutableList.copyOf(predicates);
-        this.conjunctedPredicate = AndPredicate.andOrTrue(this.predicates);
+        this.conjunctedPredicate = AndPredicate.and(this.predicates);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -394,7 +394,8 @@ message PEmptyValue {
 }
 
 message PExistsValue {
-  optional PQuantifiedObjectValue child = 1;
+  optional PQuantifiedObjectValue child = 1; // deprecated
+  optional string alias = 2;
 }
 
 message PFieldValue {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcher.java
@@ -45,7 +45,7 @@ public class FilterMatcher extends PlanMatcherWithChild {
     public boolean matchesSafely(@Nonnull RecordQueryPlan plan) {
         final QueryPredicate predicate;
         if (plan instanceof RecordQueryPredicatesFilterPlan) {
-            predicate = AndPredicate.andOrTrue(((RecordQueryPredicatesFilterPlan)plan).getPredicates());
+            predicate = AndPredicate.and(((RecordQueryPredicatesFilterPlan)plan).getPredicates());
         } else {
             return false;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcherWithComponent.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/FilterMatcherWithComponent.java
@@ -65,7 +65,7 @@ public class FilterMatcherWithComponent extends PlanMatcherWithChild {
 
             // we lazily convert the given component to a predicate and let semantic equals establish equality
             // under the given equivalence: baseAlias <-> planBaseAlias
-            final QueryPredicate predicate = AndPredicate.andOrTrue(((RecordQueryPredicatesFilterPlan)plan).getPredicates());
+            final QueryPredicate predicate = AndPredicate.and(((RecordQueryPredicatesFilterPlan)plan).getPredicates());
             
             if (predicate instanceof PredicateWithValue) {
                 final Set<CorrelationIdentifier> predicateCorrelatedTo = predicate.getCorrelatedTo();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/planning/BooleanPredicateNormalizerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/planning/BooleanPredicateNormalizerTest.java
@@ -195,7 +195,7 @@ class BooleanPredicateNormalizerTest {
             }
             conjuncts.add(or(disjuncts));
         }
-        final QueryPredicate cnf = and(conjuncts);
+        final QueryPredicate cnf = AndPredicate.and(conjuncts);
 
         final BooleanPredicateNormalizer normalizer = BooleanPredicateNormalizer.getDefaultInstanceForDnf();
         assertNotEquals(cnf, normalizer.normalizeAndSimplify(cnf, true).orElse(cnf));
@@ -212,7 +212,7 @@ class BooleanPredicateNormalizerTest {
 
     @Test
     void bigNonCnf() {
-        final QueryPredicate cnf = and(
+        final QueryPredicate cnf = AndPredicate.and(
                 IntStream.rangeClosed(1, 9).boxed().map(i ->
                         or(IntStream.rangeClosed(1, 9).boxed()
                                 .map(j -> and(
@@ -244,7 +244,7 @@ class BooleanPredicateNormalizerTest {
             }
             conjuncts.add(or(disjuncts));
         }
-        final QueryPredicate cnf = and(conjuncts);
+        final QueryPredicate cnf = AndPredicate.and(conjuncts);
         final BooleanPredicateNormalizer normalizer = BooleanPredicateNormalizer.getDefaultInstanceForDnf();
         assertEquals(4611686018427387904L, normalizer.getNormalizedSize(cnf));
         assertThrows(BooleanPredicateNormalizer.NormalFormTooLargeException.class, () -> normalizer.normalizeAndSimplify(cnf, true));


### PR DESCRIPTION
This PR adds/changes the following:
- new `BooleanWithConstraint` to capture a boolean data type that also records a `QueryPlanConstraint` if `true`. Such a boolean is either `false`, or `true` under the assumption that the constraint holds. The constraint may be `QueryPlanConstraint.tautology()` if it is not actually constrained.
- new `ValueEquivalence` which defines e.g. aliases to be considered equal or value trees to be considered equal. This functions as a generalization of `AliasMap`s.
- new `UsesValueEquivalence` interface which can be implemented (currently implemented in `Comparisons.Comparison`, `Value`, `RangeConstraints`, and `QueryPredicate`) to indicate that the class provides `BooleanWIthConstraint semanticEquals(Object, ValueEquivalence)`
- new `semanticEquals(Object, ValueEquivalence)` method call tree (including `equalsWithoutChildren`, `equalsForChildren`) which work as before but instead of returning a `boolean` now return a `BooleanWithConstraint`