### PR TITLE
Resolves #2826: Add new LuceneGetMetadataInfo operation

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** IndexOperation for getting Lucene index metadata [(Issue #2826)](https://github.com/FoundationDB/fdb-record-layer/issues/2826)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneGetMetadataInfo.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneGetMetadataInfo.java
@@ -1,0 +1,90 @@
+/*
+ * LuceneGetMetadataInfo.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperation;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Get metadata information about a given lucene index.
+ * <p>
+ *     This is currently intended to be used for debugging purposes.
+ * </p>
+ */
+@API(API.Status.INTERNAL)
+public class LuceneGetMetadataInfo extends IndexOperation {
+
+    @Nonnull
+    private final Tuple groupingKey;
+    @Nullable
+    private final Integer partitionId;
+    private final boolean justPartitionInfo;
+
+    /**
+     * Create a new operation to get metadata about the lucene index.
+     * <p>
+     *     The parameters can be used to limit the scope of information gathered so that it can fit in a single
+     *     transaction.
+     * </p>
+     * @param groupingKey the grouping key, or an empty {@code Tuple} if this index is not grouped
+     * @param partitionId if {@code null}, this will return information for all partitions, otherwise just the given partition
+     * @param justPartitionInfo if {@code true} then only the partition info will be fetched, otherwise information from
+     * lucene itself will be fetched
+     */
+    public LuceneGetMetadataInfo(@Nonnull Tuple groupingKey,
+                                 @Nullable Integer partitionId,
+                                 boolean justPartitionInfo) {
+        this.groupingKey = groupingKey;
+        this.partitionId = partitionId;
+        this.justPartitionInfo = justPartitionInfo;
+    }
+
+    /**
+     * The grouping key to inspect.
+     * @return the grouping key or an empty {@code Tuple} if this index is not grouped
+     */
+    @Nonnull
+    public Tuple getGroupingKey() {
+        return groupingKey;
+    }
+
+    /**
+     * The partition id to inpsect.
+     * @return the partition id to inspect or {@code null} to inspect all partitions.
+     */
+    @Nullable
+    public Integer getPartitionId() {
+        return partitionId;
+    }
+
+    /**
+     * Just fetch the partition info, and not the information for each partition.
+     * @return if {@code true} only the partition info will be fetched, otherwise it will fetch the information for
+     * the lucene indexes
+     */
+    public boolean isJustPartitionInfo() {
+        return justPartitionInfo;
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneGetMetadataInfo.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneGetMetadataInfo.java
@@ -87,4 +87,13 @@ public class LuceneGetMetadataInfo extends IndexOperation {
     public boolean isJustPartitionInfo() {
         return justPartitionInfo;
     }
+
+    @Override
+    public String toString() {
+        return "LuceneGetMetadataInfo{" +
+                "groupingKey=" + groupingKey +
+                ", partitionId=" + partitionId +
+                ", justPartitionInfo=" + justPartitionInfo +
+                '}';
+    }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -77,6 +77,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -99,6 +100,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Index maintainer for Lucene Indexes backed by FDB.  The insert, update, and delete functionality
@@ -656,8 +658,67 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     @Nonnull
     public CompletableFuture<IndexOperationResult> performOperation(@Nonnull IndexOperation operation) {
         LOG.trace("performOperation operation={}", operation);
-        return CompletableFuture.completedFuture(new IndexOperationResult() {
-        });
+        if (operation instanceof LuceneGetMetadataInfo) {
+            final LuceneGetMetadataInfo request = (LuceneGetMetadataInfo)operation;
+            if (request.isJustPartitionInfo()) {
+                if (partitioner.isPartitioningEnabled()) {
+                    return partitioner.getAllPartitionMetaInfo(request.getGroupingKey())
+                            .thenApply(partitionInfos -> new LuceneMetadataInfo(partitionInfos, Map.of()));
+                } else {
+                    return CompletableFuture.completedFuture(new LuceneMetadataInfo(List.of(), Map.of()));
+                }
+            } else {
+                if (partitioner.isPartitioningEnabled()) {
+                    return getLuceneInfoForAllPartitions(request);
+                } else {
+                    return getLuceneInfo(request.getGroupingKey(), null)
+                            .thenApply(luceneInfos -> new LuceneMetadataInfo(List.of(),
+                                    Map.of(0, luceneInfos)));
+
+                }
+            }
+        }
+
+        return super.performOperation(operation);
+    }
+
+    private CompletableFuture<IndexOperationResult> getLuceneInfoForAllPartitions(final LuceneGetMetadataInfo request) {
+        return partitioner.getAllPartitionMetaInfo(request.getGroupingKey())
+                .thenCompose(partitionInfos -> {
+                    Stream<LucenePartitionInfoProto.LucenePartitionInfo> infoStream = partitionInfos.stream();
+                    // There isn't a more efficient way to get partition info by id than loading it all, and
+                    // if you can't load it all and one partition's lucene index in a single transaction,
+                    // you won't be able to repartition
+                    if (request.getPartitionId() != null) {
+                        infoStream = infoStream.filter(info -> info.getId() == request.getPartitionId());
+                    }
+                    final List<CompletableFuture<Map.Entry<Integer, LuceneMetadataInfo.LuceneInfo>>> luceneInfos =
+                            infoStream.map(partitionInfo ->
+                                            getLuceneInfo(request.getGroupingKey(), partitionInfo.getId())
+                                                    .thenApply(luceneInfo -> Map.entry(partitionInfo.getId(), luceneInfo)))
+                                    .collect(Collectors.toList());
+                    return AsyncUtil.getAll(luceneInfos).thenApply(entries ->
+                            new LuceneMetadataInfo(partitionInfos,
+                                    entries.stream()
+                                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+                });
+    }
+
+
+    @SuppressWarnings("PMD.CloseResource") // the indexReader and directory are closed by the directoryManager
+    private CompletableFuture<LuceneMetadataInfo.LuceneInfo> getLuceneInfo(final Tuple groupingKey, final Integer partitionId) {
+        try {
+            final IndexReader indexReader = directoryManager.getIndexReader(groupingKey, partitionId);
+            final FDBDirectory directory = getDirectory(groupingKey, partitionId);
+            final CompletableFuture<Integer> fieldInfosFuture = directory.getFieldInfosCount();
+            return directory.listAllAsync()
+                    .thenCombine(fieldInfosFuture, (fileList, fieldInfosCount) ->
+                            new LuceneMetadataInfo.LuceneInfo(
+                                    indexReader.numDocs(),
+                                    fileList, fieldInfosCount));
+        } catch (IOException e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 
     @VisibleForTesting

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -661,6 +661,9 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         if (operation instanceof LuceneGetMetadataInfo) {
             final LuceneGetMetadataInfo request = (LuceneGetMetadataInfo)operation;
             if (request.isJustPartitionInfo()) {
+                // There isn't a more efficient way to get partition info by id than loading it all, and
+                // if you can't load it all and one partition's lucene index in a single transaction,
+                // you won't be able to repartition, so we always provide all the partition info.
                 if (partitioner.isPartitioningEnabled()) {
                     return partitioner.getAllPartitionMetaInfo(request.getGroupingKey())
                             .thenApply(partitionInfos -> new LuceneMetadataInfo(partitionInfos, Map.of()));
@@ -688,7 +691,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                     Stream<LucenePartitionInfoProto.LucenePartitionInfo> infoStream = partitionInfos.stream();
                     // There isn't a more efficient way to get partition info by id than loading it all, and
                     // if you can't load it all and one partition's lucene index in a single transaction,
-                    // you won't be able to repartition
+                    // you won't be able to repartition, so we always provide all the partition info.
                     if (request.getPartitionId() != null) {
                         infoStream = infoStream.filter(info -> info.getId() == request.getPartitionId());
                     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.record.provider.foundationdb.IndexOperationResult;
 
 import javax.annotation.Nonnull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -61,10 +62,10 @@ public class LuceneMetadataInfo extends IndexOperationResult {
      */
     public static class LuceneInfo {
         private final int documentCount;
-        private final List<String> files;
+        private final Collection<String> files;
         private final int fieldInfoCount;
 
-        public LuceneInfo(final int documentCount, final List<String> files, final int fieldInfoCount) {
+        public LuceneInfo(final int documentCount, final Collection<String> files, final int fieldInfoCount) {
             this.documentCount = documentCount;
             this.files = files;
             this.fieldInfoCount = fieldInfoCount;
@@ -80,9 +81,10 @@ public class LuceneMetadataInfo extends IndexOperationResult {
 
         /**
          * The file listing from the directory.
+         *
          * @return the list of files in the directory
          */
-        public List<String> getFiles() {
+        public Collection<String> getFiles() {
             return files;
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
@@ -1,0 +1,114 @@
+/*
+ * LuceneMetadataInfo.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperationResult;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Metadata information about a lucene index, in response to {@link LuceneGetMetadataInfo}.
+ */
+public class LuceneMetadataInfo extends IndexOperationResult {
+    private List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo;
+    private Map<Integer, LuceneInfo> luceneInfo;
+
+    public LuceneMetadataInfo(@Nonnull final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo,
+                              @Nonnull final Map<Integer, LuceneInfo> luceneInfo) {
+        this.partitionInfo = partitionInfo;
+        this.luceneInfo = luceneInfo;
+    }
+
+    /**
+     * List of the metadata information for a given partition, most-recent will be first.
+     * @return the list of metadata information for all the partitions
+     */
+    public List<LucenePartitionInfoProto.LucenePartitionInfo> getPartitionInfo() {
+        return partitionInfo;
+    }
+
+    /**
+     * Map from partition id to information from lucene.
+     * @return the information from lucene for all partitions, or the one partition request if that was requested
+     */
+    public Map<Integer, LuceneInfo> getLuceneInfo() {
+        return luceneInfo;
+    }
+
+    /**
+     * Information about an individual Lucene directory.
+     */
+    public static class LuceneInfo {
+        private final int documentCount;
+        private final List<String> files;
+        private final int fieldInfoCount;
+
+        public LuceneInfo(final int documentCount, final List<String> files, final int fieldInfoCount) {
+            this.documentCount = documentCount;
+            this.files = files;
+            this.fieldInfoCount = fieldInfoCount;
+        }
+
+        /**
+         * The number of documents that lucene thinks are in the index.
+         * @return the number of documents
+         */
+        public int getDocumentCount() {
+            return documentCount;
+        }
+
+        /**
+         * The file listing from the directory.
+         * @return the list of files in the directory
+         */
+        public List<String> getFiles() {
+            return files;
+        }
+
+        /**
+         * The number of FieldInfos in the directory; see {@link com.apple.foundationdb.record.lucene.directory.FieldInfosStorage}.
+         * @return the number of field infos in the directory
+         */
+        public int getFieldInfoCount() {
+            return fieldInfoCount;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final LuceneInfo that = (LuceneInfo)o;
+            return documentCount == that.documentCount && fieldInfoCount == that.fieldInfoCount && Objects.equals(files, that.files);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(documentCount, files, fieldInfoCount);
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -354,6 +354,11 @@ public class FDBDirectory extends Directory  {
                 .map(keyValue -> NonnullPair.of(fieldInfosSubspace.unpack(keyValue.getKey()).getLong(0), keyValue.getValue()));
     }
 
+    public CompletableFuture<Integer> getFieldInfosCount() {
+        return agilityContext.apply(aContext -> aContext.ensureActive().getRange(fieldInfosSubspace.range()).asList())
+                .thenApply(List::size);
+    }
+
     public static boolean isSegmentInfo(String name) {
         return name.endsWith(SI_EXTENSION)
                && !name.startsWith(IndexFileNames.SEGMENTS)
@@ -574,6 +579,10 @@ public class FDBDirectory extends Directory  {
         } finally {
             agilityContext.recordEvent(LuceneEvents.Events.LUCENE_LIST_ALL, System.nanoTime() - startTime);
         }
+    }
+
+    public CompletableFuture<List<String>> listAllAsync() {
+        return getFileReferenceCacheAsync().thenApply(references -> List.copyOf(references.keySet()));
     }
 
     @VisibleForTesting

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -581,7 +581,7 @@ public class FDBDirectory extends Directory  {
         }
     }
 
-    public CompletableFuture<List<String>> listAllAsync() {
+    public CompletableFuture<Collection<String>> listAllAsync() {
         return getFileReferenceCacheAsync().thenApply(references -> List.copyOf(references.keySet()));
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexDataModel.java
@@ -1,0 +1,147 @@
+/*
+ * LuceneIndexModel.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.TestRecordsGroupedParentChildProto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.JoinedRecordTypeBuilder;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Model for creating a lucene appropriate dataset with various configurations.
+ */
+public class LuceneIndexDataModel {
+
+    @Nonnull
+    static Tuple saveRecords(final FDBRecordStore recordStore,
+                             final boolean isSynthetic,
+                             final int group,
+                             final int countInGroup,
+                             final long timestamp,
+                             final RandomTextGenerator textGenerator,
+                             final Random random) {
+        var parent = TestRecordsGroupedParentChildProto.MyParentRecord.newBuilder()
+                .setGroup(group)
+                .setRecNo(1001L + countInGroup)
+                .setTimestamp(timestamp)
+                .setTextValue(isSynthetic ? "This is not the text that goes in lucene"
+                              : textGenerator.generateRandomText("about"))
+                .setIntValue(random.nextInt())
+                .setChildRecNo(1000L - countInGroup)
+                .build();
+        Tuple primaryKey;
+        if (isSynthetic) {
+            var child = TestRecordsGroupedParentChildProto.MyChildRecord.newBuilder()
+                    .setGroup(group)
+                    .setRecNo(1000L - countInGroup)
+                    .setStrValue(textGenerator.generateRandomText("forth"))
+                    .setOtherValue(random.nextInt())
+                    .build();
+            final Tuple syntheticRecordTypeKey = recordStore.getRecordMetaData()
+                    .getSyntheticRecordType("JoinChildren")
+                    .getRecordTypeKeyTuple();
+            primaryKey = Tuple.from(syntheticRecordTypeKey.getItems().get(0),
+                    recordStore.saveRecord(parent).getPrimaryKey().getItems(),
+                    recordStore.saveRecord(child).getPrimaryKey().getItems());
+        } else {
+            primaryKey = recordStore.saveRecord(parent).getPrimaryKey();
+        }
+        return primaryKey;
+    }
+
+    @Nonnull
+    static Index addIndex(final boolean isSynthetic, final KeyExpression rootExpression, final Map<String, String> options, final RecordMetaDataBuilder metaDataBuilder) {
+        Index index;
+        index = new Index("joinNestedConcat", rootExpression, LuceneIndexTypes.LUCENE, options);
+
+        if (isSynthetic) {
+            final JoinedRecordTypeBuilder joinBuilder = metaDataBuilder.addJoinedRecordType("JoinChildren");
+            joinBuilder.addConstituent("parent", "MyParentRecord");
+            joinBuilder.addConstituent("child", "MyChildRecord");
+            joinBuilder.addJoin("parent", Key.Expressions.field("group"),
+                    "child", Key.Expressions.field("group"));
+            joinBuilder.addJoin("parent", Key.Expressions.field("child_rec_no"),
+                    "child", Key.Expressions.field("rec_no"));
+            metaDataBuilder.addIndex("JoinChildren", index);
+        } else {
+            metaDataBuilder.addIndex("MyParentRecord", index);
+        }
+        return index;
+    }
+
+    @Nonnull
+    static KeyExpression createRootExpression(final boolean isGrouped, final boolean isSynthetic) {
+        ThenKeyExpression baseExpression;
+        KeyExpression groupingExpression;
+        if (isSynthetic) {
+            baseExpression = Key.Expressions.concat(
+                    Key.Expressions.field("parent")
+                            .nest(Key.Expressions.function(LuceneFunctionNames.LUCENE_STORED,
+                                    Key.Expressions.field("int_value"))),
+                    Key.Expressions.field("child")
+                            .nest(Key.Expressions.function(LuceneFunctionNames.LUCENE_TEXT,
+                                    Key.Expressions.field("str_value"))),
+                    Key.Expressions.field("parent")
+                            .nest(Key.Expressions.function(LuceneFunctionNames.LUCENE_SORTED,
+                                    Key.Expressions.field("timestamp")))
+            );
+            groupingExpression = Key.Expressions.field("parent").nest("group");
+        } else {
+            baseExpression = Key.Expressions.concat(
+                    Key.Expressions.function(LuceneFunctionNames.LUCENE_STORED,
+                            Key.Expressions.field("int_value")),
+                    Key.Expressions.function(LuceneFunctionNames.LUCENE_TEXT,
+                            Key.Expressions.field("text_value")),
+                    Key.Expressions.function(LuceneFunctionNames.LUCENE_SORTED,
+                            Key.Expressions.field("timestamp"))
+            );
+            groupingExpression = Key.Expressions.field("group");
+        }
+        KeyExpression rootExpression;
+        if (isGrouped) {
+            rootExpression = baseExpression.groupBy(groupingExpression);
+        } else {
+            rootExpression = baseExpression;
+        }
+        return rootExpression;
+    }
+
+    @Nonnull
+    static RecordMetaDataBuilder createBaseMetaDataBuilder() {
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder()
+                .setRecords(TestRecordsGroupedParentChildProto.getDescriptor());
+        metaDataBuilder.getRecordType("MyParentRecord")
+                .setPrimaryKey(Key.Expressions.concatenateFields("group", "rec_no"));
+        metaDataBuilder.getRecordType("MyChildRecord")
+                .setPrimaryKey(Key.Expressions.concatenateFields("group", "rec_no"));
+        return metaDataBuilder;
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -61,7 +61,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
     @ParameterizedTest
     @MethodSource("arguments")
     void getMetadata(boolean justPartitionInfo, boolean isGrouped) {
-        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
                 .setPartitionHighWatermark(-1) // disable partitioning
                 .setIsGrouped(isGrouped)
                 .build();
@@ -92,7 +92,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
     @ParameterizedTest
     @MethodSource("arguments")
     void getMetadataPartitioned(boolean justPartitionInfo, boolean isGrouped) {
-        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
                 .setPartitionHighWatermark(10)
                 .setIsGrouped(isGrouped)
                 .build();
@@ -136,7 +136,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
 
     @Test
     void getMetadataAfterDelete() {
-        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
                 .setPartitionHighWatermark(10)
                 .setIsGrouped(false)
                 .build();
@@ -200,7 +200,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
 
     private LuceneMetadataInfo getLuceneMetadataInfo(final boolean justPartitionInfo,
                                                      @Nonnull final Tuple groupingKey,
-                                                     @Nonnull final LuceneIndexDataModel dataModel,
+                                                     @Nonnull final LuceneIndexTestDataModel dataModel,
                                                      @Nullable final Integer partitionId) {
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore store = dataModel.schemaSetup.apply(context);
@@ -219,7 +219,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
         return segmentCount * 4 + 1;
     }
 
-    private void explicitMergeIndex(LuceneIndexDataModel dataModel) {
+    private void explicitMergeIndex(LuceneIndexTestDataModel dataModel) {
         try (FDBRecordContext context = openContext()) {
             FDBRecordStore recordStore = Objects.requireNonNull(dataModel.schemaSetup.apply(context));
             try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -112,9 +112,9 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
             // most recent is first
             final List<Integer> partitionIds = isGrouped ? List.of(0, 2, 1) : List.of(0, 5, 4, 3, 2, 1);
             assertEquals(partitionIds,
-                    partitionInfo.stream().map(LucenePartitionInfoProto.LucenePartitionInfo::getId).collect(Collectors.toList()));
+                    partitionInfo.stream().map(info -> info.getId()).collect(Collectors.toList()));
             assertEquals(partitionIds.stream().map(i -> 10).collect(Collectors.toList()),
-                    partitionInfo.stream().map(LucenePartitionInfoProto.LucenePartitionInfo::getCount).collect(Collectors.toList()));
+                    partitionInfo.stream().map(info -> info.getCount()).collect(Collectors.toList()));
             assertPartitionInfosHaveCorrectFromTo(partitionInfo);
             if (justPartitionInfo) {
                 assertEquals(Map.of(), result.getLuceneInfo());
@@ -126,7 +126,8 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                     assertThat(luceneInfo.getFiles(), Matchers.hasSize(segmentCountToFileCount(1)));
                     assertEquals(1, luceneInfo.getFieldInfoCount());
 
-                    final LuceneMetadataInfo resultForPartition = getLuceneMetadataInfo(justPartitionInfo, groupingKey, dataModel, partitionId);
+                    final LuceneMetadataInfo resultForPartition = getLuceneMetadataInfo(
+                            justPartitionInfo, groupingKey, dataModel, partitionId);
                     assertEquals(Set.of(partitionId), resultForPartition.getLuceneInfo().keySet());
                     assertEquals(luceneInfo, resultForPartition.getLuceneInfo().get(partitionId));
                 }
@@ -188,7 +189,8 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
         }
     }
 
-    private static void assertPartitionInfosHaveCorrectFromTo(final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo) {
+    private static void assertPartitionInfosHaveCorrectFromTo(
+            final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo) {
         for (int i = 0; i < partitionInfo.size(); i++) {
             final LucenePartitionInfoProto.LucenePartitionInfo info = partitionInfo.get(i);
             assertLessThan(info.getFrom(), info.getTo());

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -1,0 +1,234 @@
+/*
+ * LuceneIndexGetMetadataInfoTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexOperationResult;
+import com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.protobuf.ByteString;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests around {@link LuceneGetMetadataInfo}.
+ */
+public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
+
+    static Stream<Arguments> arguments() {
+        return Stream.of(true, false)
+                .flatMap(justPartitionInfo ->
+                        Stream.of(true, false)
+                                .map(isGrouped -> Arguments.of(justPartitionInfo, isGrouped)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void getMetadata(boolean justPartitionInfo, boolean isGrouped) {
+        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
+                .setPartitionHighWatermark(-1) // disable partitioning
+                .setIsGrouped(isGrouped)
+                .build();
+        final long start = Instant.now().toEpochMilli();
+        for (int i = 0; i < 5; i++) {
+            try (FDBRecordContext context = openContext()) {
+                dataModel.saveRecords(10, start, context, i);
+                commit(context);
+            }
+        }
+
+        final Set<Tuple> groupingKeys = isGrouped ? dataModel.ids.keySet() : Set.of(Tuple.from());
+        for (final Tuple groupingKey : groupingKeys) {
+            final LuceneMetadataInfo result = getLuceneMetadataInfo(justPartitionInfo, groupingKey, dataModel, null);
+            assertEquals(List.of(), result.getPartitionInfo());
+            if (justPartitionInfo) {
+                assertEquals(Map.of(), result.getLuceneInfo());
+            } else {
+                assertEquals(Set.of(0), result.getLuceneInfo().keySet());
+                final LuceneMetadataInfo.LuceneInfo luceneInfo = result.getLuceneInfo().get(0);
+                assertEquals(dataModel.ids.get(groupingKey).size(), luceneInfo.getDocumentCount());
+                assertThat(luceneInfo.getFiles(), Matchers.hasSize(segmentCountToFileCount(isGrouped ? 1 : 5)));
+                assertEquals(1, luceneInfo.getFieldInfoCount());
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void getMetadataPartitioned(boolean justPartitionInfo, boolean isGrouped) {
+        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
+                .setPartitionHighWatermark(10)
+                .setIsGrouped(isGrouped)
+                .build();
+        final long start = Instant.now().toEpochMilli();
+        for (int i = 0; i < 6; i++) {
+            try (FDBRecordContext context = openContext()) {
+                dataModel.saveRecords(10, start, context, i / 3);
+                commit(context);
+            }
+            explicitMergeIndex(dataModel);
+        }
+
+        final Set<Tuple> groupingKeys = isGrouped ? dataModel.ids.keySet() : Set.of(Tuple.from());
+        for (final Tuple groupingKey : groupingKeys) {
+            final LuceneMetadataInfo result = getLuceneMetadataInfo(justPartitionInfo, groupingKey, dataModel, null);
+            final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo = result.getPartitionInfo();
+            // most recent is first
+            final List<Integer> partitionIds = isGrouped ? List.of(0, 2, 1) : List.of(0, 5, 4, 3, 2, 1);
+            assertEquals(partitionIds,
+                    partitionInfo.stream().map(LucenePartitionInfoProto.LucenePartitionInfo::getId).collect(Collectors.toList()));
+            assertEquals(partitionIds.stream().map(i -> 10).collect(Collectors.toList()),
+                    partitionInfo.stream().map(LucenePartitionInfoProto.LucenePartitionInfo::getCount).collect(Collectors.toList()));
+            assertPartitionInfosHaveCorrectFromTo(partitionInfo);
+            if (justPartitionInfo) {
+                assertEquals(Map.of(), result.getLuceneInfo());
+            } else {
+                assertEquals(Set.copyOf(partitionIds), result.getLuceneInfo().keySet());
+                for (final Integer partitionId : partitionIds) {
+                    final LuceneMetadataInfo.LuceneInfo luceneInfo = result.getLuceneInfo().get(partitionId);
+                    assertEquals(10, luceneInfo.getDocumentCount());
+                    assertThat(luceneInfo.getFiles(), Matchers.hasSize(segmentCountToFileCount(1)));
+                    assertEquals(1, luceneInfo.getFieldInfoCount());
+
+                    final LuceneMetadataInfo resultForPartition = getLuceneMetadataInfo(justPartitionInfo, groupingKey, dataModel, partitionId);
+                    assertEquals(Set.of(partitionId), resultForPartition.getLuceneInfo().keySet());
+                    assertEquals(luceneInfo, resultForPartition.getLuceneInfo().get(partitionId));
+                }
+            }
+        }
+    }
+
+    @Test
+    void getMetadataAfterDelete() {
+        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
+                .setPartitionHighWatermark(10)
+                .setIsGrouped(false)
+                .build();
+        final long start = Instant.now().toEpochMilli();
+        for (int i = 0; i < 6; i++) {
+            try (FDBRecordContext context = openContext()) {
+                dataModel.saveRecords(10, start, context, i / 3);
+                commit(context);
+            }
+            explicitMergeIndex(dataModel);
+        }
+
+        final Tuple groupingKey = Tuple.from();
+
+        try (FDBRecordContext context = openContext()) {
+            final Tuple toDelete = dataModel.ids.get(groupingKey).keySet().stream().findFirst().orElseThrow();
+            dataModel.deleteRecord(context, toDelete);
+            commit(context);
+        }
+
+        final LuceneMetadataInfo result = getLuceneMetadataInfo(false, groupingKey, dataModel, null);
+        final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo = result.getPartitionInfo();
+        // most recent is first
+        final List<Integer> partitionIds = List.of(0, 5, 4, 3, 2, 1);
+        assertEquals(partitionIds,
+                partitionInfo.stream().map(LucenePartitionInfoProto.LucenePartitionInfo::getId).collect(Collectors.toList()));
+        // one will be decremented from 10 down to 9
+        final List<Integer> partitionCounts = partitionInfo.stream()
+                .map(LucenePartitionInfoProto.LucenePartitionInfo::getCount)
+                .collect(Collectors.toList());
+        assertThat(partitionCounts,
+                Matchers.containsInAnyOrder(9, 10, 10, 10, 10, 10));
+        assertPartitionInfosHaveCorrectFromTo(partitionInfo);
+        assertEquals(Set.copyOf(partitionIds), result.getLuceneInfo().keySet());
+        final int smallerPartition = partitionInfo.stream().filter(partition -> partition.getCount() == 9)
+                .map(LucenePartitionInfoProto.LucenePartitionInfo::getId)
+                .findFirst().orElseThrow();
+        for (final Integer partitionId : partitionIds) {
+            final LuceneMetadataInfo.LuceneInfo luceneInfo = result.getLuceneInfo().get(partitionId);
+            if (partitionId == smallerPartition) {
+                assertEquals(9, luceneInfo.getDocumentCount());
+                // one extra file for the `.liv`
+                assertThat(luceneInfo.getFiles(), Matchers.hasSize(segmentCountToFileCount(1) + 1));
+            } else {
+                assertEquals(10, luceneInfo.getDocumentCount());
+                assertThat(luceneInfo.getFiles(), Matchers.hasSize(segmentCountToFileCount(1)));
+            }
+            assertEquals(1, luceneInfo.getFieldInfoCount());
+        }
+    }
+
+    private static void assertPartitionInfosHaveCorrectFromTo(final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo) {
+        for (int i = 0; i < partitionInfo.size(); i++) {
+            final LucenePartitionInfoProto.LucenePartitionInfo info = partitionInfo.get(i);
+            assertLessThan(info.getFrom(), info.getTo());
+            if (i > 0) {
+                assertLessThan(info.getTo(), partitionInfo.get(i - 1).getFrom());
+            }
+        }
+    }
+
+    private LuceneMetadataInfo getLuceneMetadataInfo(final boolean justPartitionInfo,
+                                                     @Nonnull final Tuple groupingKey,
+                                                     @Nonnull final LuceneIndexDataModel dataModel,
+                                                     @Nullable final Integer partitionId) {
+        try (FDBRecordContext context = openContext()) {
+            final FDBRecordStore store = dataModel.schemaSetup.apply(context);
+            final IndexOperationResult indexOperationResult = store.performIndexOperation(dataModel.index.getName(),
+                    new LuceneGetMetadataInfo(groupingKey, partitionId, justPartitionInfo));
+            assertThat(indexOperationResult, Matchers.instanceOf(LuceneMetadataInfo.class));
+            return (LuceneMetadataInfo)indexOperationResult;
+        }
+    }
+
+    private static void assertLessThan(final ByteString from, final ByteString to) {
+        assertThat(Tuple.fromBytes(from.toByteArray()), Matchers.lessThan(Tuple.fromBytes(to.toByteArray())));
+    }
+
+    private static int segmentCountToFileCount(final int segmentCount) {
+        return segmentCount * 4 + 1;
+    }
+
+    private void explicitMergeIndex(LuceneIndexDataModel dataModel) {
+        try (FDBRecordContext context = openContext()) {
+            FDBRecordStore recordStore = Objects.requireNonNull(dataModel.schemaSetup.apply(context));
+            try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
+                    .setRecordStore(recordStore)
+                    .setIndex(dataModel.index)
+                    .setTimer(timer)
+                    .build()) {
+                indexBuilder.mergeIndex();
+            }
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -1018,13 +1018,13 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
     }
 
     @Nonnull
-    private Tuple saveRecords(final FDBRecordStore recordStore,
-                              final boolean isSynthetic,
-                              final int group,
-                              final int countInGroup,
-                              final long timestamp,
-                              final RandomTextGenerator textGenerator,
-                              final Random random) {
+    private static Tuple saveRecords(final FDBRecordStore recordStore,
+                                     final boolean isSynthetic,
+                                     final int group,
+                                     final int countInGroup,
+                                     final long timestamp,
+                                     final RandomTextGenerator textGenerator,
+                                     final Random random) {
         var parent = TestRecordsGroupedParentChildProto.MyParentRecord.newBuilder()
                 .setGroup(group)
                 .setRecNo(1001L + countInGroup)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -940,7 +940,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
                 recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
                 for (int j = 0; j < docCount; j++) {
-                    LuceneIndexDataModel.saveRecord(isGrouped, isSynthetic, random, ids, textGenerator, start, recordStore);
+                    LuceneIndexDataModel.saveRecord(isGrouped, isSynthetic, random, ids, textGenerator, start, recordStore, isGrouped ? random.nextInt(random.nextInt(10) + 1) : 0);
                 }
                 commit(context);
                 documentCount.addAndGet(docCount);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -144,7 +144,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                                    int repartitionCount,
                                    int minDocumentCount,
                                    long seed) throws IOException {
-        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(seed, this::getStoreBuilder, pathManager)
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
                 .setIsGrouped(isGrouped)
                 .setIsSynthetic(isSynthetic)
                 .setPrimaryKeySegmentIndexEnabled(primaryKeySegmentIndexEnabled)
@@ -246,7 +246,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                       int loopCount,
                       int maxTransactionsPerLoop,
                       long seed) throws IOException {
-        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(seed, this::getStoreBuilder, pathManager)
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
                 .setIsGrouped(isGrouped)
                 .setIsSynthetic(isSynthetic)
                 .setPrimaryKeySegmentIndexEnabled(primaryKeySegmentIndexEnabled)
@@ -335,7 +335,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                     long seed,
                     boolean requireFailure) throws IOException {
 
-        final LuceneIndexDataModel dataModel = new LuceneIndexDataModel.Builder(seed, this::getStoreBuilder, pathManager)
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
                 .setIsGrouped(isGrouped)
                 .setIsSynthetic(isSynthetic)
                 .setPrimaryKeySegmentIndexEnabled(primaryKeySegmentIndexEnabled)
@@ -746,9 +746,9 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(1000),
                 LuceneIndexOptions.PRIMARY_KEY_SEGMENT_INDEX_V2_ENABLED, String.valueOf(primaryKeySegmentIndexEnabled));
 
-        final RecordMetaDataBuilder metaDataBuilder = LuceneIndexDataModel.createBaseMetaDataBuilder();
-        final KeyExpression rootExpression = LuceneIndexDataModel.createRootExpression(isGrouped, isSynthetic);
-        Index index = LuceneIndexDataModel.addIndex(isSynthetic, rootExpression, options, metaDataBuilder);
+        final RecordMetaDataBuilder metaDataBuilder = LuceneIndexTestDataModel.createBaseMetaDataBuilder();
+        final KeyExpression rootExpression = LuceneIndexTestDataModel.createRootExpression(isGrouped, isSynthetic);
+        Index index = LuceneIndexTestDataModel.addIndex(isSynthetic, rootExpression, options, metaDataBuilder);
         final RecordMetaData metadata = metaDataBuilder.build();
         Random random = new Random(seed);
         final int repartitionCount = 2;
@@ -940,7 +940,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
                 recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
                 for (int j = 0; j < docCount; j++) {
-                    LuceneIndexDataModel.saveRecord(isGrouped, isSynthetic, random, ids, textGenerator, start, recordStore, isGrouped ? random.nextInt(random.nextInt(10) + 1) : 0);
+                    LuceneIndexTestDataModel.saveRecord(isGrouped, isSynthetic, random, ids, textGenerator, start, recordStore, isGrouped ? random.nextInt(random.nextInt(10) + 1) : 0);
                 }
                 commit(context);
                 documentCount.addAndGet(docCount);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -45,7 +45,7 @@ import java.util.function.Function;
 /**
  * Model for creating a lucene appropriate dataset with various configurations.
  */
-public class LuceneIndexDataModel {
+public class LuceneIndexTestDataModel {
 
     final boolean isGrouped;
     final boolean isSynthetic;
@@ -57,7 +57,7 @@ public class LuceneIndexDataModel {
     final Function<FDBRecordContext, FDBRecordStore> schemaSetup;
     final Map<Tuple, Map<Tuple, Tuple>> ids;
 
-    public LuceneIndexDataModel(final Builder builder) {
+    public LuceneIndexTestDataModel(final Builder builder) {
         random = builder.random;
         textGenerator = builder.textGenerator;
         isGrouped = builder.isGrouped;
@@ -72,9 +72,9 @@ public class LuceneIndexDataModel {
             options.put(LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(partitionHighWatermark));
         }
 
-        final RecordMetaDataBuilder metaDataBuilder = LuceneIndexDataModel.createBaseMetaDataBuilder();
-        final KeyExpression rootExpression = LuceneIndexDataModel.createRootExpression(isGrouped, isSynthetic);
-        index = LuceneIndexDataModel.addIndex(isSynthetic, rootExpression, options, metaDataBuilder);
+        final RecordMetaDataBuilder metaDataBuilder = LuceneIndexTestDataModel.createBaseMetaDataBuilder();
+        final KeyExpression rootExpression = LuceneIndexTestDataModel.createRootExpression(isGrouped, isSynthetic);
+        index = LuceneIndexTestDataModel.addIndex(isSynthetic, rootExpression, options, metaDataBuilder);
         final RecordMetaData metadata = metaDataBuilder.build();
         final StoreBuilderSupplier storeBuilderSupplier = builder.storeBuilderSupplier;
         final KeySpacePath path = builder.path;
@@ -102,7 +102,7 @@ public class LuceneIndexDataModel {
         FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
         recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
         for (int j = 0; j < count; j++) {
-            LuceneIndexDataModel.saveRecord(isGrouped, isSynthetic, random, ids, textGenerator, start, recordStore, group);
+            LuceneIndexTestDataModel.saveRecord(isGrouped, isSynthetic, random, ids, textGenerator, start, recordStore, group);
         }
     }
 
@@ -263,8 +263,8 @@ public class LuceneIndexDataModel {
             return this;
         }
 
-        public LuceneIndexDataModel build() {
-            return new LuceneIndexDataModel(this);
+        public LuceneIndexTestDataModel build() {
+            return new LuceneIndexTestDataModel(this);
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -57,7 +57,7 @@ public class LuceneIndexTestDataModel {
     final Function<FDBRecordContext, FDBRecordStore> schemaSetup;
     final Map<Tuple, Map<Tuple, Tuple>> ids;
 
-    public LuceneIndexTestDataModel(final Builder builder) {
+    private LuceneIndexTestDataModel(final Builder builder) {
         random = builder.random;
         textGenerator = builder.textGenerator;
         isGrouped = builder.isGrouped;
@@ -107,7 +107,8 @@ public class LuceneIndexTestDataModel {
     }
 
     static void saveRecord(final boolean isGrouped, final boolean isSynthetic, final Random random,
-                           final Map<Tuple, Map<Tuple, Tuple>> ids, final RandomTextGenerator textGenerator, final long start, final FDBRecordStore recordStore, final int group) {
+                           final Map<Tuple, Map<Tuple, Tuple>> ids, final RandomTextGenerator textGenerator,
+                           final long start, final FDBRecordStore recordStore, final int group) {
         final Tuple groupTuple = isGrouped ? Tuple.from(group) : Tuple.from();
         final int countInGroup = ids.computeIfAbsent(groupTuple, key -> new HashMap<>()).size();
         long timestamp = start + countInGroup + random.nextInt(20) - 5;
@@ -153,7 +154,8 @@ public class LuceneIndexTestDataModel {
     }
 
     @Nonnull
-    static Index addIndex(final boolean isSynthetic, final KeyExpression rootExpression, final Map<String, String> options, final RecordMetaDataBuilder metaDataBuilder) {
+    static Index addIndex(final boolean isSynthetic, final KeyExpression rootExpression,
+                          final Map<String, String> options, final RecordMetaDataBuilder metaDataBuilder) {
         Index index;
         index = new Index("joinNestedConcat", rootExpression, LuceneIndexTypes.LUCENE, options);
 


### PR DESCRIPTION
This returns the partition metadata information, and, optionally, some metadata from the IndexWriter.


In order to create a new test fixture for this behavior, felt it would be valuable to extract some shared code out of `LuceneIndexMaintainerTest`, so that's what the first few commits are. This allows the new fixture to easily toggle on/off grouping and partitioning.
