### PR TITLE
Remove static LuceneIndexTestDataModel methods

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -933,7 +933,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         public Map<Tuple, Map<Tuple, Tuple>> get() {
             int maxTransactionsPerLoop = 5;
             final LuceneIndexTestValidator luceneIndexTestValidator = new LuceneIndexTestValidator(() -> openContext(contextProps),
-                    context -> Objects.requireNonNull(dataModel.schemaSetup.apply(context)));
+                    dataModel::createOrOpenRecordStore);
             int currentLoop = 0;
             while (System.nanoTime() < endTime) {
                 currentLoop++;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -26,8 +26,6 @@ import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.LoggableTimeoutException;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.RecordMetaData;
-import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecordsTextProto;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
@@ -37,7 +35,6 @@ import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
 import com.apple.foundationdb.record.lucene.directory.FDBDirectoryLockFactory;
 import com.apple.foundationdb.record.lucene.directory.FDBDirectoryWrapper;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
@@ -73,10 +70,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -192,12 +187,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         if (isGrouped) {
             validateDeleteWhere(isSynthetic, dataModel.groupingKeyToPrimaryKeyToPartitionKey, contextProps, dataModel.schemaSetup, dataModel.index);
         }
-    }
-
-    private @Nonnull Function<FDBRecordContext, FDBRecordStore> getSchemaSetup(final RecordMetaDataBuilder metaDataBuilder) {
-        final RecordMetaData metadata = metaDataBuilder.build();
-        final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
-        return context -> createOrOpenRecordStore(context, metadata, path).getLeft();
     }
 
     static Stream<Arguments> manyDocumentsArgumentsSlow() {
@@ -892,16 +881,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         // that should take long to take 30+ minutes.... But we're probably getting pretty good coverage if it is just
         // running in a loop for 5 minutes even if it doesn't hit the requested loop count
         final long end = System.nanoTime() + TimeUnit.MINUTES.toNanos(5);
-
-        final Map<String, String> options = Map.of(
-                LuceneIndexOptions.INDEX_PARTITION_BY_FIELD_NAME, isSynthetic ? "parent.timestamp" : "timestamp",
-                LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(1000),
-                LuceneIndexOptions.PRIMARY_KEY_SEGMENT_INDEX_V2_ENABLED, String.valueOf(primaryKeySegmentIndexEnabled));
-
-        final RecordMetaDataBuilder metaDataBuilder = LuceneIndexTestDataModel.createBaseMetaDataBuilder();
-        final KeyExpression rootExpression = LuceneIndexTestDataModel.createRootExpression(isGrouped, isSynthetic);
-        Index index = LuceneIndexTestDataModel.addIndex(isSynthetic, rootExpression, options, metaDataBuilder);
-        final RecordMetaData metadata = metaDataBuilder.build();
         Random random = new Random(seed);
         final int repartitionCount = 2;
         final RandomTextGenerator outerTextGenerator = new RandomTextGenerator(random);
@@ -910,14 +889,19 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 .addProp(LuceneRecordContextProperties.LUCENE_MAX_DOCUMENTS_TO_MOVE_DURING_REPARTITIONING, random.nextInt(1000) + repartitionCount)
                 .addProp(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER, (double)random.nextInt(10) + 2) // it must be at least 2.0
                 .build();
+        // We create one builder here, and reuse it so that the dataModel for each thread has the same metadata,
+        // but different paths.
+        final LuceneIndexTestDataModel.Builder dataModelBuilder = new LuceneIndexTestDataModel
+                .Builder(random.nextLong(), LuceneIndexMaintenanceTest.this::getStoreBuilder, pathManager)
+                .setIsGrouped(isGrouped)
+                .setIsSynthetic(isSynthetic)
+                .setPrimaryKeySegmentIndexEnabled(primaryKeySegmentIndexEnabled)
+                .setPartitionHighWatermark(1000)
+                .setTextGeneratorWithNewRandom(outerTextGenerator);
 
         final List<ConcurrentStoreTestRunner> runners = IntStream.range(0, storeCount)
-                .mapToObj(i -> {
-                    final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
-                    return new ConcurrentStoreTestRunner(contextProps, context -> createOrOpenRecordStore(context, metadata, path).getLeft(),
-                            end, isGrouped, isSynthetic, new Random(random.nextLong()),
-                            index, outerTextGenerator);
-                }).collect(Collectors.toList());
+                .mapToObj(i -> new ConcurrentStoreTestRunner(contextProps, end, dataModelBuilder))
+                .collect(Collectors.toList());
 
         final List<Map<Tuple, Map<Tuple, Tuple>>> allIds = AsyncUtil.getAll(runners.stream()
                         .map(CompletableFuture::supplyAsync)
@@ -934,77 +918,50 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
     }
 
     private class ConcurrentStoreTestRunner implements Supplier<Map<Tuple, Map<Tuple, Tuple>>> {
-
-
-        private final AtomicInteger currentLoop;
-        private final RandomTextGenerator textGenerator;
         private final RecordLayerPropertyStorage contextProps;
-        Function<FDBRecordContext, FDBRecordStore> schemaSetup;
+        private final LuceneIndexTestDataModel dataModel;
         private final long endTime;
-        private final boolean isGrouped;
-        private final boolean isSynthetic;
-        private final Random random;
-        private final Index index;
-        final Map<Tuple, Map<Tuple, Tuple>> ids;
-        private final AtomicInteger transactionCounter;
-        private final AtomicInteger documentCount;
 
         public ConcurrentStoreTestRunner(final RecordLayerPropertyStorage contextProps,
-                                         final Function<FDBRecordContext, FDBRecordStore> schemaSetup,
-                                         final long endTime,
-                                         final boolean isGrouped,
-                                         final boolean isSynthetic,
-                                         final Random random,
-                                         final Index index,
-                                         final RandomTextGenerator outerTextGenerator) {
+                                         final long endTime, final LuceneIndexTestDataModel.Builder dataModelBuilder) {
             this.contextProps = contextProps;
-            this.schemaSetup = schemaSetup;
             this.endTime = endTime;
-            this.isGrouped = isGrouped;
-            this.isSynthetic = isSynthetic;
-            this.random = random;
-            this.index = index;
-            this.textGenerator = outerTextGenerator.withNewRandom(random);
-            this.currentLoop = new AtomicInteger(-1);
-            this.ids = new HashMap<>();
-            this.transactionCounter = new AtomicInteger();
-            this.documentCount = new AtomicInteger();
+            this.dataModel = dataModelBuilder.build();
         }
 
         @Override
         public Map<Tuple, Map<Tuple, Tuple>> get() {
             int maxTransactionsPerLoop = 5;
             final LuceneIndexTestValidator luceneIndexTestValidator = new LuceneIndexTestValidator(() -> openContext(contextProps),
-                    context -> Objects.requireNonNull(schemaSetup.apply(context)));
-            currentLoop.set(0);
+                    context -> Objects.requireNonNull(dataModel.schemaSetup.apply(context)));
+            int currentLoop = 0;
             while (System.nanoTime() < endTime) {
-                currentLoop.incrementAndGet();
+                currentLoop++;
                 try {
-                    transactionCounter.set(0);
-                    generateDocuments(isGrouped, isSynthetic, 1, random,
-                            contextProps, schemaSetup, random.nextInt(maxTransactionsPerLoop - 1) + 1, ids, textGenerator, transactionCounter, documentCount);
+                    dataModel.saveManyRecords(1, () -> openContext(contextProps), dataModel.nextInt(maxTransactionsPerLoop - 1) + 1);
                 } catch (RuntimeException e) {
-                    throw new RuntimeException("Failed to generate documents at iteration " + currentLoop.get(), e);
+                    throw new RuntimeException("Failed to generate documents at iteration " + currentLoop, e);
                 }
 
-                boolean mergeFailed = mergeIndex();
+                boolean mergeFailed = mergeIndex(currentLoop);
                 try {
-                    luceneIndexTestValidator.validate(index, ids, isSynthetic ? "child_str_value:forth" : "text_value:about", mergeFailed);
+                    luceneIndexTestValidator.validate(dataModel.index, dataModel.groupingKeyToPrimaryKeyToPartitionKey,
+                            dataModel.isSynthetic ? "child_str_value:forth" : "text_value:about", mergeFailed);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
             }
-            return ids;
+            return dataModel.groupingKeyToPrimaryKeyToPartitionKey;
         }
 
-        private boolean mergeIndex() {
+        private boolean mergeIndex(final int currentLoop) {
             try {
-                explicitMergeIndex(index, contextProps, schemaSetup);
+                explicitMergeIndex(dataModel.index, contextProps, dataModel.schemaSetup);
             } catch (FDBExceptions.FDBStoreRetriableException e) {
                 if (e.getCause() instanceof FDBException) {
                     final FDBException fe = (FDBException)e.getCause();
                     if (fe.getCode() == 1051) { // Batch GRV request rate limit exceeded
-                        LOGGER.info("Batch GRV exceeded at iteration " + currentLoop.get(), e);
+                        LOGGER.info("Batch GRV exceeded at iteration " + currentLoop, e);
                         try {
                             Thread.sleep(50);
                             return true;
@@ -1014,9 +971,9 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                         }
                     }
                 }
-                throw new RuntimeException("Failed merge at iteration " + currentLoop.get(), e);
+                throw new RuntimeException("Failed merge at iteration " + currentLoop, e);
             } catch (RuntimeException e) {
-                throw new RuntimeException("Failed merge at iteration " + currentLoop.get(), e);
+                throw new RuntimeException("Failed merge at iteration " + currentLoop, e);
             }
             return false;
         }
@@ -1069,41 +1026,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
             }
         }
         return null;
-    }
-
-    private void generateDocuments(final boolean isGrouped,
-                                   final boolean isSynthetic,
-                                   final int minDocumentCount,
-                                   final Random random,
-                                   final RecordLayerPropertyStorage contextProps,
-                                   final Function<FDBRecordContext, FDBRecordStore> schemaSetup,
-                                   final int transactionCount,
-                                   final Map<Tuple, Map<Tuple, Tuple>> ids,
-                                   final RandomTextGenerator textGenerator,
-                                   AtomicInteger transactionCounter,
-                                   final AtomicInteger documentCount) {
-        final long start = Instant.now().toEpochMilli();
-        int i = 0;
-        while (i < transactionCount ||
-                // keep inserting data until at least two groups have at least minDocumentCount
-                ids.values().stream()
-                        .map(Map::size)
-                        .sorted(Comparator.reverseOrder())
-                        .limit(2).skip(isGrouped ? 1 : 0).findFirst()
-                        .orElse(0) < minDocumentCount) {
-            final int docCount = random.nextInt(10) + 1;
-            try (FDBRecordContext context = openContext(contextProps)) {
-                FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
-                recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
-                for (int j = 0; j < docCount; j++) {
-                    LuceneIndexTestDataModel.saveRecord(isGrouped, isSynthetic, random, ids, textGenerator, start, recordStore, isGrouped ? random.nextInt(random.nextInt(10) + 1) : 0);
-                }
-                commit(context);
-                documentCount.addAndGet(docCount);
-            }
-            transactionCounter.incrementAndGet();
-            i++;
-        }
     }
 
     @Nonnull

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -182,10 +182,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 .addProp(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER, (double)dataModel.nextInt(10) + 2) // it must be at least 2.0
                 .build();
 
-        // Generate random documents
-        generateDocuments(isGrouped, isSynthetic, minDocumentCount, dataModel.random, contextProps, dataModel.schemaSetup,
-                dataModel.nextInt(15) + 1, dataModel.groupingKeyToPrimaryKeyToPartitionKey, dataModel.textGenerator,
-                new AtomicInteger(), new AtomicInteger());
+        dataModel.saveManyRecords(minDocumentCount, () -> openContext(contextProps), dataModel.nextInt(15) + 1);
 
         explicitMergeIndex(dataModel.index, contextProps, dataModel.schemaSetup);
 
@@ -293,8 +290,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                     "docCount", dataModel.groupingKeyToPrimaryKeyToPartitionKey.values().stream().mapToInt(Map::size).sum(),
                     "docMinPerGroup", dataModel.groupingKeyToPrimaryKeyToPartitionKey.values().stream().mapToInt(Map::size).min(),
                     "docMaxPerGroup", dataModel.groupingKeyToPrimaryKeyToPartitionKey.values().stream().mapToInt(Map::size).max()));
-            generateDocuments(isGrouped, isSynthetic, 1, dataModel.random,
-                    contextProps, dataModel.schemaSetup, dataModel.nextInt(maxTransactionsPerLoop - 1) + 1, dataModel.groupingKeyToPrimaryKeyToPartitionKey, dataModel.textGenerator, new AtomicInteger(), new AtomicInteger());
+            dataModel.saveManyRecords(1, () -> openContext(contextProps), dataModel.nextInt(maxTransactionsPerLoop - 1) + 1);
 
             explicitMergeIndex(dataModel.index, contextProps, dataModel.schemaSetup);
         }
@@ -376,7 +372,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
 
         // Generate random documents
         final int transactionCount = dataModel.nextInt(15) + 10;
-        generateDocuments(isGrouped, isSynthetic, minDocumentCount, dataModel.random, contextProps, dataModel.schemaSetup, transactionCount, dataModel.groupingKeyToPrimaryKeyToPartitionKey, dataModel.textGenerator, new AtomicInteger(), new AtomicInteger());
+        dataModel.saveManyRecords(minDocumentCount, () -> openContext(contextProps), transactionCount);
 
         final Function<StoreTimer.Wait, Duration> oldAsyncToSyncTimeout = fdb.getAsyncToSyncTimeout();
         AtomicInteger waitCounts = new AtomicInteger();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
@@ -80,10 +80,10 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
         try (FDBRecordContext context = openContext()) {
             final long start = Instant.now().toEpochMilli();
             final FDBRecordStore store = dataModel.createOrOpenRecordStore(context);
-            group1ContentDoc = dataModel.saveRecord(isGrouped, isSynthetic, start, store, 1);
-            group2ContentDoc = dataModel.saveRecord(isGrouped, isSynthetic, start, store, 2);
+            group1ContentDoc = dataModel.saveRecord(start, store, 1);
+            group2ContentDoc = dataModel.saveRecord(start, store, 2);
             if (includeEmptyDoc) {
-                group2EmptyDoc = dataModel.saveEmptyRecord(isGrouped, isSynthetic, start, store, 2);
+                group2EmptyDoc = dataModel.saveEmptyRecord(start, store, 2);
             }
             commit(context);
         }


### PR DESCRIPTION
There was only one usage of this that wasn't already creating a `LuceneIndexTestDataModel`, this changes `concurrentStoreTest` so that it can just use the model and then removes the static methods.
Removing the static methods will allow us to more easily maintain state, without having to add more and more parameters to the `saveRecord` method.

Resolves: #3002