### PR TITLE
Fixes #2881: VerifyException in Compensation if unmatched quantifiers is only non-empty thing requiring compensation

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,7 +19,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 
 * **Bug fix** Remove uncommitted version mutations during `deleteRecordsWhere` to avoid corrupting record stores if there are outstanding record saves when `deleteRecordsWhere` is called  [(Issue #2275)](https://github.com/FoundationDB/fdb-record-layer/issues/2275)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Clean up `VerifyException` that could occur with certain existential queries [(Issue #2880)](https://github.com/FoundationDB/fdb-record-layer/issues/2880)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
@@ -335,7 +335,7 @@ public interface Compensation {
                                                            @Nonnull final Set<Quantifier> unmatchedQuantifiers,
                                                            @Nonnull final Set<CorrelationIdentifier> compensatedAliases,
                                                            @Nonnull final Optional<Value> remainingComputationOptional) {
-        Verify.verify(!predicateCompensationMap.isEmpty() || remainingComputationOptional.isPresent());
+        Verify.verify(!predicateCompensationMap.isEmpty() || !unmatchedQuantifiers.isEmpty() || remainingComputationOptional.isPresent());
         return new ForMatch(isImpossible, childCompensation, predicateCompensationMap, matchedQuantifiers, unmatchedQuantifiers, compensatedAliases, remainingComputationOptional);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Compensation.java
@@ -709,7 +709,7 @@ public interface Compensation {
                                                                           @Nonnull final Set<? extends Quantifier> unmatchedQuantifiers,
                                                                           @Nonnull final Set<CorrelationIdentifier> compensatedAliases,
                                                                           @Nonnull final Optional<Value> remainingComputationValueOptional) {
-            Verify.verify(!predicateCompensationMap.isEmpty() || remainingComputationValueOptional.isPresent());
+            Verify.verify(!predicateCompensationMap.isEmpty() || !unmatchedQuantifiers.isEmpty() || remainingComputationValueOptional.isPresent());
             return new ForMatch(isImpossible, childCompensation, predicateCompensationMap, matchedQuantifiers, unmatchedQuantifiers, compensatedAliases, remainingComputationValueOptional);
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBRecordStoreQueryTestBase.java
@@ -287,7 +287,7 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         };
     }
 
-    protected void openHierarchicalRecordStore(FDBRecordContext context) throws Exception {
+    protected void openHierarchicalRecordStore(FDBRecordContext context) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords3Proto.getDescriptor());
         metaDataBuilder.addUniversalIndex(globalCountIndex());
         metaDataBuilder.getRecordType("MyHierarchicalRecord").setPrimaryKey(
@@ -295,15 +295,15 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 
-    protected void openNestedRecordStore(FDBRecordContext context) throws Exception {
+    protected void openNestedRecordStore(FDBRecordContext context) {
         openNestedRecordStore(context, null);
     }
 
-    protected void openNestedRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook) throws Exception {
+    protected void openNestedRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook) {
         createOrOpenRecordStore(context, nestedMetaData(hook));
     }
 
-    protected void openNestedWrappedArrayRecordStore(@Nonnull FDBRecordContext context) throws Exception {
+    protected void openNestedWrappedArrayRecordStore(@Nonnull FDBRecordContext context, @Nullable RecordMetaDataHook hook) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecords4WrapperProto.getDescriptor());
         metaDataBuilder.addUniversalIndex(globalCountIndex());
         metaDataBuilder.addIndex("RestaurantRecord", "review_rating", field("reviews", FanType.None).nest(field("values", FanType.FanOut).nest("rating")));
@@ -312,6 +312,9 @@ public abstract class FDBRecordStoreQueryTestBase extends FDBRecordStoreTestBase
         metaDataBuilder.addIndex("RestaurantRecord", "customers", field("customer", FanType.None).nest(field("values", FanType.FanOut)));
         metaDataBuilder.addIndex("RestaurantRecord", "customers-name", concat(field("customer", FanType.None).nest(field("values", FanType.FanOut)), field("name")));
         metaDataBuilder.addIndex("RestaurantReviewer", "stats$school", field("stats").nest(field("start_date")));
+        if (hook != null) {
+            hook.apply(metaDataBuilder);
+        }
         createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBSimpleQueryGraphTest.java
@@ -298,6 +298,27 @@ public class FDBSimpleQueryGraphTest extends FDBRecordStoreQueryTestBase {
                         .where(mapResult(recordConstructorValue(exactly(fieldValueWithFieldNames("name"), fieldValueWithFieldNames("rest_no"))))));
     }
 
+    /**
+     * Test a query running a simple existential query against a FanOut index on the relevant field. This test
+     * is actually designed to exercise a code path that was hit by
+     * <a href="https://github.com/FoundationDB/fdb-record-layer/issues/2881">Issue #2881</a>. This makes the
+     * test somewhat brittle in the sense that if the planner changes in a way that means that it no longer needs
+     * to construct certain kinds {@link com.apple.foundationdb.record.query.plan.cascades.Compensation}s to make the
+     * plan work, then we may lose coverage (absent other changes to our testing strategy).
+     *
+     * <p>
+     * There are several elements of this test that are necessary at time of writing to make it hit the code
+     * path under test:
+     * </p>
+     * <ol>
+     *     <li>A nested existential query on a single field</li>
+     *     <li>The inner query has an IN predicate on that field</li>
+     *     <li>The inner query projects the column (even though the result value is effectively erased by the existential quantifier)</li>
+     *     <li>An index that contains that precisely that field</li>
+     * </ol>
+     *
+     * @param inComparison whether the inner existential predicate should be an IN or EQUALS predicate
+     */
     @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
     @ParameterizedTest
     @BooleanSource


### PR DESCRIPTION
This updates the `VerifyException` in `Compensation` so that it does not reject inputs that `SelectExpression.compensate` expects to be able to hand to it.

This fixes #2881.