### PR TITLE
Log fdbcli status after failed test

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -147,10 +147,28 @@ tasks.withType(Test) { theTask ->
     }
     beforeTest { descriptor -> 
         println "${Instant.now()} ${getFullDisplayName(descriptor)} STARTED"
-    } 
+    }
     afterTest { descriptor, result ->
         def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
         println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
+        // investigative tool to help with: https://github.com/FoundationDB/fdb-record-layer/issues/2842
+        // The theory is that we have broken the FDB cluster under test, hopefully this will give some information.
+        // This is a bit aggressive, and will dump extra text for unrelated test failures
+        if (result.resultType == TestResult.ResultType.FAILURE) {
+            println('----------')
+            println('printing fdb status in case a broken FDB cluster caused the failure')
+            try {
+                def fdbStatus = new ProcessBuilder('fdbcli', '--exec', 'status details').start()
+                fdbStatus.waitFor()
+                println(fdbStatus.exitValue())
+                println(fdbStatus.err.text)
+                println(fdbStatus.text)
+            } catch (Exception e) {
+                println("Failed to print status")
+                e.printStackTrace();
+            }
+            println('----------')
+        }
         println()
     }
     reports {


### PR DESCRIPTION
This is an attempt to investigate Issue #2842 in a remote environment. The theory is that the cluster is in a state where it is rejecting all transactions, but the hope is that it is in a state where status works, and will tell us what is wrong.

This is resiliant to not having `fdbcli` on your path or if you are using `fdb-environment.properties` instead of the default cluster file, but it will just print errors that it could not get the status.