### PR TITLE
Decrease the timeout on @SuperSlow from 1 hour to 20 minutes

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/test/SuperSlow.java
+++ b/fdb-extensions/src/test/java/com/apple/test/SuperSlow.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@Timeout(value = 1, unit = TimeUnit.HOURS)
+@Timeout(value = 20, unit = TimeUnit.MINUTES)
 @Tag("SuperSlow")
 public @interface SuperSlow {
 }


### PR DESCRIPTION
Even for our most expensive tests that we have right now, anything more than 20 minutes is a bug.