### PR TITLE
Resolve #2917: Allow converting a single/multi target indexing session to mutual one

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** asyncToSync without exception mapping for Lucene [(Issue #2926)](https://github.com/FoundationDB/fdb-record-layer/issues/2926)
-* **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Allow converting a single/multi target indexing session to mutual one [(Issue #2917)](https://github.com/FoundationDB/fdb-record-layer/issues/2917)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -1226,7 +1226,7 @@ public abstract class IndexingBase {
      * thrown when partly built by another method.
      */
     @SuppressWarnings("serial")
-    public static class  PartlyBuiltException extends RecordCoreException {
+    public static class PartlyBuiltException extends RecordCoreException {
         final IndexBuildProto.IndexBuildIndexingStamp savedStamp;
         final IndexBuildProto.IndexBuildIndexingStamp expectedStamp;
         final String indexName;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -499,7 +499,7 @@ public abstract class IndexingBase {
     }
 
     private boolean shouldAllowTypeConversionContinue(IndexBuildProto.IndexBuildIndexingStamp newStamp, IndexBuildProto.IndexBuildIndexingStamp savedStamp) {
-        return policy.shouldAllowTypeConversionContinue(newStamp.getMethod(), savedStamp.getMethod());
+        return policy.shouldAllowTypeConversionContinue(newStamp, savedStamp);
     }
 
     private static boolean areSimilar(IndexBuildProto.IndexBuildIndexingStamp newStamp, IndexBuildProto.IndexBuildIndexingStamp savedStamp) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1118,7 +1118,6 @@ public class OnlineIndexer implements AutoCloseable {
         private final DesiredAction ifMismatchPrevious;
         private final DesiredAction ifReadable;
         private final boolean allowUniquePendingState;
-        private final boolean allowTakeoverContinue;
         private final Set<TakeoverTypes> allowedTakeoverSet;
         private final long checkIndexingMethodFrequencyMilliseconds;
         private final boolean mutualIndexing;
@@ -1167,8 +1166,7 @@ public class OnlineIndexer implements AutoCloseable {
          * @param ifMismatchPrevious desired action if the index is partly built, but by a different method then currently requested
          * @param ifReadable desired action if the existing index state is READABLE (i.e. already built)
          * @param allowUniquePendingState if false, forbid {@link IndexState#READABLE_UNIQUE_PENDING} state
-         * @param allowTakeoverContinue if true and possible, allow indexing continuation of a different indexing method
-         * @param allowedTakeoverSet if non-null, allow a subset of indexing type conversion (non-null overrides allowTakeoverContinue)
+         * @param allowedTakeoverSet a subset of {@link TakeoverTypes}, with allowed indexing type conversion
          * @param mutualIndexing if true, use mutual indexing (i.e., index in a way that allows other processes to cooperatively build the index)
          * @param mutualIndexingBoundaries if present, use this predefined list of ranges. Else, split ranges by shards
          * @param allowUnblock if true, allow unblocking
@@ -1179,7 +1177,7 @@ public class OnlineIndexer implements AutoCloseable {
         @SuppressWarnings("squid:S00107") // too many parameters
         private IndexingPolicy(@Nullable String sourceIndex, @Nullable Object sourceIndexSubspaceKey, boolean forbidRecordScan,
                                DesiredAction ifDisabled, DesiredAction ifWriteOnly, DesiredAction ifMismatchPrevious, DesiredAction ifReadable,
-                               boolean allowUniquePendingState, boolean allowTakeoverContinue, Set<TakeoverTypes> allowedTakeoverSet,
+                               boolean allowUniquePendingState, Set<TakeoverTypes> allowedTakeoverSet,
                                long checkIndexingMethodFrequencyMilliseconds,
                                boolean mutualIndexing, List<Tuple> mutualIndexingBoundaries,
                                boolean allowUnblock, String allowUnblockId,
@@ -1193,7 +1191,6 @@ public class OnlineIndexer implements AutoCloseable {
             this.ifMismatchPrevious = ifMismatchPrevious;
             this.ifReadable = ifReadable;
             this.allowUniquePendingState = allowUniquePendingState;
-            this.allowTakeoverContinue = allowTakeoverContinue;
             this.allowedTakeoverSet = allowedTakeoverSet;
             this.checkIndexingMethodFrequencyMilliseconds = checkIndexingMethodFrequencyMilliseconds;
             this.mutualIndexing = mutualIndexing;
@@ -1266,7 +1263,6 @@ public class OnlineIndexer implements AutoCloseable {
                     .setIfMismatchPrevious(ifMismatchPrevious)
                     .setIfReadable(ifReadable)
                     .allowUniquePendingState(allowUniquePendingState)
-                    .allowTakeoverContinue(allowTakeoverContinue)
                     .allowTakeoverContinue(allowedTakeoverSet)
                     .checkIndexingStampFrequencyMilliseconds(checkIndexingMethodFrequencyMilliseconds)
                     .setMutualIndexing(mutualIndexing)
@@ -1320,7 +1316,7 @@ public class OnlineIndexer implements AutoCloseable {
                 case WRITE_ONLY:    return getIfWriteOnly();
                 case READABLE:      return getIfReadable();
                 case READABLE_UNIQUE_PENDING: return DesiredAction.MARK_READABLE;
-                default: throw new RecordCoreException("bad index state: " + state.toString());
+                default: throw new RecordCoreException("bad index state: " + state);
             }
         }
 
@@ -1336,13 +1332,17 @@ public class OnlineIndexer implements AutoCloseable {
         /**
          * If true, allow - in some specific cases - to continue building an index that was partly built by a different indexing method.
          * (See {@link Builder#allowTakeoverContinue(Collection)} and {@link Builder#allowTakeoverContinue(boolean)}).
-         * @param newMethod the new (attempting to continue) indexing method
-         * @param oldMethod the old (previously used) indexing method
+         * @param newStamp the new (attempting to continue) indexing type stamp
+         * @param oldStamp the old (previously used) indexing type stamp
          * @return true if allowed
          */
-        public boolean shouldAllowTypeConversionContinue(IndexBuildProto.IndexBuildIndexingStamp.Method newMethod,
-                                                         IndexBuildProto.IndexBuildIndexingStamp.Method oldMethod) {
+        public boolean shouldAllowTypeConversionContinue(IndexBuildProto.IndexBuildIndexingStamp newStamp,
+                                                         IndexBuildProto.IndexBuildIndexingStamp oldStamp) {
+            final IndexBuildProto.IndexBuildIndexingStamp.Method newMethod = newStamp.getMethod();
+            final IndexBuildProto.IndexBuildIndexingStamp.Method oldMethod = oldStamp.getMethod();
             if (newMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS) {
+                // Here: if allowed, an index that was partly built as a set will be continued as a single. Note that other target
+                // indexes from the original set may have already continued individually.
                 if (oldMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS) {
                     return isTypeConversionAllowed(TakeoverTypes.MULTI_TARGET_TO_SINGLE);
                 }
@@ -1351,20 +1351,29 @@ public class OnlineIndexer implements AutoCloseable {
                 }
             }
             if (newMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.MUTUAL_BY_RECORDS) {
-                if (oldMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS ||
-                        oldMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS) {
+                if (!isTypeConversionAllowed(TakeoverTypes.BY_RECORDS_TO_MUTUAL)) {
+                    // This conversion is not allowed, check no further
+                    return false;
+                }
+                if (oldMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS) {
+                    // This conversion should be allowed if:
+                    // a) The new mutual indexing set is identical to the old one
+                    // b) The mutual indexing continues only one target index (splitting it to one at a tiem)
+                    return newStamp.getTargetIndexCount() == 1 ||
+                            (newStamp.getTargetIndexCount() == oldStamp.getTargetIndexCount() &&
+                                    new HashSet<>(newStamp.getTargetIndexList()).containsAll(oldStamp.getTargetIndexList()));
+                }
+
+                if (oldMethod == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS) {
                     // Note that single-target-mutual is a private case of multi-target-mutual
-                    return isTypeConversionAllowed(TakeoverTypes.BY_RECORDS_TO_MUTUAL);
+                    return newStamp.getTargetIndexCount() == 1; // No real need to check the stamp's index name
                 }
             }
             return false;
         }
 
         private boolean isTypeConversionAllowed(TakeoverTypes takeoverType) {
-            return
-                    allowedTakeoverSet == null ?
-                    allowTakeoverContinue :
-                    allowedTakeoverSet.contains(takeoverType);
+            return allowedTakeoverSet != null && allowedTakeoverSet.contains(takeoverType);
         }
 
 
@@ -1426,8 +1435,7 @@ public class OnlineIndexer implements AutoCloseable {
             private DesiredAction ifWriteOnly = DesiredAction.CONTINUE;
             private DesiredAction ifMismatchPrevious = DesiredAction.CONTINUE;
             private DesiredAction ifReadable = DesiredAction.CONTINUE;
-            private boolean doAllowUniqueuPendingState = false;
-            private boolean doAllowTakeoverContinue = false;
+            private boolean doAllowUniquePendingState = false;
             private Set<TakeoverTypes> allowedTakeoverSet = null;
             private long checkIndexingStampFrequency = 60_000;
             private boolean useMutualIndexing = false;
@@ -1563,7 +1571,7 @@ public class OnlineIndexer implements AutoCloseable {
              * @return this builder
              */
             public Builder allowUniquePendingState(boolean allow) {
-                this.doAllowUniqueuPendingState = allow;
+                this.doAllowUniquePendingState = allow;
                 return this;
             }
 
@@ -1584,13 +1592,13 @@ public class OnlineIndexer implements AutoCloseable {
              * <li>"Single index by records" may continue a multi index session.</li>
              * <li>"Single index by records" may continue a mutually built session.</li>
              *  </ul>
-             *  This function may be too general; {@link #allowTakeoverContinue(Collection)} supports allowing a subset of these conversions.
+             *  This function will allow/disallow the all possible conversion types. {@link #allowTakeoverContinue(Collection)} supports allowing a subset of these conversions.
              *  Note - if {@link #allowTakeoverContinue(Collection)} is called with a non-null argument, it will override this function's argument.
              * @param allow if true, allow takeover.
              * @return this builder
              */
             public Builder allowTakeoverContinue(boolean allow) {
-                this.doAllowTakeoverContinue = allow;
+                this.allowedTakeoverSet = allow ? EnumSet.allOf(TakeoverTypes.class) : EnumSet.noneOf(TakeoverTypes.class);
                 return this;
             }
 
@@ -1731,7 +1739,7 @@ public class OnlineIndexer implements AutoCloseable {
                 }
                 return new IndexingPolicy(sourceIndex, sourceIndexSubspaceKey, forbidRecordScan,
                         ifDisabled, ifWriteOnly, ifMismatchPrevious, ifReadable,
-                        doAllowUniqueuPendingState, doAllowTakeoverContinue, allowedTakeoverSet,
+                        doAllowUniquePendingState, allowedTakeoverSet,
                         checkIndexingStampFrequency,
                         useMutualIndexing, useMutualIndexingBoundaries, allowUnblock, allowUnblockId,
                         initialMergesCountLimit, reverseScanOrder);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -1592,7 +1592,7 @@ public class OnlineIndexer implements AutoCloseable {
              * <li>"Single index by records" may continue a multi index session.</li>
              * <li>"Single index by records" may continue a mutually built session.</li>
              *  </ul>
-             *  This function will allow/disallow the all possible conversion types. {@link #allowTakeoverContinue(Collection)} supports allowing a subset of these conversions.
+             *  This function will allow/disallow all possible conversion types. {@link #allowTakeoverContinue(Collection)} supports allowing a subset of these conversions.
              *  Note - if {@link #allowTakeoverContinue(Collection)} is called with a non-null argument, it will override this function's argument.
              * @param allow if true, allow takeover.
              * @return this builder

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -924,8 +924,9 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                                 pauseMutualBuildSemaphore.acquire(); // pause to try building indexes
                             } catch (InterruptedException e) {
                                 throw new RuntimeException(e);
+                            } finally {
+                                pauseMutualBuildSemaphore.release();
                             }
-                            pauseMutualBuildSemaphore.release();
                         } else {
                             passed.set(true);
                         }
@@ -989,8 +990,9 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                                 pauseMutualBuildSemaphore.acquire(); // pause to try building indexes
                             } catch (InterruptedException e) {
                                 throw new RuntimeException(e);
+                            } finally {
+                                pauseMutualBuildSemaphore.release();
                             }
-                            pauseMutualBuildSemaphore.release();
                         } else {
                             passed.set(true);
                         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -448,8 +448,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
             try (OnlineIndexer indexBuilder = newIndexerBuilder()
                     .setIndex(index)
                     .setTimer(timer)
-                    .setIndexingPolicy(mutualTakeOverIndexingPolicy(explicit, false)
-                            .allowTakeoverContinue(true))
+                    .setIndexingPolicy(mutualTakeOverIndexingPolicy(explicit, false))
                     .build()) {
                 indexBuilder.buildIndex();
             }
@@ -766,7 +765,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
             indexBuilder.buildIndex();
         }
 
-        // let the other thread finish, verify that it did was not completed
+        // let the other thread finish, verify that it was not completed
         pauseMutualBuildSemaphore.release();
         t1.join();
         int indexedAsMulti = timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -405,13 +405,13 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
     OnlineIndexer.IndexingPolicy.Builder mutualTakeOverIndexingPolicy(boolean explicit, boolean mutual) {
         final OnlineIndexer.IndexingPolicy.Builder builder = OnlineIndexer.IndexingPolicy.newBuilder();
-        final List<OnlineIndexer.IndexingPolicy.TakeoverTypes> convertionSet =
+        final List<OnlineIndexer.IndexingPolicy.TakeoverTypes> conversionSet =
                 mutual ?
                 List.of(OnlineIndexer.IndexingPolicy.TakeoverTypes.BY_RECORDS_TO_MUTUAL) :
                 List.of(OnlineIndexer.IndexingPolicy.TakeoverTypes.MUTUAL_TO_SINGLE);
 
         return explicit ?
-               builder.allowTakeoverContinue(convertionSet) :
+               builder.allowTakeoverContinue(conversionSet) :
                builder.allowTakeoverContinue();
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -403,10 +403,10 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         assertAllValidated(indexes);
     }
 
-    OnlineIndexer.IndexingPolicy.Builder mutualTakeOverIndexingPolicy(boolean explicit, boolean mutual) {
+    OnlineIndexer.IndexingPolicy.Builder mutualTakeOverIndexingPolicy(boolean explicit, boolean toMutual) {
         final OnlineIndexer.IndexingPolicy.Builder builder = OnlineIndexer.IndexingPolicy.newBuilder();
         final List<OnlineIndexer.IndexingPolicy.TakeoverTypes> conversionSet =
-                mutual ?
+                toMutual ?
                 List.of(OnlineIndexer.IndexingPolicy.TakeoverTypes.BY_RECORDS_TO_MUTUAL) :
                 List.of(OnlineIndexer.IndexingPolicy.TakeoverTypes.MUTUAL_TO_SINGLE);
 


### PR DESCRIPTION
This change should allow speeding up an indexing session with insufficient performance by converting it to mutual session without loosing all the progress that was already made. 