### PR TITLE
Fixes #2901: In-unions on aggregate indexes can be planned with insufficient comparison keys in the presence of repeated fields

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** In-union plans should now do a better job of not incorrectly de-duping groups in the presence of repeated fields [(Issue #2901)](https://github.com/FoundationDB/fdb-record-layer/issues/2901)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)


### PR DESCRIPTION
The logic to calculate the `Ordering` of aggregate queries has been augmented to include all values, not just the values even when there are repeated fields. This should be acceptable because with aggregate indexes, repeated fields don't change the cardinality in the same way that they do with `Value` indexes. (The value index logic may also consider tweaking how it works a bit, but that's not something this change attempts to handle.) The test suite for the permuted min/max indexes have been augmented to include more tests with repeated keys, including ones that would produce results that get incorrectly de-duplicated with previous `Ordering` logic.

This fixes #2901.