### PR TITLE
Add commas to test durations

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -149,7 +149,7 @@ tasks.withType(Test) { theTask ->
         println "${Instant.now()} ${getFullDisplayName(descriptor)} STARTED"
     } 
     afterTest { descriptor, result ->
-        def duration = String.format("%,d", result.endTime - result.startTime)
+        def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
         println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
         println()
     }

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -149,7 +149,7 @@ tasks.withType(Test) { theTask ->
         println "${Instant.now()} ${getFullDisplayName(descriptor)} STARTED"
     } 
     afterTest { descriptor, result ->
-        def duration = result.endTime - result.startTime
+        def duration = String.format("%,d", result.endTime - result.startTime)
         println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
         println()
     }


### PR DESCRIPTION
Not having them makes it a bit harder to read.
I thought about using `Duration.ofMillis` but the `toString` on that is like PT0.234 or PT1.4098 which I, personally find hard to parse visually.