### PR TITLE
Add some sleep between tests in LuceneIndexMaintenanceTest

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -65,6 +65,7 @@ import com.apple.test.Tags;
 import com.apple.test.TestConfigurationUtils;
 import org.apache.lucene.store.Lock;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -124,6 +125,14 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 return org.apache.commons.lang3.tuple.Pair.of(7L, TimeUnit.SECONDS);
             }
         });
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        // A fairly hacky attempt to solving: https://github.com/FoundationDB/fdb-record-layer/issues/2842
+        // The theory is that these tests put *a lot* of load on the system, and can overwhelm it if you are just
+        // pointing to a single-instance cluster. The hope here is that this will allow the system to recover.
+        Thread.sleep(1000);
     }
 
     static Stream<Arguments> configurationArguments() {


### PR DESCRIPTION
The idea here being that the tests cause enough load on the fdb cluster that it can't handle anything else. Adding a 1 second sleep in between may allow it to recover and proceed to the next set of tests in a healthy state.