### PR TITLE
Align aggregate query behaviour on empty tables more towards SQL standard

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
@@ -168,6 +168,9 @@ public final class QueryVisitor extends DelegatingVisitor<BaseVisitor> {
             final var literals = getDelegate().getPlanGenerationContext().getLiteralsBuilder();
             final var groupBy = LogicalOperator.generateGroupBy(getDelegate().getLogicalOperators(), groupByExpressions,
                     selectExpressions, where, outerCorrelations, literals);
+            if (groupByExpressions.isEmpty() && !getDelegate().isForDdl()) {
+                selectExpressions = LogicalOperator.adjustCountOnEmpty(selectExpressions);
+            }
             selectExpressions = selectExpressions.dereferenced(literals).expanded().pullUp(Expression.ofUnnamed(groupBy.getQuantifier().getRangesOver().get().getResultValue()).dereferenced(literals).getSingleItem().getUnderlying(), groupBy.getQuantifier().getAlias(), outerCorrelations).clearQualifier();
             final var finalOuterCorrelation = outerCorrelations;
             where = where.map(predicate -> predicate.pullUp(groupBy.getQuantifier().getRangesOver().get().getResultValue(), groupBy.getQuantifier().getAlias(), finalOuterCorrelation));

--- a/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
@@ -3,7 +3,7 @@
 #
 # This source file is part of the FoundationDB open source project
 #
-# Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,15 +35,15 @@ test_block:
   tests:
     -
       - query: select count(*) from T1;
-      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T1 where col1 = 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T1 where col1 > 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T1 where col1 = 0 group by col1;
@@ -61,17 +61,16 @@ test_block:
       - query: select count(*) from T1 where col1 > 0 group by col1;
       - error: "0AF00"
     -
-      # TODO (count query returns nothing instead of zero when running on aggregate index)
       - query: select count(*) from T2;
-      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
-#      - result: [{0}]
+      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - result: [{0}]
     -
       - query: select count(*) from T2 where col1 = 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T2 where col1 > 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T2 group by col1;
@@ -87,15 +86,15 @@ test_block:
       - result: []
     -
       - query: select count(*) from T3;
-      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T3 where col1 = 0;
-      - explain: "ISCAN(T3_I1 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T3 where col1 > 0;
-      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from T3 group by col1;
@@ -111,15 +110,15 @@ test_block:
       - result: []
     -
       - query: select count(col2) from T1;
-      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T1 where col1 = 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T1 where col1 > 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T1 where col1 = 0 group by col1;
@@ -137,17 +136,16 @@ test_block:
       - query: select count(col2) from T1 where col1 > 0 group by col1;
       - error: "0AF00"
     -
-      # TODO (count query returns nothing instead of zero when running on aggregate index)
       - query: select count(col2) from T2;
-      - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
-#      - result: [{0}]
+      - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - result: [{0}]
     -
       - query: select count(col2) from T2 where col1 = 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T2 where col1 > 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T2 group by col1;
@@ -163,15 +161,15 @@ test_block:
       - result: []
     -
       - query: select count(col2) from T3;
-      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T3 where col1 = 0;
-      - explain: "ISCAN(T3_I1 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T3 where col1 > 0;
-      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col2) from T3 group by col1;
@@ -187,44 +185,43 @@ test_block:
       - result: []
     -
       - query: select sum(col1) from T1;
-      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T1 where col1 = 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T1 where col2 = 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL2 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL2 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T1 where col1 > 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T1 where col2 > 0;
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL2 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL2 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
-      # TODO (sum query returns nothing instead of null when running on aggregate index)
       - query: select sum(col1) from T2;
-      - explain: "AISCAN(T2_I5 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
-#      - result: [{!null _}]
+      - explain: "AISCAN(T2_I5 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
+      - result: [{!null _}]
     -
       - query: select sum(col1) from T2 where col1 = 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T2 where col2 = 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL2 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL2 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T2 where col1 > 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL1 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T2 where col2 > 0;
-      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL2 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "SCAN(<,>) | TFILTER T2 | FILTER _.COL2 GREATER_THAN promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T2 where col1 = 0 group by col2;
@@ -242,23 +239,23 @@ test_block:
       - result: []
     -
       - query: select sum(col1) from T3;
-      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T3 where col1 = 0;
-      - explain: "ISCAN(T3_I1 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T3 where col2 = 0;
-      - explain: "ISCAN(T3_I2 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I2 [EQUALS promote(@c11 AS LONG)]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T3 where col1 > 0;
-      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T3 where col2 > 0;
-      - explain: "ISCAN(T3_I2 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(T3_I2 [[GREATER_THAN promote(@c11 AS LONG)]]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!null _}]
     -
       - query: select sum(col1) from T3 where col1 = 0 group by col2;
@@ -325,10 +322,9 @@ test_block:
     -
       - query: select count(*) from T1 where col1 > 0 group by col1;
       - error: "0AF00"
-#    -
-#      # TODO (count query returns nothing instead of zero when running on aggregate index)
-#      - query: select count(*) from T2;
-#      - result: [{0}]
+    -
+      - query: select count(*) from T2;
+      - result: [{0}]
     -
       - query: select count(*) from T2 where col1 = 0;
       - result: [{0}]
@@ -388,10 +384,9 @@ test_block:
     -
       - query: select count(col2) from T1 where col1 > 0 group by col1;
       - error: "0AF00"
-#    -
-#      # TODO (count query returns nothing instead of zero when running on aggregate index)
-#      - query: select count(col2) from T2;
-#      - result: [{0}]
+    -
+      - query: select count(col2) from T2;
+      - result: [{0}]
     -
       - query: select count(col2) from T2 where col1 = 0;
       - result: [{0}]
@@ -442,10 +437,14 @@ test_block:
     -
       - query: select sum(col1) from T1 where col2 > 0;
       - result: [{!null _}]
-#    -
-#      # TODO (sum query returns nothing instead of null when running on aggregate index)
-#      - query: select sum(col1) from T2;
-#      - result: [{!null _}]
+    -
+      # TODO (enhance SUM aggregate index to disambiguate null results and 0 results)
+      # This query is using the index T2_I5, the reason we're returning 0 here comes from the SUM index maintainer that
+      # is configured by default to:
+      # - subtract the indexed value when the corresponding tuple is removed from the base table.
+      # - if the sum reaches zero, it keeps it in the sum index and does not remove the entry from there.
+      - query: select sum(col1) from T2;
+      - result: [{0}]
     -
       - query: select sum(col1) from T2 where col1 = 0;
       - result: [{!null _}]

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.yamsql
@@ -31,16 +31,16 @@ test_block:
   tests:
     -
       - query: select count(*) from t1
-      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
-      - result: []
+      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - result: [{0}]
     -
       - query: select count(*) from t1 group by col2
       - explain: "AISCAN(MV2 <,> BY_GROUP -> [_0: [_0: KEY[0]], _1: [_0: VALUE[0]]]) | MAP (_._1._0 AS _0)"
       - result: []
     -
       - query: select count(col1) from t1
-      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
-      - result: []
+      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - result: [{0}]
     -
       - query: select count(col1) from t1 group by col2
       - explain: "AISCAN(MV4 <,> BY_GROUP -> [_0: [_0: KEY[0]], _1: [_0: VALUE[0]]]) | MAP (_._1._0 AS _0)"
@@ -50,7 +50,7 @@ test_block:
       - result: []
     -
       - query: select count(*) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(*) from t2 group by col2
@@ -58,7 +58,7 @@ test_block:
       - result: []
     -
       - query: select count(col1) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{0}]
     -
       - query: select count(col1) from t2 group by col2

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count.yamsql
@@ -45,7 +45,7 @@ test_block:
                  {ID: 4, 12, 2}]
     -
       - query: select count(*) from t1
-      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
+      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{4}]
     -
       - query: select count(*) from t1 group by col2
@@ -53,7 +53,7 @@ test_block:
       - result: [{1}, {3}]
     -
       - query: select count(col1) from t1
-      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
+      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{2}]
     -
       - query: select count(col1) from t1 group by col2
@@ -78,7 +78,7 @@ test_block:
                  {ID: 4, 12, 2, 20}]
     -
       - query: select count(*) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{4}]
     -
       - query: select count(*) from t2 group by col2
@@ -86,7 +86,7 @@ test_block:
       - result: [{1}, {3}]
     -
       - query: select count(col1) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{2}]
     -
       - query: select count(col1) from t2 group by col2

--- a/yaml-tests/src/test/resources/aggregate-index-tests.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-index-tests.yamsql
@@ -131,7 +131,7 @@ test_block:
        # At some point, should be able to roll up values from the aggregate index. However, even
        # controlling for that, it can still use the index
        - query: select max(col2) from T1 use index (mv8);
-       - explain: "ISCAN(MV8 <,>) | MAP (_ AS _0) | AGG (max_l(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+       - explain: "ISCAN(MV8 <,>) | MAP (_ AS _0) | AGG (max_l(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
        - result: [{!l 13}]
     -
        # Min/max indexes need keep what amounts to a standard value index on their keys (in order to properly look up
@@ -152,7 +152,7 @@ test_block:
       # this should use the aggregate index in the future, for now, it is using streaming aggregate
       # over base table scan.
       - query: select max(col2) from t2;
-      - explain: "ISCAN(MV3 <,>) | MAP (_ AS _0) | AGG (max_l(_._0.COL2) AS _0) | MAP (_._0._0 AS _0)"
+      - explain: "ISCAN(MV3 <,>) | MAP (_ AS _0) | AGG (max_l(_._0.COL2) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
       - result: [{!l 2}]
     -
       - query: select col1, sum(col2) from T1 USE INDEX (vi1) group by col1;
@@ -232,7 +232,7 @@ test_block:
       - result: [{!l 1}]
     -
       - query: select min_ever(col3) from t2
-      - explain: "AISCAN(MV7 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | MAP (_._0._0 AS _0)"
+      - explain: "AISCAN(MV7 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
     -
       - query: select col1, max_ever(col2) from T1 group by col1;
       - result: [{!l 10, !l 5}, {!l 20, !l 13}]

--- a/yaml-tests/src/test/resources/union-empty-tables.yamsql
+++ b/yaml-tests/src/test/resources/union-empty-tables.yamsql
@@ -66,11 +66,11 @@ test_block:
       - unorderedResult: []
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as X
-      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c22 AS DOUBLE)]] BY_GROUP -> [_0: [_0: KEY[0]], _1: [_0: VALUE[0]]]) | MAP (_._1._0 AS Y) | MAP (_.Y AS Y) ⊎ SCAN(<,>) | TFILTER T4 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | MAP (_._0._0 AS S)"
+      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c22 AS DOUBLE)]] BY_GROUP -> [_0: [_0: KEY[0]], _1: [_0: VALUE[0]]]) | MAP (_._1._0 AS Y) | MAP (_.Y AS Y) ⊎ SCAN(<,>) | TFILTER T4 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - unorderedResult: [{0}]
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as X
-      - explain: "SCAN(<,>) | TFILTER T3 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS Y) | MAP (_.Y AS Y) ⊎ SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | MAP (_._0._0 AS S)"
+      - explain: "SCAN(<,>) | TFILTER T3 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) | MAP (_.Y AS Y) ⊎ SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - unorderedResult: [{0}]
     -
       - query: select col2 from t1 where exists (select a from t3 where col2 <= id union all select b from t4 where col2 <= id)

--- a/yaml-tests/src/test/resources/union.yamsql
+++ b/yaml-tests/src/test/resources/union.yamsql
@@ -26,6 +26,10 @@ schema_template:
     create index mv10 as select count(*) from t3 group by a
     create table t4(id bigint, a bigint, b double, primary key(id))
     create table t5(id bigint, a string, b string, primary key(id))
+    create table t6(id bigint, col1 bigint, col2 bigint, primary key(id))
+    create table t7(id bigint, col1 bigint, col2 bigint, primary key(id))
+    create index mv11 as select count(*) from t6
+    create index mv12 as select count(*) from t7
 ---
 setup:
   steps:
@@ -150,11 +154,11 @@ test_block:
                           {A: 10.0, B: 20.0}]
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as X
-      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c22 AS DOUBLE)]] BY_GROUP -> [_0: [_0: KEY[0]], _1: [_0: VALUE[0]]]) | MAP (_._1._0 AS Y) | MAP (_.Y AS Y) ⊎ SCAN(<,>) | TFILTER T4 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | MAP (_._0._0 AS S)"
+      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c22 AS DOUBLE)]] BY_GROUP -> [_0: [_0: KEY[0]], _1: [_0: VALUE[0]]]) | MAP (_._1._0 AS Y) | MAP (_.Y AS Y) ⊎ SCAN(<,>) | TFILTER T4 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - result: [{S: 2}]
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as X
-      - explain: "SCAN(<,>) | TFILTER T3 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS Y) | MAP (_.Y AS Y) ⊎ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | MAP (_._0._0 AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | MAP (_._0._0 AS S)"
+      - explain: "SCAN(<,>) | TFILTER T3 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) | MAP (_.Y AS Y) ⊎ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - result: [{S: 5}]
     -
       - query: select col2 from t1 where exists (select a from t3 where col2 <= id union all select b from t4 where col2 <= id)
@@ -168,4 +172,8 @@ test_block:
     -
       - query: select col1, col2 from t1 union all select a, b from t5
       - error: "42F65"
+    -
+      - query: select sum(Y) as S from (select count(*) as Y from t6 union all select count(*) from t7) as X
+      - explain: "AISCAN(MV11 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) | MAP (_.Y AS Y) ⊎ AISCAN(MV12 <,> BY_GROUP -> [_0: [_0: VALUE[0]]]) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS S)"
+      - result: [{0}]
 ...


### PR DESCRIPTION
Aggregate plans currently do not return the expected results as defined by SQL standard; as per SQL standard section 4.16.4 (Aggregate functions):
> If no row qualifies, then the result of COUNT is 0 (zero), and the result of any other aggregate function is the null value.

However, when the table is empty [*], no rows are returned, i.e.:

```sql
create table t1(col1 int);
select count(*) from t1; -- returns nothing, instead of 0
select sum(col1) from t1; -- returns nothing, instead of null
```

This mostly consumes a previous [fix](https://github.com/FoundationDB/fdb-record-layer/pull/2931) that expands the semantics of `ForEach` quantifier, it adapts the plan generation making the group by quantifier cognizant to empty results case, effectively fixing the issues above.
___
[*] an "empty" table is more nuanced; empty in the context of this fix means the table did have any mutations (yet), although a table could become empty again when all existing rows are truncated, the underlying aggregate index maintainers behave differently, and sometimes keep a certain aggregate value, even if no more elements remain in the group, this behaviour is controlled by the index option `CLEAR_WHEN_ZERO` and is outside the context of this fix.