### PR TITLE
Resolves #2923: Create a new version of AsyncToSync

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** asyncToSync without exception mapping for Lucene [(Issue #2926)](https://github.com/FoundationDB/fdb-record-layer/issues/2926)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -1238,7 +1238,8 @@ public class FDBDatabase {
         return latencyInjector.apply(fdbLatencySource);
     }
 
-    private void checkIfBlockingInFuture(CompletableFuture<?> future) {
+    @API(API.Status.INTERNAL)
+    public void checkIfBlockingInFuture(CompletableFuture<?> future) {
         BlockingInAsyncDetection behavior = getBlockingInAsyncDetection();
         if (behavior == BlockingInAsyncDetection.DISABLED) {
             return;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -1410,6 +1410,11 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
         this.hookForAsyncToSync = hook;
     }
 
+    @Nullable
+    public Consumer<FDBStoreTimer.Wait> getHookForAsyncToSync() {
+        return hookForAsyncToSync;
+    }
+
     public boolean hasHookForAsyncToSync() {
         return hookForAsyncToSync != null;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
@@ -1,0 +1,162 @@
+/*
+ * LuceneConcurrency.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.MoreAsyncUtil;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.apple.foundationdb.record.lucene.LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC;
+
+/**
+ * Utility class for methods related to synchronizing Futures.
+ */
+public class LuceneConcurrency {
+
+    /**
+     * An implementation of {@code asyncToSync} that is isolated from external exception injections.
+     * This implementation does NOT perform exception mapping, nor does it check whether the calls have
+     * "async" in the stack trace (as the original {@link FDBRecordContext#asyncToSync} does).
+     * This method is meant to be used internally in places where obtaining and using the result pf asynchronous
+     * operation is required.
+     * This method uses the {@link FDBDatabase#getAsyncToSyncTimeout} to find the period to use for the timeout.
+     * This method will throw the runtime exception that was thrown by the Future's realization in case such error
+     * occurred.
+     * This method will use the legacy  {@link FDBRecordContext#asyncToSync} if the LUCENE_USE_LEGACY_ASYNC_TO_SYNC
+     * property is set to TRUE (the default)
+     *
+     * @param event the timer event to use for recording the waits
+     * @param async the future to wait on
+     * @param recordContext the context to use for callback, recording the event and getting the timeout
+     *
+     * @return the result of the future's operation
+     */
+    @Nullable
+    @API(API.Status.INTERNAL)
+    public static <T> T asyncToSync(@Nonnull StoreTimer.Wait event, @Nonnull CompletableFuture<T> async, @Nonnull FDBRecordContext recordContext) {
+        if (recordContext.getPropertyStorage().getPropertyValue(LUCENE_USE_LEGACY_ASYNC_TO_SYNC)) {
+            return recordContext.asyncToSync(event, async);
+        }
+
+        if (recordContext.hasHookForAsyncToSync() && !MoreAsyncUtil.isCompletedNormally(async)) {
+            recordContext.getHookForAsyncToSync().accept(event);
+        }
+        if (async.isDone()) {
+            try {
+                return async.get();
+            } catch (ExecutionException ex) {
+                throw FDBExceptions.wrapException(ex);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                // TODO: The original mapping for InterruptedException would be INTERNAL_ERROR, now it will be RecordCoreInterruptedException
+                throw FDBExceptions.wrapException(ex);
+            }
+        } else {
+            final Pair<Long, TimeUnit> asyncToSyncTimeout = recordContext.getDatabase().getAsyncToSyncTimeout(event);
+            Timeout timeout = (asyncToSyncTimeout == null) ? null : Timeout.of(asyncToSyncTimeout.getLeft(), asyncToSyncTimeout.getRight());
+            final FDBStoreTimer timer = recordContext.getTimer();
+            final long startTime = System.nanoTime();
+            try {
+                if (timeout != null) {
+                    return async.get(timeout.getDuration(), timeout.getTimeUnit());
+                } else {
+                    return async.get();
+                }
+            } catch (TimeoutException ex) {
+                if (timer != null) {
+                    timer.recordTimeout(event, startTime);
+                    throw new AsyncToSyncTimeoutException(ex.getMessage(), ex, LogMessageKeys.TIME_LIMIT.toString(), timeout.getDuration(), LogMessageKeys.TIME_UNIT.toString(), timeout.getTimeUnit());
+                }
+                throw new AsyncToSyncTimeoutException(ex.getMessage(), ex);
+            } catch (ExecutionException ex) {
+                throw FDBExceptions.wrapException(ex);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                // TODO: The original mapping for InterruptedException would be INTERNAL_ERROR, now it will be RecordCoreInterruptedException
+                throw FDBExceptions.wrapException(ex);
+            } finally {
+                if (timer != null) {
+                    timer.recordSinceNanoTime(event, startTime);
+                }
+            }
+        }
+    }
+
+    private LuceneConcurrency() {
+    }
+
+    /**
+     * A representation of a timeout value: A duration and a time unit.
+     */
+    public static class Timeout {
+        private final long duration;
+        @Nonnull
+        private final TimeUnit timeUnit;
+
+        public Timeout(final long duration, @Nonnull final TimeUnit timeUnit) {
+            this.duration = duration;
+            this.timeUnit = timeUnit;
+        }
+
+        public static Timeout of(final long duration, @Nonnull final TimeUnit timeUnit) {
+            return new Timeout(duration, timeUnit);
+        }
+
+        public long getDuration() {
+            return duration;
+        }
+
+        @Nonnull
+        public TimeUnit getTimeUnit() {
+            return timeUnit;
+        }
+    }
+
+    /**
+     * An exception that is thrown when the async to sync operation times out.
+     */
+    public static class AsyncToSyncTimeoutException extends RecordCoreException {
+        private static final long serialVersionUID = -1L;
+
+        public AsyncToSyncTimeoutException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+
+        public AsyncToSyncTimeoutException(final String message, final Throwable cause, final Object... keyValues) {
+            super(message, cause);
+            addLogInfo(keyValues);
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
@@ -38,8 +38,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.apple.foundationdb.record.lucene.LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC;
-
 /**
  * Utility class for methods related to synchronizing Futures.
  */
@@ -65,7 +63,7 @@ public class LuceneConcurrency {
     @Nullable
     @API(API.Status.INTERNAL)
     public static <T> T asyncToSync(@Nonnull StoreTimer.Wait event, @Nonnull CompletableFuture<T> async, @Nonnull FDBRecordContext recordContext) {
-        if (recordContext.getPropertyStorage().getPropertyValue(LUCENE_USE_LEGACY_ASYNC_TO_SYNC)) {
+        if (recordContext.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC)) {
             return recordContext.asyncToSync(event, async);
         }
 
@@ -98,7 +96,9 @@ public class LuceneConcurrency {
             } catch (TimeoutException ex) {
                 if (timer != null) {
                     timer.recordTimeout(event, startTime);
-                    throw new AsyncToSyncTimeoutException(ex.getMessage(), ex, LogMessageKeys.TIME_LIMIT.toString(), timeout.getDuration(), LogMessageKeys.TIME_UNIT.toString(), timeout.getTimeUnit());
+                    throw new AsyncToSyncTimeoutException(ex.getMessage(), ex,
+                            LogMessageKeys.TIME_LIMIT.toString(), timeout.getDuration(),
+                            LogMessageKeys.TIME_UNIT.toString(), timeout.getTimeUnit());
                 }
                 throw new AsyncToSyncTimeoutException(ex.getMessage(), ex);
             } catch (ExecutionException ex) {
@@ -125,7 +125,7 @@ public class LuceneConcurrency {
         @Nonnull
         private final TimeUnit timeUnit;
 
-        public Timeout(final long duration, @Nonnull final TimeUnit timeUnit) {
+        private Timeout(final long duration, @Nonnull final TimeUnit timeUnit) {
             this.duration = duration;
             this.timeUnit = timeUnit;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -195,7 +195,7 @@ public class LucenePartitioner {
      * no partitioning metadata exist for the given query
      */
     public PartitionedQueryHint selectQueryPartition(@Nonnull Tuple groupKey, @Nullable LuceneScanQuery luceneScanQuery) {
-        return state.context.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, selectQueryPartitionAsync(groupKey, luceneScanQuery));
+        return LuceneConcurrency.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, selectQueryPartitionAsync(groupKey, luceneScanQuery), state.context);
     }
 
     /**

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
@@ -91,8 +91,8 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
                 .setContext(aContext)
                 .setScanProperties(ScanProperties.FORWARD_SCAN)
                 .build();
-                 RecordCursor<Tuple> entries = kvs.map(kv -> subspace.unpack(kv.getKey()))) {
-            tuples = aContext.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList());
+                RecordCursor<Tuple> entries = kvs.map(kv -> subspace.unpack(kv.getKey()))) {
+            tuples = LuceneConcurrency.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList(), aContext);
         }
         list.set(tuples.stream().map(t -> {
             List<Object> items = t.getItems();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
@@ -79,7 +79,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
                 .setScanProperties(ScanProperties.FORWARD_SCAN)
                 .build();
                  RecordCursor<Tuple> entries = kvs.map(kv -> subspace.unpack(kv.getKey()))) {
-            tuples = aContext.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList());
+            tuples = LuceneConcurrency.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList(), aContext);
         }
         list.set(tuples.stream().map(t -> {
             List<Object> items = t.getItems();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordContextProperties.java
@@ -121,4 +121,8 @@ public final class LuceneRecordContextProperties {
      * Lucene block cache maximum size. At most these many blocks will be stored in cache.
      */
     public static final RecordLayerPropertyKey<Integer> LUCENE_BLOCK_CACHE_MAXIMUM_SIZE = RecordLayerPropertyKey.integerPropertyKey("com.apple.foundationdb.record.lucene.block.cache.size", FDBDirectory.DEFAULT_BLOCK_CACHE_MAXIMUM_SIZE);
+    /**
+     * Lucene async to sync behavior: Whether to use the legacy async to sync calls or the non-exception-mapping behavior.
+     */
+    public static final RecordLayerPropertyKey<Boolean> LUCENE_USE_LEGACY_ASYNC_TO_SYNC = RecordLayerPropertyKey.booleanPropertyKey("com.apple.foundationdb.record.lucene.exception.mapping.enabled", true);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -524,7 +524,6 @@ public class FDBDirectory extends Directory  {
             ));
         } catch (ExecutionException e) {
             // This would happen when the cache.get() fails to execute the lambda (not when the block's future is joined)
-            // TODO: Add the execution exception as suppressed?
             throw new RecordCoreException(e.getCause());
         }
     }
@@ -995,7 +994,8 @@ public class FDBDirectory extends Directory  {
     }
 
     @Nullable
-    public <T> T asyncToSync(@Nonnull StoreTimer.Wait event, @Nonnull CompletableFuture<T> async) {
+    public <T> T asyncToSync(StoreTimer.Wait event,
+                             @Nonnull CompletableFuture<T> async ) {
         return agilityContext.asyncToSync(event, async);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -524,6 +524,7 @@ public class FDBDirectory extends Directory  {
             ));
         } catch (ExecutionException e) {
             // This would happen when the cache.get() fails to execute the lambda (not when the block's future is joined)
+            // TODO: Add the execution exception as suppressed?
             throw new RecordCoreException(e.getCause());
         }
     }
@@ -994,8 +995,7 @@ public class FDBDirectory extends Directory  {
     }
 
     @Nullable
-    public <T> T asyncToSync(StoreTimer.Wait event,
-                             @Nonnull CompletableFuture<T> async ) {
+    public <T> T asyncToSync(@Nonnull StoreTimer.Wait event, @Nonnull CompletableFuture<T> async) {
         return agilityContext.asyncToSync(event, async);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -53,6 +53,7 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.test.TestKeySpace;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.util.LoggableKeysAndValues;
 import com.apple.test.RandomizedTestUtils;
 import com.apple.test.SuperSlow;
 import com.apple.test.Tags;
@@ -405,7 +406,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                     assertFalse(requireFailure && i < 15, i + " merge should have failed");
                     success = true;
                 } catch (RecordCoreException e) {
-                    final LoggableTimeoutException timeoutException = findTimeoutException(e);
+                    final LoggableKeysAndValues<? extends Exception> timeoutException = findTimeoutException(e);
                     LOGGER.info(KeyValueLogMessage.of("Merge failed",
                             "iteration", i,
                             "cause", e.getClass(),
@@ -479,7 +480,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
             try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(
                     index,
                     LuceneIndexTestValidator.groupedSortedTextSearch(recordStore, index, "text:word", null, 1), null, ScanProperties.FORWARD_SCAN)) {
-                List<Tuple> primaryKeys = context.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, cursor.asList())
+                List<Tuple> primaryKeys = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, cursor.asList(), context)
                         .stream()
                         .map(IndexEntry::getPrimaryKey)
                         .collect(Collectors.toList());
@@ -959,15 +960,18 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         }
     }
 
-    private static LoggableTimeoutException findTimeoutException(final RecordCoreException e) {
+    private static LoggableKeysAndValues<? extends Exception> findTimeoutException(final RecordCoreException e) {
         Map<Throwable, String> visited = new IdentityHashMap<>();
         ArrayDeque<Throwable> toVisit = new ArrayDeque<>();
         toVisit.push(e);
         while (!toVisit.isEmpty()) {
             Throwable cause = toVisit.removeFirst();
             if (!visited.containsKey(cause)) {
+                // TODO: This should eventually be removed since LoggableTimeoutException would not be thrown
                 if (cause instanceof LoggableTimeoutException) {
                     return (LoggableTimeoutException) cause;
+                } else if (cause instanceof LuceneConcurrency.AsyncToSyncTimeoutException) {
+                    return (LuceneConcurrency.AsyncToSyncTimeoutException) cause;
                 }
                 if (cause.getCause() != null) {
                     toVisit.addLast(cause.getCause());

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -562,8 +562,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                             try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(
                                     index,
                                     LuceneIndexTestValidator.groupedSortedTextSearch(recordStore, index, "text:word", null, 1), null, ScanProperties.FORWARD_SCAN)) {
-                                List<IndexEntry> matches = context.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR,
-                                        cursor.asList());
+                                List<IndexEntry> matches = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, cursor.asList(), context);
                                 assertFalse(matches.isEmpty());
                             }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -966,7 +966,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         while (!toVisit.isEmpty()) {
             Throwable cause = toVisit.removeFirst();
             if (!visited.containsKey(cause)) {
-                // TODO: This should eventually be removed since LoggableTimeoutException would not be thrown
+                // This will get throws when the legacy asyncToSync is called
                 if (cause instanceof LoggableTimeoutException) {
                     return (LoggableTimeoutException) cause;
                 } else if (cause instanceof LuceneConcurrency.AsyncToSyncTimeoutException) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -6453,5 +6453,16 @@ public class LuceneIndexTest extends FDBRecordStoreTestBase {
             context.commit();
         }
     }
+
+    /**
+     * A version of the tests that runs with the new version of asyncToSync.
+     */
+    public static class LuceneIndexWithLuceneAsyncToSyncTest extends LuceneIndexTest {
+        @Override
+        protected RecordLayerPropertyStorage.Builder addDefaultProps(final RecordLayerPropertyStorage.Builder props) {
+            return super.addDefaultProps(props)
+                    .addProp(LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC, false);
+        }
+    }
 }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.lucene.LuceneConcurrency;
 import com.apple.foundationdb.record.lucene.LuceneEvents;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
@@ -132,7 +133,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         );
         final FDBRecordContext context = directory.getCallerContext();
         assertThrows(RecordCoreArgumentException.class,
-                () -> context.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_DATA_BLOCK, seekFuture));
+                () -> LuceneConcurrency.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_DATA_BLOCK, seekFuture, context));
     }
 
     @Test

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecordsTextProto;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.lucene.LuceneConcurrency;
 import com.apple.foundationdb.record.lucene.LuceneFunctionNames;
 import com.apple.foundationdb.record.lucene.LuceneIndexOptions;
 import com.apple.foundationdb.record.lucene.LuceneIndexTestUtils;
@@ -517,8 +518,8 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
         private void disableIndex() {
             try (FDBRecordContext context = openContext()) {
                 final FDBRecordStore store = openStore(context);
-                maxDocId = context.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
-                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount());
+                maxDocId = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
+                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount(), context);
                 continuing = maxDocId > 0;
                 logger.info("Disabling index");
                 store.markIndexDisabled(INDEX.getName());
@@ -530,8 +531,8 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
             OnlineIndexer.Builder indexBuilder = null;
             try (FDBRecordContext context = openContext()) {
                 final FDBRecordStore store = openStore(context);
-                maxDocId = context.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
-                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount());
+                maxDocId = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
+                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount(), context);
                 continuing = maxDocId > 0;
                 if (!store.isIndexReadable(INDEX.getName())) {
                     indexBuilder = OnlineIndexer.newBuilder()


### PR DESCRIPTION
The existing implementation of context AsyncToSync allows exceptions to be mapped to other exceptions. In order to be able to reason about the errors throws by futures when relalized by AsyncToSync this PR creates a new version of AsyncToSync, to be used by Lucene code, so that exception mapping is no longer taking place.
This is the first step in handling Lucene exceptions, the others being mapping to -and from- IOExceptions on Lucene code boundaries.
