### PR TITLE
Upgrade Gradle to 7.6 and deal with Checkstyle consequences

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
@@ -571,7 +571,7 @@ public class RangeSetTest {
         assertArrayEquals(new byte[]{(byte)0xff}, r1.end);
 
         // Now, add some ranges to make the gaps interesting.
-        List<Range> toAdd = Arrays.asList(
+        final List<Range> toAdd = Arrays.asList(
                 new Range(new byte[]{0x10}, new byte[]{0x20}),
                 new Range(new byte[]{0x20}, new byte[]{0x20, 0x00}),
                 new Range(new byte[]{0x30}, new byte[]{0x40}),
@@ -581,7 +581,7 @@ public class RangeSetTest {
                 new Range(new byte[]{0x71}, new byte[]{0x72}),
                 new Range(new byte[]{0x72}, new byte[]{0x7f})
         );
-        List<Range> expected = Arrays.asList(
+        final List<Range> expected = Arrays.asList(
                 new Range(new byte[]{0x00}, new byte[]{0x10}),
                 new Range(new byte[]{0x20, 0x00}, new byte[]{0x30}),
                 new Range(new byte[]{0x40}, new byte[]{0x40, 0x00}),
@@ -589,7 +589,7 @@ public class RangeSetTest {
                 new Range(new byte[]{0x70}, new byte[]{0x71}),
                 new Range(new byte[]{0x7f}, new byte[]{(byte)0xff})
         );
-        List<Boolean> added = db.runAsync(tr -> {
+        final List<Boolean> added = db.runAsync(tr -> {
             List<CompletableFuture<Boolean>> futures = new ArrayList<>();
             for (Range range : toAdd) {
                 futures.add(rs.insertRange(tr, range));

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/ClientLogEventCounterTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/ClientLogEventCounterTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 
 class ClientLogEventCounterTest {
 
-    @SuppressWarnings("PMD.SystemPrintln")
+    @SuppressWarnings({"PMD.SystemPrintln", "checkstyle:VariableDeclarationUsageDistance"})
     public static void main(String[] args) {
         String cluster = null;
         Instant start = null;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/Key.java
@@ -159,7 +159,7 @@ public class Key {
         }
 
         /**
-         * Shortuct for `concat(field(first), field(second), field(rest[0]), ...)`
+         * Shortcut for `concat(field(first), field(second), field(rest[0]), ...)`.
          * @param first the name of the first field to use in the index
          * @param second the name of the second field to use in the index
          * @param fields this supports any number fields (at least 2), this is the rest of them

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -267,7 +267,7 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
     }
 
     protected void decompress(@Nonnull TransformState state, @Nullable StoreTimer timer) throws DataFormatException {
-        long startTime = System.nanoTime();
+        final long startTime = System.nanoTime();
 
         // At the moment, there is only one compression version, so
         // we after we've verified it is in the right range, we

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainer.java
@@ -128,7 +128,7 @@ public class AtomicMutationIndexMaintainer extends StandardIndexMaintainer {
         final MutationType mutationType = mutation.getMutationType();
         final int groupPrefixSize = getGroupingCount();
         for (IndexEntry indexEntry : indexEntries) {
-            long startTime = System.nanoTime();
+            final long startTime = System.nanoTime();
             final Tuple groupKey;
             final IndexEntry groupedValue;
             if (groupPrefixSize <= 0) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlanner.java
@@ -1639,7 +1639,7 @@ public class RecordQueryPlanner implements QueryPlanner {
     }
 
     @Nullable
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    @SuppressWarnings({"PMD.CompareObjectsWithEquals", "checkstyle:VariableDeclarationUsageDistance"})
     private ScoredPlan planRankWithAnd(@Nonnull CandidateScan candidateScan,
                                        @Nonnull Index index, @Nonnull GroupingKeyExpression indexExpr,
                                        @Nonnull AndComponent and) {
@@ -2763,7 +2763,7 @@ public class RecordQueryPlanner implements QueryPlanner {
                                   @Nonnull ThenKeyExpression indexExpr,
                                   @Nonnull List<QueryComponent> filters,
                                   @Nullable KeyExpression sort) {
-            this (candidateScan, indexExpr, indexExpr.getChildren(), filters, sort);
+            this(candidateScan, indexExpr, indexExpr.getChildren(), filters, sort);
         }
 
         @SpotBugsSuppressWarnings(value = {"NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", "NP_NONNULL_PARAM_VIOLATION"}, justification = "maybe https://github.com/spotbugs/spotbugs/issues/616?")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/QueryPlanCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/QueryPlanCursorTest.java
@@ -84,6 +84,12 @@ public class QueryPlanCursorTest extends FDBRecordStoreTestBase {
         }
     }
 
+    private void compareSkipsAndCursors(RecordQueryPlan plan) throws Exception {
+        for (int amount : amounts) {
+            compareSkipsAndCursors(plan, amount);
+        }
+    }
+
     private void compareSkipsAndCursors(RecordQueryPlan plan, int amount) throws Exception {
         final Function<FDBQueriedRecord<Message>, Long> getRecNo = r -> {
             TestRecords1Proto.MySimpleRecord.Builder record = TestRecords1Proto.MySimpleRecord.newBuilder();
@@ -140,12 +146,6 @@ public class QueryPlanCursorTest extends FDBRecordStoreTestBase {
     }
 
     final int[] amounts = { 1, 2, 3, 10 };
-
-    private void compareSkipsAndCursors(RecordQueryPlan plan) throws Exception {
-        for (int amount : amounts) {
-            compareSkipsAndCursors(plan, amount);
-        }
-    }
 
     private RecordQueryPlan scanPlan() {
         return new RecordQueryScanPlan(ScanComparisons.EMPTY, false);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -496,7 +496,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     }
 
     private TopDocs searchForTopDocs(int limit) throws IOException {
-        long startTime = System.nanoTime();
+        final long startTime = System.nanoTime();
         indexReader = getIndexReader();
         searcher = new LuceneOptimizedIndexSearcher(indexReader, executorService);
         TopDocs newTopDocs;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
@@ -171,7 +171,7 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
         if (spellcheckSuggestions != null) {
             return;
         }
-        long startTime = System.nanoTime();
+        final long startTime = System.nanoTime();
         indexReader = getIndexReader();
 
         List<Suggestion> suggestionResults = new ArrayList<>();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/CjkUnigramFilter.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/CjkUnigramFilter.java
@@ -129,7 +129,7 @@ public final class CjkUnigramFilter extends TokenFilter {
             index -= last;
         }
 
-        char[] termBuffer = termAtt.buffer();
+        final char[] termBuffer = termAtt.buffer();
         int len = termAtt.length();
 
         int newSize = bufferLen + len;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -1912,14 +1912,14 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
         try (FDBRecordContext context = openContext(contextProps)) {
             schemaSetup.accept(context);
-            LucenePartitioner partitioner = getIndexMaintainer(index).getPartitioner();
+            final LucenePartitioner partitioner = getIndexMaintainer(index).getPartitioner();
             Tuple groupKey = Tuple.from(1L);
-            
+
             // timestamps present in partition keys
             long time0 = Math.abs(startTime);
             long time1 = time0 + 1000;
             long time2 = time0 + 2000;
-            
+
             // timestamp not in partition keys, but within a partition
             long time1_2 = time1 + 500; // between time1 and time2
 
@@ -1927,7 +1927,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
             long timeTooOld = time0 - 500;
             long timeTooNew = time2 + 500;
 
-            Map<Long, String> timesForLogging = Map.of(
+            final Map<Long, String> timesForLogging = Map.of(
                     time0, "time0",
                     time1, "time1",
                     time2, "time2",

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedDocValuesFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedDocValuesFormatTest.java
@@ -280,6 +280,7 @@ public class LuceneOptimizedDocValuesFormatTest extends BaseDocValuesFormatTestC
      * @throws IOException if there's issues
      */
     @Override
+    @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     protected void doTestSortedVsStoredFields(final int numDocs, final double density, final Supplier<byte[]> bytes) throws Exception {
         // --BEGIN CUSTOM--
         Directory dir;

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -43,12 +43,13 @@ tasks.withType(Checkstyle) { task ->
     checkstyleAll.dependsOn task
     task.exclude '**/protogen/**'
     task.configProperties = ["projectDir" : rootProject.projectDir, 'bannedImports': BANNED_IMPORTS.join(',')]
+    task.maxHeapSize.set("1g")
 }
 
 checkstyle {
     ignoreFailures = false
     configFile = rootProject.file('gradle/codequality/checkstyle.xml')
-    toolVersion = "10.2"
+    toolVersion = "10.20.1"
 }
 
 task checkstyleMandatory(type: Checkstyle) { task ->

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e6d864e3b5bc05cc62041842b306383fc1fefcec359e70cebb1d470a6094ca82
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionSha256Sum=fe696c020f241a5f69c30f763c5a7f38eec54b490db19cd2b0962dda420d7d12
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Update wrapper to newest Gradle 7 release.
* Specify memory size for Checkstyle task now that it uses workers.
   Fixes #2977 .
* Upgrade Checkstyle tool version.
* Fix `checkstyleAll` failures with the new version.