### PR TITLE
Fixes #548: Fix concurrency issues with MapPipelinedCursor.close

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -20,7 +20,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Bug fix** Missing subspace provider information added to `FDBRecordStore` logs [(Issue #2936)](https://github.com/FoundationDB/fdb-record-layer/issues/2936)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Fix concurrency issues with MapPipelinedCursor.close [(Issue #548)](https://github.com/FoundationDB/fdb-record-layer/issues/548)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
@@ -181,12 +181,7 @@ public class MapPipelinedCursor<T, V> implements RecordCursor<V> {
     @Nonnull
     private CompletableFuture<Boolean> cancellAll() {
         while (!pipeline.isEmpty()) {
-            final CompletableFuture<RecordCursorResult<V>> outstanding = pipeline.poll();
-            // outstanding here, could be null if an onNext future is also being processed, and it has just removed the
-            // only future in the pipeline
-            if (outstanding != null) {
-                outstanding.cancel(false);
-            }
+            pipeline.remove().cancel(false);
         }
         final CompletableFuture<Boolean> cancelled = new CompletableFuture<>();
         cancelled.cancel(true);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
@@ -1278,7 +1277,7 @@ public class RecordCursorTest {
 
     }
 
-    @RepeatedTest(100)
+    @Test
     public void mapPipelineCloseWhileCancelling() {
         Map<Class<? extends Throwable>, Integer> exceptionCount = new HashMap<>();
         for (int i = 0; i < 2000; i++) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -1280,7 +1280,7 @@ public class RecordCursorTest {
     @Test
     public void mapPipelineCloseWhileCancelling() {
         Map<Class<? extends Throwable>, Integer> exceptionCount = new HashMap<>();
-        for (int i = 0; i < 2000; i++) {
+        for (int i = 0; i < 20_000; i++) {
             try {
                 LOGGER.info(KeyValueLogMessage.of("running map pipeline close test", "iteration", i));
                 CompletableFuture<Void> signal = new CompletableFuture<>();


### PR DESCRIPTION
The underlying issue is that multiple threads are interacting with the (non-thread-safe) queue at the same time, in complex ways. We could add `synchronized` to a `close` and `onNext`, (or some part of onNext), but instead I changed the cleanup around so that it only interacts with the pipeline in a single chain of futures.
The other change is the introduction of the `nextFuture` field, which removes the code that assumes that the pipeline will be non-empty, this seems like a good change to have, even if the other change makes it unnecessary.

I tried to do some trickery around how it interacts with the queue to make sure it handles an empty queue correctly, but since `ArrayDeque` is not thread safe, that resulted in `close` getting into an infinite loop with an-emptyable queue. I left the first attempt there as the first commit in this PR, although I think none of the code change remains. 