### PR TITLE
Remove LuceneIndexMaintenanceTest.rest

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -155,7 +155,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                                    int partitionHighWatermark,
                                    int repartitionCount,
                                    int minDocumentCount,
-                                   long seed) throws IOException, InterruptedException {
+                                   long seed) throws IOException {
         final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
                 .setIsGrouped(isGrouped)
                 .setIsSynthetic(isSynthetic)
@@ -221,7 +221,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                           int partitionHighWatermark,
                           int repartitionCount,
                           int loopCount,
-                          long seed) throws IOException, InterruptedException {
+                          long seed) throws IOException {
         manyDocument(isGrouped, isSynthetic, primaryKeySegmentIndexEnabled, partitionHighWatermark,
                 repartitionCount, loopCount, 10, seed);
     }
@@ -259,7 +259,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                       int repartitionCount,
                       int loopCount,
                       int maxTransactionsPerLoop,
-                      long seed) throws IOException, InterruptedException {
+                      long seed) throws IOException {
         final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
                 .setIsGrouped(isGrouped)
                 .setIsSynthetic(isSynthetic)
@@ -324,7 +324,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
 
     @Test
     @Tag(Tags.Slow)
-    void flakyMergeQuick() throws IOException, InterruptedException {
+    void flakyMergeQuick() throws IOException {
         flakyMerge(true, true, true, 31, -644766138635622644L, true);
     }
 
@@ -347,7 +347,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                     boolean primaryKeySegmentIndexEnabled,
                     int minDocumentCount,
                     long seed,
-                    boolean requireFailure) throws IOException, InterruptedException {
+                    boolean requireFailure) throws IOException {
 
         final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
                 .setIsGrouped(isGrouped)
@@ -846,9 +846,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                             contextProps, schemaSetup, random.nextInt(maxTransactionsPerLoop - 1) + 1, ids, textGenerator, transactionCounter, documentCount);
                 } catch (RuntimeException e) {
                     throw new RuntimeException("Failed to generate documents at iteration " + currentLoop.get(), e);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException("Interrupted generating documents at iteration " + currentLoop.get(), e);
                 }
 
                 boolean mergeFailed = mergeIndex();
@@ -942,7 +939,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                                    final Map<Tuple, Map<Tuple, Tuple>> ids,
                                    final RandomTextGenerator textGenerator,
                                    AtomicInteger transactionCounter,
-                                   final AtomicInteger documentCount) throws InterruptedException {
+                                   final AtomicInteger documentCount) {
         final long start = Instant.now().toEpochMilli();
         int i = 0;
         while (i < transactionCount ||
@@ -962,20 +959,9 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 commit(context);
                 documentCount.addAndGet(docCount);
             }
-            rest();
             transactionCounter.incrementAndGet();
             i++;
         }
-    }
-
-    /**
-     * Rest to
-     // A fairly hacky attempt to solving: https://github.com/FoundationDB/fdb-record-layer/issues/2842
-     // The theory is that these tests put *a lot* of load on the system, and can overwhelm it if you are just
-     // pointing to a single-instance cluster. The hope here is that this will allow the system to recover.
-     */
-    private void rest() throws InterruptedException {
-        Thread.sleep(200);
     }
 
     @Nonnull


### PR DESCRIPTION
This effectively reverts: #2860, but that was based off #2844 and I don't want to add that back.