### PR TITLE
Expand semantics of `ForEach` quantifier.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,6 +22,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Expand `ForEach` quantifier semantics [(Issue #2930)](https://github.com/FoundationDB/fdb-record-layer/issues/2930)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanStringRepresentation.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.query.plan.plans.InSource;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
@@ -296,6 +297,16 @@ public class PlanStringRepresentation implements RecordQueryPlanVisitor<PlanStri
     @Override
     public PlanStringRepresentation visitFirstOrDefaultPlan(@Nonnull RecordQueryFirstOrDefaultPlan element) {
         return append("firstOrDefault(")
+                .visit(element.getChild())
+                .append(" || ")
+                .append(element.getOnEmptyResultValue())
+                .append(")");
+    }
+
+    @Nonnull
+    @Override
+    public PlanStringRepresentation visitDefaultOnEmptyPlan(@Nonnull RecordQueryDefaultOnEmptyPlan element) {
+        return append("defaultOnEmpty(")
                 .visit(element.getChild())
                 .append(" || ")
                 .append(element.getOnEmptyResultValue())

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
@@ -282,7 +282,7 @@ public class AggregateIndexExpansionVisitor extends KeyExpressionExpansionVisito
                 ? null
                 : FieldValue.ofOrdinalNumber(groupByQun.getFlowedObjectValue(), 0);
 
-        Value aggregateValueReference = FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupByQun.getFlowedObjectValue(), groupingValueReference == null ? 0 : 1), 0);
+        final var aggregateValueReference = FieldValue.ofOrdinalNumberAndFuseIfPossible(FieldValue.ofOrdinalNumber(groupByQun.getFlowedObjectValue(), groupingValueReference == null ? 0 : 1), 0);
 
         final var placeholderAliases = ImmutableList.<CorrelationIdentifier>builder();
         final var selectHavingGraphExpansionBuilder = GraphExpansion.builder().addQuantifier(groupByQun);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexExpansionVisitor.java
@@ -33,7 +33,6 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.MatchableSo
 import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.Placeholder;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.PredicateWithValueAndRanges;
-import com.apple.foundationdb.record.query.plan.cascades.values.AggregateValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.ArithmeticValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.CountValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.EmptyValue;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleSet.java
@@ -52,6 +52,7 @@ import com.apple.foundationdb.record.query.plan.cascades.rules.NormalizePredicat
 import com.apple.foundationdb.record.query.plan.cascades.rules.PartitionBinarySelectRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PartitionSelectRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PredicateToLogicalUnionRule;
+import com.apple.foundationdb.record.query.plan.cascades.rules.PullUpNullOnEmptyRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushDistinctBelowFilterRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushDistinctThroughFetchRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PushFilterThroughFetchRule;
@@ -109,7 +110,8 @@ public class PlannerRuleSet {
     private static final List<CascadesRule<? extends RelationalExpression>> REWRITE_RULES = ImmutableList.of(
             new CombineFilterRule(),
             new InComparisonToExplodeRule(),
-            new SplitSelectExtractIndependentQuantifiersRule()
+            new SplitSelectExtractIndependentQuantifiersRule(),
+            new PullUpNullOnEmptyRule()
     );
     private static final List<CascadesRule<? extends RelationalExpression>> MATCHING_RULES = ImmutableList.of(
             new MatchLeafRule(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
@@ -163,8 +163,7 @@ public abstract class Quantifier implements Correlated<Quantifier> {
             @Nonnull
             @Override
             public ForEachBuilder from(final ForEach quantifier) {
-                final var builder = withAlias(quantifier.getAlias());
-                return quantifier.isNullOnEmpty() ? builder.setNullOnEmpty(quantifier.isNullOnEmpty) : builder;
+                return withAlias(quantifier.getAlias()).setNullOnEmpty(quantifier.isNullOnEmpty());
             }
 
             @Nonnull
@@ -246,16 +245,13 @@ public abstract class Quantifier implements Correlated<Quantifier> {
 
         @Override
         public int semanticHashCode() {
-            if (isNullOnEmpty()) {
-                return Objects.hash(getShorthand(), getRangesOver().semanticHashCode(), isNullOnEmpty());
-            }
-            return Objects.hash(getShorthand(), getRangesOver().semanticHashCode());
+            return Objects.hash(getShorthand(), getRangesOver().semanticHashCode(), isNullOnEmpty());
         }
 
         @Override
         @Nonnull
         public String toString() {
-            final var isNullOnEmpty = isNullOnEmpty() ? "nullIfEmpty" : "";
+            final var isNullOnEmpty = isNullOnEmpty() ? "nOE" : "";
             return getShorthand() + "(" + getAlias() + ")" + isNullOnEmpty + " -> {" +
                     getCorrelatedTo().stream().map(CorrelationIdentifier::toString).collect(Collectors.joining(", ")) +
                     "}";

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifiers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifiers.java
@@ -224,7 +224,7 @@ public class Quantifiers {
                                                  @Nonnull final MatchPredicate<Quantifier> matchPredicate) {
         // quantifiers must be equal on kind
         final MatchPredicate<Quantifier> quantifierMatchPredicate =
-                (quantifier, otherQuantifier, eM) -> quantifier.equalsOnKind(otherQuantifier);
+                (quantifier, otherQuantifier, eM) -> quantifier.semanticEqualsWithoutChildren(otherQuantifier);
         return predicatedMatcher(
                 boundAliasesMap,
                 quantifiers,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/PlannerGraph.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/PlannerGraph.java
@@ -87,7 +87,7 @@ public class PlannerGraph extends AbstractPlannerGraph<PlannerGraph.Node, Planne
             if (quantifier instanceof Quantifier.Existential) {
                 edge = new ExistentialQuantifierEdge(label, dependsOn);
             } else if (quantifier instanceof Quantifier.ForEach) {
-                edge = new ForEachQuantifierEdge(label, dependsOn);
+                edge = new ForEachQuantifierEdge(label, ((Quantifier.ForEach)quantifier).isNullOnEmpty(), dependsOn);
             } else if (quantifier instanceof Quantifier.Physical) {
                 edge = new PhysicalQuantifierEdge(label, dependsOn);
             } else {
@@ -808,7 +808,11 @@ public class PlannerGraph extends AbstractPlannerGraph<PlannerGraph.Node, Planne
         }
 
         public ForEachQuantifierEdge(@Nullable final String label, final Set<? extends AbstractEdge> dependsOn) {
-            super(label, dependsOn);
+            this(label, false, dependsOn);
+        }
+
+        public ForEachQuantifierEdge(@Nullable final String label, boolean isNullIfEmpty, final Set<? extends AbstractEdge> dependsOn) {
+            super(isNullIfEmpty ? label + "||∅" : label, dependsOn);
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/PlannerGraph.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/PlannerGraph.java
@@ -799,12 +799,15 @@ public class PlannerGraph extends AbstractPlannerGraph<PlannerGraph.Node, Planne
      * Edge class for for-each quantifiers.
      */
     public static class ForEachQuantifierEdge extends ReferenceEdge {
+
+        private final boolean isNullIsEmpty;
+
         public ForEachQuantifierEdge() {
             this(null, ImmutableSet.of());
         }
 
         public ForEachQuantifierEdge(final Set<? extends AbstractEdge> dependsOn) {
-            super(null, dependsOn);
+            this(null, dependsOn);
         }
 
         public ForEachQuantifierEdge(@Nullable final String label, final Set<? extends AbstractEdge> dependsOn) {
@@ -812,7 +815,14 @@ public class PlannerGraph extends AbstractPlannerGraph<PlannerGraph.Node, Planne
         }
 
         public ForEachQuantifierEdge(@Nullable final String label, boolean isNullIfEmpty, final Set<? extends AbstractEdge> dependsOn) {
-            super(isNullIfEmpty ? label + "||∅" : label, dependsOn);
+            super(label, dependsOn);
+            this.isNullIsEmpty = isNullIfEmpty;
+        }
+
+        @Nonnull
+        @Override
+        public String getColor() {
+            return isNullIsEmpty ? "khaki3" : super.getColor();
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
@@ -777,7 +777,7 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
                 .anyMatch(quantifier -> {
                     final Quantifier otherQuantifier =
                             Objects.requireNonNull(otherAliasToQuantifierMap.get(aliasMap.getTarget(quantifier.getAlias())));
-                    return !quantifier.equalsOnKind(otherQuantifier);
+                    return !quantifier.semanticEqualsWithoutChildren(otherQuantifier);
                 });
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/QuantifierMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/QuantifierMatchers.java
@@ -119,7 +119,7 @@ public class QuantifierMatchers {
     @Nonnull
     public static BindingMatcher<Quantifier.ForEach> forEachQuantifierWithDefaultOnEmpty() {
         return typedWithDownstream(Quantifier.ForEach.class,
-                Extractor.of(Quantifier.ForEach::hasDefaultOnEmpty, name -> "withDefaultOnEmpty(" + name + ")"),
+                Extractor.of(Quantifier.ForEach::isNullOnEmpty, name -> "withDefaultOnEmpty(" + name + ")"),
                 PrimitiveMatchers.equalsObject(true));
     }
 
@@ -129,13 +129,13 @@ public class QuantifierMatchers {
     }
 
     @Nonnull
-    public static BindingMatcher<Quantifier.ForEach> forEachQuantifierWithDefaultOnEmptyOverRef(@Nonnull final BindingMatcher<? extends RelationalExpression> downstream) {
+    public static BindingMatcher<Quantifier.ForEach> forEachQuantifierWithDefaultOnEmptyOverRef(@Nonnull final BindingMatcher<? extends Reference> downstream) {
         return typedWithDownstream(Quantifier.ForEach.class,
                 Extractor.identity(),
                 AllOfMatcher.matchingAllOf(Quantifier.ForEach.class,
                         ImmutableList.of(
                                 typedWithDownstream(Quantifier.ForEach.class,
-                                        Extractor.of(Quantifier.ForEach::hasDefaultOnEmpty, name -> "withDefaultOnEmpty(" + name + ")"),
+                                        Extractor.of(Quantifier.ForEach::isNullOnEmpty, name -> "withDefaultOnEmpty(" + name + ")"),
                                         PrimitiveMatchers.equalsObject(true)),
                                 typedWithDownstream(Quantifier.ForEach.class,
                                         Extractor.of(Quantifier::getRangesOver, name -> "rangesOver(" + name + ")"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/QuantifierMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/QuantifierMatchers.java
@@ -49,14 +49,14 @@ public class QuantifierMatchers {
 
     public static <Q extends Quantifier> BindingMatcher<Q> ofTypeRangingOver(@Nonnull final Class<Q> bindableClass,
                                                                              @Nonnull final BindingMatcher<? extends Collection<? extends RelationalExpression>> downstream) {
-        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(bindableClass,
+        return typedWithDownstream(bindableClass,
                 Extractor.of(q -> q.getRangesOver().getMembers(), name -> "rangesOver(getMembers(" + name + "))"),
                 downstream);
     }
 
     public static <Q extends Quantifier> BindingMatcher<Q> ofTypeRangingOverRef(@Nonnull final Class<Q> bindableClass,
                                                                                 @Nonnull final BindingMatcher<? extends Reference> downstream) {
-        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(bindableClass,
+        return typedWithDownstream(bindableClass,
                 Extractor.of(Quantifier::getRangesOver, name -> "rangesOver(" + name + ")"),
                 downstream);
     }
@@ -118,7 +118,7 @@ public class QuantifierMatchers {
 
     @Nonnull
     public static BindingMatcher<Quantifier.ForEach> forEachQuantifierWithDefaultOnEmpty() {
-        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(Quantifier.ForEach.class,
+        return typedWithDownstream(Quantifier.ForEach.class,
                 Extractor.of(Quantifier.ForEach::hasDefaultOnEmpty, name -> "withDefaultOnEmpty(" + name + ")"),
                 PrimitiveMatchers.equalsObject(true));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/QuantifierMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/QuantifierMatchers.java
@@ -25,12 +25,14 @@ import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.members;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.TypedMatcher.typed;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.TypedMatcherWithExtractAndDownstream.typedWithDownstream;
 
 /**
  * Matchers for {@link Quantifier}s.
@@ -115,8 +117,29 @@ public class QuantifierMatchers {
     }
 
     @Nonnull
+    public static BindingMatcher<Quantifier.ForEach> forEachQuantifierWithDefaultOnEmpty() {
+        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(Quantifier.ForEach.class,
+                Extractor.of(Quantifier.ForEach::hasDefaultOnEmpty, name -> "withDefaultOnEmpty(" + name + ")"),
+                PrimitiveMatchers.equalsObject(true));
+    }
+
+    @Nonnull
     public static BindingMatcher<Quantifier.ForEach> forEachQuantifierOverRef(@Nonnull final BindingMatcher<? extends Reference> downstream) {
         return ofTypeRangingOverRef(Quantifier.ForEach.class, downstream);
+    }
+
+    @Nonnull
+    public static BindingMatcher<Quantifier.ForEach> forEachQuantifierWithDefaultOnEmptyOverRef(@Nonnull final BindingMatcher<? extends RelationalExpression> downstream) {
+        return typedWithDownstream(Quantifier.ForEach.class,
+                Extractor.identity(),
+                AllOfMatcher.matchingAllOf(Quantifier.ForEach.class,
+                        ImmutableList.of(
+                                typedWithDownstream(Quantifier.ForEach.class,
+                                        Extractor.of(Quantifier.ForEach::hasDefaultOnEmpty, name -> "withDefaultOnEmpty(" + name + ")"),
+                                        PrimitiveMatchers.equalsObject(true)),
+                                typedWithDownstream(Quantifier.ForEach.class,
+                                        Extractor.of(Quantifier::getRangesOver, name -> "rangesOver(" + name + ")"),
+                                        downstream))));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
@@ -56,6 +56,7 @@ import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
@@ -301,6 +302,13 @@ public class CardinalitiesProperty implements ExpressionProperty<CardinalitiesPr
     @Override
     public Cardinalities visitRecordQueryFirstOrDefaultPlan(@Nonnull final RecordQueryFirstOrDefaultPlan element) {
         return new Cardinalities(Cardinality.ofCardinality(1L), Cardinality.ofCardinality(1L));
+    }
+
+    @Nonnull
+    @Override
+    public Cardinalities visitRecordQueryDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan defaultOnEmptyPlan) {
+        final var cardinalitiesFromChild = fromChild(defaultOnEmptyPlan);
+        return new Cardinalities(Cardinality.ofCardinality(1), cardinalitiesFromChild.maxCardinality);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
@@ -43,6 +43,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
@@ -366,6 +367,24 @@ public class DerivationsProperty implements PlanProperty<DerivationsProperty.Der
             final var childDerivations = derivationsFromSingleChild(firstOrDefaultPlan);
             final var childResultValues = childDerivations.getResultValues();
             final var onEmptyResultValue = firstOrDefaultPlan.getOnEmptyResultValue();
+            final var localValuesBuilder = ImmutableList.<Value>builder();
+            localValuesBuilder.addAll(childDerivations.getLocalValues());
+            for (final var childResultValue : childResultValues) {
+                final var resultsTranslationMap = TranslationMap.builder()
+                        .when(rangesOver.getAlias()).then(((sourceAlias, leafValue) -> childResultValue))
+                        .build();
+                localValuesBuilder.add(onEmptyResultValue.translateCorrelationsAndSimplify(resultsTranslationMap));
+            }
+            return new Derivations(childDerivations.getResultValues(), localValuesBuilder.build());
+        }
+
+        @Nonnull
+        @Override
+        public Derivations visitDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan defaultOnEmptyPlan) {
+            final Quantifier rangesOver = Iterables.getOnlyElement(defaultOnEmptyPlan.getQuantifiers());
+            final var childDerivations = derivationsFromSingleChild(defaultOnEmptyPlan);
+            final var childResultValues = childDerivations.getResultValues();
+            final var onEmptyResultValue = defaultOnEmptyPlan.getOnEmptyResultValue();
             final var localValuesBuilder = ImmutableList.<Value>builder();
             localValuesBuilder.addAll(childDerivations.getLocalValues());
             for (final var childResultValue : childResultValues) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObject
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
@@ -233,6 +234,12 @@ public class DistinctRecordsProperty implements PlanProperty<Boolean> {
         @Override
         public Boolean visitFirstOrDefaultPlan(@Nonnull final RecordQueryFirstOrDefaultPlan element) {
             return true;
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan element) {
+            return distinctRecordsFromSingleChild(element);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
@@ -43,6 +43,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
@@ -321,6 +322,12 @@ public class OrderingProperty implements PlanProperty<Ordering> {
             // TODO This plan is sorted by anything it's flowing as its max cardinality is one.
             //      We cannot express that as of yet.
             return Ordering.empty();
+        }
+
+        @Nonnull
+        @Override
+        public Ordering visitDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan element) {
+            return orderingFromSingleChild(element);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
@@ -234,7 +234,7 @@ public class PrimaryKeyProperty implements PlanProperty<Optional<List<Value>>> {
         @Nonnull
         @Override
         public Optional<List<Value>> visitDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan defaultOnEmptyPlan) {
-            return primaryKeyFromSingleChild(defaultOnEmptyPlan);
+            return Optional.empty();
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
@@ -228,6 +229,12 @@ public class PrimaryKeyProperty implements PlanProperty<Optional<List<Value>>> {
         @Override
         public Optional<List<Value>> visitFirstOrDefaultPlan(@Nonnull final RecordQueryFirstOrDefaultPlan firstOrDefaultPlan) {
             return primaryKeyFromSingleChild(firstOrDefaultPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Optional<List<Value>> visitDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan defaultOnEmptyPlan) {
+            return primaryKeyFromSingleChild(defaultOnEmptyPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryAggregateIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryComparatorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryDeletePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryExplodePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
@@ -215,6 +216,12 @@ public class StoredRecordProperty implements PlanProperty<Boolean> {
         @Override
         public Boolean visitFirstOrDefaultPlan(@Nonnull final RecordQueryFirstOrDefaultPlan element) {
             return false;
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan element) {
+            return storedRecordsFromSingleChild(element);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
@@ -221,7 +221,7 @@ public class StoredRecordProperty implements PlanProperty<Boolean> {
         @Nonnull
         @Override
         public Boolean visitDefaultOnEmptyPlan(@Nonnull final RecordQueryDefaultOnEmptyPlan element) {
-            return storedRecordsFromSingleChild(element);
+            return false;
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
@@ -161,12 +161,11 @@ public class ImplementNestedLoopJoinRule extends CascadesRule<SelectExpression> 
             outerRef = call.memoizePlans(
                     new RecordQueryFirstOrDefaultPlan(Quantifier.physicalBuilder().withAlias(outerAlias).build(outerRef),
                             new NullValue(outerQuantifier.getFlowedObjectType())));
-        }  else if (outerQuantifier instanceof Quantifier.ForEach && ((Quantifier.ForEach)outerQuantifier).hasDefaultOnEmpty()) {
-            final var forEachQuantifier = ((Quantifier.ForEach)outerQuantifier);
+        }  else if (outerQuantifier instanceof Quantifier.ForEach && ((Quantifier.ForEach)outerQuantifier).isNullOnEmpty()) {
             outerRef = call.memoizePlans(
                     new RecordQueryDefaultOnEmptyPlan(
                             Quantifier.physicalBuilder().withAlias(outerAlias).build(outerRef),
-                            forEachQuantifier.getDefaultOnEmpty()));
+                            new NullValue(outerQuantifier.getFlowedObjectType())));
         }
 
         if (!outerPredicates.isEmpty()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpre
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFirstOrDefaultPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFlatMapPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
@@ -160,6 +161,12 @@ public class ImplementNestedLoopJoinRule extends CascadesRule<SelectExpression> 
             outerRef = call.memoizePlans(
                     new RecordQueryFirstOrDefaultPlan(Quantifier.physicalBuilder().withAlias(outerAlias).build(outerRef),
                             new NullValue(outerQuantifier.getFlowedObjectType())));
+        }  else if (outerQuantifier instanceof Quantifier.ForEach && ((Quantifier.ForEach)outerQuantifier).hasDefaultOnEmpty()) {
+            final var forEachQuantifier = ((Quantifier.ForEach)outerQuantifier);
+            outerRef = call.memoizePlans(
+                    new RecordQueryDefaultOnEmptyPlan(
+                            Quantifier.physicalBuilder().withAlias(outerAlias).build(outerRef),
+                            forEachQuantifier.getDefaultOnEmpty()));
         }
 
         if (!outerPredicates.isEmpty()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementSimpleSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementSimpleSelectRule.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Bind
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFirstOrDefaultPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryMapPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
@@ -107,6 +108,14 @@ public class ImplementSimpleSelectRule extends CascadesRule<SelectExpression> {
                                     .withAlias(quantifier.getAlias())
                                     .build(referenceBuilder.reference()),
                             new NullValue(quantifier.getFlowedObjectType())));
+        } else if (quantifier instanceof Quantifier.ForEach && ((Quantifier.ForEach)quantifier).hasDefaultOnEmpty()) {
+            final var defaultValue = ((Quantifier.ForEach)quantifier).getDefaultOnEmpty();
+            referenceBuilder = call.memoizePlansBuilder(
+                    new RecordQueryDefaultOnEmptyPlan(
+                            Quantifier.physicalBuilder()
+                                    .withAlias(quantifier.getAlias())
+                                    .build(referenceBuilder.reference()),
+                            defaultValue));
         }
 
         final var nonTautologyPredicates =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementSimpleSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementSimpleSelectRule.java
@@ -108,14 +108,13 @@ public class ImplementSimpleSelectRule extends CascadesRule<SelectExpression> {
                                     .withAlias(quantifier.getAlias())
                                     .build(referenceBuilder.reference()),
                             new NullValue(quantifier.getFlowedObjectType())));
-        } else if (quantifier instanceof Quantifier.ForEach && ((Quantifier.ForEach)quantifier).hasDefaultOnEmpty()) {
-            final var defaultValue = ((Quantifier.ForEach)quantifier).getDefaultOnEmpty();
+        } else if (quantifier instanceof Quantifier.ForEach && ((Quantifier.ForEach)quantifier).isNullOnEmpty()) {
             referenceBuilder = call.memoizePlansBuilder(
                     new RecordQueryDefaultOnEmptyPlan(
                             Quantifier.physicalBuilder()
                                     .withAlias(quantifier.getAlias())
                                     .build(referenceBuilder.reference()),
-                            defaultValue));
+                            new NullValue(quantifier.getFlowedObjectType())));
         }
 
         final var nonTautologyPredicates =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
@@ -31,8 +31,11 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Bind
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
+
+import java.util.LinkedHashSet;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierWithDefaultOnEmptyOverRef;
@@ -116,6 +119,13 @@ public class PullUpNullOnEmptyRule extends CascadesRule<SelectExpression> {
         if (selectExpression.getQuantifiers().size() > 1) {
             return true;
         }
-        return !Iterables.getOnlyElement(selectExpression.getQuantifiers()).getAlias().equals(quantifier.getAlias());
+        if (!Iterables.getOnlyElement(selectExpression.getQuantifiers()).getAlias().equals(quantifier.getAlias())) {
+            return true;
+        }
+
+        // if all predicates are not the same, bail out, otherwise, we can pull up.
+        final var predicates = selectOnTopExpression.getPredicates();
+        final var otherPredicates = selectExpression.getPredicates();
+        return !predicates.equals(otherPredicates);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
@@ -1,0 +1,181 @@
+/*
+ * PullUpNullOnEmptyRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
+import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+
+import javax.annotation.Nonnull;
+
+import java.util.Optional;
+
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierWithDefaultOnEmptyOverRef;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.anyRef;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.selectExpression;
+
+/**
+ * A rewrite rule that splits a {@link SelectExpression} expression that quantifies over a child with a {@link Quantifier}
+ * that has {@code null-on-empty} semantics to two parts:
+ * <ol>
+ *     <li> a lower {@link SelectExpression} expression that quantifies over the child with a normal {@link Quantifier}, i.e. one
+ *     without {@code null-on-empty} semantics.
+ *     <li> an upper {@link SelectExpression} expression that quantifies over the lower the {@link SelectExpression} with a
+ *     {@code Quantifier} that has null-on-empty semantics, and the same set of predicates as of the lower {@link SelectExpression}.
+ * </ol>
+ * The purpose of this rewrite rule is to create an alternative that has a better chance of matching an index (since the lower
+ * {@link SelectExpression} has a normal {@link Quantifier}), the purpose of the upper {@link SelectExpression} is to reapply
+ * the predicates on top of its {@link Quantifier} with {@code null-on-empty} giving them a chance of acting on any {@code null}s
+ * produced by this quantifier, which guarantees semantic equivalency.
+ */
+public class PullUpNullOnEmptyRule extends CascadesRule<SelectExpression> {
+
+    @Nonnull
+    private static final BindingMatcher<Quantifier.ForEach> defaultOnEmptyQuantifier = forEachQuantifierWithDefaultOnEmptyOverRef(anyRef());
+
+    @Nonnull
+    private static final BindingMatcher<SelectExpression> root = selectExpression(defaultOnEmptyQuantifier);
+
+    public PullUpNullOnEmptyRule() {
+        super(root);
+    }
+
+    @Override
+    public void onMatch(@Nonnull final CascadesRuleCall call) {
+        final var bindings = call.getBindings();
+        final var selectExpression = bindings.get(root);
+        final var quantifier = bindings.get(defaultOnEmptyQuantifier);
+        final var childExpressions = quantifier.getRangesOver().getMembers().stream()
+                .filter(expression -> isPermittedToPullFrom(selectExpression, quantifier, expression))
+                .collect(ImmutableList.toImmutableList());
+        if (childExpressions.isEmpty()) {
+            // it is impossible to pullUp the expression, or it might introduce infinite recursion, bailout.
+            return;
+        }
+
+        final Quantifier.ForEach newChildrenQuantifier;
+        if (childExpressions.size() < quantifier.getRangesOver().getMembers().size()) {
+            newChildrenQuantifier = Quantifier.forEach(Reference.from(childExpressions));
+        } else {
+            newChildrenQuantifier = Quantifier.forEachBuilder().withAlias(quantifier.getAlias()).build(quantifier.getRangesOver());
+        }
+        call.memoizeReference(newChildrenQuantifier.getRangesOver());
+
+        // Create the lower select expression.
+        final var newSelectExpression = call.memoizeExpression(GraphExpansion.builder()
+                .addQuantifier(newChildrenQuantifier)
+                .addAllPredicates(selectExpression.getPredicates())
+                .build().buildSimpleSelectOverQuantifier(newChildrenQuantifier));
+
+        // Create the upper select expression.
+        final var topLevelSelectQuantifier = Quantifier.forEachBuilder().from(quantifier).build(newSelectExpression);
+        final var topLevelSelectExpression = GraphExpansion.builder()
+                .addQuantifier(topLevelSelectQuantifier)
+                .build().buildSelectWithResultValue(selectExpression.getResultValue());
+
+        call.yieldExpression(topLevelSelectExpression);
+    }
+
+    @SuppressWarnings({"UnstableApiUsage", "PMD.CompareObjectsWithEquals"})
+    public boolean isPermittedToPullFrom(@Nonnull final SelectExpression selectOnTop,
+                                         @Nonnull final Quantifier.ForEach quantifier,
+                                         @Nonnull final RelationalExpression expression) {
+        if (expression instanceof RecordQueryPlan) {
+            return false;
+        }
+        if (!(expression instanceof SelectExpression)) {
+            return true;
+        }
+        final var selectExpression = (SelectExpression)expression;
+        if (selectExpression.getPredicates().isEmpty() && selectOnTop.getPredicates().isEmpty()) {
+            return false;
+        }
+
+        final var joinPredicatesCount = countJoinPredicates(selectExpression);
+        if (joinPredicatesCount > 0) {
+            return false;
+        }
+
+        final var aliasMapMaybe = createAliasMapMaybe(selectOnTop, quantifier, selectExpression);
+        if (aliasMapMaybe.isEmpty()) {
+            return false;
+        }
+
+        final var predicates = selectOnTop.getPredicates();
+        final var otherPredicates = selectExpression.getPredicates();
+        // if all predicates are not the same, bail out, otherwise, we can pull up.
+        return predicates.size() != otherPredicates.size() ||
+                Streams.zip(predicates.stream(),
+                                otherPredicates.stream(),
+                                (queryPredicate, otherQueryPredicate) -> queryPredicate.semanticEquals(otherQueryPredicate, aliasMapMaybe.get()))
+                        .anyMatch(isSame -> !isSame);
+    }
+
+    private static long countJoinPredicates(@Nonnull final SelectExpression selectExpression) {
+        final var quantifierAliases = selectExpression.getAliasToQuantifierMap().keySet();
+        return selectExpression.getPredicates()
+                .stream()
+                .filter(predicate -> Sets.intersection(predicate.getCorrelatedTo(), quantifierAliases).size() > 1).count();
+    }
+
+    @Nonnull
+    private static Optional<AliasMap> createAliasMapMaybe(@Nonnull final SelectExpression topLevelSelectExpression,
+                                                          @Nonnull final Quantifier.ForEach quantifierWithNullOnEmpty,
+                                                          @Nonnull final SelectExpression selectExpression) {
+        final var resultBuilder = AliasMap.builder();
+
+        final var topLevelQuantifiers = topLevelSelectExpression.getAliasToQuantifierMap().keySet();
+        final var topLevelConstantCorrelations = Sets.difference(topLevelSelectExpression.getCorrelatedTo(), topLevelQuantifiers);
+
+        final var selectQuantifiers = selectExpression.getAliasToQuantifierMap().keySet();
+        final var selectConstantCorrelations = Sets.difference(selectExpression.getCorrelatedTo(), selectQuantifiers);
+
+        if (topLevelConstantCorrelations.equals(selectConstantCorrelations)) {
+            return Optional.empty();
+        }
+        resultBuilder.identitiesFor(topLevelConstantCorrelations);
+
+        final var predicateCorrelation = selectExpression.getPredicates().stream()
+                .flatMap(predicate -> Sets.difference(predicate.getCorrelatedTo(), selectConstantCorrelations).stream())
+                .distinct().collect(ImmutableSet.toImmutableSet());
+
+        if (predicateCorrelation.size() > 1) {
+            return Optional.empty();
+        }
+
+        if (!predicateCorrelation.isEmpty()) {
+            resultBuilder.put(predicateCorrelation.stream().findFirst().get(), quantifierWithNullOnEmpty.getAlias());
+        }
+
+        return Optional.of(resultBuilder.build());
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
@@ -31,11 +31,8 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Bind
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
-
-import java.util.LinkedHashSet;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierWithDefaultOnEmptyOverRef;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectDataAccessRule.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
-import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.MatchPartition;
@@ -107,9 +106,10 @@ public class SelectDataAccessRule extends AbstractDataAccessRule<SelectExpressio
                             if (!compensatedAliases.containsAll(aliases)) {
                                 return Stream.empty();
                             }
-                            final Set<CorrelationIdentifier> matchedForEachAliases =
+                            final Set<Quantifier.ForEach> matchedForEachAliases =
                                     compensatedAliases.stream()
                                             .filter(matchedAlias -> Objects.requireNonNull(aliasToQuantifierMap.get(matchedAlias)) instanceof Quantifier.ForEach)
+                                            .map(matchedAlias -> (Quantifier.ForEach)aliasToQuantifierMap.get(matchedAlias))
                                             .collect(ImmutableSet.toImmutableSet());
                             if (matchedForEachAliases.size() == 1) {
                                 return Stream.of(NonnullPair.of(Iterables.getOnlyElement(matchedForEachAliases), match));
@@ -123,7 +123,7 @@ public class SelectDataAccessRule extends AbstractDataAccessRule<SelectExpressio
 
         // loop through all compensated alias sets and their associated match partitions
         for (final var matchPartitionByMatchAliasEntry : matchPartitionByMatchAliasMap.entrySet()) {
-            final var matchedAlias = matchPartitionByMatchAliasEntry.getKey();
+            final var matchedQuantifier = matchPartitionByMatchAliasEntry.getKey();
             final var matchPartitionForMatchedAlias = matchPartitionByMatchAliasEntry.getValue();
 
             //
@@ -131,7 +131,7 @@ public class SelectDataAccessRule extends AbstractDataAccessRule<SelectExpressio
             //
             final var pushedRequestedOrderings =
                     requestedOrderings.stream()
-                            .map(requestedOrdering -> requestedOrdering.pushDown(expression.getResultValue(), matchedAlias, AliasMap.emptyMap(), correlatedTo))
+                            .map(requestedOrdering -> requestedOrdering.pushDown(expression.getResultValue(), matchedQuantifier.getAlias(), AliasMap.emptyMap(), correlatedTo))
                             .collect(ImmutableSet.toImmutableSet());
 
             //
@@ -173,8 +173,7 @@ public class SelectDataAccessRule extends AbstractDataAccessRule<SelectExpressio
                     continue;
                 }
 
-                final var dataAccessQuantifier = Quantifier.forEachBuilder()
-                        .withAlias(matchedAlias)
+                final var dataAccessQuantifier = Quantifier.ForEach.forEachBuilder().from(matchedQuantifier)
                         .build(call.memoizeReference(Reference.from(dataAccessExpressions)));
                 
                 final var compensatedDataAccessExpression =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
@@ -1,0 +1,261 @@
+/*
+ * RecordQueryDefaultOnEmptyPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanDeserializer;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.planprotos.PRecordQueryDefaultOnEmptyPlan;
+import com.apple.foundationdb.record.planprotos.PRecordQueryPlan;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.PlanStringRepresentation;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.Memoizer;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
+import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
+import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpressionWithChildren;
+import com.apple.foundationdb.record.query.plan.cascades.values.DerivedValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.google.auto.service.AutoService;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A query plan that only flows all the records it processes from its inner. If the inner is empty, i.e. does not
+ * produce any records, a default value that is passed into the constructor is returned in place of the first record.
+ */
+@API(API.Status.INTERNAL)
+public class RecordQueryDefaultOnEmptyPlan implements RecordQueryPlanWithChild, RelationalExpressionWithChildren {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Record-Query-Default-On-Empty-Plan");
+
+    @Nonnull
+    private final Quantifier.Physical inner;
+    @Nonnull
+    private final Value onEmptyResultValue;
+    @Nonnull
+    private final Value resultValue;
+
+    public RecordQueryDefaultOnEmptyPlan(@Nonnull Quantifier.Physical inner,
+                                         @Nonnull Value onEmptyResultValue) {
+        Verify.verify(inner.getFlowedObjectType().nullable().equals(onEmptyResultValue.getResultType().nullable()));
+        this.inner = inner;
+        this.onEmptyResultValue = onEmptyResultValue;
+        this.resultValue = new DerivedValue(ImmutableList.of(inner.getFlowedObjectValue(), onEmptyResultValue), inner.getFlowedObjectType());
+    }
+
+    @Nonnull
+    public Value getOnEmptyResultValue() {
+        return onEmptyResultValue;
+    }
+
+    @Nonnull
+    @Override
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
+        return RecordCursor.orElse(cont -> getChild().executePlan(store, context, cont, executeProperties),
+                (executor, cont) -> RecordCursor.fromList(ImmutableList.of(QueryResult.ofComputed(onEmptyResultValue.eval(store, context)))),
+                continuation);
+    }
+
+    @Override
+    public RecordQueryPlan getChild() {
+        return inner.getRangesOverPlan();
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final Reference childRef) {
+        return new RecordQueryDefaultOnEmptyPlan(Quantifier.physical(childRef, inner.getAlias()), onEmptyResultValue);
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> getCorrelatedToWithoutChildren() {
+        return onEmptyResultValue.getCorrelatedTo();
+    }
+
+    @Nonnull
+    @Override
+    public RelationalExpression translateCorrelations(@Nonnull final TranslationMap translationMap, @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
+        Verify.verify(translatedQuantifiers.size() == 1);
+        final Value rebasedResultValues = onEmptyResultValue.translateCorrelations(translationMap);
+        return new RecordQueryDefaultOnEmptyPlan(Iterables.getOnlyElement(translatedQuantifiers).narrow(Quantifier.Physical.class), rebasedResultValues);
+    }
+
+    @Override
+    public boolean isReverse() {
+        return getChild().isReverse();
+    }
+
+    @Override
+    public boolean isStrictlySorted() {
+        return false;
+    }
+
+    @Override
+    public RecordQueryDefaultOnEmptyPlan strictlySorted(@Nonnull Memoizer memoizer) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Value getResultValue() {
+        return resultValue;
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return PlanStringRepresentation.toString(this);
+    }
+
+    @Override
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public boolean equalsWithoutChildren(@Nonnull final RelationalExpression otherExpression,
+                                         @Nonnull final AliasMap aliasMap) {
+        if (this == otherExpression) {
+            return true;
+        }
+        if (getClass() != otherExpression.getClass()) {
+            return false;
+        }
+        return semanticEqualsForResults(otherExpression, aliasMap);
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(final Object other) {
+        return structuralEquals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return structuralHashCode();
+    }
+
+    @Override
+    public int hashCodeWithoutChildren() {
+        return Objects.hash(getResultValue());
+    }
+
+    @Override
+    public void logPlanStructure(StoreTimer timer) {
+        // nothing to increment
+    }
+
+    @Override
+    public int getComplexity() {
+        return getChild().getComplexity();
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode mode) {
+        switch (mode.getKind()) {
+            case LEGACY:
+            case FOR_CONTINUATION:
+                return PlanHashable.objectsPlanHash(mode, BASE_HASH, getChild(), getResultValue());
+            default:
+                throw new UnsupportedOperationException("Hash kind " + mode.name() + " is not supported");
+        }
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(inner);
+    }
+
+    @Nonnull
+    @Override
+    public PlannerGraph rewritePlannerGraph(@Nonnull final List<? extends PlannerGraph> childGraphs) {
+        return PlannerGraph.fromNodeAndChildGraphs(
+                new PlannerGraph.OperatorNodeWithInfo(this,
+                        NodeInfo.VALUE_COMPUTATION_OPERATOR,
+                        ImmutableList.of("{{inner}} OR {{expr}}"),
+                        ImmutableMap.of("inner", Attribute.gml("$" + inner.getAlias()),
+                                "expr", Attribute.gml(onEmptyResultValue.toString()))),
+                childGraphs);
+    }
+
+    @Nonnull
+    @Override
+    public PRecordQueryDefaultOnEmptyPlan toProto(@Nonnull final PlanSerializationContext serializationContext) {
+        return PRecordQueryDefaultOnEmptyPlan.newBuilder()
+                .setInner(inner.toProto(serializationContext))
+                .setOnEmptyResultValue(onEmptyResultValue.toValueProto(serializationContext))
+                .build();
+    }
+
+    @Nonnull
+    @Override
+    public PRecordQueryPlan toRecordQueryPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+        return PRecordQueryPlan.newBuilder().setDefaultOnEmptyPlan(toProto(serializationContext)).build();
+    }
+
+    @Nonnull
+    public static RecordQueryDefaultOnEmptyPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                          @Nonnull final PRecordQueryDefaultOnEmptyPlan recordQueryDefaultOnEmptyPlanProto) {
+        return new RecordQueryDefaultOnEmptyPlan(Quantifier.Physical.fromProto(serializationContext, Objects.requireNonNull(recordQueryDefaultOnEmptyPlanProto.getInner())),
+                Value.fromValueProto(serializationContext, Objects.requireNonNull(recordQueryDefaultOnEmptyPlanProto.getOnEmptyResultValue())));
+    }
+
+    /**
+     * Deserializer.
+     */
+    @AutoService(PlanDeserializer.class)
+    public static class Deserializer implements PlanDeserializer<PRecordQueryDefaultOnEmptyPlan, RecordQueryDefaultOnEmptyPlan> {
+        @Nonnull
+        @Override
+        public Class<PRecordQueryDefaultOnEmptyPlan> getProtoMessageClass() {
+            return PRecordQueryDefaultOnEmptyPlan.class;
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryDefaultOnEmptyPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                       @Nonnull final PRecordQueryDefaultOnEmptyPlan recordQueryDefaultOnEmptyPlanProto) {
+            return RecordQueryDefaultOnEmptyPlan.fromProto(serializationContext, recordQueryDefaultOnEmptyPlanProto);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
@@ -130,7 +130,7 @@ public class RecordQueryDefaultOnEmptyPlan implements RecordQueryPlanWithChild, 
 
     @Override
     public boolean isStrictlySorted() {
-        return false;
+        return getChild().isStrictlySorted();
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1192,6 +1192,7 @@ message PRecordQueryPlan {
     PRecordQueryUnorderedPrimaryKeyDistinctPlan unordered_primary_key_distinct_plan = 30;
     PRecordQueryUnorderedUnionPlan unordered_union_plan = 31;
     PRecordQueryUpdatePlan update_plan = 32;
+    PRecordQueryDefaultOnEmptyPlan default_on_empty_plan = 33;
   }
 }
 
@@ -1332,6 +1333,14 @@ message PRecordQueryFilterPlanBase {
 // PRecordQueryFirstOrDefaultPlan
 //
 message PRecordQueryFirstOrDefaultPlan {
+  optional PPhysicalQuantifier inner = 1;
+  optional PValue on_empty_result_value = 2;
+}
+
+//
+// PRecordQueryDefaultOnEmptyPlan
+//
+message PRecordQueryDefaultOnEmptyPlan {
   optional PPhysicalQuantifier inner = 1;
   optional PValue on_empty_result_value = 2;
 }


### PR DESCRIPTION
Aggregate plans currently do not return the expected results as defined by SQL standard; as per SQL standard section 4.16.4 (Aggregate functions):
> If no row qualifies, then the result of COUNT is 0 (zero), and the result of any other aggregate function is the null value.

However, when the table is empty [*], no rows are returned, i.e.:

```sql
create table t1(col1 int);
select count(*) from t1; -- returns nothing, instead of 0
select sum(col1) from t1; -- returns nothing, instead of null
```

To fix this behaviour, we would like to expand the semantics of `ForEach` quantifiers and make them reactive of the emptiness of the underlying quantified expression, making them able to return `null` if the underlying expression is not returning any rows.

This fixes #2930 .
___
[*] an "empty" table is more nuanced; empty in the context of this fix means the table did have any mutations (yet), although a table could become empty again when all existing rows are truncated, the underlying aggregate index maintainers behave differently, and sometimes keep a certain aggregate value, even if no more elements remain in the group, this behaviour is controlled by the index option `CLEAR_WHEN_ZERO` and is outside the context of this fix.