### PR TITLE
Resolve #2794: OnlineIndexer / OnlineIndexScrubber: move the sync ses sion lease length to Config

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** OnlineIndexer / OnlineIndexScrubber: move the sync session lease length to Config [(Issue #2794)](https://github.com/FoundationDB/fdb-record-layer/issues/2794)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -207,7 +207,7 @@ public abstract class IndexingBase {
             buildIndexAsyncFuture = runner
                     .runAsync(context -> openRecordStore(context).thenApply(store -> indexBuildLockSubspace(store, index)),
                             common.indexLogMessageKeyValues("IndexingBase::indexBuildLockSubspace"))
-                    .thenCompose(lockSubspace -> runner.startSynchronizedSessionAsync(lockSubspace, common.getLeaseLengthMillis()))
+                    .thenCompose(lockSubspace -> runner.startSynchronizedSessionAsync(lockSubspace, common.config.getLeaseLengthMillis()))
                     .thenCompose(synchronizedRunner -> {
                         message.addKeyAndValue(LogMessageKeys.SESSION_ID, synchronizedRunner.getSessionId());
                         return runWithSynchronizedRunnerAndEndSession(synchronizedRunner,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -57,9 +57,7 @@ public class IndexingCommon {
 
     @Nonnull private final FDBRecordStore.Builder recordStoreBuilder;
     @Nonnull private final AtomicLong totalRecordsScanned;
-    private final boolean useSynchronizedSession;
     private final boolean trackProgress;
-    private final long leaseLengthMillis;
 
     @Nonnull public OnlineIndexOperationConfig config; // this item may be modified on the fly
     @Nullable private final Function<OnlineIndexOperationConfig, OnlineIndexOperationConfig> configLoader;
@@ -96,16 +94,12 @@ public class IndexingCommon {
                    @Nullable Collection<RecordType> allRecordTypes,
                    @Nullable UnaryOperator<OnlineIndexOperationConfig> configLoader,
                    @Nonnull OnlineIndexOperationConfig config,
-                   boolean trackProgress,
-                   boolean useSynchronizedSession,
-                   long leaseLengthMillis) {
-        this.useSynchronizedSession = useSynchronizedSession;
+                   boolean trackProgress) {
         this.runner = runner;
         this.configLoader = configLoader;
         this.config = config;
         this.trackProgress = trackProgress;
         this.recordStoreBuilder = recordStoreBuilder;
-        this.leaseLengthMillis = leaseLengthMillis;
 
         this.totalRecordsScanned = new AtomicLong(0);
         this.targetIndexContexts = new ArrayList<>(targetIndexes.size());
@@ -145,10 +139,6 @@ public class IndexingCommon {
 
     public UUID getUuid() {
         return uuid;
-    }
-
-    public boolean shouldUseSynchronizedSession() {
-        return useSynchronizedSession;
     }
 
     public List<Object> indexLogMessageKeyValues() {
@@ -284,10 +274,6 @@ public class IndexingCommon {
 
     public int getConfigLoaderInvocationCount() {
         return configLoaderInvocationCount;
-    }
-
-    public long getLeaseLengthMillis() {
-        return leaseLengthMillis;
     }
 
     public boolean loadConfig() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
+import com.apple.foundationdb.record.provider.foundationdb.synchronizedsession.SynchronizedSessionRunner;
 import com.apple.foundationdb.subspace.Subspace;
 import com.google.protobuf.Message;
 
@@ -704,6 +705,33 @@ public abstract class OnlineIndexOperationBaseBuilder<B extends OnlineIndexOpera
         configBuilder.setTransactionTimeLimitMilliseconds(timeLimitMilliseconds);
         return self();
     }
+
+    /**
+     * Set the use of a synchronized session during the index operation. Synchronized sessions help performing
+     * the multiple transactions operations in a resource efficient way.
+     * Normally this should be {@code true}.
+     *
+     * @see SynchronizedSessionRunner
+     * @param useSynchronizedSession use synchronize session if true, otherwise false
+     * @return this builder
+     */
+    public B setUseSynchronizedSession(boolean useSynchronizedSession) {
+        configBuilder.setUseSynchronizedSession(useSynchronizedSession);
+        return self();
+    }
+
+    /**
+     * Set the lease length in milliseconds if the synchronized session is used. The default value is {@link OnlineIndexOperationConfig#DEFAULT_LEASE_LENGTH_MILLIS}.
+     * @see #setUseSynchronizedSession(boolean)
+     * @see com.apple.foundationdb.synchronizedsession.SynchronizedSession
+     * @param leaseLengthMillis length between last access and lease's end time in milliseconds
+     * @return this builder
+     */
+    public B setLeaseLengthMillis(long leaseLengthMillis) {
+        configBuilder.setLeaseLengthMillis(leaseLengthMillis);
+        return self();
+    }
+
 
     @Nonnull
     protected OnlineIndexOperationConfig getConfig() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -1013,8 +1013,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                     Collections.emptyList(),
                     null,
                     config,
-                    false, false, 0
-                    );
+                    false);
 
             final IndexingThrottle.Booker booker = new IndexingThrottle.Booker(common);
             assertEquals(4, booker.getRecordsLimit());
@@ -1087,8 +1086,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                     Collections.emptyList(),
                     null,
                     config,
-                    false, false, 0
-            );
+                    false);
 
             final IndexingThrottle.Booker booker = new IndexingThrottle.Booker(common);
             assertEquals(100, booker.getRecordsLimit());
@@ -1124,8 +1122,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                     Collections.emptyList(),
                     null,
                     config,
-                    false, false, 0
-            );
+                    false);
 
             final IndexingThrottle.Booker booker = new IndexingThrottle.Booker(common);
             postTransaction(booker, 1, 1000, true); // set last failure count to 1000


### PR DESCRIPTION

   As a code cleanup, and following PR #2788, move the sync session parameters to OnlineIndexOperationConfig.