### PR TITLE
Implement mixed sort ordering index scans for Cascades.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpressionWithValue
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.metadata.expressions.ListKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.OrderFunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.query.plan.cascades.KeyExpressionExpansionVisitor.VisitorState;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
@@ -98,6 +99,9 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
     @Nonnull
     @Override
     public final GraphExpansion visitExpression(@Nonnull final KeyExpression keyExpression) {
+        if (keyExpression instanceof OrderFunctionKeyExpression) {
+            return ((OrderFunctionKeyExpression)keyExpression).getChild().expand(this);
+        }
         throw new UnsupportedOperationException("visitor method for this key expression is not implemented");
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/OrderingPart.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/OrderingPart.java
@@ -278,7 +278,9 @@ public class OrderingPart<S extends OrderingPart.SortOrder> {
      */
     public enum MatchedSortOrder implements SortOrder {
         ASCENDING("↑"),
-        DESCENDING("↓");
+        DESCENDING("↓"),
+        ASCENDING_NULLS_LAST("↗"),
+        DESCENDING_NULLS_FIRST("↙");
 
         @Nonnull
         private final String arrowIndicator;
@@ -294,12 +296,16 @@ public class OrderingPart<S extends OrderingPart.SortOrder> {
         }
 
         public boolean isReverse() {
-            return this == DESCENDING;
+            return this == DESCENDING || this == DESCENDING_NULLS_FIRST;
         }
 
         @Override
         public boolean isDirectional() {
             return true;
+        }
+
+        public boolean isCounterflowNulls() {
+            return this == ASCENDING_NULLS_LAST || this == DESCENDING_NULLS_FIRST;
         }
 
         @Nonnull
@@ -314,6 +320,10 @@ public class OrderingPart<S extends OrderingPart.SortOrder> {
                     return isReverse ? ProvidedSortOrder.DESCENDING : ProvidedSortOrder.ASCENDING;
                 case DESCENDING:
                     return isReverse ? ProvidedSortOrder.ASCENDING : ProvidedSortOrder.DESCENDING;
+                case ASCENDING_NULLS_LAST:
+                    return isReverse ? ProvidedSortOrder.DESCENDING_NULLS_FIRST : ProvidedSortOrder.ASCENDING_NULLS_LAST;
+                case DESCENDING_NULLS_FIRST:
+                    return isReverse ? ProvidedSortOrder.ASCENDING_NULLS_LAST : ProvidedSortOrder.DESCENDING_NULLS_FIRST;
                 default:
                     throw new RecordCoreException("cannot translate this sort order to provided sort order");
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpressionWithValue
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.metadata.expressions.ListKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.OrderFunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.EmptyValue;
@@ -105,6 +106,9 @@ public class ScalarTranslationVisitor implements KeyExpressionVisitor<ScalarTran
     @Nonnull
     @Override
     public final Value visitExpression(@Nonnull final KeyExpression keyExpression) {
+        if (keyExpression instanceof OrderFunctionKeyExpression) {
+            return ((OrderFunctionKeyExpression)keyExpression).getChild().expand(this);
+        }
         throw new UnsupportedOperationException("visitor method for this key expression is not implemented");
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
@@ -457,7 +457,9 @@ public abstract class AbstractDataAccessRule<R extends RelationalExpression> ext
                     if (requestedSortOrder != OrderingPart.RequestedSortOrder.ANY) {
                         final var matchedSortOrder = orderingPart.getSortOrder();
 
-                        // TODO: Will matchedSortOrder have counterflow nulls?
+                        if (matchedSortOrder.isCounterflowNulls() != requestedSortOrder.isCounterflowNulls()) {
+                            return Optional.empty();
+                        }
 
                         if (matchedSortOrder.isReverse() == requestedSortOrder.isReverse()) {
                             scanDirectionForPart = ScanDirection.FORWARD;


### PR DESCRIPTION
This is done without introducing new Values to represent the order inverting key function. Instead, the index's original key expression is consulted at the right time to refine the field value.