### PR TITLE
Fixes #2971: Test failure in MoreAsyncUtilTest.getWithDeadlineRunsOnExecutor

### DIFF
--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -32,6 +32,7 @@ dependencies {
     testCompileOnly "com.google.code.findbugs:jsr305:${jsr305Version}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
+    testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}" // binding
     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}" // library


### PR DESCRIPTION
There was a race condition in a test assertion, and it was actually possible for a test callback to land on the same thread as the test worker if setting up the future chain took longer than the deadline in the test. That should be fairly unlikely, but it could happen, and so this expands the assertion to include that case.

This fixes #2971.