### PR TITLE
Add a test that does concurrent lucene updates

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -784,6 +784,15 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         }
     }
 
+    /**
+     * Test that updating records in the same transaction does not cause issues with the executor, and doesn't result in
+     * a corrupted index.
+     * <p>
+     *     See issues: <a href="https://github.com/FoundationDB/fdb-record-layer/issues/2989">#2989</a> and
+     *     <a href="https://github.com/FoundationDB/fdb-record-layer/issues/2990">#2990</a>.
+     * </p>
+     * @throws IOException if there's an issue with Lucene
+     */
     @Test
     void concurrentUpdate() throws IOException {
         // Once the two issues noted below are fixed, we should make this parameterized, and run with additional random

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -75,6 +75,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -86,6 +87,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -778,6 +781,85 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                     }
                 }
             };
+        }
+    }
+
+    @Test
+    void concurrentUpdate() throws IOException {
+        // Once the two issues noted below are fixed, we should make this parameterized, and run with additional random
+        // configurations.
+        AtomicInteger threadCounter = new AtomicInteger();
+        // Synchronization blocks in FDBDirectoryWrapper can cause a deadlock
+        // see https://github.com/FoundationDB/fdb-record-layer/issues/2989
+        // So set the pool large enough to overcome that
+        this.dbExtension.getDatabaseFactory().setExecutor(new ForkJoinPool(30,
+                pool -> {
+                    final ForkJoinWorkerThread thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+                    thread.setName("ConcurrentUpdatePool-" + threadCounter.getAndIncrement());
+                    return thread;
+                },
+                null, false));
+        final long seed = 320947L;
+        final boolean isGrouped = true;
+        // updating the parent & child concurrently is not thread safe, we may want to fix the behavior, or say that is
+        // not supported, as it is the same as updating the same record concurrently, which I don't think is generally
+        // supported.
+        final boolean isSynthetic = false;
+        final boolean primaryKeySegmentIndexEnabled = true;
+        // LucenePartitioner is not thread safe, and the counts get broken
+        // See: https://github.com/FoundationDB/fdb-record-layer/issues/2990
+        final int partitionHighWatermark = -1;
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
+                .setIsGrouped(isGrouped)
+                .setIsSynthetic(isSynthetic)
+                .setPrimaryKeySegmentIndexEnabled(primaryKeySegmentIndexEnabled)
+                .setPartitionHighWatermark(partitionHighWatermark)
+                .build();
+
+        final int repartitionCount = 10;
+        final int loopCount = 30;
+
+        final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
+                .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, repartitionCount)
+                .addProp(LuceneRecordContextProperties.LUCENE_MAX_DOCUMENTS_TO_MOVE_DURING_REPARTITIONING, dataModel.nextInt(1000) + repartitionCount)
+                .addProp(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER, (double)dataModel.nextInt(10) + 2) // it must be at least 2.0
+                .build();
+        for (int i = 0; i < loopCount; i++) {
+            LOGGER.info(KeyValueLogMessage.of("concurrentUpdate loop",
+                    "iteration", i,
+                    "groupCount", dataModel.groupingKeyToPrimaryKeyToPartitionKey.size(),
+                    "docCount", dataModel.groupingKeyToPrimaryKeyToPartitionKey.values().stream().mapToInt(Map::size).sum(),
+                    "docMinPerGroup", dataModel.groupingKeyToPrimaryKeyToPartitionKey.values().stream().mapToInt(Map::size).min(),
+                    "docMaxPerGroup", dataModel.groupingKeyToPrimaryKeyToPartitionKey.values().stream().mapToInt(Map::size).max()));
+
+            long start = 234098;
+            try (FDBRecordContext context = openContext(contextProps)) {
+                dataModel.saveRecords(10, start, context, 1);
+                commit(context);
+            }
+            explicitMergeIndex(dataModel.index, contextProps, dataModel.schemaSetup);
+        }
+
+
+        try (FDBRecordContext context = openContext(contextProps)) {
+            FDBRecordStore recordStore = Objects.requireNonNull(dataModel.schemaSetup.apply(context));
+            recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
+            assertThat(dataModel.updateableRecords, Matchers.aMapWithSize(Matchers.greaterThan(30)));
+            LOGGER.info("concurrentUpdate: Starting updates");
+            RecordCursor.fromList(new ArrayList<>(dataModel.updateableRecords.entrySet()))
+                    .mapPipelined(entry -> {
+                        return dataModel.updateRecord(recordStore, entry.getKey(), entry.getValue());
+                    }, 10)
+                    .asList().join();
+            commit(context);
+        }
+
+
+        final LuceneIndexTestValidator luceneIndexTestValidator = new LuceneIndexTestValidator(() -> openContext(contextProps), context -> Objects.requireNonNull(dataModel.schemaSetup.apply(context)));
+        luceneIndexTestValidator.validate(dataModel.index, dataModel.groupingKeyToPrimaryKeyToPartitionKey, isSynthetic ? "child_str_value:forth" : "text_value:about");
+
+        if (isGrouped) {
+            validateDeleteWhere(isSynthetic, dataModel.groupingKeyToPrimaryKeyToPartitionKey, contextProps, dataModel.schemaSetup, dataModel.index);
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
@@ -59,6 +59,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -112,11 +113,8 @@ public class LuceneIndexTestValidator {
      */
     void validate(Index index, final Map<Tuple, Map<Tuple, Tuple>> expectedDocumentInformation,
                   final String universalSearch, final boolean allowDuplicatePrimaryKeys) throws IOException {
-        final int partitionHighWatermark = Integer.parseInt(index.getOption(LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK));
-        String partitionLowWaterMarkStr = index.getOption(LuceneIndexOptions.INDEX_PARTITION_LOW_WATERMARK);
-        final int partitionLowWatermark = partitionLowWaterMarkStr == null ?
-                                          Math.max(LucenePartitioner.DEFAULT_PARTITION_LOW_WATERMARK, 1) :
-                                          Integer.parseInt(partitionLowWaterMarkStr);
+        final int partitionHighWatermark = getPartitionHighWatermark(index);
+        final int partitionLowWatermark = getPartitionLowWatermark(index);
 
         Map<Tuple, Map<Tuple, Tuple>> missingDocuments = new HashMap<>();
         expectedDocumentInformation.forEach((groupingKey, groupedIds) -> {
@@ -128,71 +126,102 @@ public class LuceneIndexTestValidator {
                     "group", groupingKey,
                     "expectedCount", entry.getValue().size()));
 
-            final Set<Map.Entry<Tuple, Tuple>> entries = entry.getValue().entrySet();
-            final List<Tuple> records = entries.stream()
-                    // I think in theory, this should be able to be:
-                    // Map.Entry.comparingByValue().thenComparing(Map.Entry.comparingByKey())
-                    // but I could not get the types to work
-                    .sorted((c1, c2) -> {
-                        final int valueComparison = c1.getValue().compareTo(c2.getValue());
-                        if (valueComparison != 0) {
-                            return valueComparison;
-                        } else {
-                            return c1.getKey().compareTo(c2.getKey());
-                        }
-                    })
+            final List<Tuple> records = entry.getValue().entrySet().stream()
+                    .sorted(Map.Entry.<Tuple, Tuple>comparingByValue().thenComparing(Map.Entry.comparingByKey()))
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
-            List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos = getPartitionMeta(index, groupingKey);
-            partitionInfos.sort(Comparator.comparing(info -> Tuple.fromBytes(info.getFrom().toByteArray())));
-            final String allCounts = partitionInfos.stream()
-                    .map(info -> Tuple.fromBytes(info.getFrom().toByteArray()).toString() + info.getCount())
-                    .collect(Collectors.joining(",", "[", "]"));
-            Set<Integer> usedPartitionIds = new HashSet<>();
-            Tuple lastToTuple = null;
-            int visitedCount = 0;
-
-            try (FDBRecordContext context = contextProvider.get()) {
-                final FDBRecordStore recordStore = schemaSetup.apply(context);
-
-                for (int i = 0; i < partitionInfos.size(); i++) {
-                    final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = partitionInfos.get(i);
-                    if (LOGGER.isTraceEnabled()) {
-                        LOGGER.trace("Group: " + groupingKey + " PartitionInfo[" + partitionInfo.getId() +
-                                "]: count:" + partitionInfo.getCount() + " " +
-                                Tuple.fromBytes(partitionInfo.getFrom().toByteArray()) + "-> " +
-                                Tuple.fromBytes(partitionInfo.getTo().toByteArray()));
-                    }
-
-                    assertTrue(isParititionCountWithinBounds(partitionInfos, i, partitionLowWatermark, partitionHighWatermark),
-                            "Group: " + groupingKey + " - " + allCounts + "\nlowWatermark: " + partitionLowWatermark + ", highWatermark: " + partitionHighWatermark +
-                                    "\nCurrent count: " + partitionInfo.getCount());
-                    assertTrue(usedPartitionIds.add(partitionInfo.getId()), () -> "Duplicate id: " + partitionInfo);
-                    final Tuple fromTuple = Tuple.fromBytes(partitionInfo.getFrom().toByteArray());
-                    if (i > 0) {
-                        assertThat(fromTuple, greaterThan(lastToTuple));
-                    }
-                    lastToTuple = Tuple.fromBytes(partitionInfo.getTo().toByteArray());
-                    assertThat(fromTuple, lessThanOrEqualTo(lastToTuple));
-
-                    LOGGER.debug(KeyValueLogMessage.of("Visited partition",
-                            "group", groupingKey,
-                            "documentsSoFar", visitedCount,
-                            "documentsInGroup", records.size(),
-                            "partitionInfo.count", partitionInfo.getCount()));
-                    final Set<Tuple> expectedPrimaryKeys = Set.copyOf(records.subList(visitedCount, visitedCount + partitionInfo.getCount()));
-                    validateDocsInPartition(recordStore, index, partitionInfo.getId(), groupingKey,
-                            expectedPrimaryKeys,
-                            universalSearch);
-                    visitedCount += partitionInfo.getCount();
-                    validatePrimaryKeySegmentIndex(recordStore, index, groupingKey, partitionInfo.getId(),
-                            expectedPrimaryKeys, allowDuplicatePrimaryKeys);
-                    expectedPrimaryKeys.forEach(primaryKey -> missingDocuments.get(groupingKey).remove(primaryKey));
-                }
+            if (partitionHighWatermark > 0) {
+                validatePartitionedGroup(index, universalSearch, allowDuplicatePrimaryKeys, groupingKey, partitionLowWatermark, partitionHighWatermark, records, missingDocuments);
+            } else {
+                validateUnpartitionedGroup(index, universalSearch, allowDuplicatePrimaryKeys, groupingKey, partitionLowWatermark, partitionHighWatermark, records, missingDocuments);
             }
         }
         missingDocuments.entrySet().removeIf(entry -> entry.getValue().isEmpty());
         assertEquals(Map.of(), missingDocuments, "We should have found all documents in the index");
+    }
+
+    private void validateUnpartitionedGroup(final Index index, final String universalSearch, final boolean allowDuplicatePrimaryKeys, final Tuple groupingKey, final int partitionLowWatermark, final int partitionHighWatermark, final List<Tuple> records, final Map<Tuple, Map<Tuple, Tuple>> missingDocuments) throws IOException {
+        try (FDBRecordContext context = contextProvider.get()) {
+            final FDBRecordStore recordStore = schemaSetup.apply(context);
+            LOGGER.debug(KeyValueLogMessage.of("Visiting group",
+                    "group", groupingKey,
+                    "documentsInGroup", records.size()));
+            validateDocsInPartition(recordStore, index, null, groupingKey, Set.copyOf(records), universalSearch);
+            validatePrimaryKeySegmentIndex(recordStore, index, groupingKey, null,
+                    Set.copyOf(records), allowDuplicatePrimaryKeys);
+            Set.copyOf(records).forEach(primaryKey -> missingDocuments.get(groupingKey).remove(primaryKey));
+        }
+    }
+
+    private void validatePartitionedGroup(final Index index, final String universalSearch, final boolean allowDuplicatePrimaryKeys, final Tuple groupingKey, final int partitionLowWatermark, final int partitionHighWatermark, final List<Tuple> records, final Map<Tuple, Map<Tuple, Tuple>> missingDocuments) throws IOException {
+        List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos = getPartitionMeta(index, groupingKey);
+        partitionInfos.sort(Comparator.comparing(info -> Tuple.fromBytes(info.getFrom().toByteArray())));
+        final String allCounts = partitionInfos.stream()
+                .map(info -> Tuple.fromBytes(info.getFrom().toByteArray()).toString() + info.getCount())
+                .collect(Collectors.joining(",", "[", "]"));
+        Set<Integer> usedPartitionIds = new HashSet<>();
+        Tuple lastToTuple = null;
+        int visitedCount = 0;
+
+        try (FDBRecordContext context = contextProvider.get()) {
+            final FDBRecordStore recordStore = schemaSetup.apply(context);
+            for (int i = 0; i < partitionInfos.size(); i++) {
+                final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = partitionInfos.get(i);
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("Group: " + groupingKey + " PartitionInfo[" + partitionInfo.getId() +
+                            "]: count:" + partitionInfo.getCount() + " " +
+                            Tuple.fromBytes(partitionInfo.getFrom().toByteArray()) + "-> " +
+                            Tuple.fromBytes(partitionInfo.getTo().toByteArray()));
+                }
+
+                assertTrue(isParititionCountWithinBounds(partitionInfos, i, partitionLowWatermark, partitionHighWatermark),
+                        "Group: " + groupingKey + " - " + allCounts + "\nlowWatermark: " + partitionLowWatermark + ", highWatermark: " + partitionHighWatermark +
+                                "\nCurrent count: " + partitionInfo.getCount());
+                assertTrue(usedPartitionIds.add(partitionInfo.getId()), () -> "Duplicate id: " + partitionInfo);
+                final Tuple fromTuple = Tuple.fromBytes(partitionInfo.getFrom().toByteArray());
+                if (i > 0) {
+                    assertThat(fromTuple, greaterThan(lastToTuple));
+                }
+                lastToTuple = Tuple.fromBytes(partitionInfo.getTo().toByteArray());
+                assertThat(fromTuple, lessThanOrEqualTo(lastToTuple));
+
+                LOGGER.debug(KeyValueLogMessage.of("Visited partition",
+                        "group", groupingKey,
+                        "documentsSoFar", visitedCount,
+                        "documentsInGroup", records.size(),
+                        "partitionInfo.count", partitionInfo.getCount()));
+                // if partitionInfo.getCount() is wrong, this can be very confusing, so a different assertion might be
+                // worthwhile
+                final Set<Tuple> expectedPrimaryKeys = Set.copyOf(records.subList(visitedCount,
+                        visitedCount + partitionInfo.getCount()));
+                validateDocsInPartition(recordStore, index, partitionInfo.getId(), groupingKey,
+                        expectedPrimaryKeys,
+                        universalSearch);
+                visitedCount += partitionInfo.getCount();
+                assertThat(records.size(), greaterThanOrEqualTo(visitedCount));
+                validatePrimaryKeySegmentIndex(recordStore, index, groupingKey, partitionInfo.getId(),
+                        expectedPrimaryKeys, allowDuplicatePrimaryKeys);
+                expectedPrimaryKeys.forEach(primaryKey -> missingDocuments.get(groupingKey).remove(primaryKey));
+            }
+        }
+    }
+
+    private static int getPartitionLowWatermark(final Index index) {
+        String partitionLowWaterMarkStr = index.getOption(LuceneIndexOptions.INDEX_PARTITION_LOW_WATERMARK);
+        if (partitionLowWaterMarkStr == null) {
+            return Math.max(LucenePartitioner.DEFAULT_PARTITION_LOW_WATERMARK, 1);
+        } else {
+            return Integer.parseInt(partitionLowWaterMarkStr);
+        }
+    }
+
+    private static int getPartitionHighWatermark(final Index index) {
+        final String option = index.getOption(LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK);
+        if (option == null) {
+            return -1;
+        } else {
+            return Integer.parseInt(option);
+        }
     }
 
     List<LucenePartitionInfoProto.LucenePartitionInfo> getPartitionMeta(Index index,
@@ -226,7 +255,8 @@ public class LuceneIndexTestValidator {
         return Math.max(0, highWatermark - count);
     }
 
-    public static void validateDocsInPartition(final FDBRecordStore recordStore, Index index, int partitionId, Tuple groupingKey,
+    public static void validateDocsInPartition(final FDBRecordStore recordStore, Index index,
+                                               @Nullable Integer partitionId, Tuple groupingKey,
                                                Set<Tuple> expectedPrimaryKeys, final String universalSearch) throws IOException {
         LuceneScanQuery scanQuery;
         if (groupingKey.isEmpty()) {
@@ -262,7 +292,7 @@ public class LuceneIndexTestValidator {
     }
 
     public static IndexReader getIndexReader(final FDBRecordStore recordStore, final Index index,
-                                             final Tuple groupingKey, final int partitionId) throws IOException {
+                                             final Tuple groupingKey, @Nullable final Integer partitionId) throws IOException {
         final FDBDirectoryManager manager = getDirectoryManager(recordStore, index);
         return manager.getIndexReader(groupingKey, partitionId);
     }


### PR DESCRIPTION
This adds a new test that does concurrent updates to different records in lucene.
The test references two specific issues:
- #2989
- #2990 

And configures itself so as to avoid hitting those issues, but as those are fixed, we can expand the test to include coverage for those issues.