### PR TITLE
Implement Value for the collate_{jre,icu} functions

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextCollatorRegistry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextCollatorRegistry.java
@@ -31,6 +31,14 @@ import javax.annotation.Nonnull;
 @API(API.Status.EXPERIMENTAL)
 public interface TextCollatorRegistry {
     /**
+     * Get the name of this collator registry.
+     * Used for serialization and debugging.
+     * @return the name of this collator registry
+     */
+    @Nonnull
+    String getName();
+
+    /**
      * Get a weak text collator for the default locale.
      *
      * In general, this means one that is case- and accent-insensitive.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextCollatorRegistryJRE.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/text/TextCollatorRegistryJRE.java
@@ -56,6 +56,12 @@ public class TextCollatorRegistryJRE implements TextCollatorRegistry {
     private TextCollatorRegistryJRE() {
     }
 
+    @Nonnull
+    @Override
+    public String getName() {
+        return "jre";
+    }
+
     @Override
     @Nonnull
     public TextCollator getTextCollator(int strength) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -892,15 +892,15 @@ public class Comparisons {
     /**
      * A comparison with a constant value.
      */
-    public static class SimpleComparison implements Comparison {
+    public abstract static class SimpleComparisonBase implements Comparison {
         private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Simple-Comparison");
 
         @Nonnull
-        private final Type type;
+        protected final Type type;
         @Nonnull
         protected final Object comparand;
 
-        public SimpleComparison(@Nonnull Type type, @Nonnull Object comparand) {
+        protected SimpleComparisonBase(@Nonnull Type type, @Nonnull Object comparand) {
             this.type = type;
             this.comparand = comparand;
         }
@@ -968,15 +968,6 @@ public class Comparisons {
             return type;
         }
 
-        @Nonnull
-        @Override
-        public Comparison withType(@Nonnull final Type newType) {
-            if (type == newType) {
-                return this;
-            }
-            return new SimpleComparison(newType, comparand);
-        }
-
         @Nullable
         @Override
         public Boolean eval(@Nonnull FDBRecordStoreBase<?> store, @Nonnull EvaluationContext context, @Nullable Object value) {
@@ -1002,7 +993,7 @@ public class Comparisons {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            SimpleComparison that = (SimpleComparison) o;
+            SimpleComparisonBase that = (SimpleComparisonBase) o;
             return type == that.type &&
                     Objects.equals(toClassWithRealEquals(comparand), toClassWithRealEquals(that.comparand));
         }
@@ -1040,6 +1031,24 @@ public class Comparisons {
         @Override
         public Comparison translateCorrelations(@Nonnull final TranslationMap translationMap) {
             return this;
+        }
+    }
+
+    /**
+     * A comparison with a constant value.
+     */
+    public static class SimpleComparison extends SimpleComparisonBase {
+        public SimpleComparison(@Nonnull Type type, @Nonnull Object comparand) {
+            super(type, comparand);
+        }
+
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new SimpleComparison(newType, comparand);
         }
 
         @Nonnull
@@ -1120,11 +1129,11 @@ public class Comparisons {
     /**
      * A comparison with a bound parameter, as opposed to a literal constant in the query.
      */
-    public static class ParameterComparison implements ComparisonWithParameter {
+    public abstract static class ParameterComparisonBase implements ComparisonWithParameter {
         private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Parameter-Comparison");
 
         @Nonnull
-        private final Type type;
+        protected final Type type;
         @Nonnull
         protected final String parameter;
         @Nullable
@@ -1132,18 +1141,11 @@ public class Comparisons {
         @Nonnull
         protected final ParameterRelationshipGraph parameterRelationshipGraph;
         @Nonnull
-        private final Supplier<Integer> hashCodeSupplier;
+        protected final Supplier<Integer> hashCodeSupplier;
 
-        public ParameterComparison(@Nonnull Type type,
-                                   @Nonnull String parameter) {
-            this(type, parameter, null, ParameterRelationshipGraph.unbound());
-        }
-
-        public ParameterComparison(@Nonnull Type type, @Nonnull String parameter, @Nullable Bindings.Internal internal) {
-            this(type, parameter, internal, ParameterRelationshipGraph.unbound());
-        }
-
-        public ParameterComparison(@Nonnull Type type, @Nonnull String parameter, @Nullable Bindings.Internal internal, @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+        protected ParameterComparisonBase(@Nonnull Type type, @Nonnull String parameter,
+                                          @Nullable Bindings.Internal internal,
+                                          @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
             checkInternalBinding(parameter, internal);
             this.type = type;
             this.parameter = parameter;
@@ -1156,6 +1158,7 @@ public class Comparisons {
         }
 
         @Override
+        @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
         public void validate(@Nonnull Descriptors.FieldDescriptor descriptor, boolean fannedOut) {
             // No additional validation.
         }
@@ -1164,15 +1167,6 @@ public class Comparisons {
         @Override
         public Type getType() {
             return type;
-        }
-
-        @Nonnull
-        @Override
-        public Comparison withType(@Nonnull final Type newType) {
-            if (type == newType) {
-                return this;
-            }
-            return new ParameterComparison(newType, parameter, internal, parameterRelationshipGraph);
         }
 
         public boolean isCorrelation() {
@@ -1218,15 +1212,14 @@ public class Comparisons {
                 if (quantifiedObjectValue == translatedQuantifiedObjectValue) {
                     return this;
                 }
-                final var translatedAlias = translatedQuantifiedObjectValue.getAlias();
-                return new ParameterComparison(type,
-                        Bindings.Internal.CORRELATION.bindingName(translatedAlias.getId()),
-                        Bindings.Internal.CORRELATION,
-                        parameterRelationshipGraph);
+                return withTranslatedCorrelation(translatedQuantifiedObjectValue.getAlias());
             } else {
                 return this;
             }
         }
+
+        @Nonnull
+        protected abstract ParameterComparisonBase withTranslatedCorrelation(@Nonnull CorrelationIdentifier translatedAlias);
 
         @Nonnull
         @Override
@@ -1240,7 +1233,7 @@ public class Comparisons {
         @Nonnull
         @Override
         public BooleanWithConstraint semanticEqualsTyped(@Nonnull final Comparison other, @Nonnull final ValueEquivalence valueEquivalence) {
-            ParameterComparison that = (ParameterComparison) other;
+            ParameterComparisonBase that = (ParameterComparisonBase) other;
             if (type != that.type) {
                 return BooleanWithConstraint.falseValue();
             }
@@ -1261,7 +1254,7 @@ public class Comparisons {
             if (!getParameter().equals(that.getParameter())) {
                 return BooleanWithConstraint.falseValue();
             }
-            
+
             return Objects.equals(relatedByEquality(), that.relatedByEquality())
                    ? BooleanWithConstraint.alwaysTrue() : BooleanWithConstraint.falseValue();
         }
@@ -1353,6 +1346,52 @@ public class Comparisons {
         }
 
         @Nonnull
+        private static String checkInternalBinding(@Nonnull String parameter, @Nullable Bindings.Internal internal) {
+            if (internal == null && Bindings.Internal.isInternal(parameter)) {
+                throw new RecordCoreException(
+                        "Parameter is internal, parameters cannot start with \"" + Bindings.Internal.PREFIX + "\"");
+            }
+            return parameter;
+        }
+    }
+
+    /**
+     * A comparison with a bound parameter, as opposed to a literal constant in the query.
+     */
+    public static class ParameterComparison extends ParameterComparisonBase {
+        protected ParameterComparison(@Nonnull Type type, @Nonnull String parameter,
+                                      @Nullable Bindings.Internal internal,
+                                      @Nonnull ParameterRelationshipGraph parameterRelationshipGraph) {
+            super(type, parameter, internal, parameterRelationshipGraph);
+        }
+
+        public ParameterComparison(@Nonnull Type type, @Nonnull String parameter) {
+            this(type, parameter, null, ParameterRelationshipGraph.unbound());
+        }
+
+        public ParameterComparison(@Nonnull Type type, @Nonnull String parameter, @Nullable Bindings.Internal internal) {
+            this(type, parameter, internal, ParameterRelationshipGraph.unbound());
+        }
+
+        @Nonnull
+        @Override
+        public Comparison withType(@Nonnull final Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new ParameterComparison(newType, parameter, internal, parameterRelationshipGraph);
+        }
+
+        @Nonnull
+        @Override
+        protected ParameterComparisonBase withTranslatedCorrelation(@Nonnull CorrelationIdentifier translatedAlias) {
+            return new ParameterComparison(type,
+                                           Bindings.Internal.CORRELATION.bindingName(translatedAlias.getId()),
+                                           Bindings.Internal.CORRELATION,
+                                           parameterRelationshipGraph);
+        }
+
+        @Nonnull
         @Override
         public Comparison withParameterRelationshipMap(@Nonnull final ParameterRelationshipGraph parameterRelationshipGraph) {
             Verify.verify(this.parameterRelationshipGraph.isUnbound());
@@ -1390,15 +1429,6 @@ public class Comparisons {
             return new ParameterComparison(Type.fromProto(serializationContext, Objects.requireNonNull(parameterComparisonProto.getType())),
                     Objects.requireNonNull(parameterComparisonProto.getParameter()),
                     internal);
-        }
-
-        @Nonnull
-        private static String checkInternalBinding(@Nonnull String parameter, @Nullable Bindings.Internal internal) {
-            if (internal == null && Bindings.Internal.isInternal(parameter)) {
-                throw new RecordCoreException(
-                        "Parameter is internal, parameters cannot start with \"" + Bindings.Internal.PREFIX + "\"");
-            }
-            return parameter;
         }
 
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpression.java
@@ -21,13 +21,23 @@
 package com.apple.foundationdb.record.query.expressions;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.Bindings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanDeserializer;
 import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.QueryableKeyExpression;
+import com.apple.foundationdb.record.planprotos.PComparison;
+import com.apple.foundationdb.record.planprotos.PConversionParameterComparison;
+import com.apple.foundationdb.record.planprotos.PConversionSimpleComparison;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.serialization.PlanSerialization;
 import com.apple.foundationdb.record.util.HashUtils;
+import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 
 import javax.annotation.Nonnull;
@@ -217,9 +227,8 @@ public class QueryKeyExpression {
 
         @Nonnull
         private QueryKeyExpressionWithOneOfComparison simpleComparison(@Nonnull Comparisons.Type type, @Nonnull Object comparand) {
-            final Function<Object, Object> conversion = keyExpression.getComparandConversionFunction();
-            if (conversion != null) {
-                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new ConversionSimpleComparison(type, comparand, conversion));
+            if (keyExpression.getComparandConversionFunction() != null) {
+                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new ConversionSimpleComparison(type, comparand, keyExpression));
             } else {
                 return new QueryKeyExpressionWithOneOfComparison(keyExpression, new Comparisons.SimpleComparison(type, comparand));
             }
@@ -232,9 +241,8 @@ public class QueryKeyExpression {
 
         @Nonnull
         private QueryKeyExpressionWithOneOfComparison parameterComparison(@Nonnull Comparisons.Type type, @Nonnull String param) {
-            final Function<Object, Object> conversion = keyExpression.getComparandConversionFunction();
-            if (conversion != null) {
-                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new ConversionParameterComparison(type, param, conversion));
+            if (keyExpression.getComparandConversionFunction() != null) {
+                return new QueryKeyExpressionWithOneOfComparison(keyExpression, new ConversionParameterComparison(type, param, keyExpression));
             } else {
                 return new QueryKeyExpressionWithOneOfComparison(keyExpression, new Comparisons.ParameterComparison(type, param));
             }
@@ -243,9 +251,8 @@ public class QueryKeyExpression {
 
     @Nonnull
     protected QueryKeyExpressionWithComparison simpleComparison(@Nonnull Comparisons.Type type, @Nonnull Object comparand) {
-        final Function<Object, Object> conversion = keyExpression.getComparandConversionFunction();
-        if (conversion != null) {
-            return new QueryKeyExpressionWithComparison(keyExpression, new ConversionSimpleComparison(type, comparand, conversion));
+        if (keyExpression.getComparandConversionFunction() != null) {
+            return new QueryKeyExpressionWithComparison(keyExpression, new ConversionSimpleComparison(type, comparand, keyExpression));
         } else {
             return new QueryKeyExpressionWithComparison(keyExpression, new Comparisons.SimpleComparison(type, comparand));
         }
@@ -258,24 +265,23 @@ public class QueryKeyExpression {
 
     @Nonnull
     protected QueryKeyExpressionWithComparison parameterComparison(@Nonnull Comparisons.Type type, @Nonnull String param) {
-        final Function<Object, Object> conversion = keyExpression.getComparandConversionFunction();
-        if (conversion != null) {
-            return new QueryKeyExpressionWithComparison(keyExpression, new ConversionParameterComparison(type, param, conversion));
+        if (keyExpression.getComparandConversionFunction() != null) {
+            return new QueryKeyExpressionWithComparison(keyExpression, new ConversionParameterComparison(type, param, keyExpression));
         } else {
             return new QueryKeyExpressionWithComparison(keyExpression, new Comparisons.ParameterComparison(type, param));
         }
     }
 
-    private final class ConversionSimpleComparison extends Comparisons.SimpleComparison {
+    private static final class ConversionSimpleComparison extends Comparisons.SimpleComparisonBase {
         @Nonnull
-        private final Function<Object, Object> conversion;
+        private final QueryableKeyExpression keyExpression;
         @Nonnull
         private final Object unconvertedComparand;
 
         public ConversionSimpleComparison(@Nonnull Comparisons.Type type, @Nonnull Object comparand,
-                                          @Nonnull Function<Object, Object> conversion) {
-            super(type, conversion.apply(comparand));
-            this.conversion = conversion;
+                                          @Nonnull QueryableKeyExpression keyExpression) {
+            super(type, keyExpression.getComparandConversionFunction().apply(comparand));
+            this.keyExpression = keyExpression;
             this.unconvertedComparand = comparand;
         }
 
@@ -326,24 +332,86 @@ public class QueryKeyExpression {
         public int queryHash(@Nonnull final QueryHashKind hashKind) {
             return HashUtils.queryHash(hashKind, SIMPLE_COMPARISON_BASE_HASH, super.queryHash(hashKind), getKeyExpression());
         }
+
+        @Nonnull
+        @Override
+        public Comparisons.Comparison withType(@Nonnull final Comparisons.Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new ConversionSimpleComparison(newType, unconvertedComparand, keyExpression);
+        }
+
+        @Nonnull
+        @Override
+        public PConversionSimpleComparison toProto(@Nonnull final PlanSerializationContext serializationContext) {
+            return PConversionSimpleComparison.newBuilder()
+                    .setType(type.toProto(serializationContext))
+                    .setObject(PlanSerialization.valueObjectToProto(unconvertedComparand))
+                    .setConversion(keyExpression.toKeyExpression())
+                    .build();
+        }
+
+        @Nonnull
+        @Override
+        public PComparison toComparisonProto(@Nonnull final PlanSerializationContext serializationContext) {
+            return PComparison.newBuilder().setConversionSimpleComparison(toProto(serializationContext)).build();
+        }
+
+        @Nonnull
+        public static ConversionSimpleComparison fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                           @Nonnull final PConversionSimpleComparison simpleComparisonProto) {
+            return new ConversionSimpleComparison(Comparisons.Type.fromProto(serializationContext, Objects.requireNonNull(simpleComparisonProto.getType())),
+                    Objects.requireNonNull(PlanSerialization.protoToValueObject(Objects.requireNonNull(simpleComparisonProto.getObject()))),
+                    (QueryableKeyExpression)KeyExpression.fromProto(simpleComparisonProto.getConversion()));
+        }
+
+        /**
+         * Deserializer.
+         */
+        @AutoService(PlanDeserializer.class)
+        public static class Deserializer implements PlanDeserializer<PConversionSimpleComparison, ConversionSimpleComparison> {
+            @Nonnull
+            @Override
+            public Class<PConversionSimpleComparison> getProtoMessageClass() {
+                return PConversionSimpleComparison.class;
+            }
+
+            @Nonnull
+            @Override
+            public ConversionSimpleComparison fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                        @Nonnull final PConversionSimpleComparison conversionSimpleComparisonProto) {
+                return ConversionSimpleComparison.fromProto(serializationContext, conversionSimpleComparisonProto);
+            }
+        }
     }
 
-    private final class ConversionParameterComparison extends Comparisons.ParameterComparison {
+    private static final class ConversionParameterComparison extends Comparisons.ParameterComparisonBase {
+        @Nonnull
+        private final QueryableKeyExpression keyExpression;
         @Nonnull
         private final Function<Object, Object> conversion;
 
-        public ConversionParameterComparison(@Nonnull Comparisons.Type type,
-                                             @Nonnull String param,
-                                             @Nonnull Function<Object, Object> conversion) {
-            this(type, param, ParameterRelationshipGraph.unbound(), conversion);
+        protected ConversionParameterComparison(@Nonnull Comparisons.Type type, @Nonnull String parameter,
+                                                @Nullable Bindings.Internal internal,
+                                                @Nonnull ParameterRelationshipGraph parameterRelationshipGraph,
+                                                @Nonnull QueryableKeyExpression keyExpression) {
+            super(type, parameter, internal, parameterRelationshipGraph);
+            this.keyExpression = keyExpression;
+            this.conversion = Objects.requireNonNull(keyExpression.getComparandConversionFunction());
         }
 
         public ConversionParameterComparison(@Nonnull Comparisons.Type type,
                                              @Nonnull String param,
                                              @Nonnull ParameterRelationshipGraph parameterRelationshipGraph,
-                                             @Nonnull Function<Object, Object> conversion) {
-            super(type, param, null, parameterRelationshipGraph);
-            this.conversion = conversion;
+                                             @Nonnull QueryableKeyExpression keyExpression) {
+            this(type, param, null, parameterRelationshipGraph, keyExpression);
+        }
+
+        public ConversionParameterComparison(@Nonnull Comparisons.Type type,
+                                             @Nonnull String param,
+                                             @Nonnull QueryableKeyExpression keyExpression) {
+            this(type, param, ParameterRelationshipGraph.unbound(), keyExpression);
         }
 
         @Nonnull
@@ -371,6 +439,15 @@ public class QueryKeyExpression {
         @Override
         public String typelessString() {
             return getKeyExpression().getName() + "(" + super.typelessString() + ")";
+        }
+
+        @Nonnull
+        @Override
+        public Comparisons.Comparison withType(@Nonnull final Comparisons.Type newType) {
+            if (type == newType) {
+                return this;
+            }
+            return new ConversionParameterComparison(newType, parameter, internal, parameterRelationshipGraph, keyExpression);
         }
 
         @Override
@@ -412,9 +489,74 @@ public class QueryKeyExpression {
 
         @Nonnull
         @Override
+        protected Comparisons.ParameterComparisonBase withTranslatedCorrelation(@Nonnull CorrelationIdentifier translatedAlias) {
+            return new ConversionParameterComparison(type,
+                    Bindings.Internal.CORRELATION.bindingName(translatedAlias.getId()),
+                    Bindings.Internal.CORRELATION,
+                    parameterRelationshipGraph,
+                    keyExpression);
+        }
+
+        @Nonnull
+        @Override
         public Comparisons.Comparison withParameterRelationshipMap(@Nonnull final ParameterRelationshipGraph parameterRelationshipGraph) {
             Verify.verify(this.parameterRelationshipGraph.isUnbound());
-            return new ConversionParameterComparison(getType(), parameter, parameterRelationshipGraph, conversion);
+            return new ConversionParameterComparison(type, parameter, internal, parameterRelationshipGraph, keyExpression);
+        }
+
+        @Nonnull
+        @Override
+        public PConversionParameterComparison toProto(@Nonnull final PlanSerializationContext serializationContext) {
+            final PConversionParameterComparison.Builder builder = PConversionParameterComparison.newBuilder()
+                    .setType(type.toProto(serializationContext))
+                    .setParameter(parameter)
+                    .setConversion(keyExpression.toKeyExpression());
+            if (internal != null) {
+                builder.setInternal(internal.toProto(serializationContext));
+            }
+            return builder.build();
+        }
+
+        @Nonnull
+        @Override
+        public PComparison toComparisonProto(@Nonnull final PlanSerializationContext serializationContext) {
+            return PComparison.newBuilder().setConversionParameterComparison(toProto(serializationContext)).build();
+        }
+
+        @Nonnull
+        public static ConversionParameterComparison fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                              @Nonnull final PConversionParameterComparison conversionParameterComparisonProto) {
+            final Bindings.Internal internal;
+            if (conversionParameterComparisonProto.hasInternal()) {
+                internal = Bindings.Internal.fromProto(serializationContext, Objects.requireNonNull(conversionParameterComparisonProto.getInternal()));
+            } else {
+                internal = null;
+            }
+            final QueryableKeyExpression keyExpression = (QueryableKeyExpression)
+                    KeyExpression.fromProto(conversionParameterComparisonProto.getConversion());
+            return new ConversionParameterComparison(Comparisons.Type.fromProto(serializationContext, Objects.requireNonNull(conversionParameterComparisonProto.getType())),
+                    Objects.requireNonNull(conversionParameterComparisonProto.getParameter()),
+                    internal, ParameterRelationshipGraph.unbound(),
+                    keyExpression);
+        }
+
+        /**
+         * Deserializer.
+         */
+        @AutoService(PlanDeserializer.class)
+        public static class Deserializer implements PlanDeserializer<PConversionParameterComparison, ConversionParameterComparison> {
+            @Nonnull
+            @Override
+            public Class<PConversionParameterComparison> getProtoMessageClass() {
+                return PConversionParameterComparison.class;
+            }
+
+            @Nonnull
+            @Override
+            public ConversionParameterComparison fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                           @Nonnull final PConversionParameterComparison conversionParameterComparisonProto) {
+                return ConversionParameterComparison.fromProto(serializationContext, conversionParameterComparisonProto);
+            }
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpressionWithValue
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.metadata.expressions.ListKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.QueryableKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.EmptyValue;
@@ -105,6 +106,10 @@ public class ScalarTranslationVisitor implements KeyExpressionVisitor<ScalarTran
     @Nonnull
     @Override
     public final Value visitExpression(@Nonnull final KeyExpression keyExpression) {
+        if (keyExpression instanceof QueryableKeyExpression) {
+            final ScalarVisitorState state = getCurrentState();
+            return ((QueryableKeyExpression)keyExpression).toValue(state.baseAlias, state.inputType, state.fieldNamePrefix);
+        }
         throw new UnsupportedOperationException("visitor method for this key expression is not implemented");
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CollateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CollateValue.java
@@ -1,0 +1,401 @@
+/*
+ * CollateValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.values;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanDeserializer;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.CollateFunctionKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.CollateFunctionKeyExpressionFactoryJRE;
+import com.apple.foundationdb.record.planprotos.PCollateValue;
+import com.apple.foundationdb.record.planprotos.PValue;
+import com.apple.foundationdb.record.provider.common.text.TextCollator;
+import com.apple.foundationdb.record.provider.common.text.TextCollatorRegistry;
+import com.apple.foundationdb.record.provider.common.text.TextCollatorRegistryJRE;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
+import com.apple.foundationdb.record.query.plan.cascades.Formatter;
+import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type.TypeCode;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
+import com.google.auto.service.AutoService;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A {@link Value} that turns a string into a locale-specific sort key.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class CollateValue extends AbstractValue {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Collate-Value");
+
+    @Nonnull
+    private final TextCollatorRegistry collatorRegistry;
+    @Nonnull
+    private final Value stringChild;
+    @Nullable
+    private final Value localeChild;
+    @Nullable
+    private final Value strengthChild;
+    @Nullable
+    private final TextCollator invariableCollator;
+
+    public CollateValue(@Nonnull final TextCollatorRegistry collatorRegistry,
+                        @Nonnull final Value stringChild, @Nullable final Value localeChild, @Nullable final Value strengthChild) {
+        this.collatorRegistry = collatorRegistry;
+        this.stringChild = stringChild;
+        this.localeChild = localeChild;
+        this.strengthChild = strengthChild;
+        this.invariableCollator = getInvariableCollator(collatorRegistry, localeChild, strengthChild);
+    }
+
+    @Nonnull
+    public TextCollatorRegistry getCollatorRegistry() {
+        return collatorRegistry;
+    }
+
+    @Nullable
+    @Override
+    public <M extends Message> ByteString eval(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context) {
+        final String str = (String)stringChild.eval(store, context);
+        final TextCollator collator = getTextCollator(store, context);
+        return collator.getKey(str);
+    }
+
+    @Nonnull
+    @Override
+    public String explain(@Nonnull final Formatter formatter) {
+        StringBuilder str = new StringBuilder(stringChild.explain(formatter));
+        str.append(" COLLATE ");
+        if (localeChild != null) {
+            str.append(localeChild.explain(formatter));
+        } else {
+            str.append("DEFAULT");
+        }
+        if (strengthChild != null) {
+            str.append(" STRENGTH ");
+            str.append(strengthChild.explain(formatter));
+        }
+        return str.toString();
+    }
+
+    @Nonnull
+    @Override
+    public Type getResultType() {
+        return Type.primitiveType(TypeCode.BYTES);
+    }
+
+    @Nonnull
+    @Override
+    protected Iterable<? extends Value> computeChildren() {
+        ImmutableList.Builder<Value> list = ImmutableList.builder();
+        list.add(stringChild);
+        if (localeChild != null) {
+            list.add(localeChild);
+        }
+        if (strengthChild != null) {
+            list.add(strengthChild);
+        }
+        return list.build();
+    }
+
+    @Nonnull
+    @Override
+    public CollateValue withChildren(final Iterable<? extends Value> newChildren) {
+        final Iterator<? extends Value> iter = newChildren.iterator();
+        Verify.verify(iter.hasNext());
+        final Value stringChild = iter.next();
+        final Value localeChild;
+        final Value strengthChild;
+        if (iter.hasNext()) {
+            localeChild = iter.next();
+            if (iter.hasNext()) {
+                strengthChild = iter.next();
+            } else {
+                strengthChild = null;
+            }
+        } else {
+            strengthChild = localeChild = null;
+        }
+        Verify.verify(!iter.hasNext());
+        return new CollateValue(collatorRegistry, stringChild, localeChild, strengthChild);
+    }
+
+    @Override
+    public int hashCodeWithoutChildren() {
+        return PlanHashable.objectsPlanHash(PlanHashable.CURRENT_FOR_CONTINUATION, BASE_HASH, collatorRegistry.getName());
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode mode) {
+        return PlanHashable.objectsPlanHash(mode, BASE_HASH, collatorRegistry.getName(),
+                                            stringChild, localeChild, strengthChild);
+    }
+
+    @Nonnull
+    @Override
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other).filter(ignored -> {
+            CollateValue otherCollate = (CollateValue)other;
+            return collatorRegistry.equals(otherCollate.collatorRegistry);
+        });
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder("collate(");
+        str.append(stringChild);
+        str.append(", ");
+        if (localeChild != null) {
+            str.append(localeChild);
+        } else {
+            str.append("DEFAULT");
+        }
+        str.append(", ");
+        if (strengthChild != null) {
+            str.append(strengthChild);
+        } else {
+            str.append("DEFAULT");
+        }
+        str.append(")");
+        return str.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @Override
+    public boolean equals(final Object other) {
+        return semanticEquals(other, AliasMap.emptyMap());
+    }
+
+    @Nonnull
+    @Override
+    public PCollateValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
+        PCollateValue.Builder builder = PCollateValue.newBuilder();
+        builder.setCollatorRegistry(collatorRegistry.getName());
+        builder.setStringChild(stringChild.toValueProto(serializationContext));
+        if (localeChild != null) {
+            builder.setLocaleChild(localeChild.toValueProto(serializationContext));
+        }
+        if (strengthChild != null) {
+            builder.setStrengthChild(strengthChild.toValueProto(serializationContext));
+        }
+        return builder.build();
+    }
+
+    @Nonnull
+    @Override
+    public PValue toValueProto(@Nonnull final PlanSerializationContext serializationContext) {
+        return PValue.newBuilder().setCollateValue(toProto(serializationContext)).build();
+    }
+
+    @Nonnull
+    public static CollateValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                         @Nonnull final PCollateValue collateValueProto) {
+        final TextCollatorRegistry collatorRegistry = getCollatorRegistryFromProto(collateValueProto.getCollatorRegistry());
+        final Value stringChild = Value.fromValueProto(serializationContext, collateValueProto.getStringChild());
+        final Value localeChild;
+        final Value strengthChild;
+        if (collateValueProto.hasLocaleChild()) {
+            localeChild = Value.fromValueProto(serializationContext, collateValueProto.getLocaleChild());
+        } else {
+            localeChild = null;
+        }
+        if (collateValueProto.hasStrengthChild()) {
+            strengthChild = Value.fromValueProto(serializationContext, collateValueProto.getStrengthChild());
+        } else {
+            strengthChild = null;
+        }
+        return new CollateValue(collatorRegistry, stringChild, localeChild, strengthChild);
+    }
+
+    /**
+     * Deserializer for {@link PCollateValue}.
+     */
+    @AutoService(PlanDeserializer.class)
+    public static class Deserializer implements PlanDeserializer<PCollateValue, CollateValue> {
+        @Nonnull
+        @Override
+        public Class<PCollateValue> getProtoMessageClass() {
+            return PCollateValue.class;
+        }
+
+        @Nonnull
+        @Override
+        public CollateValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                      @Nonnull final PCollateValue collateValueProto) {
+            return CollateValue.fromProto(serializationContext, collateValueProto);
+        }
+    }
+
+    @Nullable
+    @SuppressWarnings("unchecked")
+    protected static TextCollator getInvariableCollator(@Nonnull final TextCollatorRegistry collatorRegistry,
+                                                        @Nullable final Value localeChild, @Nullable final Value strengthChild) {
+        if (localeChild == null) {
+            if (strengthChild == null) {
+                return collatorRegistry.getTextCollator();
+            }
+            if (strengthChild instanceof LiteralValue) {
+                final Integer strength = ((LiteralValue<Integer>)strengthChild).getLiteralValue();
+                return collatorRegistry.getTextCollator(strength == null ? 0 : strength);
+            }
+        } else if (localeChild instanceof LiteralValue) {
+            final String locale = ((LiteralValue<String>)localeChild).getLiteralValue();
+            if (locale == null) {
+                if (strengthChild == null) {
+                    return collatorRegistry.getTextCollator();
+                }
+                if (strengthChild instanceof LiteralValue) {
+                    final Integer strength = ((LiteralValue<Integer>)strengthChild).getLiteralValue();
+                    return collatorRegistry.getTextCollator(strength == null ? 0 : strength);
+                }
+            } else {
+                if (strengthChild == null) {
+                    return collatorRegistry.getTextCollator(locale);
+                }
+                if (strengthChild instanceof LiteralValue) {
+                    final Integer strength = ((LiteralValue<Integer>)strengthChild).getLiteralValue();
+                    return collatorRegistry.getTextCollator(locale, strength == null ? 0 : strength);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Nonnull
+    private <M extends Message> TextCollator getTextCollator(@Nonnull final FDBRecordStoreBase<M> store,
+                                                             @Nonnull final EvaluationContext context) {
+        if (invariableCollator != null) {
+            return invariableCollator;
+        }
+        if (localeChild != null) {
+            final String locale = (String)localeChild.eval(store, context);
+            if (strengthChild != null) {
+                final int strength = (Integer)strengthChild.eval(store, context);
+                return collatorRegistry.getTextCollator(locale, strength);
+            }
+            return collatorRegistry.getTextCollator(locale);
+        } else if (strengthChild != null) {
+            final int strength = (Integer)strengthChild.eval(store, context);
+            return collatorRegistry.getTextCollator(strength);
+        } else {
+            return collatorRegistry.getTextCollator();
+        }
+    }
+
+    private static TextCollatorRegistry getCollatorRegistryFromProto(@Nonnull final String name) {
+        CollateFunctionKeyExpression keyExpression = (CollateFunctionKeyExpression)
+                Key.Expressions.function("collate_" + name,
+                        Key.Expressions.concatenateFields("_string", "_locale", "_strength"));
+        return keyExpression.getCollatorRegistry();
+    }
+
+    /**
+     * Base class for defining collation built-in function.
+     */
+    public static class CollateFunction extends BuiltInFunction<Value> {
+        public CollateFunction(@Nonnull final String functionName,
+                               @Nonnull final TextCollatorRegistry collatorRegistry) {
+            super(functionName,
+                    ImmutableList.of(Type.primitiveType(Type.TypeCode.STRING)), Type.any(),
+                    (builtInFunction, arguments) -> CollateValue.encapsulate(collatorRegistry, arguments));
+        }
+
+        @Nonnull
+        @Override
+        public Optional<BuiltInFunction<Value>> validateCall(@Nonnull final List<Type> argumentTypes) {
+            // We claimed to be string + variadic any.
+            return super.validateCall(argumentTypes).filter(ignoreThis -> {
+                final int nargs = argumentTypes.size();
+                if (nargs < 2) {
+                    return true;
+                }
+                if (nargs > 3) {
+                    return false;
+                }
+                if (argumentTypes.get(1).getTypeCode() != TypeCode.STRING) {
+                    return false;
+                }
+                if (nargs < 3) {
+                    return true;
+                }
+                return argumentTypes.get(2).getTypeCode() == TypeCode.INT;
+            });
+        }
+    }
+
+    @Nonnull
+    private static Value encapsulate(@Nonnull final TextCollatorRegistry collatorRegistry,
+                                     @Nonnull final List<? extends Typed> arguments) {
+        final int nargs = arguments.size();
+        Verify.verify(nargs >= 1 && nargs <= 3);
+        final Typed stringArg = arguments.get(0);
+        SemanticException.check(stringArg.getResultType().isPrimitive(), SemanticException.ErrorCode.ARGUMENT_TO_ARITHMETIC_OPERATOR_IS_OF_COMPLEX_TYPE);
+        final Typed localeArg;
+        if (nargs > 1) {
+            localeArg = arguments.get(1);
+            SemanticException.check(localeArg.getResultType().isPrimitive(), SemanticException.ErrorCode.ARGUMENT_TO_ARITHMETIC_OPERATOR_IS_OF_COMPLEX_TYPE);
+        } else {
+            localeArg = null;
+        }
+        final Typed strengthArg;
+        if (nargs > 2) {
+            strengthArg = arguments.get(2);
+            SemanticException.check(strengthArg.getResultType().isPrimitive(), SemanticException.ErrorCode.ARGUMENT_TO_ARITHMETIC_OPERATOR_IS_OF_COMPLEX_TYPE);
+        } else {
+            strengthArg = null;
+        }
+        return new CollateValue(collatorRegistry, (Value)stringArg, (Value)localeArg, (Value)strengthArg);
+    }
+
+    /**
+     * Define {@code collate_jre} built-in function.
+     */
+    @AutoService(BuiltInFunction.class)
+    @SuppressWarnings("checkstyle:abbreviationaswordinname") // Allow JRE here.
+    public static class CollateValueJRE extends CollateFunction {
+        public CollateValueJRE() {
+            super(CollateFunctionKeyExpressionFactoryJRE.FUNCTION_NAME, TextCollatorRegistryJRE.instance());
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RelOpValue.java
@@ -654,6 +654,14 @@ public abstract class RelOpValue extends AbstractValue implements BooleanValue {
         NEQ_BYU(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.UNKNOWN, (l, r) -> null),
         NEQ_BYBY(Comparisons.Type.NOT_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.BYTES, (l, r) -> Comparisons.evalComparison(Comparisons.Type.NOT_EQUALS, l, r)),
         NEQ_UBY(Comparisons.Type.NOT_EQUALS, Type.TypeCode.UNKNOWN, Type.TypeCode.BYTES, (l, r) -> null),
+        LT_BYU(Comparisons.Type.LESS_THAN, Type.TypeCode.BYTES, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        LT_BYBY(Comparisons.Type.LESS_THAN, Type.TypeCode.BYTES, Type.TypeCode.BYTES, (l, r) -> Comparisons.evalComparison(Comparisons.Type.LESS_THAN, l, r)),
+        LTE_BYU(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        LTE_BYBY(Comparisons.Type.LESS_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.BYTES, (l, r) -> Comparisons.evalComparison(Comparisons.Type.LESS_THAN_OR_EQUALS, l, r)),
+        GT_BYU(Comparisons.Type.GREATER_THAN, Type.TypeCode.BYTES, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        GT_BYBY(Comparisons.Type.GREATER_THAN, Type.TypeCode.BYTES, Type.TypeCode.BYTES, (l, r) -> Comparisons.evalComparison(Comparisons.Type.GREATER_THAN, l, r)),
+        GTE_BYU(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.UNKNOWN, (l, r) -> null),
+        GTE_BYBY(Comparisons.Type.GREATER_THAN_OR_EQUALS, Type.TypeCode.BYTES, Type.TypeCode.BYTES, (l, r) -> Comparisons.evalComparison(Comparisons.Type.GREATER_THAN_OR_EQUALS, l, r)),
         ;
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -905,12 +905,20 @@ message PComparison {
     PMultiColumnComparison multi_column_comparison = 8;
     PInvertedFunctionComparison inverted_function_comparison = 9;
     PRecordTypeComparison record_type_comparison = 10;
+    PConversionSimpleComparison conversion_simple_comparison = 11;
+    PConversionParameterComparison conversion_parameter_comparison = 12;
   }
 }
 
 message PSimpleComparison {
   optional PComparison.PComparisonType type = 1;
   optional PComparableObject object = 2;
+}
+
+message PConversionSimpleComparison {
+  optional PComparison.PComparisonType type = 1;
+  optional PComparableObject object = 2;
+  optional KeyExpression conversion = 3;
 }
 
 message PComparableObject {
@@ -948,6 +956,13 @@ message PParameterComparison {
   optional PComparison.PComparisonType type = 1;
   optional string parameter = 2;
   optional PBindingKind internal = 3;
+}
+
+message PConversionParameterComparison {
+  optional PComparison.PComparisonType type = 1;
+  optional string parameter = 2;
+  optional PParameterComparison.PBindingKind internal = 3;
+  optional KeyExpression conversion = 4;
 }
 
 message PValueComparison {

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -237,6 +237,7 @@ message PValue {
     PVersionValue version_value = 38;
     PFirstOrDefaultValue first_or_default_value = 39;
     PThrowsValue throws_value = 40;
+    PCollateValue collate_value = 41;
   }
 }
 
@@ -865,6 +866,13 @@ message PVersionValue {
 message PWindowedValue {
   repeated PValue partitioning_values = 1;
   repeated PValue argument_values = 2;
+}
+
+message PCollateValue {
+  optional string collator_registry = 1;
+  optional PValue string_child = 2;
+  optional PValue locale_child = 3;
+  optional PValue strength_child = 4;
 }
 
 //

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -783,6 +783,14 @@ message PBinaryRelOpValue {
       NEQ_BYU = 200;
       NEQ_BYBY = 201;
       NEQ_UBY = 202;
+      LT_BYU = 203;
+      LT_BYBY = 204;
+      LTE_BYU = 205;
+      LTE_BYBY = 206;
+      GT_BYU = 207;
+      GT_BYBY = 208;
+      GTE_BYU = 209;
+      GTE_BYBY = 210;
 
   }
   optional PRelOpValue super = 1;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCollateQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBCollateQueryTest.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -141,17 +140,17 @@ public abstract class FDBCollateQueryTest extends FDBRecordStoreQueryTestBase {
         assertEquals(Arrays.asList(expected), actual);
     }
 
-    @Test
+    @DualPlannerTest
     public void sortOnlyUnicode() throws Exception {
         sortOnly(null, "Ampère", "Faraday", "Gauß", "Maxwell", "Stokes", "Ångström", "Ørsted");
     }
 
-    @Test
+    @DualPlannerTest
     public void sortOnlyDa() throws Exception {
         sortOnly("da_DK", "Ampère", "Faraday", "Gauß", "Maxwell", "Stokes", "Ørsted", "Ångström");
     }
 
-    @Test
+    @DualPlannerTest
     public void sortOnlyFr() throws Exception {
         if (CollateFunctionKeyExpressionFactoryJRE.FUNCTION_NAME.equals(collateFunctionName)) {
             // Does not recognize Ø as an accented O.
@@ -161,7 +160,7 @@ public abstract class FDBCollateQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Test
+    @DualPlannerTest
     public void noIndex() throws Exception {
         loadNames(NO_HOOK);
         final RecordQuery query = RecordQuery.newBuilder()
@@ -174,7 +173,7 @@ public abstract class FDBCollateQueryTest extends FDBRecordStoreQueryTestBase {
         assertEquals(expected, actual);
     }
 
-    @Test
+    @DualPlannerTest
     public void rangeScan() throws Exception {
         final KeyExpression key = function(collateFunctionName, concat(NAME_FIELD, value("da_DK")));
         final RecordMetaDataHook hook = md -> {
@@ -194,7 +193,7 @@ public abstract class FDBCollateQueryTest extends FDBRecordStoreQueryTestBase {
         assertThat(plan, indexScan("collated_name"));
     }
 
-    @Test
+    @DualPlannerTest
     public void coveringIndex() throws Exception {
         // Note how the name field needs to be repeated in the value because it can't be recovered from an index
         // entry after transformation to a collation key.
@@ -217,7 +216,7 @@ public abstract class FDBCollateQueryTest extends FDBRecordStoreQueryTestBase {
         assertThat(plan, coveringIndexScan(indexScan("collated_name")));
     }
 
-    @Test
+    @DualPlannerTest
     public void compareParameter() throws Exception {
         final KeyExpression key = function(collateFunctionName, concat(NAME_FIELD, value("de_DE")));
         final RecordMetaDataHook hook = md -> {

--- a/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/CollateValueICU.java
+++ b/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/CollateValueICU.java
@@ -1,0 +1,36 @@
+/*
+ * CollateValueICU.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.icu;
+
+import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
+import com.apple.foundationdb.record.query.plan.cascades.values.CollateValue;
+import com.google.auto.service.AutoService;
+
+/**
+ * Define {@code collate_icu} built-in function.
+ */
+@AutoService(BuiltInFunction.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname") // Allow ICU here.
+public class CollateValueICU extends CollateValue.CollateFunction {
+    public CollateValueICU() {
+        super(CollateFunctionKeyExpressionFactoryICU.FUNCTION_NAME, TextCollatorRegistryICU.instance());
+    }
+}

--- a/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/TextCollatorRegistryICU.java
+++ b/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/TextCollatorRegistryICU.java
@@ -59,6 +59,12 @@ public class TextCollatorRegistryICU implements TextCollatorRegistry {
     private TextCollatorRegistryICU() {
     }
 
+    @Nonnull
+    @Override
+    public String getName() {
+        return "icu";
+    }
+
     @Override
     @Nonnull
     public TextCollator getTextCollator(int strength) {


### PR DESCRIPTION
Also includes some places where `QueryableKeyExpression` wasn't completely handled by Cascades:
* Transform in some `Value`-oriented visitors, using its `toValue` method.
* Support all comparisons with `BYTES` type.
* The `Conversion` variants of `Comparison` need their own, separate, serialization.

With all that, the existing query tests in `FDBCollateQueryTest` can now use `@DualPlannerTest`.