### PR TITLE
Fixes #2975: Test failure in MoreAsyncUtilTest.executeDelayedCallbackOnExecutor

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
@@ -22,11 +22,13 @@ package com.apple.foundationdb.async;
 
 import com.apple.foundationdb.test.TestExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -99,13 +101,24 @@ public class MoreAsyncUtilTest {
         assertTrue(end - start >= 100, "Delay was not long enough");
     }
 
+    /**
+     * Assert that callbacks on {@link MoreAsyncUtil#delayedFuture(long, TimeUnit, ScheduledExecutorService)}
+     * are executed on a scheduled executor service. Note that if the delayed future completes before the
+     * callback is added (which can happen), the callbacks can actually be executed on the calling main thread.
+     * For that reason, the asserts here also tolerate the callback being executed on the calling thread. The
+     * main thing it is trying to test is that: (1) if a custom executor is passed, it does not use the default
+     * executor, and (2) it doesn't use some other thread pool or executor service.
+     *
+     * @throws ExecutionException from waiting on futures
+     * @throws InterruptedException from while waiting on futures
+     */
     @Test
     public void executeDelayedCallbackOnExecutor() throws ExecutionException, InterruptedException {
         String callbackThreadName = MoreAsyncUtil.delayedFuture(5, TimeUnit.MILLISECONDS)
                 .thenApply(ignore -> Thread.currentThread().getName())
                 .get();
         assertThat("Callback should have been executed on thread started by default scheduled executor",
-                callbackThreadName, startsWith("fdb-scheduled"));
+                callbackThreadName, isCurrentThreadNameOr(startsWith("fdb-scheduled-executor-")));
 
         ScheduledExecutorService scheduledExecutor = new ScheduledThreadPoolExecutor(1, new ThreadFactoryBuilder()
                 .setDaemon(true)
@@ -115,7 +128,7 @@ public class MoreAsyncUtilTest {
             final String customExecutorThreadName = MoreAsyncUtil.delayedFuture(5, TimeUnit.MILLISECONDS, scheduledExecutor)
                     .thenApply(ignore -> Thread.currentThread().getName())
                     .get();
-            assertEquals("test-delayed-executor-thread-0", customExecutorThreadName);
+            assertThat(customExecutorThreadName, isCurrentThreadNameOr("test-delayed-executor-thread-0"));
         } finally {
             scheduledExecutor.shutdown();
         }
@@ -143,7 +156,7 @@ public class MoreAsyncUtilTest {
             // setting up the future chain takes longer than the deadline time, then it's possible for the callback to complete on
             // the test worker thread
             assertThat("Callback should have been executed on thread managed by scheduled executor or by calling thread",
-                    callbackThreadName, either(equalTo("test-deadline-exceeded-thread-0")).or(equalTo(Thread.currentThread().getName())));
+                    callbackThreadName, isCurrentThreadNameOr("test-deadline-exceeded-thread-0"));
         } finally {
             scheduledExecutor.shutdown();
         }
@@ -272,4 +285,13 @@ public class MoreAsyncUtilTest {
         assertEquals(runtimeException1, executionException.getCause());
     }
 
+    @Nonnull
+    private static Matcher<String> isCurrentThreadNameOr(@Nonnull String threadName) {
+        return isCurrentThreadNameOr(equalTo(threadName));
+    }
+
+    @Nonnull
+    private static Matcher<String> isCurrentThreadNameOr(@Nonnull Matcher<String> threadMatcher) {
+        return either(threadMatcher).or(equalTo(Thread.currentThread().getName()));
+    }
 }


### PR DESCRIPTION
As was done in #2972, this updates the assertions for some tests in `MoreAsyncUtilTest` that were designed to make sure that the wrong thread pool wasn't accidentally being used for callbacks on delayed futures. The test neglected the fact that the calling thread could also end up executing the callback if the future completed quickly (or if there were a delay between when the future is created and the callback added). This can happen in certain environments, including during some of our nightly CI builds, though it's not the only place it has been noticed.

This fixes #2975.