### PR TITLE
Ability to prevent yamsql tests from running against old versions.

### DIFF
--- a/scripts/YAML-SQL.xml
+++ b/scripts/YAML-SQL.xml
@@ -47,12 +47,12 @@
     timezone_;timezone_minute;to;trailing;transaction;translate;translation;trim;type;union;unique;unknown;update;
     upper;usage;user;using;value;values;varying;view;when;whenever;where;with;work;write;year;zone" ignore_case="true" />
     <keywords2 keywords="bigint;bit;boolean;bytes;char;char_;character;date;dec;decimal;double;float;int;integer;nchar;
-    numeric;real;smallint;string;time;timestamp;varchar;!!;!r;!in;!a;" />
+    numeric;real;smallint;string;time;timestamp;varchar;!!;!r;!in;!a;!current_version" />
     <keywords3 keywords="false;null;true;ordered;randomized;parallelized;test;block;single_repetition_ordered;
     single_repetition_randomized;single_repetition_parallelized;multi_repetition_ordered;multi_repetition_randomized;
     multi_repetition_parallelized" />
     <keywords4 keywords="connect:;query:;load schema template:;set schema state:;result:;unorderedresult:;explain:;
-    explaincontains:;count:;error:;planhash:;setup:;schema_template:;test_block:;options:;tests:;mode:;repetition:;seed:;
+    explaincontains:;count:;error:;planhash:;setup:;schema_template:;supported_version:;test_block:;options:;tests:;mode:;repetition:;seed:;
     check_cache:;connection_lifecycle:;steps:;preset:;statement_type:;!r;!in;!a;" />
   </highlighting>
   <extensionMap>

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.yamltests;
 
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.util.Assert;
+import com.apple.foundationdb.relational.yamltests.block.FileOptions;
 import com.apple.foundationdb.relational.yamltests.block.SetupBlock;
 import com.apple.foundationdb.relational.yamltests.block.TestBlock;
 import com.apple.foundationdb.relational.yamltests.command.Command;
@@ -34,10 +35,13 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
 
 public class CustomYamlConstructor extends SafeConstructor {
 
@@ -51,8 +55,10 @@ public class CustomYamlConstructor extends SafeConstructor {
         yamlConstructors.put(new Tag("!sc"), new ConstructStringContains());
         yamlConstructors.put(new Tag("!null"), new ConstructNullPlaceholder());
         yamlConstructors.put(new Tag("!not_null"), new ConstructNotNull());
+        yamlConstructors.put(new Tag("!current_version"), new ConstructCurrentVersion());
 
         //blocks
+        requireLineNumber.add(FileOptions.OPTIONS);
         requireLineNumber.add(SetupBlock.SETUP_BLOCK);
         requireLineNumber.add(SetupBlock.SchemaTemplateBlock.SCHEMA_TEMPLATE_BLOCK);
         requireLineNumber.add(TestBlock.TEST_BLOCK);
@@ -91,6 +97,24 @@ public class CustomYamlConstructor extends SafeConstructor {
         private LinedObject(final Object object, final int lineNumber) {
             this.object = object;
             this.lineNumber = lineNumber;
+        }
+
+        /**
+         * Remove the {@link LinedObject} wrappers from keys and create a new map
+         * @param blockMap a map from a yaml file that may have keys that had lines added
+         * @return a new map where the keys do not have lines added
+         */
+        public static Map<?, ?> unlineKeys(Map<?, ?> blockMap) {
+            return blockMap.entrySet().stream()
+                    .collect(Collectors.toMap(
+                            entry -> {
+                                if (entry.getKey() instanceof LinedObject) {
+                                    return ((LinedObject)entry.getKey()).getObject();
+                                } else {
+                                    return entry.getKey();
+                                }
+                            },
+                            Map.Entry::getValue));
         }
 
         @Nonnull
@@ -146,6 +170,14 @@ public class CustomYamlConstructor extends SafeConstructor {
         @Override
         public Object construct(Node node) {
             return CustomTag.NotNull.INSTANCE;
+        }
+    }
+
+    private class ConstructCurrentVersion extends AbstractConstruct {
+
+        @Override
+        public Object construct(Node node) {
+            return FileOptions.CurrentVersion.INSTANCE;
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -100,7 +100,7 @@ public class CustomYamlConstructor extends SafeConstructor {
         }
 
         /**
-         * Remove the {@link LinedObject} wrappers from keys and create a new map
+         * Remove the {@link LinedObject} wrappers from keys and create a new map.
          * @param blockMap a map from a yaml file that may have keys that had lines added
          * @return a new map where the keys do not have lines added
          */
@@ -173,7 +173,7 @@ public class CustomYamlConstructor extends SafeConstructor {
         }
     }
 
-    private class ConstructCurrentVersion extends AbstractConstruct {
+    private static class ConstructCurrentVersion extends AbstractConstruct {
 
         @Override
         public Object construct(Node node) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
@@ -24,10 +24,10 @@ import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.api.RelationalStatement;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.Array;
 import java.sql.DatabaseMetaData;
@@ -38,9 +38,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * A connection factory that creates a connection that can be used with multiple servers.
@@ -65,7 +62,7 @@ public class MultiServerConnectionFactory implements YamlRunner.YamlConnectionFa
     private final int initialConnection;
     @Nonnull
     private final YamlRunner.YamlConnectionFactory defaultFactory;
-    @Nullable
+    @Nonnull
     private final List<YamlRunner.YamlConnectionFactory> alternateFactories;
 
     public MultiServerConnectionFactory(@Nonnull final YamlRunner.YamlConnectionFactory defaultFactory,
@@ -97,19 +94,15 @@ public class MultiServerConnectionFactory implements YamlRunner.YamlConnectionFa
         return versionsUnderTest;
     }
 
-    @Nullable
+    @Nonnull
     private List<RelationalConnection> alternateConnections(URI connectPath) {
-        if (alternateFactories == null) {
-            return null;
-        } else {
-            return alternateFactories.stream().map(factory -> {
-                try {
-                    return factory.getNewConnection(connectPath);
-                } catch (SQLException e) {
-                    throw new IllegalStateException("Failed to create a connection", e);
-                }
-            }).collect(Collectors.toList());
-        }
+        return alternateFactories.stream().map(factory -> {
+            try {
+                return factory.getNewConnection(connectPath);
+            } catch (SQLException e) {
+                throw new IllegalStateException("Failed to create a connection", e);
+            }
+        }).collect(Collectors.toList());
     }
 
     /**
@@ -129,15 +122,13 @@ public class MultiServerConnectionFactory implements YamlRunner.YamlConnectionFa
         public MultiServerRelationalConnection(@Nonnull ConnectionSelectionPolicy connectionSelectionPolicy,
                                              final int initialConnecion,
                                              @Nonnull final RelationalConnection defaultConnection,
-                                             @Nullable List<RelationalConnection> alternateConnections) {
+                                             @Nonnull List<RelationalConnection> alternateConnections) {
             this.connectionSelectionPolicy = connectionSelectionPolicy;
             this.currentConnectionSelector = initialConnecion;
             allConnections = new ArrayList<>();
             // The default connection is always the one at location 0
             allConnections.add(defaultConnection);
-            if (alternateConnections != null) {
-                allConnections.addAll(alternateConnections);
-            }
+            allConnections.addAll(alternateConnections);
         }
 
         @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -28,8 +28,6 @@ import com.apple.foundationdb.relational.yamltests.block.Block;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -39,6 +37,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @SuppressWarnings({"PMD.GuardLogStatement"}) // It already is, but PMD is confused and reporting error in unrelated locations.
 public final class YamlExecutionContext {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
@@ -67,7 +67,23 @@ public final class YamlRunner {
     private final YamlExecutionContext executionContext;
 
     public interface YamlConnectionFactory {
+        /**
+         * Convert a connection uri into an actual connection.
+         * @param connectPath the path to connect to
+         * @return A new {@link RelationalConnection} for the given path appropriate for this test class
+         * @throws SQLException if we cannot connect
+         */
         RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException;
+
+        /**
+         * The versions that the connection has, other than the current code.
+         * <p>
+         *     If we are just testing against the current code, this will be empty, but otherwise it will include the
+         *     versions that we're testing. In the future we may want to support tests that don't run against the
+         *     current version, but that's not currently needed, so not supported.
+         * </p>
+         * @return A set of versions that we are testing against
+         */
         Set<String> getVersionsUnderTest();
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
@@ -35,7 +35,6 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
 
-import javax.annotation.Nonnull;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,6 +46,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
 
 @SuppressWarnings({"PMD.GuardLogStatement"}) // It already is, but PMD is confused and reporting error in unrelated locations.
 public final class YamlRunner {
@@ -66,6 +68,7 @@ public final class YamlRunner {
 
     public interface YamlConnectionFactory {
         RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException;
+        Set<String> getVersionsUnderTest();
     }
 
     public YamlRunner(@Nonnull String resourcePath, @Nonnull YamlConnectionFactory factory, boolean correctExplain) throws RelationalException {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
@@ -35,6 +35,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
 
+import javax.annotation.Nonnull;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,8 +48,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
 
 @SuppressWarnings({"PMD.GuardLogStatement"}) // It already is, but PMD is confused and reporting error in unrelated locations.
 public final class YamlRunner {
@@ -82,7 +81,8 @@ public final class YamlRunner {
          *     versions that we're testing. In the future we may want to support tests that don't run against the
          *     current version, but that's not currently needed, so not supported.
          * </p>
-         * @return A set of versions that we are testing against
+         * @return A set of versions that we are testing against, or an empty set if just testing against the current
+         * version
          */
         Set<String> getVersionsUnderTest();
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
@@ -20,98 +20,36 @@
 
 package com.apple.foundationdb.relational.yamltests.block;
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
 import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import javax.annotation.Nonnull;
-import java.net.URI;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
- * Block is a single region in the YAMSQL file that can either be a {@link SetupBlock} or {@link TestBlock}.
+ * Block is a single region in the YAMSQL file that can either be a
+ * {@link FileOptions}, {@link SetupBlock} or {@link TestBlock}.
  * <ul>
+ *      <li> {@link FileOptions}: Controls whether a file should be run at all, and other configuration that runs before
+ *          creating the connection.</li>
  *      <li> {@link SetupBlock}: It can be either a `setup` block or a `destruct` block. The motive of these block
  *          is to "setup" and "clean" the environment needed to run the `test-block`s. A Setup block consist of a list
  *          of commands.</li>
  *      <li> {@link TestBlock}: Defines a scope for a group of tests by setting the knobs that determines how those
  *          tests are run.</li>
  * </ul>
- * <p>
- * Each block needs to be associated with a `connectionURI` which provides it with the address to the database to which
- * the block connects to for running its executables. The block does so through the
- * {@link com.apple.foundationdb.relational.yamltests.YamlRunner.YamlConnectionFactory}. A block is free to implement `how` and `when`
- * it wants to use the factory to create a connection and also manages the lifecycle of the established connection.
  */
-@SuppressWarnings({"PMD.GuardLogStatement"})
-public abstract class Block {
-
-    private static final Logger logger = LogManager.getLogger(Block.class);
-
-    static final String BLOCK_CONNECT = "connect";
-
-    int lineNumber;
-    @Nonnull
-    YamlExecutionContext executionContext;
-    @Nonnull
-    private final URI connectionURI;
-    @Nonnull
-    final List<Consumer<RelationalConnection>> executables;
-
-    Block(int lineNumber, @Nonnull List<Consumer<RelationalConnection>> executables, @Nonnull URI connectionURI, @Nonnull YamlExecutionContext executionContext) {
-        this.lineNumber = lineNumber;
-        this.executables = executables;
-        this.connectionURI = connectionURI;
-        this.executionContext = executionContext;
-    }
-
-    public int getLineNumber() {
-        return lineNumber;
-    }
-
-    /**
-     * Executes the executables from the parsed block in a single connection.
-     */
-    public abstract void execute();
-
-    protected final void executeExecutables(@Nonnull Collection<Consumer<RelationalConnection>> list) {
-        connectToDatabaseAndExecute(connection -> list.forEach(t -> t.accept(connection)));
-    }
-
-    /**
-     * Tries connecting to a database and execute the consumer using the established connection.
-     *
-     * @param consumer operations to be performed on the database using the established connection.
-     */
-    void connectToDatabaseAndExecute(Consumer<RelationalConnection> consumer) {
-        logger.debug("🚠 Connecting to database: `{}`", connectionURI);
-        try (var connection = executionContext.getConnectionFactory().getNewConnection(connectionURI)) {
-            logger.debug("✅ Connected to database: `{}`", connectionURI);
-            consumer.accept(connection);
-        } catch (SQLException sqle) {
-            throw executionContext.wrapContext(sqle,
-                    () -> String.format("‼️ Error connecting to the database `%s` in block at line %d", connectionURI, lineNumber),
-                    "connection [" + connectionURI + "]", getLineNumber());
-        }
-    }
-
+public interface Block {
     /**
      * Looks at the block to determine if its one of the valid blocks. If it is a valid one, parses it to that. This
      * method dispatches the execution to the right block which takes care of reading from the block and initializing
-     * the correctly configured {@link Block} for execution.
+     * the correctly configured {@link ConnectedBlock} for execution.
      *
      * @param document a region in the file
      * @param executionContext information needed to carry out the execution
      */
-    public static Block parse(@Nonnull Object document, @Nonnull YamlExecutionContext executionContext) {
+    static Block parse(@Nonnull Object document, @Nonnull YamlExecutionContext executionContext) {
         final var blockObject = Matchers.map(document, "block");
         Assert.thatUnchecked(blockObject.size() == 1, "Illegal Format: A block is expected to be a map of size 1");
         final var entry = Matchers.firstEntry(blockObject, "block key-value");
@@ -124,8 +62,17 @@ public abstract class Block {
                 return TestBlock.parse(lineNumber, entry.getValue(), executionContext);
             case SetupBlock.SchemaTemplateBlock.SCHEMA_TEMPLATE_BLOCK:
                 return SetupBlock.SchemaTemplateBlock.parse(lineNumber, entry.getValue(), executionContext);
+            case FileOptions.OPTIONS:
+                return FileOptions.parse(lineNumber, entry.getValue(), executionContext);
             default:
                 throw new RuntimeException("Cannot recognize the type of block");
         }
     }
+
+    int getLineNumber();
+
+    /**
+     * Executes the executables from the parsed block in a single connection.
+     */
+    void execute();
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
@@ -1,0 +1,94 @@
+/*
+ * ConnectedBlock.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.block;
+
+import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link Block} that requires an active connection for execution.
+ * <p>
+ * Each block needs to be associated with a `connectionURI` which provides it with the address to the database to which
+ * the block connects to for running its executables. The block does so through the
+ * {@link com.apple.foundationdb.relational.yamltests.YamlRunner.YamlConnectionFactory}. A block is free to implement `how` and `when`
+ * it wants to use the factory to create a connection and also manages the lifecycle of the established connection.
+ * </p>
+ */
+@SuppressWarnings({"PMD.GuardLogStatement"})
+public abstract class ConnectedBlock implements Block {
+
+    private static final Logger logger = LogManager.getLogger(ConnectedBlock.class);
+
+    static final String BLOCK_CONNECT = "connect";
+
+    int lineNumber;
+    @Nonnull
+    YamlExecutionContext executionContext;
+    @Nonnull
+    private final URI connectionURI;
+    @Nonnull
+    final List<Consumer<RelationalConnection>> executables;
+
+    ConnectedBlock(int lineNumber, @Nonnull List<Consumer<RelationalConnection>> executables, @Nonnull URI connectionURI, @Nonnull YamlExecutionContext executionContext) {
+        this.lineNumber = lineNumber;
+        this.executables = executables;
+        this.connectionURI = connectionURI;
+        this.executionContext = executionContext;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    protected final void executeExecutables(@Nonnull Collection<Consumer<RelationalConnection>> list) {
+        connectToDatabaseAndExecute(connection -> list.forEach(t -> t.accept(connection)));
+    }
+
+    /**
+     * Tries connecting to a database and execute the consumer using the established connection.
+     *
+     * @param consumer operations to be performed on the database using the established connection.
+     */
+    void connectToDatabaseAndExecute(Consumer<RelationalConnection> consumer) {
+        logger.debug("🚠 Connecting to database: `{}`", connectionURI);
+        try (var connection = executionContext.getConnectionFactory().getNewConnection(connectionURI)) {
+            logger.debug("✅ Connected to database: `{}`", connectionURI);
+            consumer.accept(connection);
+        } catch (SQLException sqle) {
+            throw executionContext.wrapContext(sqle,
+                    () -> String.format("‼️ Error connecting to the database `%s` in block at line %d", connectionURI, lineNumber),
+                    "connection [" + connectionURI + "]", getLineNumber());
+        }
+    }
+
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
@@ -1,0 +1,105 @@
+/*
+ * FileOptions.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.block;
+
+import com.apple.foundationdb.relational.yamltests.Matchers;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assumptions;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Block that configures aspects of the test that do not require a connection yet.
+ * <p>
+ *     This supports the following sub-commands:
+ *     <ul>
+ *         <li>{@code supported_version}: if this is set, it will disable the test when running against a server
+ *         of a specific version (or newer). The special yaml tag {@code !current_version} can be used to indicate that
+ *         it should work against the current code, but is not expected to work with any older versions.
+ *         In the future, the release script will update these automatically to the version being released.
+ *         <p>
+ *             <b>Example:</b>
+ *             <pre>{@code
+ *                 ---
+ *                 options:
+ *                     supported_version: !current_version
+ *             }</pre>
+ *         </p></li>
+ *     </ul>
+ * </p>
+ */
+public class FileOptions {
+    public static final String OPTIONS = "options";
+    private static final String SUPPORTED_VERSION = "supported_version";
+    private static final Logger logger = LogManager.getLogger(FileOptions.class);
+
+    public static Block parse(int lineNumber, Object document, YamlExecutionContext executionContext) {
+        final Map<?, ?> options = Matchers.map(document, OPTIONS);
+        Object supportedVersion = options.get(SUPPORTED_VERSION);
+        if (supportedVersion instanceof CurrentVersion) {
+            final Set<String> versionsUnderTest = executionContext.getConnectionFactory().getVersionsUnderTest();
+            // IntelliJ, at least, doesn't display the reason, so log it
+            logger.info(
+                    "Skipping test that only works against the current version, when we're running with these versions: " +
+                    versionsUnderTest);
+            Assumptions.assumeTrue(versionsUnderTest.isEmpty(),
+                    () -> "Test only works against the current version, but we are running with these versions: " +
+                    versionsUnderTest);
+        } else {
+            throw new RuntimeException("Unsupported supported_version: " + supportedVersion);
+        }
+        return new NoOpBlock(lineNumber);
+    }
+
+    public static final class CurrentVersion {
+        public static final CurrentVersion INSTANCE = new CurrentVersion();
+
+        private CurrentVersion() {
+        }
+
+        @Override
+        public String toString() {
+            return "!current_version";
+        }
+    }
+
+    private static class NoOpBlock implements Block {
+        private final int lineNumber;
+
+        NoOpBlock(int lineNumber) {
+            this.lineNumber = lineNumber;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return this.lineNumber;
+        }
+
+        @Override
+        public void execute() {
+
+        }
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
@@ -46,9 +46,7 @@ import java.util.Set;
  *                 options:
  *                     supported_version: !current_version
  *             }</pre>
- *         </p></li>
  *     </ul>
- * </p>
  */
 public class FileOptions {
     public static final String OPTIONS = "options";

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
@@ -62,7 +62,7 @@ public class FileOptions {
             final Set<String> versionsUnderTest = executionContext.getConnectionFactory().getVersionsUnderTest();
             // IntelliJ, at least, doesn't display the reason, so log it
             logger.info(
-                    "Skipping test that only works against the current version, when we're running with these versions: " +
+                    "Skipping test that only works against the current version, when we're running with these versions: {}",
                     versionsUnderTest);
             Assumptions.assumeTrue(versionsUnderTest.isEmpty(),
                     () -> "Test only works against the current version, but we are running with these versions: " +

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
@@ -36,7 +36,7 @@ import java.util.Set;
  *     This supports the following sub-commands:
  *     <ul>
  *         <li>{@code supported_version}: if this is set, it will disable the test when running against a server
- *         of a specific version (or newer). The special yaml tag {@code !current_version} can be used to indicate that
+ *         older than a specific version. The special yaml tag {@code !current_version} can be used to indicate that
  *         it should work against the current code, but is not expected to work with any older versions.
  *         In the future, the release script will update these automatically to the version being released.
  *         <p>

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.command.Command;
 import com.apple.foundationdb.relational.yamltests.command.QueryCommand;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +34,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
+
+import javax.annotation.Nonnull;
 
 /**
  * Implementation of block that serves the purpose of creating the 'environment' needed to run the {@link TestBlock}
@@ -44,10 +45,10 @@ import java.util.function.Consumer;
  * <p>
  * The failure handling in case of {@link SetupBlock} is straight-forward. It {@code throws} downstream exceptions
  * and errors to handled in the consumer. The rationale for this is that if the {@link SetupBlock} fails at step,
- * there is no guarantee **as of now** that some following {@link Block} can run independent of this failure.
+ * there is no guarantee **as of now** that some following {@link ConnectedBlock} can run independent of this failure.
  */
 @SuppressWarnings({"PMD.AvoidCatchingThrowable"})
-public class SetupBlock extends Block {
+public class SetupBlock extends ConnectedBlock {
 
     public static final String SETUP_BLOCK = "setup";
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
@@ -39,8 +39,7 @@ import java.util.jar.Manifest;
  * Extension to run an external server, add as a field, annotated with {@link org.junit.jupiter.api.extension.RegisterExtension}.
  * <p>
  *     For example:
- *     <pre>{@code
- * @RegisterExtension
+ *     <pre>{@code @RegisterExtension
  * static final RunExternalServerExtension = new RunExternalServerExtension();
  *     }</pre>
  */

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
@@ -43,7 +43,6 @@ import java.util.jar.Manifest;
  * @RegisterExtension
  * static final RunExternalServerExtension = new RunExternalServerExtension();
  *     }</pre>
- * </p>
  */
 public class RunExternalServerExtension implements BeforeAllCallback, AfterAllCallback {
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
@@ -93,8 +93,8 @@ public class RunExternalServerExtension implements BeforeAllCallback, AfterAllCa
         File jar;
         if (jarName == null) {
             final File externalDirectory = new File(Objects.requireNonNull(System.getProperty(EXTERNAL_SERVER_PROPERTY_NAME)));
-            final File[] externalServers = externalDirectory.listFiles(file -> file.getName().endsWith(".jar"));
-            Assertions.assertEquals(1, Objects.requireNonNull(externalServers).length);
+            final File[] externalServers = Objects.requireNonNull(externalDirectory.listFiles(file -> file.getName().endsWith(".jar")));
+            Assertions.assertEquals(1, externalServers.length);
             jar = externalServers[0];
         } else {
             jar = new File(jarName);
@@ -113,7 +113,7 @@ public class RunExternalServerExtension implements BeforeAllCallback, AfterAllCa
         }
 
         this.version = getVersion(jar);
-        logger.info("Started " + jar + " Version: " + version);
+        logger.info("Started {} Version: {}", jar, version);
     }
 
     private static String getVersion(File jar) throws IOException {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
@@ -1,0 +1,139 @@
+/*
+ * RunExternalServerExtension.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.server;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+/**
+ * Extension to run an external server, add as a field, annotated with {@link org.junit.jupiter.api.extension.RegisterExtension}.
+ * <p>
+ *     For example:
+ *     <pre>{@code
+ * @RegisterExtension
+ * static final RunExternalServerExtension = new RunExternalServerExtension();
+ *     }</pre>
+ * </p>
+ */
+public class RunExternalServerExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private static final Logger logger = LogManager.getLogger(RunExternalServerExtension.class);
+    public static final String EXTERNAL_SERVER_PROPERTY_NAME = "yaml_testing_external_server";
+
+    private static final int SERVER_PORT = 1111;
+    private final String jarName;
+    private String version;
+    private Process serverProcess;
+
+    /**
+     * Create a new extension that will run latest released version of the server, as downloaded by gradle.
+     */
+    public RunExternalServerExtension() {
+        this(null);
+    }
+
+    /**
+     * Create a new extension that will run a specific jar.
+     * @param jarName the path to the jar to run
+     */
+    public RunExternalServerExtension(String jarName) {
+        this.jarName = jarName;
+    }
+
+    /**
+     * Get the port to use when connecting.
+     * @return the grpc port that the server is listening to
+     */
+    public int getPort() {
+        return SERVER_PORT;
+    }
+
+    /**
+     * Get the version of the server.
+     * @return the version of the server being run.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        Assumptions.abort(); // Will be able to re-enable when we have a published external server to use here
+        File jar;
+        if (jarName == null) {
+            final File externalDirectory = new File(Objects.requireNonNull(System.getProperty(EXTERNAL_SERVER_PROPERTY_NAME)));
+            final File[] externalServers = externalDirectory.listFiles(file -> file.getName().endsWith(".jar"));
+            Assertions.assertEquals(1, Objects.requireNonNull(externalServers).length);
+            jar = externalServers[0];
+        } else {
+            jar = new File(jarName);
+        }
+        Assertions.assertTrue(jar.exists(), "Jar could not be found " + jar.getAbsolutePath());
+        ProcessBuilder processBuilder = new ProcessBuilder("java", "-jar", jar.getAbsolutePath());
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+
+        this.serverProcess = processBuilder.start();
+
+        // TODO: There should be a better way to figure out that the server is fully up and  running
+        Thread.sleep(3000);
+        if (!serverProcess.isAlive()) {
+            Assertions.fail("Failed to start the external server");
+        }
+
+        this.version = getVersion(jar);
+        logger.info("Started " + jar + " Version: " + version);
+    }
+
+    private static String getVersion(File jar) throws IOException {
+        try (JarFile jarFile = new JarFile(jar)) {
+            final Manifest manifest = jarFile.getManifest();
+            final Attributes mainAttributes = manifest.getMainAttributes();
+            String version = mainAttributes.getValue("Specification-Version");
+            if (version != null) {
+                return version;
+            } else {
+                return Assertions.fail("Server does not specify a version in the manifest: " + jar.getAbsolutePath());
+            }
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        if ((serverProcess != null) && serverProcess.isAlive()) {
+            serverProcess.destroy();
+        }
+    }
+
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for interacting with an external server while running yaml tests.
+ */
+package com.apple.foundationdb.relational.yamltests.server;

--- a/yaml-tests/src/test/java/EmbeddedYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/EmbeddedYamlIntegrationTests.java
@@ -21,12 +21,11 @@
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
+import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
 
 public class EmbeddedYamlIntegrationTests extends YamlIntegrationTests {
     YamlRunner.YamlConnectionFactory createConnectionFactory() {

--- a/yaml-tests/src/test/java/EmbeddedYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/EmbeddedYamlIntegrationTests.java
@@ -21,11 +21,26 @@
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
+import java.net.URI;
 import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
 
 public class EmbeddedYamlIntegrationTests extends YamlIntegrationTests {
     YamlRunner.YamlConnectionFactory createConnectionFactory() {
-        return connectPath -> DriverManager.getConnection(connectPath.toString()).unwrap(RelationalConnection.class);
+        return new YamlRunner.YamlConnectionFactory() {
+            @Override
+            public RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+                return DriverManager.getConnection(connectPath.toString()).unwrap(RelationalConnection.class);
+            }
+
+            @Override
+            public Set<String> getVersionsUnderTest() {
+                return Set.of();
+            }
+        };
     }
 
 }

--- a/yaml-tests/src/test/java/JDBCExternalYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/JDBCExternalYamlIntegrationTests.java
@@ -25,12 +25,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Disabled;
 
+import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
 
 /**
  * A version of {@link YamlIntegrationTests} that points to an external running server.

--- a/yaml-tests/src/test/java/JDBCInProcessYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/JDBCInProcessYamlIntegrationTests.java
@@ -30,13 +30,12 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Like {@link EmbeddedYamlIntegrationTests} only it runs the YAML via the fdb-relational-jdbc client


### PR DESCRIPTION
With the new mixed-mode tests being run as part of PRB, we'll need a way to say that a test should not run against old versions. This adds support for disabling an entire yaml file. Future steps would be to allow disabling a specific query, providing a specific supported version, and also having the build update the `!current_version` to the version being released.