### PR TITLE
resolved #2940: do not plan redundant/useless intersections

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Performance** avoid creating useless/redundant intersections when planning data access [(Issue #2940)](https://github.com/FoundationDB/fdb-record-layer/issues/2940)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
@@ -275,14 +275,16 @@ public class Ordering {
      * @return a set of {@link RequestedOrdering}s that can be pushed down the legs of the set operation
      */
     @Nonnull
-    public Set<RequestedOrdering> deriveRequestedOrderings(@Nonnull final RequestedOrdering requestedOrdering) {
+    public Set<RequestedOrdering> deriveRequestedOrderings(@Nonnull final RequestedOrdering requestedOrdering,
+                                                           final boolean isExhaustive) {
         if (requestedOrdering.isDistinct() && !isDistinct()) {
             return ImmutableSet.of();
         }
 
         final var satisfyingEnumeratedOrderings = enumerateCompatibleRequestedOrderings(requestedOrdering);
         return Streams.stream(satisfyingEnumeratedOrderings)
-                .map(keyParts -> RequestedOrdering.ofPrimitiveParts(keyParts, RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS))
+                .map(keyParts -> RequestedOrdering.ofPrimitiveParts(keyParts,
+                        RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS, isExhaustive))
                 .collect(ImmutableSet.toImmutableSet());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
@@ -905,7 +905,7 @@ public class Ordering {
             }
             for (final var rightElement : Sets.difference(rightElements, leftElements)) {
                 final var combinedBindings =
-                        mergeOperator.combineBindings(ImmutableSet.of(), leftBindingMap.get(rightElement));
+                        mergeOperator.combineBindings(ImmutableSet.of(), rightBindingMap.get(rightElement));
                 if (!combinedBindings.isEmpty()) {
                     elementsBuilder.add(rightElement);
                     bindingMapBuilder.putAll(rightElement, combinedBindings);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
@@ -91,7 +91,7 @@ public class PartialMatch {
     private final Supplier<Map<CorrelationIdentifier, ComparisonRange>> boundParameterPrefixMapSupplier;
 
     @Nonnull
-    private final Supplier<Set<QueryPredicate>> bindingPredicatesSupplier;
+    private final Supplier<Set<QueryPredicate>> boundPlaceholdersSupplier;
 
     @Nonnull
     private final Supplier<Set<Quantifier>> matchedQuantifiersSupplier;
@@ -115,7 +115,7 @@ public class PartialMatch {
         this.candidateRef = candidateRef;
         this.matchInfo = matchInfo;
         this.boundParameterPrefixMapSupplier = Suppliers.memoize(this::computeBoundParameterPrefixMap);
-        this.bindingPredicatesSupplier = Suppliers.memoize(this::computeBindingQueryPredicates);
+        this.boundPlaceholdersSupplier = Suppliers.memoize(this::computeBoundPlaceholders);
         this.matchedQuantifiersSupplier = Suppliers.memoize(this::computeMatchedQuantifiers);
         this.unmatchedQuantifiersSupplier = Suppliers.memoize(this::computeUnmatchedQuantifiers);
         this.compensatedAliasesSupplier = Suppliers.memoize(this::computeCompensatedAliases);
@@ -192,14 +192,14 @@ public class PartialMatch {
     }
 
     @Nonnull
-    public final Set<QueryPredicate> getBindingPredicates() {
-        return bindingPredicatesSupplier.get();
+    public final Set<QueryPredicate> getBoundPlaceholders() {
+        return boundPlaceholdersSupplier.get();
     }
 
     @Nonnull
-    private Set<QueryPredicate> computeBindingQueryPredicates() {
+    private Set<QueryPredicate> computeBoundPlaceholders() {
         final var boundParameterPrefixMap = getBoundParameterPrefixMap();
-        final var bindingQueryPredicates = Sets.<QueryPredicate>newIdentityHashSet();
+        final var boundPlaceholders = Sets.<QueryPredicate>newIdentityHashSet();
 
         //
         // Go through all accumulated parameter bindings -- find the query predicates binding the parameters. Those
@@ -221,11 +221,11 @@ public class PartialMatch {
 
             final var placeholder = (Placeholder)candidatePredicate;
             if (boundParameterPrefixMap.containsKey(placeholder.getParameterAlias())) {
-                bindingQueryPredicates.add(predicateMapping.getQueryPredicate());
+                boundPlaceholders.add(predicateMapping.getCandidatePredicate());
             }
         }
 
-        return bindingQueryPredicates;
+        return boundPlaceholders;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RequestedOrdering.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RequestedOrdering.java
@@ -66,15 +66,19 @@ public class RequestedOrdering {
      */
     @Nonnull
     private final List<RequestedOrderingPart> orderingParts;
-
+    @Nonnull
     private final Distinctness distinctness;
+    private final boolean isExhaustive;
 
     @Nonnull
     private final Supplier<Map<Value, RequestedSortOrder>> valueRequestedSortOrderMapSupplier;
 
-    private RequestedOrdering(@Nonnull final List<RequestedOrderingPart> orderingParts, final Distinctness distinctness) {
+    private RequestedOrdering(@Nonnull final List<RequestedOrderingPart> orderingParts,
+                              @Nonnull final Distinctness distinctness,
+                              @Nonnull final boolean isExhaustive) {
         this.orderingParts = ImmutableList.copyOf(orderingParts);
         this.distinctness = distinctness;
+        this.isExhaustive = isExhaustive;
         this.valueRequestedSortOrderMapSupplier = Suppliers.memoize(this::computeValueSortOrderMap);
     }
 
@@ -84,6 +88,10 @@ public class RequestedOrdering {
 
     public boolean isDistinct() {
         return distinctness == Distinctness.DISTINCT;
+    }
+
+    public boolean isExhaustive() {
+        return isExhaustive;
     }
 
     /**
@@ -198,7 +206,7 @@ public class RequestedOrdering {
             final var rebasedOrderingValue = orderingValue.rebase(translationMap);
             pushedDownOrderingPartsBuilder.add(new RequestedOrderingPart(rebasedOrderingValue, orderingPart.getSortOrder()));
         }
-        return new RequestedOrdering(pushedDownOrderingPartsBuilder.build(), Distinctness.PRESERVE_DISTINCTNESS);
+        return new RequestedOrdering(pushedDownOrderingPartsBuilder.build(), Distinctness.PRESERVE_DISTINCTNESS, isExhaustive());
     }
 
     @Nonnull
@@ -219,7 +227,15 @@ public class RequestedOrdering {
         if (this.distinctness == distinctness) {
             return this;
         }
-        return new RequestedOrdering(orderingParts, distinctness);
+        return new RequestedOrdering(getOrderingParts(), distinctness, isExhaustive());
+    }
+
+    @Nonnull
+    public RequestedOrdering exhaustive() {
+        if (this.isExhaustive()) {
+            return this;
+        }
+        return new RequestedOrdering(getOrderingParts(), getDistinctness(), true);
     }
 
     /**
@@ -228,12 +244,13 @@ public class RequestedOrdering {
      */
     @Nonnull
     public static RequestedOrdering preserve() {
-        return new RequestedOrdering(ImmutableList.of(), Distinctness.PRESERVE_DISTINCTNESS);
+        return new RequestedOrdering(ImmutableList.of(), Distinctness.PRESERVE_DISTINCTNESS, false);
     }
 
     @Nonnull
     public static RequestedOrdering ofParts(@Nonnull final List<RequestedOrderingPart> requestedOrderingParts,
                                             @Nonnull final Distinctness distinctness,
+                                            final boolean isExhaustive,
                                             @Nonnull final Set<CorrelationIdentifier> constantAliases) {
         final var primitiveRequestedOrderingParts = ImmutableList.<RequestedOrderingPart>builder();
         for (final var requestedOrderingPart : requestedOrderingParts) {
@@ -248,17 +265,18 @@ public class RequestedOrdering {
                 primitiveRequestedOrderingParts.add(simplifiedRequestedOrderingPart);
             }
         }
-        return ofPrimitiveParts(primitiveRequestedOrderingParts.build(), distinctness);
+        return ofPrimitiveParts(primitiveRequestedOrderingParts.build(), distinctness, isExhaustive);
     }
 
     @Nonnull
     public static RequestedOrdering ofPrimitiveParts(@Nonnull final List<RequestedOrderingPart> requestedOrderingParts,
-                                                     @Nonnull final Distinctness distinctness) {
+                                                     @Nonnull final Distinctness distinctness,
+                                                     final boolean isExhaustive) {
         Debugger.sanityCheck(() -> Verify.verify(
                 requestedOrderingParts.stream()
                         .allMatch(requestedOrderingPart -> requestedOrderingPart.getValue()
                                 .getResultType().isPrimitive())));
-        return new RequestedOrdering(requestedOrderingParts, distinctness);
+        return new RequestedOrdering(requestedOrderingParts, distinctness, isExhaustive);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RequestedOrdering.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RequestedOrdering.java
@@ -68,6 +68,11 @@ public class RequestedOrdering {
     private final List<RequestedOrderingPart> orderingParts;
     @Nonnull
     private final Distinctness distinctness;
+
+    /**
+     * Boolean to indicate that we are interested in all plans satisfying this requested ordering (if {@code true})
+     * or what would be considered the best plan per requirement.
+     */
     private final boolean isExhaustive;
 
     @Nonnull
@@ -75,7 +80,7 @@ public class RequestedOrdering {
 
     private RequestedOrdering(@Nonnull final List<RequestedOrderingPart> orderingParts,
                               @Nonnull final Distinctness distinctness,
-                              @Nonnull final boolean isExhaustive) {
+                              final boolean isExhaustive) {
         this.orderingParts = ImmutableList.copyOf(orderingParts);
         this.distinctness = distinctness;
         this.isExhaustive = isExhaustive;
@@ -90,6 +95,10 @@ public class RequestedOrdering {
         return distinctness == Distinctness.DISTINCT;
     }
 
+    /**
+     * Method to return if we are interested in all plans satisfying this requested ordering (iff {@code true})
+     * or what would just be preemptively considered the best plan per given requirement.
+     */
     public boolean isExhaustive() {
         return isExhaustive;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/GroupByExpression.java
@@ -328,6 +328,7 @@ public class GroupByExpression implements RelationalExpressionWithChildren, Inte
         return RequestedOrdering.ofParts(
                 ImmutableList.of(new RequestedOrderingPart(currentGroupingValue, RequestedSortOrder.ANY)),
                 RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS,
+                false,
                 inner.getCorrelatedTo());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalSortExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalSortExpression.java
@@ -74,7 +74,7 @@ public class LogicalSortExpression implements RelationalExpressionWithChildren, 
         final RequestedOrdering.Distinctness distinctness = RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS;
         final var requestedOrderingParts =
                 sortValues.stream().map(value -> new OrderingPart.RequestedOrderingPart(value, order)).collect(Collectors.toList());
-        return RequestedOrdering.ofParts(requestedOrderingParts, distinctness, inner.getCorrelatedTo());
+        return RequestedOrdering.ofParts(requestedOrderingParts, distinctness, false, inner.getCorrelatedTo());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
@@ -237,7 +237,8 @@ public class ImplementDistinctUnionRule extends CascadesRule<LogicalDistinctExpr
                                        @Nonnull final RequestedOrdering requestedOrdering) {
         final var unionRef = unionForEachQuantifier.getRangesOver();
         for (final var providedOrdering : providedOrderings) {
-            final var requestedOrderings = providedOrdering.deriveRequestedOrderings(requestedOrdering);
+            final var requestedOrderings =
+                    providedOrdering.deriveRequestedOrderings(requestedOrdering, false);
             call.pushConstraint(unionRef, RequestedOrderingConstraint.REQUESTED_ORDERING, requestedOrderings);
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughGroupByRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughGroupByRule.java
@@ -160,7 +160,7 @@ public class PushRequestedOrderingThroughGroupByRule extends CascadesRule<GroupB
                                     .map(value -> new RequestedOrderingPart(value, RequestedSortOrder.ANY))
                                     .forEach(resultOrderingPartsBuilder::add);
                             toBePushedRequestedOrderingsBuilder.add(RequestedOrdering.ofPrimitiveParts(resultOrderingPartsBuilder.build(),
-                                    pushedRequestedOrdering.getDistinctness()));
+                                    pushedRequestedOrdering.getDistinctness(), false));
                         }
                     }
                 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSortRule.java
@@ -82,7 +82,7 @@ public class PushRequestedOrderingThroughSortRule extends CascadesRule<LogicalSo
             }
 
             final var orderings =
-                    Set.of(RequestedOrdering.ofPrimitiveParts(translatedBuilder.build(), requestedOrdering.getDistinctness()));
+                    Set.of(RequestedOrdering.ofPrimitiveParts(translatedBuilder.build(), requestedOrdering.getDistinctness(), false));
 
             call.pushConstraint(lowerRef,
                     RequestedOrderingConstraint.REQUESTED_ORDERING,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/OrderingTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/OrderingTest.java
@@ -59,7 +59,7 @@ class OrderingTest {
         final var c = ValueTestHelpers.field(qov, "c");
 
         final var requestedOrdering =
-                RequestedOrdering.ofPrimitiveParts(requested(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT);
+                RequestedOrdering.ofPrimitiveParts(requested(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT, false);
 
         final var providedOrdering =
                 Ordering.ofOrderingSequence(
@@ -85,7 +85,7 @@ class OrderingTest {
         final var c = ValueTestHelpers.field(qov, "c");
 
         final var requestedOrdering =
-                RequestedOrdering.ofPrimitiveParts(requested(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT);
+                RequestedOrdering.ofPrimitiveParts(requested(a, b, c), RequestedOrdering.Distinctness.NOT_DISTINCT, false);
 
         final var providedOrdering =
                 Ordering.ofOrderingSequence(
@@ -421,7 +421,7 @@ class OrderingTest {
 
         final var requestedOrdering =
                 RequestedOrdering.ofPrimitiveParts(requested(a, b, c),
-                        RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS);
+                        RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS, false);
 
         final var satisfyingOrderingsIterable = mergedOrdering.enumerateCompatibleRequestedOrderings(requestedOrdering);
         final var onlySatisfyingOrdering =
@@ -458,7 +458,7 @@ class OrderingTest {
                 Ordering.merge(ImmutableList.of(one, two), Ordering.UNION, (left, right) -> false);
 
         var requestedOrdering = RequestedOrdering.ofPrimitiveParts(requested(a, b, c, x),
-                RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS);
+                RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS, false);
 
         final var satisfyingOrderingsIterable = mergedOrdering.enumerateCompatibleRequestedOrderings(requestedOrdering);
         final var onlySatisfyingOrdering =
@@ -495,7 +495,7 @@ class OrderingTest {
                 Ordering.merge(ImmutableList.of(one, two), Ordering.UNION, (left, right) -> false);
 
         final var requestedOrdering = RequestedOrdering.ofPrimitiveParts(requested(a, c, b, x),
-                RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS);
+                RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS, false);
 
         final var satisfyingOrderingsIterable = mergedOrdering.enumerateCompatibleRequestedOrderings(requestedOrdering);
         final var onlySatisfyingOrdering =
@@ -533,7 +533,7 @@ class OrderingTest {
 
         var requestedOrdering =
                 RequestedOrdering.ofPrimitiveParts(requested(a, b, x),
-                        RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS);
+                        RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS, false);
 
         assertFalse(mergedOrdering.satisfies(requestedOrdering));
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/OrderingValueSimplificationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/OrderingValueSimplificationTest.java
@@ -120,6 +120,7 @@ class OrderingValueSimplificationTest {
         final var requestedOrdering = RequestedOrdering.ofParts(
                 ImmutableList.of(new OrderingPart.RequestedOrderingPart(outerRecordConstructor, OrderingPart.RequestedSortOrder.ANY)),
                 RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS,
+                false,
                 ImmutableSet.of());
 
         final var simplifiedValues =
@@ -163,6 +164,7 @@ class OrderingValueSimplificationTest {
         final var requestedOrdering = RequestedOrdering.ofParts(
                 ImmutableList.of(new OrderingPart.RequestedOrderingPart(recordConstructor4, OrderingPart.RequestedSortOrder.ANY)),
                 RequestedOrdering.Distinctness.PRESERVE_DISTINCTNESS,
+                false,
                 ImmutableSet.of());
 
         final var simplifiedValues =


### PR DESCRIPTION
Do not plan intersections during data access that do not have a chance of contributing an improving factor:
1. Do not plan an intersection of n accesses if the intersection's equality-bound keys and ordering are the same as any intersection of (n-1) accesses, that is the smaller intersection has the same cardinality and order as the current intersection that is being planned.
2. Do not plan an intersection if there is some other intersection of a true superset of accesses that is not redundant as to point 1.
3. Do not plan an intersection if one of the accesses participating in the intersection has a max cardinality of `0` or `1`.