### PR TITLE
Add comparison keys to plan string for in-union

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
@@ -345,7 +345,9 @@ public class PlanStringRepresentation implements RecordQueryPlanVisitor<PlanStri
     private PlanStringRepresentation visitInUnionPlan(@Nonnull RecordQueryInUnionPlan element) {
         return append("∪(")
                 .appendItems(element.getInSources(), ", ")
-                .append(") ")
+                .append(")")
+                .append(element.getComparisonKeyFunction())
+                .append(" ")
                 .visit(element.getChild());
     }
 


### PR DESCRIPTION
The `comparisonKeyFunction` is currently not included in the plan representation of `InUnion` plans. This can make it hard to inspect bugs that could be a result of an in-union improperly merging results from different legs of a union. This does make the plan representation a little more verbose, though hopefully manageably so. It should be less intrusive, for example, than a regular union, which puts the comparison key between each leg of the union (unless the comparison is by primary key).