### PR TITLE
Resolve #2878: Lucene partition balancing: reduce the number of retries

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -26,7 +26,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** Lucene partition balancing: reduce the number of retries [(Issue #2878)](https://github.com/FoundationDB/fdb-record-layer/issues/2878)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
@@ -76,7 +76,7 @@ public class IndexingMerger {
         return AsyncUtil.whileTrue(() ->
                 // Merge operation may take a long time, hence the runner's context must be a read-only. Ensure that it
                 // isn't a synchronized one, which may attempt a heartbeat write
-                // TODO: find a solution to seemingly stale synchronized sessions during slow merges
+                // Note: this runAsync will retry according to the runner's "maxAttempts" setting
                 common.getNonSynchronizedRunner().runAsync(context -> openRecordStore(context)
                                 .thenCompose(store -> {
                                     mergeStartTime.set(System.nanoTime());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -408,6 +408,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
 
         final FDBRecordStore.Builder storeBuilder = state.store.asBuilder();
         FDBDatabaseRunner runner = state.context.newRunner();
+        runner.setMaxAttempts(1); // retries (and throttling) are performed by the caller
         return rebalancePartitions(runner, storeBuilder, state, mergeControl)
                 .whenComplete((result, error) -> {
                     runner.close();


### PR DESCRIPTION
   1. Since the rebalance code is executed by two nested runners, force the inner runner's "maxAttempts" to one. The outer runner is called by the online indexer and its retry limit can be set by the external caller.
   2. Add debug log messages to the rebalance code to help finding  a performance issue.