### PR TITLE
Fixes #2936: Missing subspace provider in FDBRecordStore logs

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -17,7 +17,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Missing subspace provider information added to `FDBRecordStore` logs [(Issue #2936)](https://github.com/FoundationDB/fdb-record-layer/issues/2936)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1985,8 +1985,10 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         private CompletableFuture<Void> run() {
             if (evaluated == null) {
                 // no record types
-                LOGGER.warn(KeyValueLogMessage.of("Tried to delete prefix with no record types",
-                        subspaceProvider.logKey(), subspaceProvider.toString(context)));
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(KeyValueLogMessage.of("Tried to delete prefix with no record types",
+                            subspaceProvider.logKey(), subspaceProvider.toString(context)));
+                }
                 return AsyncUtil.DONE;
             }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1985,7 +1985,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         private CompletableFuture<Void> run() {
             if (evaluated == null) {
                 // no record types
-                LOGGER.warn("Tried to delete prefix with no record types");
+                LOGGER.warn(KeyValueLogMessage.of("Tried to delete prefix with no record types",
+                        subspaceProvider.logKey(), subspaceProvider.toString(context)));
                 return AsyncUtil.DONE;
             }
 
@@ -3168,7 +3169,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info(KeyValueLogMessage.of("index state change",
                     LogMessageKeys.INDEX_NAME, indexName,
-                    LogMessageKeys.TARGET_INDEX_STATE, indexState.name()
+                    LogMessageKeys.TARGET_INDEX_STATE, indexState.name(),
+                    subspaceProvider.logKey(), subspaceProvider.toString(context)
             ));
         }
         if (recordStoreStateRef.get() == null) {
@@ -3507,6 +3509,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     message.addKeysAndValues(((LoggableException)ex).getLogInfo());
                 }
             }
+            message.addKeyAndValue(subspaceProvider.logKey(), subspaceProvider.toString(context));
             LOGGER.warn(message.toString(), exception);
         }
     }
@@ -4226,7 +4229,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                 LogMessageKeys.INDEX_NAME, index.getName(),
                                 LogMessageKeys.INDEX_VERSION, index.getLastModifiedVersion(),
                                 LogMessageKeys.REASON, reason.name(),
-                                subspaceProvider.logKey(), subspaceProvider.toString(context),
                                 LogMessageKeys.SUBSPACE_KEY, index.getSubspaceKey()), t);
                     }
                     // Only call method that builds in the current transaction, so never any pending work,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -1128,9 +1128,14 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                 } catch (UnsupportedRemoteFetchIndexException ex) {
                     // In this case (e.g. the index maintainer does not support remote fetch), log as info
                     if (LOGGER.isInfoEnabled()) {
-                        LOGGER.info(KeyValueLogMessage.of("scanIndexRecords: Remote fetch unsupported, continuing with Index scan",
+                        KeyValueLogMessage msg = KeyValueLogMessage.build("scanIndexRecords: Remote fetch unsupported, continuing with Index scan",
                                 LogMessageKeys.MESSAGE, ex.getMessage(),
-                                LogMessageKeys.INDEX_NAME, index.getName()));
+                                LogMessageKeys.INDEX_NAME, index.getName());
+                        final SubspaceProvider subspaceProvider = getSubspaceProvider();
+                        if (subspaceProvider != null) {
+                            msg.addKeyAndValue(subspaceProvider.logKey(), subspaceProvider.toString(getContext()));
+                        }
+                        LOGGER.info(msg.toString());
                     }
                     return scanIndexRecords(index, scanRange.getScanType(), scanRange.getScanRange(), continuation, orphanBehavior, scanProperties);
                 } catch (Exception ex) {


### PR DESCRIPTION
There were a handful of places in the `FDBRecordStore` class that were were logging but didn't include the subspace provider as context. This means that we couldn't tell what store the logs were trying to log about, which made it hard to correlate with other operations to the store. This resolves that by adding in the missing information to the missing logs.

This fixes #2936.