### PR TITLE
Fixes #2819: ArithmeticValue's semantic equals does not include operator

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** `ArithmeticValue::semanticEquals` now includes the operator in its calculation [(Issue #2189)](https://github.com/FoundationDB/fdb-record-layer/issues/2189)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.planprotos.PArithmeticValue.PPhysicalOperat
 import com.apple.foundationdb.record.planprotos.PValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
@@ -141,6 +142,16 @@ public class ArithmeticValue extends AbstractValue {
     @Override
     public int planHash(@Nonnull final PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(mode, BASE_HASH, operator, leftChild, rightChild);
+    }
+
+    @Nonnull
+    @Override
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        if (super.equalsWithoutChildren(other).isFalse()) {
+            return BooleanWithConstraint.falseValue();
+        }
+        ArithmeticValue otherArithmetic = (ArithmeticValue)other;
+        return BooleanWithConstraint.fromBoolean(operator.equals(otherArithmetic.operator));
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -147,11 +147,10 @@ public class ArithmeticValue extends AbstractValue {
     @Nonnull
     @Override
     public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
-        if (super.equalsWithoutChildren(other).isFalse()) {
-            return BooleanWithConstraint.falseValue();
-        }
-        ArithmeticValue otherArithmetic = (ArithmeticValue)other;
-        return BooleanWithConstraint.fromBoolean(operator.equals(otherArithmetic.operator));
+        return super.equalsWithoutChildren(other).compose(ignored -> {
+            ArithmeticValue otherArithmetic = (ArithmeticValue)other;
+            return BooleanWithConstraint.fromBoolean(operator.equals(otherArithmetic.operator));
+        });
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArithmeticValue.java
@@ -147,9 +147,9 @@ public class ArithmeticValue extends AbstractValue {
     @Nonnull
     @Override
     public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
-        return super.equalsWithoutChildren(other).compose(ignored -> {
+        return super.equalsWithoutChildren(other).filter(ignored -> {
             ArithmeticValue otherArithmetic = (ArithmeticValue)other;
-            return BooleanWithConstraint.fromBoolean(operator.equals(otherArithmetic.operator));
+            return operator.equals(otherArithmetic.operator);
         });
     }
 


### PR DESCRIPTION
This overrides the implementation of `equalsWithoutChildren` on the `ArithmeticValue` so that it looks at the operator. This corrects the method, as `semanticEquals` was already considering the left and right children.

This fixes #2819.