### PR TITLE
Fixes #2919: scope the IndexUniquenessCommitCheck by subpsace

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,7 +18,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 ### NEXT_RELEASE
 
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Scope the IndexUniquenessCommitCheck by subspace [(Issue #2919)](https://github.com/FoundationDB/fdb-record-layer/issues/2919)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexUniquenessCommitCheck.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexUniquenessCommitCheck.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.subspace.Subspace;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
@@ -32,11 +33,15 @@ import java.util.concurrent.CompletableFuture;
 class IndexUniquenessCommitCheck implements FDBRecordContext.CommitCheckAsync {
     @Nonnull
     private final Index index;
+
+    @Nonnull
+    private final Subspace indexSubspace;
     @Nonnull
     private final FDBRecordContext.CommitCheckAsync underlying;
 
-    IndexUniquenessCommitCheck(@Nonnull Index index, @Nonnull CompletableFuture<Void> check) {
+    IndexUniquenessCommitCheck(@Nonnull Index index, @Nonnull Subspace indexSubspace, @Nonnull CompletableFuture<Void> check) {
         this.index = index;
+        this.indexSubspace = indexSubspace;
         this.underlying = FDBRecordContext.CommitCheckAsync.fromFuture(check);
     }
 
@@ -54,5 +59,10 @@ class IndexUniquenessCommitCheck implements FDBRecordContext.CommitCheckAsync {
     @Nonnull
     public Index getIndex() {
         return index;
+    }
+
+    @Nonnull
+    public Subspace getIndexSubspace() {
+        return indexSubspace;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
@@ -534,7 +534,7 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
                     }
                 }, getExecutor()));
         // Add a pre-commit check to prevent accidentally committing and getting into an invalid state.
-        state.store.addIndexUniquenessCommitCheck(state.index, checker);
+        state.store.addIndexUniquenessCommitCheck(state.index, state.indexSubspace, checker);
     }
 
     private boolean isWriteOnlyOrUniquePending() {


### PR DESCRIPTION
The two new tests both fail without the change.