### PR TITLE
Fixes #2813: Fail fast when Batch GRV Rate Limit Exceeded

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fail fast when Batch GRV rate limit exceeded [(Issue #2813)](https://github.com/FoundationDB/fdb-record-layer/issues/2813)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -946,6 +946,38 @@ public class MoreAsyncUtil {
     }
 
     /**
+     * Combine the results of two futures, but fail fast if either future fails.
+     * <p>
+     *     This has the same behavior as {@link CompletableFuture#thenCombine}, except, if either future fails, it won't
+     *     wait for the other one to complete before completing the result with the failure.
+     * </p>
+     * @param future1 one future
+     * @param future2 another future
+     * @param combiner a function to combine the results of both {@code future1} and {@code future2} into a single result.
+     *
+     * @param <T> the result type for {@code future1}
+     * @param <U> the result type for {@code future2}
+     * @param <R> the result type for the returned future
+     *
+     * @return a future that fails with one of the exceptions from {@code future1} or {@code future2} if either of those
+     * failed, or the result of applying {@code combiner} to their results if both succeeded.
+     */
+    public static <T, U, R> CompletableFuture<R> combineAndFailFast(CompletableFuture<T> future1,
+                                                                    CompletableFuture<U> future2,
+                                                                    BiFunction<T, U, R> combiner) {
+        return CompletableFuture.anyOf(future1, future2).thenCompose(vignore -> {
+            // We know at least one of them completed
+            if (future1.isDone() && future1.isCompletedExceptionally()) {
+                return future1.thenApply(vignore1 -> null);
+            }
+            if (future2.isDone() && future2.isCompletedExceptionally()) {
+                return future2.thenApply(vignore2 -> null);
+            }
+            return future1.thenCombine(future2, combiner);
+        });
+    }
+
+    /**
      * A {@code Boolean} function that is always true.
      * @param <T> the type of the (ignored) argument to the function
      */

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -66,7 +66,6 @@ import org.apache.lucene.store.Lock;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -757,7 +756,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
     @ParameterizedTest
     @MethodSource
     @SuperSlow
-    @Timeout(value = 10, unit = TimeUnit.MINUTES) // https://github.com/FoundationDB/fdb-record-layer/issues/2813
     void concurrentStoreTest(boolean isGrouped,
                              boolean isSynthetic,
                              boolean primaryKeySegmentIndexEnabled,


### PR DESCRIPTION
Loading the metadata version key does not seem to throw Batch GRV rate limit exceeded, while other operations on the same transaciton do. Instead it stalls forever, and the tests end up timing out at the junit level.
This change introduces a new combine that will fail when the loading the record store state fails, instead of waiting forever for the metadata version to be loaded.