### PR TITLE
Resolves #2850: handle Lucene exceptions

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Lucene exception management [(Issue #2850)](https://github.com/FoundationDB/fdb-record-layer/issues/2850)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBExceptions.java
@@ -131,6 +131,10 @@ public class FDBExceptions {
         public FDBStoreTransactionIsTooOldException(FDBException cause) {
             super(cause);
         }
+
+        public FDBStoreTransactionIsTooOldException(String message, FDBException cause) {
+            super(message, cause);
+        }
     }
 
     /**
@@ -162,6 +166,10 @@ public class FDBExceptions {
     public static class FDBStoreRetriableException extends RecordCoreRetriableTransactionException {
         public FDBStoreRetriableException(FDBException cause) {
             super(cause.getMessage(), cause);
+        }
+
+        public FDBStoreRetriableException(String message, FDBException cause) {
+            super(message, cause);
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
@@ -21,33 +21,84 @@
 package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.lucene.directory.FDBDirectoryLockFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import org.apache.lucene.store.LockObtainFailedException;
 
 import java.io.IOException;
 
 /**
- * Utility class for converting Lucene Exceptions to Record layer ones.
+ * Utility class for converting Lucene Exceptions to/from Record layer ones.
  */
 public class LuceneExceptions {
     /**
-     * Wrap the exception thrown by Lucene by a {@link RecordCoreException} that can be later interpreted by the higher levels.
+     * Copnvert the exception thrown by Lucene by a {@link RecordCoreException} that can be later interpreted by the higher levels.
      * @param message the exception's message to use; the cause's message will be appended to this one
      * @param ex the exception thrown by Lucene
      * @param additionalLogInfo (optional) additional log infos to add to the created exception
      * @return the {@link RecordCoreException} that should be thrown
      */
-    public static RecordCoreException wrapException(String message, IOException ex, Object... additionalLogInfo) {
+    public static RecordCoreException fromLucene(String message, IOException ex, Object... additionalLogInfo) {
         if (ex instanceof LockObtainFailedException) {
             // Use the retryable exception for this case
             return new FDBExceptions.FDBStoreLockTakenException(message + ": " + ex.getMessage(), ex)
                     .addLogInfo(additionalLogInfo);
+        } else if (ex instanceof LuceneTransactionTooOldException) {
+            // Use the standard retryable exception
+            Throwable cause = ex.getCause();
+            // Normally that would wrap the actual transaction-too-long from FDB
+            if (cause instanceof FDBExceptions.FDBStoreTransactionIsTooOldException) {
+                return (FDBExceptions.FDBStoreTransactionIsTooOldException)cause;
+            } else {
+                // Create a new wrapper without a cause
+                RecordCoreException result = new FDBExceptions.FDBStoreTransactionIsTooOldException(message + ": " + ex.getMessage(), null)
+                        .addLogInfo(additionalLogInfo);
+                result.addSuppressed(ex);
+                return result;
+            }
         }
 
         return new RecordCoreException(message + ": " + ex.getMessage(), ex)
                 .addLogInfo(additionalLogInfo);
     }
 
+    /**
+     * Convert an exception thrown by the lower levels to one that can be thrown by Lucene ({@link IOException}).
+     * @param ex the exception thrown by FDB
+     * @return the {@link IOException} that can be thrown through Lucene APIs
+     */
+    public static IOException toLucene(Throwable ex) {
+        if (ex instanceof FDBExceptions.FDBStoreTransactionIsTooOldException) {
+            return new LuceneExceptions.LuceneTransactionTooOldException(ex);
+        } else if (ex instanceof FDBDirectoryLockFactory.FDBDirectoryLockException) {
+            return new LockObtainFailedException(ex.getMessage(), ex);
+        } else if (ex instanceof IOException) {
+            return (IOException)ex;
+        } else {
+            return new IOException(ex);
+        }
+    }
+
     private LuceneExceptions() {
+    }
+
+    /**
+     * A Wrapper around the transaction-too-old exception that gets thrown through Lucene as an IOException.
+     * Once received, it can be translated back into a {@link FDBExceptions.FDBStoreTransactionIsTooOldException}
+     */
+    public static class LuceneTransactionTooOldException extends IOException {
+        private static final long serialVersionUID = -1L;
+
+        public LuceneTransactionTooOldException(final String message) {
+            super(message);
+        }
+
+        public LuceneTransactionTooOldException(final Throwable cause) {
+            super(cause);
+        }
+
+        public LuceneTransactionTooOldException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
@@ -32,13 +32,13 @@ import java.io.IOException;
  */
 public class LuceneExceptions {
     /**
-     * Copnvert the exception thrown by Lucene by a {@link RecordCoreException} that can be later interpreted by the higher levels.
+     * Convert the exception thrown by Lucene by a {@link RecordCoreException} that can be later interpreted by the higher levels.
      * @param message the exception's message to use; the cause's message will be appended to this one
      * @param ex the exception thrown by Lucene
      * @param additionalLogInfo (optional) additional log infos to add to the created exception
      * @return the {@link RecordCoreException} that should be thrown
      */
-    public static RecordCoreException fromLucene(String message, IOException ex, Object... additionalLogInfo) {
+    public static RecordCoreException toRecordCoreException(String message, IOException ex, Object... additionalLogInfo) {
         if (ex instanceof LockObtainFailedException) {
             // Use the retryable exception for this case
             return new FDBExceptions.FDBStoreLockTakenException(message + ": " + ex.getMessage(), ex)
@@ -67,7 +67,7 @@ public class LuceneExceptions {
      * @param ex the exception thrown by FDB
      * @return the {@link IOException} that can be thrown through Lucene APIs
      */
-    public static IOException toLucene(Throwable ex) {
+    public static IOException toIoException(Throwable ex) {
         if (ex instanceof FDBExceptions.FDBStoreTransactionIsTooOldException) {
             return new LuceneExceptions.LuceneTransactionTooOldException(ex);
         } else if (ex instanceof FDBDirectoryLockFactory.FDBDirectoryLockException) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -479,7 +479,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
             try {
                 return tryDelete(Objects.requireNonNull(oldRecord), t);
             } catch (IOException e) {
-                throw LuceneExceptions.wrapException("Issue deleting", e, "record", Objects.requireNonNull(oldRecord).getPrimaryKey());
+                throw LuceneExceptions.fromLucene("Issue deleting", e, "record", Objects.requireNonNull(oldRecord).getPrimaryKey());
             }
         }).collect(Collectors.toList())).thenCompose(ignored ->
                 // update new
@@ -490,12 +490,12 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                                     try {
                                         writeDocument(entry.getValue(), entry.getKey(), partitionId, newRecord.getPrimaryKey());
                                     } catch (IOException e) {
-                                        throw LuceneExceptions.wrapException("Issue updating new index keys", e, "newRecord", newRecord.getPrimaryKey());
+                                        throw LuceneExceptions.fromLucene("Issue updating new index keys", e, "newRecord", newRecord.getPrimaryKey());
                                     }
                                     return null;
                                 }));
                     } catch (IOException e) {
-                        throw LuceneExceptions.wrapException("Issue updating", e, "record", Objects.requireNonNull(newRecord).getPrimaryKey());
+                        throw LuceneExceptions.fromLucene("Issue updating", e, "record", Objects.requireNonNull(newRecord).getPrimaryKey());
                     }
                 }).collect(Collectors.toList())));
     }
@@ -549,7 +549,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                     }
                     return countDeleted;
                 } catch (IOException e) {
-                    throw LuceneExceptions.wrapException("Issue deleting", e, "record", record.getPrimaryKey());
+                    throw LuceneExceptions.fromLucene("Issue deleting", e, "record", record.getPrimaryKey());
                 }
             }
             return 0;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -479,7 +479,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
             try {
                 return tryDelete(Objects.requireNonNull(oldRecord), t);
             } catch (IOException e) {
-                throw LuceneExceptions.fromLucene("Issue deleting", e, "record", Objects.requireNonNull(oldRecord).getPrimaryKey());
+                throw LuceneExceptions.toRecordCoreException("Issue deleting", e, "record", Objects.requireNonNull(oldRecord).getPrimaryKey());
             }
         }).collect(Collectors.toList())).thenCompose(ignored ->
                 // update new
@@ -490,12 +490,12 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                                     try {
                                         writeDocument(entry.getValue(), entry.getKey(), partitionId, newRecord.getPrimaryKey());
                                     } catch (IOException e) {
-                                        throw LuceneExceptions.fromLucene("Issue updating new index keys", e, "newRecord", newRecord.getPrimaryKey());
+                                        throw LuceneExceptions.toRecordCoreException("Issue updating new index keys", e, "newRecord", newRecord.getPrimaryKey());
                                     }
                                     return null;
                                 }));
                     } catch (IOException e) {
-                        throw LuceneExceptions.fromLucene("Issue updating", e, "record", Objects.requireNonNull(newRecord).getPrimaryKey());
+                        throw LuceneExceptions.toRecordCoreException("Issue updating", e, "record", Objects.requireNonNull(newRecord).getPrimaryKey());
                     }
                 }).collect(Collectors.toList())));
     }
@@ -549,7 +549,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                     }
                     return countDeleted;
                 } catch (IOException e) {
-                    throw LuceneExceptions.fromLucene("Issue deleting", e, "record", record.getPrimaryKey());
+                    throw LuceneExceptions.toRecordCoreException("Issue deleting", e, "record", record.getPrimaryKey());
                 }
             }
             return 0;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -294,7 +294,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                     // but this should be interpreted as there not being any data to read
                     nextResult = RecordCursorResult.exhausted();
                 } catch (IOException ioException) {
-                    throw LuceneExceptions.fromLucene("Record Cursor failed", ioException, LogMessageKeys.QUERY, query);
+                    throw LuceneExceptions.toRecordCoreException("Record Cursor failed", ioException, LogMessageKeys.QUERY, query);
                 }
                 return CompletableFuture.completedFuture(leftToSkip >= pageSize);
             }, executor);
@@ -310,7 +310,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                             nextResult = RecordCursorResult.exhausted();
                             return CompletableFuture.completedFuture(nextResult);
                         } catch (IOException ioException) {
-                            throw LuceneExceptions.fromLucene("Record Cursor failed", ioException, LogMessageKeys.QUERY, query);
+                            throw LuceneExceptions.toRecordCoreException("Record Cursor failed", ioException, LogMessageKeys.QUERY, query);
                         }
                         return lookupResults.onNext().thenCompose(this::switchToNextPartitionAndContinue);
                     }, executor).thenCompose(Function.identity());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -294,8 +294,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                     // but this should be interpreted as there not being any data to read
                     nextResult = RecordCursorResult.exhausted();
                 } catch (IOException ioException) {
-                    throw new RecordCoreException("Exception to lookup the auto complete suggestions", ioException)
-                            .addLogInfo(LogMessageKeys.QUERY, query);
+                    throw LuceneExceptions.fromLucene("Record Cursor failed", ioException, LogMessageKeys.QUERY, query);
                 }
                 return CompletableFuture.completedFuture(leftToSkip >= pageSize);
             }, executor);
@@ -311,8 +310,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                             nextResult = RecordCursorResult.exhausted();
                             return CompletableFuture.completedFuture(nextResult);
                         } catch (IOException ioException) {
-                            throw new RecordCoreException("Exception to lookup the auto complete suggestions", ioException)
-                                    .addLogInfo(LogMessageKeys.QUERY, query);
+                            throw LuceneExceptions.fromLucene("Record Cursor failed", ioException, LogMessageKeys.QUERY, query);
                         }
                         return lookupResults.onNext().thenCompose(this::switchToNextPartitionAndContinue);
                     }, executor).thenCompose(Function.identity());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.lucene.LuceneEvents;
+import com.apple.foundationdb.record.lucene.LuceneExceptions;
 import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
@@ -34,7 +35,6 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockFactory;
-import org.apache.lucene.store.LockObtainFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +64,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             return new FDBDirectoryLock(directory.getAgilityContext(), lockName, directory.fileLockKey(lockName), timeWindowMilliseconds);
         } catch (FDBDirectoryLockException ex) {
             // Wrap in a Lucene-compatible exception (that extends IOException)
-            throw new LockObtainFailedException(ex.getMessage(), ex);
+            throw LuceneExceptions.toLucene(ex);
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -64,7 +64,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             return new FDBDirectoryLock(directory.getAgilityContext(), lockName, directory.fileLockKey(lockName), timeWindowMilliseconds);
         } catch (FDBDirectoryLockException ex) {
             // Wrap in a Lucene-compatible exception (that extends IOException)
-            throw LuceneExceptions.toLucene(ex);
+            throw LuceneExceptions.toIoException(ex);
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -197,13 +197,13 @@ public class FDBDirectoryManager implements AutoCloseable {
                             LuceneLogMessageKeys.INDEX_PARTITION, partitionId));
                 }
             } catch (IOException e) {
-                throw LuceneExceptions.fromLucene("Lucene mergeIndex failed", e,
+                throw LuceneExceptions.toRecordCoreException("Lucene mergeIndex failed", e,
                         LuceneLogMessageKeys.GROUP, groupingKey,
                         LuceneLogMessageKeys.INDEX_PARTITION, partitionId);
             }
         } catch (IOException e) {
             // there was an IOException closing the index writer
-            throw LuceneExceptions.fromLucene("Lucene mergeIndex close failed", e,
+            throw LuceneExceptions.toRecordCoreException("Lucene mergeIndex close failed", e,
                     LuceneLogMessageKeys.GROUP, groupingKey,
                     LuceneLogMessageKeys.INDEX_PARTITION, partitionId);
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -197,13 +197,13 @@ public class FDBDirectoryManager implements AutoCloseable {
                             LuceneLogMessageKeys.INDEX_PARTITION, partitionId));
                 }
             } catch (IOException e) {
-                throw LuceneExceptions.wrapException("Lucene mergeIndex failed", e,
+                throw LuceneExceptions.fromLucene("Lucene mergeIndex failed", e,
                         LuceneLogMessageKeys.GROUP, groupingKey,
                         LuceneLogMessageKeys.INDEX_PARTITION, partitionId);
             }
         } catch (IOException e) {
             // there was an IOException closing the index writer
-            throw LuceneExceptions.wrapException("Lucene mergeIndex close failed", e,
+            throw LuceneExceptions.fromLucene("Lucene mergeIndex close failed", e,
                     LuceneLogMessageKeys.GROUP, groupingKey,
                     LuceneLogMessageKeys.INDEX_PARTITION, partitionId);
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -157,7 +157,7 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
                 } catch (InterruptedException e) {
                     throw new ThreadInterruptedException(e);
                 } catch (ExecutionException e) {
-                    throw LuceneExceptions.toLucene(e.getCause());
+                    throw LuceneExceptions.toIoException(e.getCause());
                 } catch (WrapperException we) {
                     throw we.unwrap();
                 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene.search;
 
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.lucene.LuceneExceptions;
 import com.apple.foundationdb.record.util.pair.Pair;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -116,7 +117,7 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
      *          manager of collectors that receive hits
      */
     @Override
-    @SuppressWarnings("PMD.EmptyCatchBlock")
+    @SuppressWarnings({"PMD.EmptyCatchBlock", "PMD.PreserveStackTrace"})
     public <C extends Collector, T> T search(Query query, CollectorManager<C, T> collectorManager) throws IOException {
         final var leafSlices = getSlices();
         final var executor = getExecutor();
@@ -156,7 +157,7 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
                 } catch (InterruptedException e) {
                     throw new ThreadInterruptedException(e);
                 } catch (ExecutionException e) {
-                    throw new RuntimeException(e);
+                    throw LuceneExceptions.toLucene(e.getCause());
                 } catch (WrapperException we) {
                     throw we.unwrap();
                 }


### PR DESCRIPTION
Wrap and Unwrap Lucene exceptions:
- Create and throw Lucene-style transaction-too-old exception
- generalize and use LuceneException utility to wrap and unwrap exceptions thrown through the Lucene stack
- 