### PR TITLE
performance fixes

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
@@ -198,7 +198,7 @@ public class IndexScanComparisons implements IndexScanParameters {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
-        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
@@ -267,7 +267,7 @@ public class MultidimensionalIndexScanComparisons implements IndexScanParameters
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
-        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartiallyOrderedSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/combinatorics/PartiallyOrderedSet.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.combinatorics;
 
+import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
@@ -293,7 +294,7 @@ public class PartiallyOrderedSet<T> {
         }
 
         public EligibleSet<T> removeEligibleElements(@Nonnull final Set<T> toBeRemovedEligibleElements) {
-            Preconditions.checkArgument(eligibleElements().containsAll(toBeRemovedEligibleElements));
+            Debugger.sanityCheck(() -> Preconditions.checkArgument(eligibleElements().containsAll(toBeRemovedEligibleElements)));
 
             final var set = partiallyOrderedSet.getSet();
             final var newSetBuilder = ImmutableSet.<T>builder();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -1299,14 +1299,7 @@ public class Comparisons {
         @SpotBugsSuppressWarnings("EQ_UNUSUAL")
         @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
         public boolean equals(Object o) {
-            final AliasMap aliasMap;
-            if (isCorrelation()) {
-                final var alias = CorrelationIdentifier.of(Bindings.Internal.CORRELATION.identifier(parameter));
-                aliasMap = AliasMap.identitiesFor(ImmutableSet.of(alias));
-            } else {
-                aliasMap = AliasMap.emptyMap();
-            }
-            return semanticEquals(o, aliasMap);
+            return semanticEquals(o, AliasMap.emptyMap());
         }
 
         @Override
@@ -1557,7 +1550,7 @@ public class Comparisons {
         @SpotBugsSuppressWarnings("EQ_UNUSUAL")
         @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
         public boolean equals(Object o) {
-            return semanticEquals(o, AliasMap.identitiesFor(comparandValue.getCorrelatedTo()));
+            return semanticEquals(o, AliasMap.emptyMap());
         }
 
         @Override
@@ -2664,7 +2657,7 @@ public class Comparisons {
         @SpotBugsSuppressWarnings("EQ_UNUSUAL")
         @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
         public boolean equals(final Object o) {
-            return semanticEquals(o, AliasMap.identitiesFor(inner.getCorrelatedTo()));
+            return semanticEquals(o, AliasMap.emptyMap());
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/ScanComparisons.java
@@ -423,7 +423,7 @@ public class ScanComparisons implements PlanHashable, Correlated<ScanComparisons
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object o) {
-        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
@@ -179,7 +179,7 @@ public class AggregateIndexExpansionVisitor extends KeyExpressionExpansionVisito
                     // we check if the predicate value is a placeholder, if so, create a placeholder, otherwise, add it as a constraint.
                     final var maybePlaceholder = baseExpansion.getPlaceholders()
                             .stream()
-                            .filter(existingPlaceholder -> existingPlaceholder.getValue().semanticEquals(value, AliasMap.identitiesFor(existingPlaceholder.getCorrelatedTo())))
+                            .filter(existingPlaceholder -> existingPlaceholder.getValue().semanticEquals(value, AliasMap.emptyMap()))
                             .findFirst();
                     if (maybePlaceholder.isEmpty()) {
                         predicateExpansionBuilder.addPredicate(PredicateWithValueAndRanges.ofRanges(value, ImmutableSet.copyOf(valueRanges.get(value))));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRange.java
@@ -424,7 +424,7 @@ public class ComparisonRange implements PlanHashable, Correlated<ComparisonRange
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object o) {
-        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ComparisonRanges.java
@@ -349,7 +349,7 @@ public class ComparisonRanges implements PlanHashable, Correlated<ComparisonRang
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
-        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/GraphExpansion.java
@@ -239,7 +239,7 @@ public class GraphExpansion {
             for (final QueryPredicate queryPredicate : getPredicates()) {
                 if (queryPredicate instanceof Placeholder) {
                     final var localPlaceHolder = (Placeholder)queryPredicate;
-                    final var identities = AliasMap.identitiesFor(localPlaceHolder.getCorrelatedTo());
+                    final var identities = AliasMap.emptyMap();
                     final var iterator = localPlaceHolderPairs.iterator();
                     int foundAtOrdinal = -1;
                     while (iterator.hasNext()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexPredicateExpansion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/IndexPredicateExpansion.java
@@ -81,7 +81,7 @@ public class IndexPredicateExpansion {
                 if (key.isEmpty()) {
                     key = Optional.of(valuePredicate.getValue());
                 } else {
-                    if (!key.get().semanticEquals(valuePredicate.getValue(), AliasMap.identitiesFor(key.get().getCorrelatedTo()))) {
+                    if (!key.get().semanticEquals(valuePredicate.getValue(), AliasMap.emptyMap())) {
                         return false;
                     }
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NotValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NotValue.java
@@ -155,7 +155,7 @@ public class NotValue extends AbstractValue implements BooleanValue, ValueWithCh
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
@@ -47,6 +47,7 @@ import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -650,16 +651,29 @@ public class Ordering {
     @Nonnull
     public static PartiallyOrderedSet<Value> normalizeOrderingSet(@Nonnull final SetMultimap<Value, Binding> bindingMap,
                                                                   @Nonnull final PartiallyOrderedSet<Value> orderingSet) {
-        final var transitiveClosure = orderingSet.getTransitiveClosure();
         final var normalizedDependencyMapBuilder = ImmutableSetMultimap.<Value, Value>builder();
-
-        for (final var dependency : transitiveClosure.entries()) {
-            Verify.verify(bindingMap.containsKey(dependency.getKey()));
-            Verify.verify(bindingMap.containsKey(dependency.getValue()));
-            final boolean isFixed = areAllBindingsFixed(bindingMap.get(dependency.getKey())) ||
-                    areAllBindingsFixed(bindingMap.get(dependency.getValue()));
-            if (!isFixed) {
-                normalizedDependencyMapBuilder.put(dependency);
+        final var dependencyMap = orderingSet.getDependencyMap().asMap();
+        for (final var dependencySetEntry : dependencyMap.entrySet()) {
+            //
+            // If the current value is not fixed check its dependencies, completely skip the dependency if this value
+            // is fixed.
+            //
+            if (!areAllBindingsFixed(Objects.requireNonNull(bindingMap.get(dependencySetEntry.getKey())))) {
+                // follow all dependencies to values that are not fixed anymore
+                final var toBeProcessed = new ArrayDeque<>(dependencySetEntry.getValue());
+                while (!toBeProcessed.isEmpty()) {
+                    final var dependentValue = toBeProcessed.removeFirst();
+                    if (!areAllBindingsFixed(Objects.requireNonNull(bindingMap.get(dependentValue)))) {
+                        // add a direct dependency from the original value to this one
+                        normalizedDependencyMapBuilder.put(dependencySetEntry.getKey(), dependentValue);
+                    } else {
+                        // this one is fixed; we have to skip it and look at its dependencies as well
+                        final var transitivelyDependentValues = dependencyMap.get(dependentValue);
+                        if (transitivelyDependentValues != null) {
+                            toBeProcessed.addAll(transitivelyDependentValues);
+                        }
+                    }
+                }
             }
         }
         return PartiallyOrderedSet.of(orderingSet.getSet(), normalizedDependencyMapBuilder.build());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
@@ -141,7 +141,7 @@ public class ValueIndexExpansionVisitor extends KeyExpressionExpansionVisitor im
                     // we check if the predicate value is a placeholder, if so, create a placeholder, otherwise, add it as a constraint.
                     final var maybePlaceholder = keyValueExpansion.getPlaceholders()
                             .stream()
-                            .filter(existingPlaceholder -> existingPlaceholder.getValue().semanticEquals(value, AliasMap.identitiesFor(existingPlaceholder.getCorrelatedTo())))
+                            .filter(existingPlaceholder -> existingPlaceholder.getValue().semanticEquals(value, AliasMap.emptyMap()))
                             .findFirst();
                     if (maybePlaceholder.isEmpty()) {
                         predicateExpansionBuilder.addPredicate(PredicateWithValueAndRanges.ofRanges(value, ImmutableSet.copyOf(valueRanges.get(value))));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndOrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndOrPredicate.java
@@ -84,7 +84,7 @@ public abstract class AndOrPredicate extends AbstractQueryPredicate {
     @SuppressWarnings({"squid:S1206", "EqualsWhichDoesntCheckParameterClass"})
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/CompatibleTypeEvolutionPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/CompatibleTypeEvolutionPredicate.java
@@ -164,7 +164,7 @@ public class CompatibleTypeEvolutionPredicate extends AbstractQueryPredicate imp
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ConstantPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ConstantPredicate.java
@@ -108,7 +108,7 @@ public class ConstantPredicate extends AbstractQueryPredicate implements LeafQue
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
@@ -128,7 +128,7 @@ public class DatabaseObjectDependenciesPredicate extends AbstractQueryPredicate 
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ExistsPredicate.java
@@ -128,7 +128,7 @@ public class ExistsPredicate extends AbstractQueryPredicate implements LeafQuery
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/NotPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/NotPredicate.java
@@ -101,7 +101,7 @@ public class NotPredicate extends AbstractQueryPredicate implements QueryPredica
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/Placeholder.java
@@ -113,7 +113,7 @@ public class Placeholder extends PredicateWithValueAndRanges implements WithAlia
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        if (!super.semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()))) {
+        if (!super.semanticEquals(other, AliasMap.emptyMap())) {
             return false;
         }
         if (!(other instanceof Placeholder)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
@@ -165,7 +165,7 @@ public class PredicateWithValueAndRanges extends AbstractQueryPredicate implemen
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ValuePredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/ValuePredicate.java
@@ -144,7 +144,7 @@ public class ValuePredicate extends AbstractQueryPredicate implements PredicateW
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
@@ -776,7 +776,7 @@ public class DerivationsProperty implements PlanProperty<DerivationsProperty.Der
         public List<Value> simplifyLocalValues() {
             final var simplifiedLocalValuesBuilder = ImmutableList.<Value>builder();
             for (final var localValue : getLocalValues()) {
-                final var aliasMap = AliasMap.identitiesFor(localValue.getCorrelatedTo());
+                final var aliasMap = AliasMap.emptyMap();
                 simplifiedLocalValuesBuilder.add(localValue.simplify(aliasMap, ImmutableSet.of()));
             }
             return simplifiedLocalValuesBuilder.build();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
@@ -126,7 +126,7 @@ public abstract class AbstractArrayConstructorValue extends AbstractValue implem
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AndOrValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AndOrValue.java
@@ -168,7 +168,7 @@ public class AndOrValue extends AbstractValue implements BooleanValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -157,7 +157,7 @@ public class ArithmeticValue extends AbstractValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ConstantObjectValue.java
@@ -97,7 +97,7 @@ public class ConstantObjectValue extends AbstractValue implements LeafValue, Val
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
-        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CountValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CountValue.java
@@ -175,7 +175,7 @@ public class CountValue extends AbstractValue implements AggregateValue, Streama
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/DerivedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/DerivedValue.java
@@ -106,7 +106,7 @@ public class DerivedValue extends AbstractValue implements Value.CompileTimeValu
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ExistsValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ExistsValue.java
@@ -107,7 +107,7 @@ public class ExistsValue extends AbstractValue implements BooleanValue, Quantifi
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
@@ -233,7 +233,7 @@ public class FieldValue extends AbstractValue implements ValueWithChild {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(childValue.getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FirstOrDefaultValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FirstOrDefaultValue.java
@@ -141,7 +141,7 @@ public class FirstOrDefaultValue extends AbstractValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/InOpValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/InOpValue.java
@@ -174,7 +174,7 @@ public class InOpValue extends AbstractValue implements BooleanValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
@@ -186,7 +186,7 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LikeOperatorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LikeOperatorValue.java
@@ -145,7 +145,7 @@ public class LikeOperatorValue extends AbstractValue implements BooleanValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NumericAggregationValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/NumericAggregationValue.java
@@ -163,7 +163,7 @@ public abstract class NumericAggregationValue extends AbstractValue implements V
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ObjectValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ObjectValue.java
@@ -135,7 +135,7 @@ public class ObjectValue extends AbstractValue implements LeafValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(ImmutableSet.of(alias)));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OfTypeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/OfTypeValue.java
@@ -109,7 +109,7 @@ public class OfTypeValue extends AbstractValue implements Value.RangeMatchableVa
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(final Object o) {
-        return semanticEquals(o, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(o, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PatternForLikeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PatternForLikeValue.java
@@ -138,7 +138,7 @@ public class PatternForLikeValue extends AbstractValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
@@ -277,7 +277,7 @@ public class PromoteValue extends AbstractValue implements ValueWithChild, Value
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/QuantifiedObjectValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/QuantifiedObjectValue.java
@@ -38,7 +38,6 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -141,7 +140,7 @@ public class QuantifiedObjectValue extends AbstractValue implements QuantifiedVa
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(ImmutableSet.of(alias)));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
@@ -271,7 +271,7 @@ public class RecordConstructorValue extends AbstractValue implements AggregateVa
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordTypeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordTypeValue.java
@@ -37,7 +37,6 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -117,7 +116,7 @@ public class RecordTypeValue extends AbstractValue implements QuantifiedValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(ImmutableSet.of(alias)));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
@@ -233,7 +233,7 @@ public abstract class RelOpValue extends AbstractValue implements BooleanValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
@@ -143,7 +143,7 @@ public class VariadicFunctionValue extends AbstractValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
@@ -149,7 +149,7 @@ public class VersionValue extends AbstractValue implements QuantifiedValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/WindowedValue.java
@@ -161,7 +161,7 @@ public abstract class WindowedValue extends AbstractValue {
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @Override
     public boolean equals(final Object other) {
-        return semanticEquals(other, AliasMap.identitiesFor(getCorrelatedTo()));
+        return semanticEquals(other, AliasMap.emptyMap());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/translation/MaxMatchMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/translation/MaxMatchMap.java
@@ -116,7 +116,7 @@ public class MaxMatchMap {
         final var candidateResultValue = getCandidateResultValue();
         final var pulledUpCandidateSide =
                 candidateResultValue.pullUp(mapping.values(),
-                        AliasMap.identitiesFor(candidateResultValue.getCorrelatedTo()),
+                        AliasMap.emptyMap(),
                         ImmutableSet.of(), candidateCorrelation);
         //
         // We now have the right side pulled up, specifically we have a map from each candidate value below,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySetPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQuerySetPlan.java
@@ -92,7 +92,7 @@ public interface RecordQuerySetPlan extends RecordQueryPlan {
                 }
                 if (previousPushedValue == null) {
                     previousPushedValue = pushedValueOptional.get();
-                    equivalencesMap = AliasMap.identitiesFor(previousPushedValue.getCorrelatedTo());
+                    equivalencesMap = AliasMap.emptyMap();
                 } else {
                     if (!previousPushedValue.semanticEquals(pushedValueOptional.get(), equivalencesMap)) {
                         return Optional.empty();
@@ -120,7 +120,7 @@ public interface RecordQuerySetPlan extends RecordQueryPlan {
         final CorrelationIdentifier targetAlias = Quantifier.uniqueID();
 
         for (final Value value : values) {
-            final AliasMap equivalencesMap = AliasMap.identitiesFor(ImmutableSet.of(targetAlias));
+            final AliasMap equivalencesMap = AliasMap.emptyMap();
             @Nullable Value previousPushedValue = null;
 
             for (int i = 0; i < dependentFunctions.size(); i++) {


### PR DESCRIPTION
- change a ton of calls to `semanticEquals(o, AliasMap.identitiesFor(...))` to `semanticEquals(o, AliasMap.emptyMap())`
- improve `Ordering.normalizeOrderingSet()` to not require the transitive closure anymore.