### PR TITLE
Some followup from PR #2954

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -59,6 +59,8 @@ import static com.apple.foundationdb.async.AsyncUtil.whileTrue;
 @API(API.Status.UNSTABLE)
 public class MoreAsyncUtil {
 
+    public static final CompletableFuture<Boolean> ALREADY_CANCELLED;
+
     private static final Supplier<ScheduledThreadPoolExecutor> scheduledExecutorSupplier = Suppliers.memoize(() -> {
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
                 .setDaemon(true)
@@ -69,6 +71,11 @@ public class MoreAsyncUtil {
         scheduledThreadPoolExecutor.allowCoreThreadTimeOut(true);
         return scheduledThreadPoolExecutor;
     });
+
+    static {
+        ALREADY_CANCELLED = new CompletableFuture<>();
+        ALREADY_CANCELLED.cancel(false);
+    }
 
     @Nonnull
     public static <T> AsyncIterable<T> limitIterable(@Nonnull final AsyncIterable<T> iterable,

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -59,8 +59,6 @@ import static com.apple.foundationdb.async.AsyncUtil.whileTrue;
 @API(API.Status.UNSTABLE)
 public class MoreAsyncUtil {
 
-    public static final CompletableFuture<Boolean> ALREADY_CANCELLED;
-
     private static final Supplier<ScheduledThreadPoolExecutor> scheduledExecutorSupplier = Suppliers.memoize(() -> {
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
                 .setDaemon(true)
@@ -72,9 +70,10 @@ public class MoreAsyncUtil {
         return scheduledThreadPoolExecutor;
     });
 
-    static {
-        ALREADY_CANCELLED = new CompletableFuture<>();
-        ALREADY_CANCELLED.cancel(false);
+    public static <T> CompletableFuture<T> alreadyCancelled() {
+        final CompletableFuture<T> alreadyCancelled = new CompletableFuture<>();
+        alreadyCancelled.cancel(false);
+        return alreadyCancelled;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.cursors;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.ByteArrayContinuation;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
@@ -57,12 +58,6 @@ import java.util.function.Function;
 @API(API.Status.MAINTAINED)
 @SuppressWarnings("PMD.CloseResource")
 public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
-    private static final CompletableFuture<Boolean> CANCELLED;
-
-    static {
-        CANCELLED = new CompletableFuture<>();
-        CANCELLED.cancel(false);
-    }
 
     @Nonnull
     private final RecordCursor<T> outerCursor;
@@ -181,7 +176,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
     @Nonnull
     protected CompletableFuture<Boolean> tryToFillPipeline() {
         if (closed) {
-            return CANCELLED;
+            return MoreAsyncUtil.ALREADY_CANCELLED;
         }
         // Clear pipeline entries left behind by exhausted inner cursors.
         clearUnusedPipelineEntries();
@@ -189,7 +184,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         while (continueFillingPipeline()) {
             CompletableFuture<RecordCursorResult<T>> outerNext = ensureOuterCursorAdvanced();
             if (outerNext == null) {
-                return CANCELLED;
+                return MoreAsyncUtil.ALREADY_CANCELLED;
             }
 
             if (!outerNext.isDone()) {
@@ -245,7 +240,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         // that case.
         PipelineQueueEntry peeked = peekPipeline();
         if (peeked == null) {
-            return CANCELLED;
+            return MoreAsyncUtil.ALREADY_CANCELLED;
         }
         return peeked.getNextInnerPipelineFuture().thenApply(PipelineQueueEntry::doesNotHaveReturnableResult);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
@@ -59,6 +59,7 @@ import java.util.function.Function;
 @SuppressWarnings("PMD.CloseResource")
 public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
 
+    private static final CompletableFuture<Boolean> ALREADY_CANCELLED = MoreAsyncUtil.alreadyCancelled();
     @Nonnull
     private final RecordCursor<T> outerCursor;
     @Nonnull
@@ -176,7 +177,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
     @Nonnull
     protected CompletableFuture<Boolean> tryToFillPipeline() {
         if (closed) {
-            return MoreAsyncUtil.ALREADY_CANCELLED;
+            return ALREADY_CANCELLED;
         }
         // Clear pipeline entries left behind by exhausted inner cursors.
         clearUnusedPipelineEntries();
@@ -184,7 +185,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         while (continueFillingPipeline()) {
             CompletableFuture<RecordCursorResult<T>> outerNext = ensureOuterCursorAdvanced();
             if (outerNext == null) {
-                return MoreAsyncUtil.ALREADY_CANCELLED;
+                return ALREADY_CANCELLED;
             }
 
             if (!outerNext.isDone()) {
@@ -240,7 +241,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         // that case.
         PipelineQueueEntry peeked = peekPipeline();
         if (peeked == null) {
-            return MoreAsyncUtil.ALREADY_CANCELLED;
+            return ALREADY_CANCELLED;
         }
         return peeked.getNextInnerPipelineFuture().thenApply(PipelineQueueEntry::doesNotHaveReturnableResult);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.cursors;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -48,12 +49,6 @@ import java.util.function.Function;
  */
 @API(API.Status.MAINTAINED)
 public class MapPipelinedCursor<T, V> implements RecordCursor<V> {
-    private static final CompletableFuture<Boolean> CANCELLED;
-
-    static {
-        CANCELLED = new CompletableFuture<>();
-        CANCELLED.cancel(false);
-    }
 
     @Nonnull
     private final RecordCursor<T> inner;
@@ -193,7 +188,7 @@ public class MapPipelinedCursor<T, V> implements RecordCursor<V> {
         while (!pipeline.isEmpty()) {
             pipeline.remove().cancel(false);
         }
-        return CANCELLED;
+        return MoreAsyncUtil.ALREADY_CANCELLED;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/MapPipelinedCursor.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 @API(API.Status.MAINTAINED)
 public class MapPipelinedCursor<T, V> implements RecordCursor<V> {
 
+    private static final CompletableFuture<Boolean> ALREADY_CANCELLED = MoreAsyncUtil.alreadyCancelled();
     @Nonnull
     private final RecordCursor<T> inner;
     @Nonnull
@@ -188,7 +189,7 @@ public class MapPipelinedCursor<T, V> implements RecordCursor<V> {
         while (!pipeline.isEmpty()) {
             pipeline.remove().cancel(false);
         }
-        return MoreAsyncUtil.ALREADY_CANCELLED;
+        return ALREADY_CANCELLED;
     }
 
     @Nonnull


### PR DESCRIPTION
- [Add MoreAsyncUtil.ALREADY_CANCELLED](https://github.com/FoundationDB/fdb-record-layer/commit/aaf4ebd4796ff08a6795b9fc87f749a2e1fc49cd)
MapPipelineCursor and FlatMapPipelinedCursor had a version of this,
so reducing duplication.
- [Test concurrent closing with a non-singleton inner cursor](https://github.com/FoundationDB/fdb-record-layer/commit/d489748fcf00bfcf7352620f0a372a1688d89437)
