### PR TITLE
Introduce SQL support to Recursive CTEs

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -29,7 +29,7 @@ Our API stability annotations have been updated to reflect greater API instabili
 * **Performance** Improvement 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Introduce SQL support to Recursive CTEs [(Issue #3034)](https://github.com/FoundationDB/fdb-record-layer/issues/3034)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ErrorCode.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ErrorCode.java
@@ -120,6 +120,7 @@ public enum ErrorCode {
     INVALID_COLUMN_REFERENCE("42F10"), //no field of specified name in the result set
     INVALID_TABLE_DEFINITION("42F16"),
     UNKNOWN_TYPE("42F18"),
+    INVALID_RECURSION("42F19"),
     /**
      * Indicates that a schema with the given name is already mapped to a schema template.
      */

--- a/fdb-relational-core/README.md
+++ b/fdb-relational-core/README.md
@@ -24,3 +24,57 @@ The [fdb-relational-cli](../fdb-relational-cli/README.md) comes with the embedde
 Relational also bundles a JDBC client Driver that talks GRPC to a Relational
 Server/Service. See [Relational JDBC client Driver](../fdb-relational-jdbc/README.md)
 for more.
+
+## Development Environment Setup
+
+### Syntax highlighting of YAML test files ###
+To activate SQL syntax highlighting for YAMSQL files, do the following:
+- Locate your IntelliJ's [configuration location](https://www.jetbrains.com/help/idea/directories-used-by-the-ide-to-store-settings-caches-plugins-and-logs.html#config-directory). It should be
+  something like `~/Library/Application Support/JetBrains/IdeaIC2023.2`.
+- Navigate to `filetypes` folder (or create it if it does not exist), then copy the following script into a new file called `YAML-SQL.xml`.
+- Restart IntelliJ.
+
+```xml
+<filetype binary="false" default_extension="yamsql" description="YAML SQL Test files (syntax highlighting only)" name="YAML-SQL">
+  <highlighting>
+    <options>
+      <option name="LINE_COMMENT" value="#" />
+      <option name="COMMENT_START" value="" />
+      <option name="COMMENT_END" value="" />
+      <option name="HEX_PREFIX" value="" />
+      <option name="NUM_POSTFIXES" value="" />
+      <option name="HAS_BRACES" value="true" />
+      <option name="HAS_BRACKETS" value="true" />
+      <option name="HAS_PARENS" value="true" />
+      <option name="HAS_STRING_ESCAPES" value="true" />
+      <option name="LINE_COMMENT_AT_START" value="false" />
+    </options>
+    <keywords keywords="absolute;action;add;all;allocate;alter;and;any;are;array;as;asc;assertion;at;authorization;
+    avg;begin;between;bit_length;both;by;cascade;cascaded;case;cast;catalog;character_length;check;close;coalesce;
+    collate;collation;column;commit;connection;constraint;constraints;continue;convert;corresponding;count;create;
+    cross;current;current_;current_date;current_time;current_timestamp;cursor;database;day;deallocate;declare;default;
+    deferrable;deferred;delete;desc;describe;descriptor;diagnostics;disconnect;distinct;domain;drop;else;end;escape;
+    except;exception;exec;execute;exists;external;extract;fetch;first;for;foreign;found;from;full;get;global;go;goto;
+    grant;group;having;hour;identity;if;immediate;in;index;indicator;initially;inner;input;insensitive;insert;intersect;
+    interval;into;is;isolation;join;key;language;last;leading;left;length;level;like;limit;local;lower;match;max;min;
+    minute;module;month;names;national;natural;next;no;not;nullif;octet_length;of;on;only;open;option;or;order;outer;
+    output;overlaps;pad;partial;position;precision;prepare;preserve;primary;prior;privileges;procedure;public;read;
+    references;relative;restrict;revoke;right;rollback;rows;schema;scroll;second;section;select;session;session_;set;
+    recursive;references;relative;restrict;revoke;right;rollback;rows;schema;scroll;second;section;select;session;session_;set;
+    size;some;space;sql;sqlcode;sqlerror;sqlstate;struct;substring;sum;system_user;table;template;temporary;then;
+    timezone_;timezone_minute;to;trailing;transaction;translate;translation;trim;type;union;unique;unknown;update;
+    upper;usage;user;using;value;values;varying;view;when;whenever;where;with;work;write;year;zone" ignore_case="true" />
+    <keywords2 keywords="bigint;bit;boolean;bytes;char;char_;character;date;dec;decimal;double;float;int;integer;nchar;
+    numeric;real;smallint;string;time;timestamp;varchar;!!;!r;!in;!a;" />
+    <keywords3 keywords="false;null;true;ordered;randomized;parallelized;test;block;single_repetition_ordered;
+    single_repetition_randomized;single_repetition_parallelized;multi_repetition_ordered;multi_repetition_randomized;
+    multi_repetition_parallelized" />
+    <keywords4 keywords="connect:;query:;load schema template:;set schema state:;result:;unorderedresult:;explain:;
+    explaincontains:;count:;error:;planhash:;setup:;schema_template:;test_block:;options:;tests:;mode:;repetition:;seed:;
+    check_cache:;connection_lifecycle:;steps:;preset:;statement_type:;!r;!in;!a;" />
+  </highlighting>
+  <extensionMap>
+    <mapping ext="yamsql" />
+  </extensionMap>
+</filetype>
+```

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperators.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperators.java
@@ -75,6 +75,10 @@ public class LogicalOperators implements Iterable<LogicalOperator> {
         return underlying.isEmpty();
     }
 
+    public int size() {
+        return  underlying.size();
+    }
+
     @Nonnull
     public Set<CorrelationIdentifier> getCorrelations() {
         return underlying.stream().map(operator -> operator.getQuantifier().getAlias()).collect(ImmutableSet.toImmutableSet());

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -174,17 +174,17 @@ public class BaseVisitor extends AbstractParseTreeVisitor<Object> implements Typ
         return currentPlanFragment.orElseThrow().getLogicalOperatorsIncludingOuter();
     }
 
-    boolean isTopLevel() {
+    public boolean isTopLevel() {
         return !(currentPlanFragment.isPresent() && currentPlanFragment.get().hasParent());
     }
 
     @Nonnull
-    LogicalPlanFragment pushPlanFragment() {
+    public LogicalPlanFragment pushPlanFragment() {
         currentPlanFragment = Optional.of(currentPlanFragment.map(LogicalPlanFragment::addChild).orElse(LogicalPlanFragment.ofRoot()));
         return currentPlanFragment.get();
     }
 
-    void popPlanFragment() {
+    public void popPlanFragment() {
         this.currentPlanFragment = currentPlanFragment.flatMap(LogicalPlanFragment::getParentMaybe);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/MemoizedFunction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/MemoizedFunction.java
@@ -1,0 +1,58 @@
+/*
+ * MemoizedFunction.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.util;
+
+import com.google.common.base.Function;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A function that is able to memoize the codomain of its input.
+ *
+ * @param <T> The type of the function domain.
+ * @param <U> The type of the function codomain.
+ */
+public class MemoizedFunction<T, U> {
+
+    @Nonnull
+    private final Map<T, U> cache;
+
+    private MemoizedFunction() {
+        cache = new ConcurrentHashMap<>();
+    }
+
+    private Function<T, U> wrap(@Nonnull final Function<T, U> function) {
+        return input -> cache.computeIfAbsent(input, function);
+    }
+
+    /**
+     * Creates a memoized version of the provided function.
+     * @param function The function to memoize.
+     * @param <T> The type of the function domain.
+     * @param <U> The type of the function codomain.
+     * @return A memoized version of the provided function.
+     */
+    public static <T, U> Function<T, U> memoize(@Nonnull final Function<T, U> function) {
+        return new MemoizedFunction<T, U>().wrap(function);
+    }
+}

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlanGenerationStackTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlanGenerationStackTest.java
@@ -149,14 +149,20 @@ public class PlanGenerationStackTest {
                     Arguments.of(63, "select * from restaurant USE INDEX (record_name_idx), USE INDEX (reviewer_name_idx) where rest_no > 10 ", "Unknown index(es) REVIEWER_NAME_IDX"),
                     Arguments.of(64, "select * from restaurant with continuation", "syntax error[[]]select * from restaurant with continuation[[]]                                          ^^"),
                     Arguments.of(65, "select X.rest_no from (select rest_no from restaurant where 42 >= rest_no OR 42 > rest_no) X", null),
-                    Arguments.of(66, "select X.UNKNOWN from (select rest_no from restaurant where 42 >= rest_no OR 42 > rest_no) X", "Attempting to query non existing column 'X.UNKNOWN'"),
+                    Arguments.of(  66, "select X.UNKNOWN from (select rest_no from restaurant where 42 >= rest_no OR 42 > rest_no) X", "Attempting to query non existing column 'X.UNKNOWN'"),
                     Arguments.of(67, "select X.rest_no from (select Y.rest_no from (select rest_no from restaurant where 42 >= rest_no OR 42 > rest_no) Y where 42 >= Y.rest_no OR 42 > Y.rest_no) X", null),
                     Arguments.of(68, "select X.rating from restaurant AS Rec, (select rating from Rec.reviews) X", null),
                     Arguments.of(69, "select COUNT(MAX(Y.rating)) FROM (select rest_no, X.rating from restaurant AS Rec, (select rating from Rec.reviews) X) as Y GROUP BY Y.rest_no", "unsupported nested aggregate(s) count(max_l"),
                     Arguments.of(70, "select rating from restaurant GROUP BY rest_no", "Attempting to query non existing column 'RATING'"),
                     // TODO understand why the query below cannot be planned
                     //Arguments.of(71, "select rating + rest_no, MAX(rest_no) from (select rest_no, X.rating from restaurant AS Rec, (select rating from Rec.reviews) X) as Y GROUP BY rest_no, rating", null),
-                    Arguments.of(72, "insert into restaurant_reviewer values (42, \"wrong\", null, null)", "Attempting to query non existing column 'wrong'")
+                    Arguments.of(72, "insert into restaurant_reviewer values (42, \"wrong\", null, null)", "Attempting to query non existing column 'wrong'"),
+                    Arguments.of(73, "with recursive c as (with c as (select * from restaurant) select * from c) select * from c", "ambiguous nested recursive CTE name"),
+                    Arguments.of(74, "with recursive c as (with c1 as (select * from restaurant) select * from c1) select * from c", null),
+                    Arguments.of(75, "with recursive c as (select * from t, c) select * from c", "recursive CTE does not contain non-recursive term"),
+                    Arguments.of(76, "with recursive c1 as (select * from restaurant union all select * from c1) select * From c1", null),
+                    Arguments.of(77, "with recursive c as (with recursive c1 as (select * from restaurant union all select * from c1) select * From c1 union all select * from restaurant, c) select * from c", null),
+                    Arguments.of(78, "with recursive c as (with c as (select * from restaurant) select * from c union all select * from restaurant) select * from c union all select * from restaurant", "ambiguous nested recursive CTE name")
             );
         }
     }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/util/MemoizedFunctionTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/util/MemoizedFunctionTest.java
@@ -1,0 +1,73 @@
+/*
+ * MemoizedFunctionTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.util;
+
+import com.google.common.base.Function;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MemoizedFunctionTest {
+
+    private static final class StatefulFunction<U, T> {
+
+        private Set<U> seenValues;
+
+        @Nonnull
+        private final Function<U, T> underlying;
+
+        private StatefulFunction(Function<U, T> underlying) {
+            seenValues = new HashSet<>();
+            this.underlying = underlying;
+        }
+
+        public T apply(U input) {
+            if (seenValues.contains(input)) {
+                throw new RuntimeException("attempt to call function more than once for " + input);
+            }
+            seenValues.add(input);
+            return underlying.apply(input);
+        }
+    }
+
+    @Test
+    void memoizedFunctionComputesExactlyOnce() {
+        final var input = new ArrayList<Integer>(100000);
+        for (int i = 0; i < 100000; i++) {
+            input.add(i);
+        }
+        Collections.shuffle(input);
+
+        final var memoizedFunction = MemoizedFunction.memoize(new StatefulFunction<Integer, Integer>(j -> j * 2)::apply);
+        for (final var value : input) {
+            Assertions.assertEquals(value * 2, memoizedFunction.apply(value));
+        }
+
+        for (final var value : input) {
+            Assertions.assertDoesNotThrow(() ->  Assertions.assertEquals(value * 2, memoizedFunction.apply(value)));
+        }
+    }
+}

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -236,4 +236,9 @@ public abstract class YamlIntegrationTests extends YamlTestBase {
     public void bitmap() throws Exception {
         doRun("bitmap-aggregate-index.yamsql");
     }
+
+    @Test
+    public void recursiveCte() throws Exception {
+        doRun("recursive-cte.yamsql");
+    }
 }

--- a/yaml-tests/src/test/resources/cte.yamsql
+++ b/yaml-tests/src/test/resources/cte.yamsql
@@ -87,9 +87,6 @@ test_block:
       - query: with c1(w, z) as (select id, col1 from t1), c2(a, b) as (with c3(A, B) as (select id, col1 from c1 where id in (1, 2)) select * from c3) select * from c1,c2
       - error: "42F01"
     -
-      - query: with recursive c1(w, z) as (select id, col1 from t1) select * from c1
-      - error: "0AF00"
-    -
       - query: with c1(w, z, x1, x2, x3, x4) as (select id, col1 from t1) select * from c1
       - error: "42F10"
     -

--- a/yaml-tests/src/test/resources/recursive-cte.yamsql
+++ b/yaml-tests/src/test/resources/recursive-cte.yamsql
@@ -1,0 +1,79 @@
+---
+schema_template:
+    create table t1(id bigint, parent bigint, primary key(id))
+    create index parentIdx as select parent, id from t1 order by parent, id
+    create index childIdx as select id, parent from t1 order by id, parent
+---
+setup:
+  steps:
+    - query: insert into t1
+            values (1, -1),
+                   (10, 1),
+                   (20, 1),
+                   (40, 10),
+                   (50, 10),
+                   (70, 10),
+                   (100, 20),
+                   (210, 20),
+                   (250, 50)
+---
+test_block:
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: with recursive c1 as (
+            select id, parent from t1 where parent = -1
+            union all
+            select b.id, b.parent from c1 as a, t1 as b where a.id = b.parent) select id from c1
+      - unorderedResult: [{ID: 1},
+                          {ID: 10},
+                          {ID: 20},
+                          {ID: 40},
+                          {ID: 50},
+                          {ID: 70},
+                          {ID: 100},
+                          {ID: 210},
+                          {ID: 250}]
+    -
+      - query: with recursive c1 as (
+            select id, parent from t1 where id = 250
+            union all
+            select b.id, b.parent from c1 as a, t1 as b where a.parent = b.id) select id from c1
+      - result: [{ID: 250},
+                 {ID: 50},
+                 {ID: 10},
+                 {ID: 1}]
+    -
+      - query: with recursive allDescendants as (
+            with recursive ancestorsOf250 as (
+            select id, parent from t1 where id = 250
+            union all
+            select b.id, b.parent from ancestorsOf250 as a, t1 as b where a.parent = b.id) select id, parent from ancestorsOf250
+            union all
+            select b.id, b.parent from allDescendants as a, t1 as b where a.id = b.parent) select id, parent from allDescendants
+      - result: [{250, 50},
+                 {50, 10},
+                 {10, 1},
+                 {1, -1},
+                 {10, 1},
+                 {20, 1},
+                 {40, 10},
+                 {50, 10},
+                 {70, 10},
+                 {250, 50},
+                 {40, 10},
+                 {50, 10},
+                 {70, 10},
+                 {100, 20},
+                 {210, 20},
+                 {250, 50},
+                 {250, 50}]
+#    -
+# does not currently work due to bug in NLJ planning, see https://github.com/FoundationDB/fdb-record-layer/issues/2997
+#      - query: with recursive c1 as (
+#            select id, parent from t1 where id = 250
+#            union all
+#            select b.id, b.parent from c1 as a, t1 as b where a.parent = b.id and b.id > 40) select id from c1
+#      - result: [{ID: 250},
+#                 {ID: 50}]
+...


### PR DESCRIPTION
This adds SQL support to Recursive CTEs, building on top #2981 which added planning and runtime support to recursive union plans.

Some relatively complex logic is added to the semantic analyzer to allow proper resolution of the recursive CTE type and effectively understand which branches are recursive (relative to the current query block) and which are not, as this is required to build the recursive union plan and the underlying temporary table buffers correctly. This logic can be, arguably, streamlined in a better way if we had a dedicated semantic analysis phase. That is one of the reasons the analysis is not _that_ advanced, and fails for certain types of valid recursive CTEs (see newly added test cases in `PlanGenerationStackTest` for more information).

Example query (more examples can be found in `recursive-cte.yamsql`:

```sql
create table t1(id bigint, parent bigint, primary key(id))
create index parentIdx as select parent, id from t1 order by parent, id
create index childIdx as select id, parent from t1 order by id, parent
-- define a sample parent-child hierarchy, where -1 indicates root
insert into t1  values (1, -1),
                       (10, 1),
                       (20, 1),
                       (40, 10),
                       (50, 10),
                       (70, 10),
                       (100, 20),
                       (210, 20),
                       (250, 50)
-- let's calculate all the ancestors of node 250
with recursive c1 as (
            select id, parent from t1 where id = 250
            union all
            select b.id, b.parent from c1 as a, t1 as b where a.parent = b.id) select id from c1 -- notice how c1 is mentioned in the join making the CTE recursive
-- it should return
--         ID: 250
--         ID: 50
--         ID: 10
--         ID: 1
```

This fixes #3034.