### PR TITLE
Make `checkPrefixesCount` `synchronized`.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MinimumTupleSizeKeyChecker.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MinimumTupleSizeKeyChecker.java
@@ -159,7 +159,7 @@ public class MinimumTupleSizeKeyChecker implements KeyChecker {
                 Arrays.equals(key, 0, prefix.length, prefix, 0, prefix.length);
     }
 
-    private void checkPrefixesCount(@Nonnull CheckedSubspace checkedSubspace) {
+    private synchronized void checkPrefixesCount(@Nonnull CheckedSubspace checkedSubspace) {
         int count = 0;
         for (byte[] prefix : prefixes) {
             if (keyHasPrefix(prefix, checkedSubspace.prefix)) {


### PR DESCRIPTION
It is called from another `synchronized` method, but also from `close`. This probably indicates a problem elsewhere, as a `Transaction` is being used after / during `close`; but avoid `ConcurrentModificationException` here.