### PR TITLE
Change yaml-tests to download latest released server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,9 @@ allprojects {
             logger.warn 'Warning: you have enabled maven local repository. This should only be used on local workstations to test undeployed library dependencies.'
         }
         mavenCentral()
+        maven {
+            url "https://ossartifacts.jfrog.io/artifactory/fdb-record-layer/"
+        }
     }
 }
 

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -69,39 +69,54 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
 }
 
-ext.resolveOtherServer = { ->
+// This "method" resolves the latest shadowJar version of the valkyrie-server, and returns the file reference to it
+// which can be used in `Copy` tasks.
+ext.resolveOtherServer = { Set<String> rejectedVersions ->
     def configurationName = "resolveArtifact-${UUID.randomUUID()}"
     return rootProject.with {
         configurations.create(configurationName, {
             resolutionStrategy {
-                failOnChangingVersions()
                 // Note: In the root of the project we set cacheChangingModulesFor and cacheDynamicVersionFor to 0
                 // We explicitly change that for changing modules, because we should reject those anyways.
                 cacheChangingModulesFor 1000, "days" // TTL for snapshots
             }
         })
-        // I tried setting the version to 'latest.release', but that causes it to download all of the snapshots
-        // every time you execute. This is because `latest.release` becomes `LatestVersionSelector` which
-        // `requiresMetadata`, because it looks at the metadata for the module to determine if it is a release.
-        // I also tried just setting it to `+`, but that causes it to fetch the latest snapshot, which isn't exactly
-        // what we want.
+        // If you're wondering why this doesn't just use `latest.release`:
+        // `latest.release` becomes `LatestVersionSelector` which `requiresMetadata` in order to determine if the
+        // version in question is a release. This means that it can't just look at the version listing, it has to
+        // download all of them, and reject them. This adds a frustrating amount of time to the build.
+        // Instead we specify `+` which does not require the metadata, and then reject a list of versions.
+        // Every time we get a version that has `-SNAPSHOT` we add it to the `rejectedVersions` list, and recurse
+        // until we find a version that doesn't have a `-SNAPSHOT`, and that's what we use.
         dependencies.add(configurationName,
                 ['group': 'org.foundationdb',
                  'name': 'fdb-relational-server',
-                 'version': '3.5-SNAPSHOT', // todo: will have to set to a known version once a build is published
                  // the all classifier specifies that we want to fetch the shadow jar, which includes all the
                  // dependencies
                  'classifier': 'all'],
                 {
+                    version {
+                        strictly '+'
+                        if (rejectedVersions.size() > 0) {
+                            reject rejectedVersions.toArray(new String[0])
+                        }
+                    }
                     // we don't want to take in any transitive dependencies.
                     // There shouldn't be any external dependencies, but commenting this out, this fails with a missing
                     // grpc dependency.
                     transitive=false
-                    changing=true
                 })
         def configuration = configurations.getByName(configurationName, { })
 
         def resolution = configuration.resolve()[0]
+        def versionMatch = resolution.getName() =~ /^fdb-relational-server-(.*-SNAPSHOT)-all.jar$/
+        if (versionMatch.size() != 0) {
+            System.out.println("Rejecting old external server: " + resolution.getName())
+            def version = versionMatch[0][1]
+            // check that the version is new, to more obviously catch potential infinite loops
+            assert rejectedVersions.add(version)
+            return resolveOtherServer(rejectedVersions)
+        }
         System.out.println("Downloaded old external server: " + resolution.getName())
         return resolution
     }
@@ -113,8 +128,7 @@ task cleanExternalServerDirectory(type: Delete) {
 
 task downloadExternalServer(type: Copy) {
     dependsOn "cleanExternalServerDirectory"
-    // todo: will be able to uncomment once other server has been published
-    // from resolveOtherServer()
+    from resolveOtherServer(new HashSet<String>())
     into project.layout.buildDirectory.dir('externalServer')
 }
 


### PR DESCRIPTION
This changes the yaml tests to download the latest release available.

The tests that actually take advantage of this are still disabled.