### PR TITLE
Fixes #2986: TimeWindowLeaderboardIndex throws NPE on null ranks

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ The Apache Commons library has been removed as a dependency. There were a few lo
 // begin next release
 ### NEXT_RELEASE
 
-* **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Removes NPE in time-window leaderboard index that could occur if a rank was not in a leaderboard [(Issue #2986)](https://github.com/FoundationDB/fdb-record-layer/issues/2986)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -529,16 +529,18 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
      * Struct containing both the time window leaderboard entry and the rank.
      */
     public static class TimeWindowRankAndEntry {
-        private final long rank;
+        @Nullable
+        private final Long rank;
         @Nonnull
         private final Tuple entry;
 
-        private TimeWindowRankAndEntry(long rank, @Nonnull Tuple entry) {
+        private TimeWindowRankAndEntry(@Nullable Long rank, @Nonnull Tuple entry) {
             this.rank = rank;
             this.entry = entry;
         }
 
-        public long getRank() {
+        @Nullable
+        public Long getRank() {
             return rank;
         }
 
@@ -556,7 +558,7 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
                 return false;
             }
             final TimeWindowRankAndEntry that = (TimeWindowRankAndEntry)o;
-            return rank == that.rank && Objects.equals(entry, that.entry);
+            return Objects.equals(rank, that.rank) && Objects.equals(entry, that.entry);
         }
 
         @Override
@@ -566,7 +568,7 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
 
         @Override
         public String toString() {
-            return "TimeWindowRankAndEnrty{" +
+            return "TimeWindowRankAndEntry{" +
                     "rank=" + rank +
                     ", entry=" + entry +
                     '}';


### PR DESCRIPTION
This modifies the `TimeWindowRankAndEntry` struct to allow the returned `rank` to be empty. This represents the case where a record was not found in one of the leaderboards and so a `null` rank is returned. Note that this returns us to the state of the world prior to #2834, which is what introduced the struct (with its non-null `rank` field). Prior to that PR, the rank could be `null`, and so any code that worked prior to that commit (which is also the most recent change as of writing) should be able to be trivially adapted to this new version.

This fixes #2986.