### PR TITLE
Prep #2360: Ensure code compiles on JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,11 @@ subprojects {
                 exclude "com/apple/foundationdb/record/planprotos/*.java"
                 exclude "com/apple/foundationdb/record/query/plan/cascades/debug/eventprotos/*.java"
                 options.addBooleanOption('Xwerror', true)
+
+		// Quiet javadoc errors for missing comments, etc.
+		// It would be good to have more coverage, but this allows us to move forward with incomplete docs
+                options.addBooleanOption('Xdoclint:none', true)
+
                 options.addStringOption('source', '11')
                 options.with {
                     overview "src/main/javadoc/overview.html"

--- a/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
+++ b/examples/src/main/java/com/apple/foundationdb/record/sample/Main.java
@@ -79,6 +79,19 @@ public class Main {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
+    /**
+     * Helper function to query for {@code Customer} records and extract their names.
+     * It uses a pattern where the caller provides a template "record store" builder (which
+     * contains the subspace within the database and its {@link RecordMetaData}) as
+     * well as a transaction handle, and this method attaches the transaction to the store
+     * template to open the store. It then executes the provided query and extracts result
+     * information, which it then returns.
+     *
+     * @param recordStoreBuilder template used to construct {@link FDBRecordStore}s
+     * @param cx transaction to use to connect to the database
+     * @param query query to perform to select {@code Customer} records
+     * @return names of all queried records
+     */
     public static List<String> readNames(FDBRecordStore.Builder recordStoreBuilder, FDBRecordContext cx, RecordQuery query) {
         List<String> names = new ArrayList<>();
         FDBRecordStore store = recordStoreBuilder.copyBuilder().setContext(cx).open();
@@ -99,6 +112,12 @@ public class Main {
         return names;
     }
 
+    /**
+     * Runs a set of sample operations against a database. This includes populating
+     * a record store with data and then running a number of queries against that data.
+     *
+     * @param args command line arguments (ignored)
+     */
     public static void main(String[] args) {
         // Get a database connection.
         FDBDatabase fdb = FDBDatabaseFactory.instance().getDatabase();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractChangeSet.java
@@ -32,22 +32,12 @@ import javax.annotation.Nullable;
  * @param <N> node type class (self type)
  */
 public abstract class AbstractChangeSet<S extends NodeSlot, N extends AbstractNode<S, N>> implements ChangeSet {
-    /**
-     * Previous change set in the chain of change sets. Can be {@code null} if there is no previous change set.
-     */
     @Nullable
     private final ChangeSet previousChangeSet;
 
-    /**
-     * The node this change set applies to.
-     */
     @Nonnull
     private final N node;
 
-    /**
-     * The level we should use when maintaining the node slot index. If {@code level < 0}, do not maintain the node slot
-     * index.
-     */
     private final int level;
 
     AbstractChangeSet(@Nullable final ChangeSet previousChangeSet, @Nonnull final N node, final int level) {
@@ -63,16 +53,29 @@ public abstract class AbstractChangeSet<S extends NodeSlot, N extends AbstractNo
         }
     }
 
+    /**
+     * Previous change set in the chain of change sets. Can be {@code null} if there is no previous change set.
+     * @return the previous change set in the chain of change sets
+     */
     @Nullable
     public ChangeSet getPreviousChangeSet() {
         return previousChangeSet;
     }
 
+    /**
+     * The node this change set applies to.
+     * @return the node this change set applies to
+     */
     @Nonnull
     public N getNode() {
         return node;
     }
 
+    /**
+     * The level we should use when maintaining the node slot index. If {@code level < 0}, do not maintain the node slot
+     * index.
+     * @return the level used when maintaing the node slot index
+     */
     public int getLevel() {
         return level;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ChildSlot.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ChildSlot.java
@@ -34,8 +34,8 @@ import java.math.BigInteger;
  * rooted at the child.
  */
 public class ChildSlot implements NodeSlot {
-    public static final int SLOT_KEY_TUPLE_SIZE = 4;
-    public static final int SLOT_VALUE_TUPLE_SIZE = 2;
+    static final int SLOT_KEY_TUPLE_SIZE = 4;
+    static final int SLOT_VALUE_TUPLE_SIZE = 2;
 
     @Nonnull
     private final byte[] childId;
@@ -52,9 +52,9 @@ public class ChildSlot implements NodeSlot {
     private final Tuple largestKey;
 
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP2")
-    public ChildSlot(@Nonnull final BigInteger smallestHilbertValue, @Nonnull final Tuple smallestKey,
-                     @Nonnull final BigInteger largestHilbertValue, @Nonnull final Tuple largestKey,
-                     @Nonnull final byte[] childId, @Nonnull final RTree.Rectangle mbr) {
+    ChildSlot(@Nonnull final BigInteger smallestHilbertValue, @Nonnull final Tuple smallestKey,
+              @Nonnull final BigInteger largestHilbertValue, @Nonnull final Tuple largestKey,
+              @Nonnull final byte[] childId, @Nonnull final RTree.Rectangle mbr) {
         this.smallestHilbertValue = smallestHilbertValue;
         this.smallestKey = smallestKey;
         this.largestHilbertValue = largestHilbertValue;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/Node.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/Node.java
@@ -319,6 +319,11 @@ public interface Node {
      * when a node is written, mostly to avoid re-persisting all slots if not necessary.
      */
     interface ChangeSet {
+        /**
+         * Apply all mutations for the change set. These happen transactionally using the {@link Transaction}
+         * provided.
+         * @param transaction transaction to use when making all modifications
+         */
         void apply(@Nonnull Transaction transaction);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMap.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMap.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.map;
 
-import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.KeySelector;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.MutationType;
@@ -28,15 +27,18 @@ import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.StreamingMode;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.TransactionContext;
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncPeekCallbackIterator;
-import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.AsyncPeekIterator;
+import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.util.LogMessageKeys;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,8 +51,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * An implementation of a FoundationDB-backed map that bunches close keys together to minimize the
@@ -993,6 +993,24 @@ public class BunchedMap<K, V> {
     }
 
 
+    /**
+     * Overload of {@link #scanMulti(ReadTransaction, Subspace, SubspaceSplitter, byte[], byte[], byte[], int, boolean) scanMulti()}
+     * that provides a callback to run after each key is read. This hook can be used to interface with metrics collection.
+     *
+     * @param tr transaction to use when scanning the maps
+     * @param subspace subspace containing one or more maps
+     * @param splitter object to determine which map a given key is in
+     * @param subspaceStart inclusive starting suffix of <code>subspace</code> to start the scan
+     * @param subspaceEnd exclusive ending suffix of <code>subspace</code> to end the scan
+     * @param continuation continuation from previous scan (or <code>null</code> to start from the beginning)
+     * @param postReadCallback callback to execute after reading each key
+     * @param limit maximum number of entries to return
+     * @param reverse <code>true</code> if the entries should be returned in descending order or <code>false</code> otherwise
+     * @param <T> type of the tag of each map subspace
+     * @return an iterator over the entries in multiple maps
+     * @see #scanMulti(ReadTransaction, Subspace, SubspaceSplitter, byte[], byte[], byte[], int, Consumer, boolean)
+     */
+    @Nonnull
     public <T> BunchedMapMultiIterator<K, V, T> scanMulti(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace, @Nonnull SubspaceSplitter<T> splitter,
                                                           @Nullable byte[] subspaceStart, @Nullable byte[] subspaceEnd,
                                                           @Nullable byte[] continuation, int limit, @Nullable Consumer<KeyValue> postReadCallback, boolean reverse) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapException.java
@@ -37,10 +37,20 @@ import javax.annotation.Nonnull;
 @SuppressWarnings("serial")
 @API(API.Status.EXPERIMENTAL)
 public class BunchedMapException extends LoggableException {
+    /**
+     * Create a new exception with a static message.
+     * @param message error message
+     */
     public BunchedMapException(@Nonnull String message) {
         super(message);
     }
 
+    /**
+     * Create a new exception with a static message and cause.
+     *
+     * @param message error message
+     * @param cause cause
+     */
     public BunchedMapException(@Nonnull String message, @Nonnull Throwable cause) {
         super(message, cause);
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializationException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializationException.java
@@ -41,10 +41,20 @@ public class BunchedSerializationException extends BunchedMapException {
     @Nullable
     private Object value;
 
+    /**
+     * Create a new exception with a static message.
+     * @param message error message
+     */
     public BunchedSerializationException(@Nonnull String message) {
         super(message);
     }
 
+    /**
+     * Create a new exception with a static message and cause.
+     *
+     * @param message error message
+     * @param cause cause
+     */
     public BunchedSerializationException(@Nonnull String message, @Nonnull Throwable cause) {
         super(message, cause);
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -44,6 +44,14 @@ public class ByteArrayUtil2 {
     private static final char[] LOWER_CASE_HEX_CHARS =
             { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
+    /**
+     * Create a base-16 representation of the give byte array. This uses upper case letters for
+     * hex digits {@code A} through {@code F}, so the returned string will match regex
+     * {@code ([0-9A-F])*}.
+     *
+     * @param bytes a {@code byte} array
+     * @return a hex representation of {@code bytes}
+     */
     @Nullable
     public static String toHexString(@Nullable byte[] bytes) {
         if (bytes == null) {
@@ -59,6 +67,16 @@ public class ByteArrayUtil2 {
         return new String(hex);
     }
 
+    /**
+     * Creates a human-readable representation of {@code bytes} for logging purposes.
+     * This differs from {@link ByteArrayUtil#printable(byte[])} in tha it excludes the
+     * {@code =} and {@code "} characters, which can cause trouble when included as a
+     * key or value in log messages with keys and values.
+     *
+     * @param bytes a {@code byte} array
+     * @return a hex representation of {@code bytes}
+     * @see ByteArrayUtil#printable(byte[])
+     */
     @API(API.Status.MAINTAINED)
     @Nullable
     public static String loggable(@Nullable byte[] bytes) {
@@ -83,6 +101,16 @@ public class ByteArrayUtil2 {
         }
     }
 
+    /**
+     * Construct a byte array from a human-readable representation returned by
+     * {@link ByteArrayUtil#printable(byte[])} or {@link #loggable(byte[])}. This
+     * will only return {@code null} if the provided {@code loggableBytes} array
+     * is {@code null}.
+     *
+     * @param loggedBytes a string representation of a byte array in the format
+     *     returned by {@link ByteArrayUtil#printable(byte[])}
+     * @return a byte array parsed from {@code loggedBytes}
+     */
     @API(API.Status.MAINTAINED)
     @Nullable
     public static byte[] unprint(@Nullable String loggedBytes) {
@@ -117,6 +145,16 @@ public class ByteArrayUtil2 {
         return bytesArray;
     }
 
+    /**
+     * Return whether {@code bytes1} and {@code bytes2} each begin with a common
+     * prefix with a size of at least {@code prefixSize}.
+     *
+     * @param bytes1 one byte array
+     * @param bytes2 another byte array
+     * @param prefixSize a number of bytes
+     * @return whether the first {@code prefixSize} bytes from {@code bytes1} match
+     *      the first {@code prefixSize} bytes from {@code bytes2}
+     */
     public static boolean hasCommonPrefix(@Nonnull byte[] bytes1, @Nonnull byte[] bytes2, int prefixSize) {
         if (bytes1.length < prefixSize || bytes2.length < prefixSize) {
             return false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/KeyValueLogMessage.java
@@ -37,40 +37,50 @@ import java.util.TreeMap;
  */
 @API(API.Status.MAINTAINED)
 public class KeyValueLogMessage {
+    @Nonnull
     private final long timestamp;
+    @Nonnull
     private final String staticMessage;
 
+    @Nonnull
     private final Map<String, String> keyValueMap;
 
     public static String of(@Nonnull final String staticMessage, @Nullable final Object... keysAndValues) {
-        return new KeyValueLogMessage(staticMessage, keysAndValues).toString();
+        return new KeyValueLogMessage(staticMessage, mapFromKeysAndValues(keysAndValues)).toString();
     }
 
     public static KeyValueLogMessage build(@Nonnull final String staticMessage, @Nullable final Object... keysAndValues) {
-        return new KeyValueLogMessage(staticMessage, keysAndValues);
+        return new KeyValueLogMessage(staticMessage, mapFromKeysAndValues(keysAndValues));
     }
 
-    private KeyValueLogMessage(@Nonnull final String staticMessage, @Nullable final Object[] keysAndValues) {
-        this.staticMessage = staticMessage;
-        this.timestamp = System.currentTimeMillis();
-        keyValueMap = new TreeMap<>();
+    private static Map<String, String> mapFromKeysAndValues(@Nullable Object[] keysAndValues) {
+        Map<String, String> keyValueMap = new TreeMap<>();
         if (keysAndValues != null) {
             for (int i = 0; i < (keysAndValues.length / 2) * 2; i += 2) {
-                addKeyValueImpl(keysAndValues[i + 0], keysAndValues[i + 1]);
+                addKeyValueImpl(keyValueMap, keysAndValues[i], keysAndValues[i + 1]);
             }
             if (keysAndValues.length % 2 == 1) {
                 throw new IllegalArgumentException("keys and values don't match");
             }
         }
+        return keyValueMap;
     }
 
-    private void addKeyValueImpl(@Nullable final Object key, @Nullable Object value) {
+    private KeyValueLogMessage(@Nonnull final String staticMessage, @Nonnull Map<String, String> keyValueMap) {
+        this.staticMessage = staticMessage;
+        this.timestamp = System.currentTimeMillis();
+        this.keyValueMap = keyValueMap;
+    }
+
+    private static void addKeyValueImpl(@Nonnull Map<String, String> keyValueMap, @Nullable final Object key, @Nullable Object value) {
         if (key == null) {
             throw new IllegalArgumentException("null key passed to KeyValueLogMessage"); // better to throw an exception rather than silently swallow the key
         }
-        if (keyValueMap != null) {
-            keyValueMap.put(sanitizeKey(key.toString()), sanitizeValue(Optional.ofNullable(value).orElse("null").toString()));
-        }
+        keyValueMap.put(sanitizeKey(key.toString()), sanitizeValue(Optional.ofNullable(value).orElse("null").toString()));
+    }
+
+    private void addKeyValueImpl(@Nullable final Object key, @Nullable Object value) {
+        addKeyValueImpl(keyValueMap, key, value);
     }
 
     public KeyValueLogMessage addKeysAndValues(@Nonnull final Map<?, ?> map) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/DynamicMessageRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/DynamicMessageRecordSerializer.java
@@ -56,6 +56,8 @@ public class DynamicMessageRecordSerializer implements RecordSerializer<Message>
         return INSTANCE;
     }
 
+    @SpotBugsSuppressWarnings(value = "SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR",
+            justification = "Singleton is optimization as base class has no state. Subclasses are allowed and may not be singletons")
     protected DynamicMessageRecordSerializer() {
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -50,7 +50,7 @@ public abstract class FDBDatabaseFactory {
      */
     public static final int DEFAULT_DIRECTORY_CACHE_SIZE = 5000;
     /**
-     * Special value to set the transaction timeout to to indicate that transactions should use the system
+     * Special value to set the transaction timeout to indicate that transactions should use the system
      * default.
      *
      * @see #setTransactionTimeoutMillis(long)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -104,6 +104,7 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
         return impl;
     }
 
+    @SpotBugsSuppressWarnings(value = "MS_EXPOSE_REP", justification = "Returned static object is mutable to allow caching database objects")
     @Nonnull
     public static FDBDatabaseFactoryImpl instance() {
         return INSTANCE;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -60,12 +60,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -926,7 +926,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
             String name;
             // Yes, a collision is exceedingly unlikely, but...
             do {
-                name = INTERNAL_COMMIT_HOOK_PREFIX + "anon-" + (new Random()).nextInt(Integer.MAX_VALUE);
+                name = INTERNAL_COMMIT_HOOK_PREFIX + "anon-" + ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
             } while (map.containsKey(name));
             map.put(name, item);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -59,7 +59,7 @@ public class IndexingCommon {
     @Nonnull private final AtomicLong totalRecordsScanned;
     private final boolean trackProgress;
 
-    @Nonnull public OnlineIndexOperationConfig config; // this item may be modified on the fly
+    @Nonnull OnlineIndexOperationConfig config; // this item may be modified on the fly
     @Nullable private final Function<OnlineIndexOperationConfig, OnlineIndexOperationConfig> configLoader;
     private int configLoaderInvocationCount = 0;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +51,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -220,8 +220,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
         if (fragmentBoundaries == null || fragmentBoundaries.isEmpty()) {
             fragmentBoundaries = getPrimaryKeyBoundaries(store);
         }
-        // Can't use ThreadLocalRandom.current() without triggering a sonarcloud error
-        final SecureRandom rn = new SecureRandom();
+        final Random rn = ThreadLocalRandom.current();
         fragmentNum = fragmentBoundaries.size() - 1; // ranges between the boundaries = one less
         fragmentStep = getPrimeStep(fragmentNum, rn);
         fragmentFirst = rn.nextInt(fragmentNum);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/PassThroughRecordStoreStateCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/PassThroughRecordStoreStateCache.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.storestate;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
@@ -63,6 +64,7 @@ public class PassThroughRecordStoreStateCache implements FDBRecordStoreStateCach
         // Do nothing.
     }
 
+    @SpotBugsSuppressWarnings(value = "MS_EXPOSE_REP", justification = "Object is not actually mutable")
     @Nonnull
     public static PassThroughRecordStoreStateCache instance() {
         return INSTANCE;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/package-info.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/synchronizedsession/package-info.java
@@ -19,7 +19,7 @@
  */
 
 /**
- * Extends the {@link com.apple.foundationdb.synchronizedsession} package to support running operations in
+ * Extends the {@code com.apple.foundationdb.synchronizedsession} package to support running operations in
  * synchronized sessions with {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner}s
  * and {@link com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext}s.
  * @see com.apple.foundationdb.synchronizedsession.SynchronizedSession

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/DeleteExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/DeleteExpression.java
@@ -41,10 +41,10 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * A logical version of {@link RecordQueryDeletePlan}.
+ * A logical version of {@link RecordQueryDeletePlan}. This is converted to a {@code RecordQueryDeletePlan}
+ * via the {@link com.apple.foundationdb.record.query.plan.cascades.rules.ImplementDeleteRule}
  *
- * @see com.apple.foundationdb.record.query.plan.cascades.rules.ImplementDeleteRule which converts this
- *      to a {@link RecordQueryDeletePlan}
+ * @see com.apple.foundationdb.record.query.plan.cascades.rules.ImplementDeleteRule
  */
 public class DeleteExpression implements RelationalExpressionWithChildren, PlannerGraphRewritable {
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/InsertExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/InsertExpression.java
@@ -45,9 +45,10 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * A logical version of {@link RecordQueryInsertPlan}.
+ * A logical version of {@link RecordQueryInsertPlan}. This is converted to a {@code RecordQueryInsertPlan}
+ * via the {@link com.apple.foundationdb.record.query.plan.cascades.rules.ImplementInsertRule}.
  *
- * @see com.apple.foundationdb.record.query.plan.cascades.rules.ImplementInsertRule which converts this to a {@link RecordQueryInsertPlan}
+ * @see com.apple.foundationdb.record.query.plan.cascades.rules.ImplementInsertRule
  */
 public class InsertExpression implements RelationalExpressionWithChildren, PlannerGraphRewritable {
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/PrimaryScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/PrimaryScanExpression.java
@@ -47,10 +47,10 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * A logical version of {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan}.
+ * A logical version of {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan}. This
+ * is converted to {@code RecordQueryScanPlan} via the {@link ImplementPhysicalScanRule}.
  *
- * @see ImplementPhysicalScanRule which converts this
- *      to a {@link com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan}
+ * @see ImplementPhysicalScanRule
  */
 public class PrimaryScanExpression implements RelationalExpression, PlannerGraphRewritable {
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/UpdateExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/UpdateExpression.java
@@ -53,9 +53,10 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
- * A logical version of {@link RecordQueryUpdatePlan}.
+ * A logical version of {@link RecordQueryUpdatePlan}. This is converted to a {@code RecordQueryUpdatePlan}
+ * via the {@link com.apple.foundationdb.record.query.plan.cascades.rules.ImplementUpdateRule}.
  *
- * @see com.apple.foundationdb.record.query.plan.cascades.rules.ImplementUpdateRule which converts this to a {@link RecordQueryUpdatePlan}
+ * @see com.apple.foundationdb.record.query.plan.cascades.rules.ImplementUpdateRule
  */
 public class UpdateExpression implements RelationalExpressionWithChildren, PlannerGraphRewritable {
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades.properties;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
@@ -775,6 +776,7 @@ public class CardinalitiesProperty implements ExpressionProperty<CardinalitiesPr
      *  Class to capture both minimum and maximum cardinality of an expression. Also contains some helpers to combine
      *  cardinality information.
      */
+    @SpotBugsSuppressWarnings(value = "SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", justification = "False positive as this is not a singleton class")
     public static class Cardinalities {
         private static final Cardinalities unknownCardinalities = new Cardinalities(Cardinality.unknownCardinality(), Cardinality.unknownCardinality());
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.properties;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
@@ -749,6 +750,7 @@ public class DerivationsProperty implements PlanProperty<DerivationsProperty.Der
     /**
      * Cases class to capture the derivations that are being collected by the visitor.
      */
+    @SpotBugsSuppressWarnings(value = "SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR", justification = "False positive as this is not a singleton class")
     public static class Derivations {
         private static final Derivations EMPTY = new Derivations(ImmutableList.of(), ImmutableList.of());
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/BooleanNormalizer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/planning/BooleanNormalizer.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.planning;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.query.expressions.AndComponent;
@@ -85,6 +86,7 @@ public class BooleanNormalizer {
      * Obtain a normalizer with the default size limit {@link BooleanNormalizer#DEFAULT_SIZE_LIMIT}.
      * @return a normalizer with the default size limit
      */
+    @SpotBugsSuppressWarnings(value = "MS_EXPOSE_REP", justification = "Value is not actually mutable")
     @Nonnull
     public static BooleanNormalizer getDefaultInstance() {
         return DEFAULT;
@@ -95,6 +97,7 @@ public class BooleanNormalizer {
      * @param sizeLimit a limit on the size of DNF that this normalizer will produce
      * @return a normalizer with the given size limit
      */
+    @SpotBugsSuppressWarnings(value = "MS_EXPOSE_REP", justification = "Value is not actually mutable")
     @Nonnull
     public static BooleanNormalizer withLimit(int sizeLimit) {
         if (sizeLimit == DEFAULT_SIZE_LIMIT) {
@@ -116,6 +119,7 @@ public class BooleanNormalizer {
      * @param configuration a a planner configuration specifying the DNF limit that this normalizer will produce
      * @return a normalizer for the given planner configuration
      */
+    @SpotBugsSuppressWarnings(value = "MS_EXPOSE_REP", justification = "Value is not actually mutable")
     public static BooleanNormalizer forConfiguration(RecordQueryPlannerConfiguration configuration) {
         if (configuration.getComplexityThreshold() == DEFAULT_SIZE_LIMIT && !configuration.shouldCheckForDuplicateConditions() && !configuration.shouldNormalizeNestedFields()) {
             return DEFAULT;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.lucene.exact.ExactTokenAnalyzerFactory;
 import com.apple.foundationdb.record.metadata.Index;
@@ -78,6 +79,7 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
         return registry;
     }
 
+    @SpotBugsSuppressWarnings(value = "MS_EXPOSE_REP", justification = "Object is actually immutable")
     @Nonnull
     public static LuceneAnalyzerRegistry instance() {
         return INSTANCE;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene.search;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.lucene.query.BitSetQuery;
 import org.apache.lucene.document.BinaryPoint;
 import org.apache.lucene.document.DoublePoint;
@@ -191,6 +192,7 @@ public interface ConfigAwareQueryParser {
         }
     }
 
+    @SpotBugsSuppressWarnings(value = "FE_FLOATING_POINT_EQUALITY", justification = "Floating point values are special sentinel values")
     @Nonnull
     private Query newFloatRangeQuery(final String field, final boolean startInclusive, final boolean endInclusive, final Number start, final Number end) throws ParseException {
         float s = start.floatValue();
@@ -219,6 +221,7 @@ public interface ConfigAwareQueryParser {
         return FloatPoint.newRangeQuery(field, s, e);
     }
 
+    @SpotBugsSuppressWarnings(value = "FE_FLOATING_POINT_EQUALITY", justification = "Floating point values are special sentinel values")
     @Nonnull
     private Query newDoubleRangeQuery(final String field, final boolean startInclusive, final boolean endInclusive, final Number start, final Number end) throws ParseException {
         double s = start.doubleValue();

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -69,7 +69,7 @@ quickCheck.dependsOn checkstyleMandatory
 apply plugin: 'com.github.spotbugs'
 
 spotbugs {
-//  toolVersion = '4.2.1' // (current default with plugin 4.6.1)
+    toolVersion = '4.8.6'
     ignoreFailures = false
     effort = 'max'
     excludeFilter = rootProject.file('gradle/codequality/spotbugs_exclude.xml')

--- a/gradle/codequality/spotbugs_exclude.xml
+++ b/gradle/codequality/spotbugs_exclude.xml
@@ -9,4 +9,19 @@
     <Match>
         <Source name="~.*/generated/.*" />
     </Match>
+
+    <!-- Ignore EI_EXPOSE_REP errors. There are a few too many false positives, often from collections, or from raw byte[] being used for performance. -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- Classes with errors thrown in the constructor can mean we have a partially constructed class in a finalizer (of a subclass as none of our classes use finalizers).
+       Ideally, we'd protect ourselves from this, either by changing the constructor so that it can't throw or by marking the class as final, but there are a few too many
+       classes in this state right now. -->
+    <Match>
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
This makes updates to the code base in order to prepare for updating to JDK 17. Contained within this is:

1. A bunch of Javadoc warnings became errors. For the most part, these were warnings about methods or classes that were entirely missing. I began updating some of those, but ultimately, there's a bit too much, so I added a flag to loosen up the Javadoc requirements.
1. SpotBugs needed to be updated in order to handle class files generated at the newer JDK. Some of the rules changed, and in particular, the newer version is more persnickety about retunring mutable values, and it doesn't like exceptions being thrown in the constructor. Some of those will be harder to address than others, so I've excluded some of the new rules and fixed up a few other things that were caught by spotbugs.