### PR TITLE
Resolves #2929: Allow user to specify scheduled executor service for constructing delayed futures

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add more lucene exception handling tests [(Issue #2939)](https://github.com/FoundationDB/fdb-record-layer/issues/2939)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Methods interacting with delayed futures can now supply their own `ScheduledExecutorService` [(Issue #2929)](https://github.com/FoundationDB/fdb-record-layer/issues/2929)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -58,6 +58,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -112,6 +113,8 @@ public class FDBDatabase {
     /* Null until openFDB is called. */
     @Nullable
     private Database database;
+    @Nonnull
+    private final ScheduledExecutorService scheduledExecutor;
     @Nullable
     private Function<FDBStoreTimer.Wait, Pair<Long, TimeUnit>> asyncToSyncTimeout;
     @Nonnull
@@ -183,7 +186,8 @@ public class FDBDatabase {
                 .maximumSize(factory.getDirectoryCacheSize())
                 .recordStats()
                 .build();
-        this.resolverStateCache = new AsyncLoadingCache<>(factory.getStateRefreshTimeMillis());
+        this.scheduledExecutor = factory.getScheduledExecutor();
+        this.resolverStateCache = new AsyncLoadingCache<>(factory.getStateRefreshTimeMillis(), AsyncLoadingCache.DEFAULT_DEADLINE_TIME_MILLIS, AsyncLoadingCache.UNLIMITED, scheduledExecutor);
         this.latencyInjector = factory.getLatencyInjector();
         this.datacenterId = factory.getDatacenterId();
         this.localityProvider = factory.getLocalityProvider();
@@ -603,7 +607,7 @@ public class FDBDatabase {
     @VisibleForTesting
     public void setResolverStateRefreshTimeMillis(long resolverStateRefreshTimeMillis) {
         resolverStateCache.clear();
-        resolverStateCache = new AsyncLoadingCache<>(resolverStateRefreshTimeMillis);
+        resolverStateCache = new AsyncLoadingCache<>(resolverStateRefreshTimeMillis, resolverStateCache.getDeadlineTimeMillis(), resolverStateCache.getMaxSize(), getScheduledExecutor());
     }
 
     @Nonnull
@@ -738,6 +742,19 @@ public class FDBDatabase {
 
     protected Executor newContextExecutor(@Nullable Map<String, String> mdcContext) {
         return factory.newContextExecutor(mdcContext);
+    }
+
+    /**
+     * Get an executor service that can be used for scheduling tasks. It is primarily used
+     * by the {@link AsyncLoadingCache} to manage deadlines and by
+     * {@link com.apple.foundationdb.async.MoreAsyncUtil#delayedFuture(long, TimeUnit, ScheduledExecutorService) MoreAsyncUtil.delayedFuture()}
+     * to schedule tasks that are run later, e.g., injecting delay during retry loops.
+     *
+     * @return the scheduled executor service to use when interacting with this database
+     */
+    @Nonnull
+    public ScheduledExecutorService getScheduledExecutor() {
+        return scheduledExecutor;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
@@ -177,7 +177,7 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
         @SpotBugsSuppressWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "maybe https://github.com/spotbugs/spotbugs/issues/616?")
         private RunRetriable(@Nullable List<Object> additionalLogMessageKeyValues) {
             this.additionalLogMessageKeyValues = additionalLogMessageKeyValues;
-            this.delay = new ExponentialDelay(getInitialDelayMillis(), getMaxDelayMillis());
+            this.delay = createExponentialDelay();
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -447,7 +447,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
             return AsyncUtil.DONE;
         }
 
-        return instrument(latencySource.getTimerEvent(), MoreAsyncUtil.delayedFuture(latencyMillis, TimeUnit.MILLISECONDS));
+        return instrument(latencySource.getTimerEvent(), MoreAsyncUtil.delayedFuture(latencyMillis, TimeUnit.MILLISECONDS, getScheduledExecutor()));
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTransactionContext.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Wrapper class for an open FDB {@link Transaction}.
@@ -77,6 +78,17 @@ public class FDBTransactionContext {
     @Nonnull
     public Executor getExecutor() {
         return executor;
+    }
+
+    /**
+     * Get the scheduled executor to use when scheduling delayed tasks in the context of this transaction.
+     *
+     * @return a scheduled executor to use for scheduling delayed tasks
+     */
+    @API(API.Status.INTERNAL)
+    @Nonnull
+    public ScheduledExecutorService getScheduledExecutor() {
+        return database.getScheduledExecutor();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -669,7 +669,7 @@ public abstract class IndexingBase {
 
         validateTimeLimit(toWait);
 
-        CompletableFuture<Boolean> delay = MoreAsyncUtil.delayedFuture(toWait, TimeUnit.MILLISECONDS).thenApply(vignore3 -> true);
+        CompletableFuture<Boolean> delay = MoreAsyncUtil.delayedFuture(toWait, TimeUnit.MILLISECONDS, common.getRunner().getScheduledExecutor()).thenApply(vignore3 -> true);
         if (getRunner().getTimer() != null) {
             delay = getRunner().getTimer().instrument(FDBStoreTimer.Events.INDEXER_DELAY, delay, getRunner().getExecutor());
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -319,8 +319,7 @@ public class IndexingThrottle {
         AtomicLong recordsScanned = new AtomicLong(0);
         CompletableFuture<R> ret = new CompletableFuture<>();
         booker.resetStoreTimerSnapshot();
-        final ExponentialDelay delay = new ExponentialDelay(common.getRunner().getDatabase().getFactory().getInitialDelayMillis(),
-                common.getRunner().getDatabase().getFactory().getMaxDelayMillis());
+        final ExponentialDelay delay = common.getRunner().createExponentialDelay();
         AsyncUtil.whileTrue(() -> {
             loadConfig();
             // TODO: eliminate the usage of the runner - call (and handle) every transaction here

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelay.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -48,11 +49,14 @@ public class ExponentialDelay {
     private final long maxDelayMillis;
     private long currentDelayMillis;
     private long nextDelayMillis;
+    @Nonnull
+    private ScheduledExecutorService scheduledExecutor;
 
-    public ExponentialDelay(final long initialDelayMillis, final long maxDelayMillis) {
+    public ExponentialDelay(final long initialDelayMillis, final long maxDelayMillis, @Nonnull ScheduledExecutorService scheduledExecutor) {
         currentDelayMillis = initialDelayMillis;
         this.maxDelayMillis = maxDelayMillis;
         this.nextDelayMillis = calculateNextDelayMillis();
+        this.scheduledExecutor = scheduledExecutor;
     }
 
     public CompletableFuture<Void> delay() {
@@ -70,7 +74,7 @@ public class ExponentialDelay {
     @Nonnull
     @VisibleForTesting
     protected CompletableFuture<Void> delayedFuture(final long nextDelayMillis) {
-        return MoreAsyncUtil.delayedFuture(nextDelayMillis, TimeUnit.MILLISECONDS);
+        return MoreAsyncUtil.delayedFuture(nextDelayMillis, TimeUnit.MILLISECONDS, scheduledExecutor);
     }
 
     public long getNextDelayMillis() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/ReadVersionRecordStoreStateCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/ReadVersionRecordStoreStateCache.java
@@ -63,7 +63,7 @@ public class ReadVersionRecordStoreStateCache implements FDBRecordStoreStateCach
 
     ReadVersionRecordStoreStateCache(@Nonnull FDBDatabase database, long refreshTimeMillis, long deadlineTimeMillis, long maxSize) {
         this.database = database;
-        this.cache = new AsyncLoadingCache<>(refreshTimeMillis, deadlineTimeMillis, maxSize);
+        this.cache = new AsyncLoadingCache<>(refreshTimeMillis, deadlineTimeMillis, maxSize, database.getScheduledExecutor());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetectionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/BlockingInAsyncDetectionTest.java
@@ -97,7 +97,7 @@ class BlockingInAsyncDetectionTest {
 
         FDBDatabase database = factory.getDatabase();
         TestHelpers.assertLogs(FDBDatabase.class, FDBDatabase.BLOCKING_RETURNING_ASYNC_MESSAGE,
-                () -> returnAnAsync(database, MoreAsyncUtil.delayedFuture(200L, TimeUnit.MILLISECONDS)));
+                () -> returnAnAsync(database, MoreAsyncUtil.delayedFuture(200L, TimeUnit.MILLISECONDS, database.getScheduledExecutor())));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -242,7 +242,7 @@ class FDBDatabaseTest {
         } else {
             FDBDatabase database2 = factory.getDatabase();
             TestHelpers.assertLogs(FDBDatabase.class, FDBDatabase.BLOCKING_FOR_FUTURE_MESSAGE, () -> {
-                long val = database2.joinNow(MoreAsyncUtil.delayedFuture(100, TimeUnit.MILLISECONDS)
+                long val = database2.joinNow(MoreAsyncUtil.delayedFuture(100, TimeUnit.MILLISECONDS, database2.getScheduledExecutor())
                         .thenApply(vignore -> 1066L));
                 assertEquals(1066L, val);
                 return null;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
@@ -228,7 +228,7 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
             Index index2 = recordStore.getRecordMetaData().getIndex("MySimpleRecord$num_value_unique");
 
             AtomicBoolean check1Run = new AtomicBoolean(false);
-            CompletableFuture<Void> check1 = MoreAsyncUtil.delayedFuture(1L, TimeUnit.MILLISECONDS)
+            CompletableFuture<Void> check1 = MoreAsyncUtil.delayedFuture(1L, TimeUnit.MILLISECONDS, context.getScheduledExecutor())
                     .thenRun(() -> check1Run.set(true));
             recordStore.addIndexUniquenessCommitCheck(index1, recordStore.indexSubspace(index1), check1);
 
@@ -261,7 +261,7 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
             Index index = firstStore.getRecordMetaData().getIndex("MySimpleRecord$str_value_indexed");
 
             AtomicBoolean check1Run = new AtomicBoolean(false);
-            CompletableFuture<Void> check1 = MoreAsyncUtil.delayedFuture(1L, TimeUnit.MILLISECONDS)
+            CompletableFuture<Void> check1 = MoreAsyncUtil.delayedFuture(1L, TimeUnit.MILLISECONDS, context.getScheduledExecutor())
                     .thenRun(() -> check1Run.set(true));
             firstStore.addIndexUniquenessCommitCheck(index, firstStore.indexSubspace(index), check1);
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -620,7 +620,7 @@ public abstract class LocatableResolverTest {
         final List<Pair<String, ResolverResult>> cacheHits = new ArrayList<>();
         final List<Pair<Long, String>> reverseCacheHits = new ArrayList<>();
         CompletableFuture<Void> loopOperation = AsyncUtil.whileTrue(() ->
-                MoreAsyncUtil.delayedFuture(1, TimeUnit.MILLISECONDS)
+                MoreAsyncUtil.delayedFuture(1, TimeUnit.MILLISECONDS, database.getScheduledExecutor())
                         .thenRun(() -> gatherCacheHits(database.getDirectoryCache(/* always return current version */ 0), cacheHits))
                         .thenRun(() -> gatherCacheHits(database.getReverseDirectoryInMemoryCache(), reverseCacheHits))
                         .thenApply(ignored2 -> keepRunning.get())

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelayTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/ExponentialDelayTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.runners;
 
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
 import org.slf4j.Logger;
@@ -200,7 +201,7 @@ class ExponentialDelayTest {
         List<Long> requestedDelays = new ArrayList<>();
 
         public NoActualDelay(final long initialDelayMillis, final long maxDelayMillis) {
-            super(initialDelayMillis, maxDelayMillis);
+            super(initialDelayMillis, maxDelayMillis, MoreAsyncUtil.getDefaultScheduledExecutor());
         }
 
         @Nonnull


### PR DESCRIPTION
The methods in `MoreAsyncUtil` that interact with delayed futures now take a `ScheduledExecutorService` as an argument. The old static thread pool is preserved but now is the default scheduled executor, exposed as a new static method. The `FDBDatabaseFactory` can now be configured with a different scheduled executor, and then that configuration property is propagated to the various databases it creates.

This resolves #2929.