### PR TITLE
Resolves #2982: Improvements to "context not closed" logs

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -27,7 +27,7 @@ Starting with version [3.4.455.0](#344550), the semantics of `UnnestedRecordType
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Logs for unclosed contexts contain improved information [(Issue #2982)](https://github.com/FoundationDB/fdb-record-layer/issues/2982)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabase.java
@@ -47,13 +47,13 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
@@ -1193,31 +1193,44 @@ public class FDBDatabase {
     @VisibleForTesting
     @SuppressWarnings({"PMD.CloseResource", "PMD.GuardLogStatement"})
     public int warnAndCloseOldTrackedOpenContexts(long minAgeSeconds) {
-        long nanoTime = System.nanoTime() - TimeUnit.SECONDS.toNanos(minAgeSeconds);
-        if (trackedOpenContexts.isEmpty()) {
+        long cutoffTime = System.nanoTime() - TimeUnit.SECONDS.toNanos(minAgeSeconds);
+        @Nullable Map.Entry<Long, FDBRecordContext> firstEntry = trackedOpenContexts.firstEntry();
+        if (firstEntry == null || firstEntry.getKey() > cutoffTime) {
             return 0;
         }
-        try {
-            if (trackedOpenContexts.firstKey() > nanoTime) {
-                return 0;
-            }
-        } catch (NoSuchElementException ex) {
-            return 0;
-        }
+        @Nullable Map<String, String> threadMdc = MDC.getCopyOfContextMap();
+        MDC.clear();
         int count = 0;
-        for (FDBRecordContext context : trackedOpenContexts.headMap(nanoTime, true).values()) {
-            KeyValueLogMessage msg = KeyValueLogMessage.build("context not closed",
-                    LogMessageKeys.AGE_SECONDS, TimeUnit.NANOSECONDS.toSeconds(nanoTime - context.getTrackOpenTimeNanos()),
-                    LogMessageKeys.TRANSACTION_ID, context.getTransactionId());
-            if (LOGGER.isWarnEnabled()) {
-                if (context.getOpenStackTrace() != null) {
-                    LOGGER.warn(msg.toString(), context.getOpenStackTrace());
-                } else {
-                    LOGGER.warn(msg.toString());
+        try {
+            for (FDBRecordContext context : trackedOpenContexts.headMap(cutoffTime, true).values()) {
+                KeyValueLogMessage msg = KeyValueLogMessage.build("context not closed",
+                        LogMessageKeys.AGE_SECONDS, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - context.getTrackOpenTimeNanos()),
+                        LogMessageKeys.TRANSACTION_ID, context.getTransactionId(),
+                        LogMessageKeys.CLUSTER, clusterFile);
+
+                // We want to log with the MDC context that created the transaction if we can.
+                // If none is specified, go ahead and use the thread's.
+                @Nullable Map<String, String> contextMdc = context.getMdcContext();
+                if (contextMdc != null) {
+                    msg.addKeysAndValues(contextMdc);
+                } else if (threadMdc != null) {
+                    msg.addKeysAndValues(threadMdc);
                 }
+
+                if (LOGGER.isWarnEnabled()) {
+                    if (context.getOpenStackTrace() != null) {
+                        LOGGER.warn(msg.toString(), context.getOpenStackTrace());
+                    } else {
+                        LOGGER.warn(msg.toString());
+                    }
+                }
+                context.closeTransaction(true);
+                count++;
             }
-            context.closeTransaction(true);
-            count++;
+        } finally {
+            if (threadMdc != null) {
+                MDC.setContextMap(threadMdc);
+            }
         }
         return count;
     }


### PR DESCRIPTION
This updates the "context not closed" information to do the following:

* Logs contain the MDC context associated with the transaction, if set. Otherwise, it continues to use the calling thread's MDC.
* The cluster file is included in the information so that adopters can look for patterns related to the calling transaction.
* The "age seconds" is now time since the transaction was opened, not its time since it could have been closed.

This resolves #2982.