### PR TITLE
Expose `Tuple`-based `MIN_EVER` and `MAX_EVER` indexes to Cascades

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Expose `Tuple`-based `MIN_EVER` and `MAX_EVER` indexes to Cascades [(Issue #2874)](https://github.com/FoundationDB/fdb-record-layer/issues/2874)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Log Repartitioned records after writing them [(Issue #2867)](https://github.com/FoundationDB/fdb-record-layer/issues/2867)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
@@ -317,8 +317,10 @@ public class AggregateIndexExpansionVisitor extends KeyExpressionExpansionVisito
     @Nonnull
     private static Map<String, BuiltInFunction<? extends Value>> computeAggregateMap() {
         final ImmutableMap.Builder<String, BuiltInFunction<? extends Value>> mapBuilder = ImmutableMap.builder();
-        mapBuilder.put(IndexTypes.MAX_EVER_LONG, new IndexOnlyAggregateValue.MaxEverLongFn());
-        mapBuilder.put(IndexTypes.MIN_EVER_LONG, new IndexOnlyAggregateValue.MinEverLongFn());
+        mapBuilder.put(IndexTypes.MAX_EVER_LONG, new IndexOnlyAggregateValue.MaxEverFn());
+        mapBuilder.put(IndexTypes.MIN_EVER_LONG, new IndexOnlyAggregateValue.MinEverFn());
+        mapBuilder.put(IndexTypes.MAX_EVER_TUPLE, new IndexOnlyAggregateValue.MaxEverFn());
+        mapBuilder.put(IndexTypes.MIN_EVER_TUPLE, new IndexOnlyAggregateValue.MinEverFn());
         mapBuilder.put(IndexTypes.SUM, new NumericAggregationValue.SumFn());
         mapBuilder.put(IndexTypes.COUNT, new CountValue.CountFn());
         mapBuilder.put(IndexTypes.COUNT_NOT_NULL, new CountValue.CountFn());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -317,6 +317,8 @@ public interface MatchCandidate {
                         new WindowedIndexExpansionVisitor(index, queriedRecordTypes)
                 ).ifPresent(resultBuilder::add);
                 break;
+            case IndexTypes.MIN_EVER_TUPLE: // fallthrough
+            case IndexTypes.MAX_EVER_TUPLE: // fallthrough
             case IndexTypes.MAX_EVER_LONG: // fallthrough
             case IndexTypes.MIN_EVER_LONG: // fallthrough
             case IndexTypes.SUM: // fallthrough

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexOnlyAggregateValue.java
@@ -31,14 +31,13 @@ import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.planprotos.PIndexOnlyAggregateValue;
 import com.apple.foundationdb.record.planprotos.PIndexOnlyAggregateValue.PPhysicalOperator;
-import com.apple.foundationdb.record.planprotos.PMaxEverLongValue;
-import com.apple.foundationdb.record.planprotos.PMinEverLongValue;
+import com.apple.foundationdb.record.planprotos.PMaxEverValue;
+import com.apple.foundationdb.record.planprotos.PMinEverValue;
 import com.apple.foundationdb.record.planprotos.PValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
-import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
@@ -190,50 +189,49 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
     }
 
     /**
-     * Class to represent MIN_EVER(field) which can only be provided by a suitable index.
+     * Class to represent {@code MIN_EVER(field)} where {@code field} which can only be provided by a suitable index.
      */
-    public static class MinEverLongValue extends IndexOnlyAggregateValue {
+    public static class MinEverValue extends IndexOnlyAggregateValue {
 
-        MinEverLongValue(@Nonnull final PlanSerializationContext serializationContext,
-                         @Nonnull final PMinEverLongValue minEverLongValueProto) {
-            super(serializationContext, Objects.requireNonNull(minEverLongValueProto.getSuper()));
+        MinEverValue(@Nonnull final PlanSerializationContext serializationContext,
+                     @Nonnull final PMinEverValue minEverValueProto) {
+            super(serializationContext, Objects.requireNonNull(minEverValueProto.getSuper()));
         }
 
         /**
-         * Creates a new instance of {@link MinEverLongValue}.
+         * Creates a new instance of {@link MinEverValue}.
          *
          * @param operator the aggregation function.
          * @param child the child {@link Value}.
          */
-        MinEverLongValue(@Nonnull final PhysicalOperator operator, @Nonnull final Value child) {
+        MinEverValue(@Nonnull final PhysicalOperator operator, @Nonnull final Value child) {
             super(operator, child);
         }
 
+        @SuppressWarnings("deprecation")
         @Nonnull
         @Override
         public String getIndexTypeName() {
-            return IndexTypes.MIN_EVER_LONG;
+            return IndexTypes.MIN_EVER;
         }
 
         @Nonnull
         private static AggregateValue encapsulate(@Nonnull final List<? extends Typed> arguments) {
             Verify.verify(arguments.size() == 1);
             final Typed arg0 = arguments.get(0);
-            final Type type0 = arg0.getResultType();
-            SemanticException.check(type0.isNumeric(), SemanticException.ErrorCode.UNKNOWN, "only numeric types allowed in " + IndexTypes.MIN_EVER_LONG + " aggregation operation");
-            return new MinEverLongValue(PhysicalOperator.MIN_EVER_LONG, (Value)arg0);
+            return new MinEverValue(PhysicalOperator.MIN_EVER_LONG, (Value)arg0);
         }
 
         @Nonnull
         @Override
         public ValueWithChild withNewChild(@Nonnull final Value rebasedChild) {
-            return new MinEverLongValue(operator, rebasedChild);
+            return new MinEverValue(operator, rebasedChild);
         }
 
         @Nonnull
         @Override
-        public PMinEverLongValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
-            return PMinEverLongValue.newBuilder()
+        public PMinEverValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
+            return PMinEverValue.newBuilder()
                     .setSuper(toIndexOnlyAggregateValueProto(serializationContext))
                     .build();
         }
@@ -241,79 +239,78 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
         @Nonnull
         @Override
         public PValue toValueProto(@Nonnull final PlanSerializationContext serializationContext) {
-            return PValue.newBuilder().setMinEverLongValue(toProto(serializationContext)).build();
+            return PValue.newBuilder().setMinEverValue(toProto(serializationContext)).build();
         }
 
         @Nonnull
-        public static MinEverLongValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                 @Nonnull final PMinEverLongValue minEverLongValueProto) {
-            return new MinEverLongValue(serializationContext, minEverLongValueProto);
+        public static MinEverValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                             @Nonnull final PMinEverValue minEverValueProto) {
+            return new MinEverValue(serializationContext, minEverValueProto);
         }
 
         /**
          * Deserializer.
          */
         @AutoService(PlanDeserializer.class)
-        public static class Deserializer implements PlanDeserializer<PMinEverLongValue, MinEverLongValue> {
+        public static class Deserializer implements PlanDeserializer<PMinEverValue, MinEverValue> {
             @Nonnull
             @Override
-            public Class<PMinEverLongValue> getProtoMessageClass() {
-                return PMinEverLongValue.class;
+            public Class<PMinEverValue> getProtoMessageClass() {
+                return PMinEverValue.class;
             }
 
             @Nonnull
             @Override
-            public MinEverLongValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                              @Nonnull final PMinEverLongValue minEverLongValueProto) {
-                return MinEverLongValue.fromProto(serializationContext, minEverLongValueProto);
+            public MinEverValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                          @Nonnull final PMinEverValue minEverValueProto) {
+                return MinEverValue.fromProto(serializationContext, minEverValueProto);
             }
         }
     }
 
     /**
-     * Class to represent MIN_EVER(field) which can only be provided by a suitable index.
+     * Class to represent {@code MAX_EVER(field)} where {@code field} which can only be provided by a suitable index.
      */
-    public static class MaxEverLongValue extends IndexOnlyAggregateValue {
-        MaxEverLongValue(@Nonnull final PlanSerializationContext serializationContext,
-                         @Nonnull final PMaxEverLongValue maxEverLongValueProto) {
-            super(serializationContext, Objects.requireNonNull(maxEverLongValueProto.getSuper()));
+    public static class MaxEverValue extends IndexOnlyAggregateValue {
+        MaxEverValue(@Nonnull final PlanSerializationContext serializationContext,
+                     @Nonnull final PMaxEverValue maxEverValueProto) {
+            super(serializationContext, Objects.requireNonNull(maxEverValueProto.getSuper()));
         }
 
         /**
-         * Creates a new instance of {@link MaxEverLongValue}.
+         * Creates a new instance of {@link MaxEverValue}.
          *
          * @param operator the aggregation function.
          * @param child the child {@link Value}.
          */
-        MaxEverLongValue(@Nonnull final PhysicalOperator operator, @Nonnull final Value child) {
+        MaxEverValue(@Nonnull final PhysicalOperator operator, @Nonnull final Value child) {
             super(operator, child);
         }
 
+        @SuppressWarnings("deprecation")
         @Nonnull
         @Override
         public String getIndexTypeName() {
-            return IndexTypes.MAX_EVER_LONG;
+            return IndexTypes.MAX_EVER;
         }
 
         @Nonnull
         private static AggregateValue encapsulate(@Nonnull final List<? extends Typed> arguments) {
             Verify.verify(arguments.size() == 1);
             final Typed arg0 = arguments.get(0);
-            final Type type0 = arg0.getResultType();
-            SemanticException.check(type0.isNumeric(), SemanticException.ErrorCode.UNKNOWN, "only numeric types allowed in " + IndexTypes.MAX_EVER_LONG + " aggregation operation");
-            return new MaxEverLongValue(PhysicalOperator.MAX_EVER_LONG, (Value)arg0);
+            return new MaxEverValue(PhysicalOperator.MAX_EVER_LONG, (Value)arg0);
         }
 
         @Nonnull
         @Override
         public ValueWithChild withNewChild(@Nonnull final Value rebasedChild) {
-            return new MaxEverLongValue(operator, rebasedChild);
+            return new MaxEverValue(operator, rebasedChild);
         }
 
         @Nonnull
         @Override
-        public PMaxEverLongValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
-            return PMaxEverLongValue.newBuilder()
+        public PMaxEverValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
+            return PMaxEverValue.newBuilder()
                     .setSuper(toIndexOnlyAggregateValueProto(serializationContext))
                     .build();
         }
@@ -321,31 +318,31 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
         @Nonnull
         @Override
         public PValue toValueProto(@Nonnull final PlanSerializationContext serializationContext) {
-            return PValue.newBuilder().setMaxEverLongValue(toProto(serializationContext)).build();
+            return PValue.newBuilder().setMaxEverValue(toProto(serializationContext)).build();
         }
 
         @Nonnull
-        public static MaxEverLongValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                 @Nonnull final PMaxEverLongValue maxEverLongValueProto) {
-            return new MaxEverLongValue(serializationContext, maxEverLongValueProto);
+        public static MaxEverValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                             @Nonnull final PMaxEverValue maxEverValueProto) {
+            return new MaxEverValue(serializationContext, maxEverValueProto);
         }
 
         /**
          * Deserializer.
          */
         @AutoService(PlanDeserializer.class)
-        public static class Deserializer implements PlanDeserializer<PMaxEverLongValue, MaxEverLongValue> {
+        public static class Deserializer implements PlanDeserializer<PMaxEverValue, MaxEverValue> {
             @Nonnull
             @Override
-            public Class<PMaxEverLongValue> getProtoMessageClass() {
-                return PMaxEverLongValue.class;
+            public Class<PMaxEverValue> getProtoMessageClass() {
+                return PMaxEverValue.class;
             }
 
             @Nonnull
             @Override
-            public MaxEverLongValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                              @Nonnull final PMaxEverLongValue maxEverLongValueProto) {
-                return MaxEverLongValue.fromProto(serializationContext, maxEverLongValueProto);
+            public MaxEverValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                          @Nonnull final PMaxEverValue maxEverValueProto) {
+                return MaxEverValue.fromProto(serializationContext, maxEverValueProto);
             }
         }
     }
@@ -354,9 +351,9 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
      * The {@code min_ever} function.
      */
     @AutoService(BuiltInFunction.class)
-    public static class MinEverLongFn extends BuiltInFunction<AggregateValue> {
-        public MinEverLongFn() {
-            super("MIN_EVER", ImmutableList.of(new Type.Any()), (ignored, arguments) -> MinEverLongValue.encapsulate(arguments));
+    public static class MinEverFn extends BuiltInFunction<AggregateValue> {
+        public MinEverFn() {
+            super("MIN_EVER", ImmutableList.of(new Type.Any()), (ignored, arguments) -> MinEverValue.encapsulate(arguments));
         }
     }
 
@@ -364,9 +361,9 @@ public abstract class IndexOnlyAggregateValue extends AbstractValue implements A
      * The {@code max_ever} function.
      */
     @AutoService(BuiltInFunction.class)
-    public static class MaxEverLongFn extends BuiltInFunction<AggregateValue> {
-        public MaxEverLongFn() {
-            super("MAX_EVER", ImmutableList.of(new Type.Any()), (ignored, arguments) -> MaxEverLongValue.encapsulate(arguments));
+    public static class MaxEverFn extends BuiltInFunction<AggregateValue> {
+        public MaxEverFn() {
+            super("MAX_EVER", ImmutableList.of(new Type.Any()), (ignored, arguments) -> MaxEverValue.encapsulate(arguments));
         }
     }
 }

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -210,8 +210,8 @@ message PValue {
     PExistsValue exists_value = 11;
     PFieldValue field_value = 12;
     PIndexedValue indexed_value = 13;
-    PMaxEverLongValue max_ever_long_value = 14;
-    PMinEverLongValue min_ever_long_value = 15;
+    PMaxEverValue max_ever_value = 14;
+    PMinEverValue min_ever_value = 15;
     PInOpValue in_op_value = 16;
     PLikeOperatorValue like_operator_value = 17;
     PLiteralValue literal_value = 18;
@@ -451,11 +451,11 @@ message PInOpValue {
   optional PValue in_array_value = 2;
 }
 
-message PMaxEverLongValue {
+message PMaxEverValue {
   optional PIndexOnlyAggregateValue super = 1;
 }
 
-message PMinEverLongValue {
+message PMinEverValue {
   optional PIndexOnlyAggregateValue super = 1;
 }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBNestedRepeatedQueryTest.java
@@ -1360,7 +1360,7 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
             final Quantifier outerQun = outerRecQun();
             final Quantifier entryQun = explodeEntryQun(outerQun, "key", "int_value");
             final Quantifier selectWhere = selectWhereGroupByKey(outerQun, entryQun);
-            final Quantifier groupBy = groupAggregateByKey(selectWhere, new IndexOnlyAggregateValue.MaxEverLongFn(), FieldValue.ofFieldNames(selectWhere.getFlowedObjectValue(), List.of(entryQun.getAlias().getId(), "int_value")));
+            final Quantifier groupBy = groupAggregateByKey(selectWhere, new IndexOnlyAggregateValue.MaxEverFn(), FieldValue.ofFieldNames(selectWhere.getFlowedObjectValue(), List.of(entryQun.getAlias().getId(), "int_value")));
             return unsorted(selectHaving(groupBy));
         });
     }
@@ -1424,7 +1424,7 @@ class FDBNestedRepeatedQueryTest extends FDBRecordStoreQueryTestBase {
             final Quantifier entryKeyQun = explodeEntryQun(outerQun, "key");
             final Quantifier entryValueQun = explodeEntryQun(outerQun, "int_value");
             final Quantifier selectWhere = selectWhereGroupByKey(outerQun, entryKeyQun, entryValueQun);
-            final Quantifier groupBy = groupAggregateByKey(selectWhere, new IndexOnlyAggregateValue.MaxEverLongFn(), FieldValue.ofFieldNames(selectWhere.getFlowedObjectValue(), List.of(entryValueQun.getAlias().getId(), "int_value")));
+            final Quantifier groupBy = groupAggregateByKey(selectWhere, new IndexOnlyAggregateValue.MaxEverFn(), FieldValue.ofFieldNames(selectWhere.getFlowedObjectValue(), List.of(entryValueQun.getAlias().getId(), "int_value")));
             return unsorted(selectHaving(groupBy));
         });
     }


### PR DESCRIPTION
At the moment, Cascades is able to deal with `LONG`-based versions of `MIN_EVER` and `MAX_EVER` indexes. There is a variation of these indexes that internally works with FDB `Tuple`. That variation however, is not exposed to Cascades and therefore is not considered when planning a query.

Since these two variations (`LONG`-based and `TUPLE`-based) mainly differ in their storage structure, we could expose their respective match candidates exactly the same way allowing the planner to pick the right one based on the requested input/output of the index aggregate function.

This fixes #2874 .