### PR TITLE
Resolve #2927: Avoid occasional "runner has been closed" error during indexing

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,7 +21,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Avoid occasional "runner has been closed" error during indexing [(Issue #2927)](https://github.com/FoundationDB/fdb-record-layer/issues/2927)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -287,8 +287,5 @@ public class IndexingCommon {
 
     public void close() {
         runner.close();
-        if (synchronizedSessionRunner != null) {
-            synchronizedSessionRunner.close();
-        }
     }
 }


### PR DESCRIPTION
Synchronized runner is created by `runner.startSynchronizedSessionAsync`, with the calling runner setting itself as the underlying runner (which is the main runner for the indexing session).
 Let the two runners be `mainRunner` and `SyncRunner` (where the latest points to `mainRunner`).

`runWithSynchronizedRunnerAndEndSession` is called with the `syncRunner`, and saves it in `indexingCommon`, then uses `MoreAsyncUtil.composeWhenComplete` to wait for the indexing to finish, then removes the `syncRunner` from `indexingCommon`.
When the indexer is closed, `mainRunner` is closed and if the `syncRunner` is not null, it closes too.
Typically the indexer is closed only after `MoreAsyncUtil.composeWhenComplete` removes the `syncRunner` from common. But sometimes (as seen in exception path), the indexer is closed first and then:
  Closes the `mainRunner`
  Closes the `syncRunner`, which attempts to close the underlying runner, which is the `mainRunner`, which cannot be re-closed.
  
 The quick solution would be simply to avoid closing the `syncRunner`. In the longer term, it might be a good idea to use another mechanism for online indexing. 