### PR TITLE
Add a class for comparing versions of the record layer

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  *     a sequence of positive numbers ({@code 0|[1-9]\\d*} separated by {@code .}s, and an optional {@code -SNAPSHOT}
  *     at the end. Each version component is compared as integers, and versions with a different number of components
  *     are not comparable. A version with {@code -SNAPSHOT} version added to a version the less than the same set of
- *     numbers without {@code -SNAPSHOT} (e.g. {@code 3.4.5.1-SNAPSHOT < 3.4.5.1).
+ *     numbers without {@code -SNAPSHOT} (e.g. {@code 3.4.5.1-SNAPSHOT < 3.4.5.1}).
  * @see <a href="https://github.com/FoundationDB/fdb-record-layer/blob/main/docs/Versioning.md#semantic-versioning">Versioning</a>
  */
 public class SemanticVersion implements Comparable<SemanticVersion> {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.yamltests.server;
 
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -43,32 +44,47 @@ import java.util.stream.Collectors;
  *     Thus, this spec implements only slightly more than what the Record Layer needs, which is to say:
  *     a sequence of positive numbers ({@code 0|[1-9]\\d*} separated by {@code .}s, and an optional {@code -SNAPSHOT}
  *     at the end. Each version component is compared as integers, and versions with a different number of components
- *     are not comparable. A version with {@code -SNAPSHOT} version added to the less than the same set of numbers
- *     without {@code -SNAPSHOT}.
+ *     are not comparable. A version with {@code -SNAPSHOT} version added to a version the less than the same set of
+ *     numbers without {@code -SNAPSHOT} (e.g. {@code 3.4.5.1-SNAPSHOT < 3.4.5.1-SNAPSHOT}).
  * @see <a href="https://github.com/FoundationDB/fdb-record-layer/blob/main/docs/Versioning.md#semantic-versioning">Versioning</a>
  */
 public class SemanticVersion implements Comparable<SemanticVersion> {
     private static final String NUMBER_PATTERN = "(?:0|[1-9]\\d*)";
     private static final String ALPHANUMERIC_PATTERN = "\\d*[a-zA-Z-][0-9a-zA-Z-]";
     private static final String PRE_RELEASE_PART = "(?:" + NUMBER_PATTERN + "|" + ALPHANUMERIC_PATTERN + ")";
-    private static final String BUILD_PART = "(?:\\d+|" + ALPHANUMERIC_PATTERN + ")";
     private static final Pattern VERSION_PATTERN = Pattern.compile(
             "^(?<versionNumbers>" + NUMBER_PATTERN + "(?:\\." + NUMBER_PATTERN + ")*)" +
-                    "(?:-(?<prerelease>" + dotSeparated(PRE_RELEASE_PART) + "))?" +
-                    "(?:\\+(?<buildMetadata>" + dotSeparated(BUILD_PART) + "))?$");
-    private static final Pattern NUMERIC_PATTERN = Pattern.compile("\\d+");
+                    "(?:-(?<prerelease>" + dotSeparated(PRE_RELEASE_PART) + "))?");
 
+    /**
+     * The main version components.
+     * <p>
+     *     For the current record layer versioning, this would be {@code List.of(major, minor, build, patch)}, but this
+     *     class supports any number of version components.
+     *     When comparing, these are compared in order.
+     */
     private final List<Integer> versionNumbers;
+    /**
+     * The prerelease metadata, but only {@code SNAPSHOT} is supported.
+     * <p>
+     *     We only support {@code List.of("SNAPSHOT")} or {@code List.of()}, because that's the only one we use,
+     *     and gradle and maven have complicated comparison that disagrees. A version that has the same value
+     *     {@link #versionNumbers} but an empty {@code prerelease} is greater than one with a non-empty {@code prerelease}.
+     */
     private final List<String> prerelease;
-    private final String buildMetadata;
 
-    public SemanticVersion(List<Integer> versionNumbers, List<String> prerelease, String buildMetadata) {
+    private SemanticVersion(@Nonnull List<Integer> versionNumbers, @Nonnull List<String> prerelease) {
         this.versionNumbers = versionNumbers;
         this.prerelease = prerelease;
-        this.buildMetadata = buildMetadata;
     }
 
-    public static SemanticVersion parse(String versionString) {
+    /**
+     * Parse a version string (e.g. {@code 4.0.559.0} or {@code 4.0.560.0-SNAPSHOT}.
+     * @param versionString a version in string form
+     * @return a parsed version
+     */
+    @Nonnull
+    public static SemanticVersion parse(@Nonnull String versionString) {
         final Matcher matcher = VERSION_PATTERN.matcher(versionString);
         if (!matcher.matches()) {
             throw new IllegalArgumentException("Version is not valid: " + versionString);
@@ -81,14 +97,11 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
             throw new IllegalArgumentException("Only SNAPSHOT (all caps) pre-release is supported right now");
         }
         final List<String> prerelease = prereleaseString == null ? List.of() : List.of(prereleaseString.split("\\."));
-        final String buildMetadata = matcher.group("buildMetadata") == null ? "" : matcher.group("buildMetadata");
-        if (!buildMetadata.isEmpty()) {
-            throw new IllegalArgumentException("Build MetaData is not currently supported");
-        }
-        return new SemanticVersion(versionNumbers, prerelease, buildMetadata);
+        return new SemanticVersion(versionNumbers, prerelease);
     }
 
-    private static String dotSeparated(String part) {
+    @Nonnull
+    private static String dotSeparated(@Nonnull String part) {
         return part + "(." + part + ")*";
     }
 
@@ -97,9 +110,6 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         String version = versionNumbers.stream().map(Object::toString).collect(Collectors.joining("."));
         if (!prerelease.isEmpty()) {
             version = version + "-" + prerelease;
-        }
-        if (!buildMetadata.isEmpty()) {
-            version = version + "+" + buildMetadata;
         }
         return version;
     }
@@ -113,16 +123,16 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
             return false;
         }
         final SemanticVersion that = (SemanticVersion)o;
-        return Objects.equals(versionNumbers, that.versionNumbers) && Objects.equals(prerelease, that.prerelease) && Objects.equals(buildMetadata, that.buildMetadata);
+        return Objects.equals(versionNumbers, that.versionNumbers) && Objects.equals(prerelease, that.prerelease);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(versionNumbers, prerelease, buildMetadata);
+        return Objects.hash(versionNumbers, prerelease);
     }
 
     @Override
-    public int compareTo(SemanticVersion o) {
+    public int compareTo(@Nonnull SemanticVersion o) {
         // negative if this is less than o
         final int versionComparison = compareVersionNumbers(o);
         if (versionComparison != 0) {
@@ -131,7 +141,7 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         return comparePrerelease(o);
     }
 
-    private int compareVersionNumbers(SemanticVersion o) {
+    private int compareVersionNumbers(@Nonnull SemanticVersion o) {
         // semver only allows 3, we only use 4.
         // gradle supports an arbitrary number, but it gets complicated if there is a pre-release or build info
         if (versionNumbers.size() != o.versionNumbers.size()) {
@@ -139,54 +149,23 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         }
         int length = versionNumbers.size();
         for (int i = 0; i < length; i++) {
-            if (versionNumbers.get(i) < o.versionNumbers.get(i)) {
-                return -1;
-            } else if (versionNumbers.get(i) > o.versionNumbers.get(i)) {
-                return 1;
+            final int result = Integer.compare(versionNumbers.get(i), o.versionNumbers.get(i));
+            if (result != 0) {
+                return Integer.signum(result);
             }
         }
         return 0;
     }
 
-    private int comparePrerelease(SemanticVersion o) {
+    private int comparePrerelease(@Nonnull SemanticVersion o) {
         if (!prerelease.isEmpty() && o.prerelease.isEmpty()) {
             return -1;
         } else if (prerelease.isEmpty() && !o.prerelease.isEmpty()) {
             return 1;
         }
-        int length = Math.min(prerelease.size(), o.prerelease.size());
-        for (int i = 0; i < length; i++) {
-            String thisPart = prerelease.get(i);
-            String otherPart = o.prerelease.get(i);
-            if (NUMERIC_PATTERN.matcher(thisPart).matches()) {
-                if (NUMERIC_PATTERN.matcher(otherPart).matches()) {
-                    int thisNumber = Integer.parseInt(thisPart);
-                    int otherNumber = Integer.parseInt(otherPart);
-                    if (thisNumber < otherNumber) {
-                        return -1;
-                    } else if (thisNumber > otherNumber) {
-                        return 1;
-                    }
-                } else {
-                    return -1;
-                }
-            } else {
-                if (NUMERIC_PATTERN.matcher(otherPart).matches()) {
-                    return 1;
-                } else {
-                    int comparison = thisPart.compareTo(otherPart);
-                    if (comparison < 0) {
-                        return -1;
-                    } else if (comparison > 0) {
-                        return 1;
-                    }
-                }
-            }
-        }
-        if (prerelease.size() < o.prerelease.size()) {
-            return -1;
-        } else if (prerelease.size() > o.prerelease.size()) {
-            return 1;
+        if (!prerelease.equals(o.prerelease)) {
+            // We only support `List.of()` and `List.of("SNAPSHOT")`
+            throw new IllegalArgumentException("Multiple types of prerelease is not supported");
         }
         return 0;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
@@ -1,0 +1,193 @@
+/*
+ * SemanticVersion.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.server;
+
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Object representing a version of the Record Layer.
+ * <p>
+ *     This is inspired by the following three version specifications:
+ *     <ul>
+ *         <li><a href="https://semver.org">semver.org</a>
+ *         <li><a href="https://docs.gradle.org/current/userguide/dependency_versions.html#sec:version-ordering">gradle's version ordering</a>
+ *         <li><a href="https://maven.apache.org/ref/3.3.3/maven-artifact/apidocs/org/apache/maven/artifact/versioning/ComparableVersion.html">maven's version class</a>,
+ *         which is also outlined on <a href="https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">their wiki</a>.
+ *     </ul>
+ *     Gradle and Maven are the most important, as this is a java project, but they have complicated semantics, and I
+ *     had trouble reasoning about how they interact with non-ascii characters, and they appear to disagree.
+ *     Thus, this spec implements only slightly more than what the Record Layer needs, which is to say:
+ *     a sequence of positive numbers ({@code 0|[1-9]\\d*} separated by {@code .}s, and an optional {@code -SNAPSHOT}
+ *     at the end. Each version component is compared as integers, and versions with a different number of components
+ *     are not comparable. A version with {@code -SNAPSHOT} version added to the less than the same set of numbers
+ *     without {@code -SNAPSHOT}.
+ * @see <a href="https://github.com/FoundationDB/fdb-record-layer/blob/main/docs/Versioning.md#semantic-versioning">Versioning</a>
+ */
+public class SemanticVersion implements Comparable<SemanticVersion> {
+    private static final String NUMBER_PATTERN = "(?:0|[1-9]\\d*)";
+    private static final String ALPHANUMERIC_PATTERN = "\\d*[a-zA-Z-][0-9a-zA-Z-]";
+    private static final String PRE_RELEASE_PART = "(?:" + NUMBER_PATTERN + "|" + ALPHANUMERIC_PATTERN + ")";
+    private static final String BUILD_PART = "(?:\\d+|" + ALPHANUMERIC_PATTERN + ")";
+    private static final Pattern VERSION_PATTERN = Pattern.compile(
+            "^(?<versionNumbers>" + NUMBER_PATTERN + "(?:\\." + NUMBER_PATTERN + ")*)" +
+                    "(?:-(?<prerelease>" + dotSeparated(PRE_RELEASE_PART) + "))?" +
+                    "(?:\\+(?<buildMetadata>" + dotSeparated(BUILD_PART) + "))?$");
+    private static final Pattern NUMERIC_PATTERN = Pattern.compile("\\d+");
+
+    private final List<Integer> versionNumbers;
+    private final List<String> prerelease;
+    private final String buildMetadata;
+
+    public SemanticVersion(List<Integer> versionNumbers, List<String> prerelease, String buildMetadata) {
+        this.versionNumbers = versionNumbers;
+        this.prerelease = prerelease;
+        this.buildMetadata = buildMetadata;
+    }
+
+    public static SemanticVersion parse(String versionString) {
+        final Matcher matcher = VERSION_PATTERN.matcher(versionString);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Version is not valid: " + versionString);
+        }
+        List<Integer> versionNumbers = Arrays.stream(matcher.group("versionNumbers").split("\\."))
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
+        final String prereleaseString = matcher.group("prerelease");
+        if (prereleaseString != null && !prereleaseString.equals("SNAPSHOT")) {
+            throw new IllegalArgumentException("Only SNAPSHOT (all caps) pre-release is supported right now");
+        }
+        final List<String> prerelease = prereleaseString == null ? List.of() : List.of(prereleaseString.split("\\."));
+        final String buildMetadata = matcher.group("buildMetadata") == null ? "" : matcher.group("buildMetadata");
+        if (!buildMetadata.isEmpty()) {
+            throw new IllegalArgumentException("Build MetaData is not currently supported");
+        }
+        return new SemanticVersion(versionNumbers, prerelease, buildMetadata);
+    }
+
+    private static String dotSeparated(String part) {
+        return part + "(." + part + ")*";
+    }
+
+    @Override
+    public String toString() {
+        String version = versionNumbers.stream().map(Object::toString).collect(Collectors.joining("."));
+        if (!prerelease.isEmpty()) {
+            version = version + "-" + prerelease;
+        }
+        if (!buildMetadata.isEmpty()) {
+            version = version + "+" + buildMetadata;
+        }
+        return version;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SemanticVersion that = (SemanticVersion)o;
+        return Objects.equals(versionNumbers, that.versionNumbers) && Objects.equals(prerelease, that.prerelease) && Objects.equals(buildMetadata, that.buildMetadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(versionNumbers, prerelease, buildMetadata);
+    }
+
+    @Override
+    public int compareTo(SemanticVersion o) {
+        // negative if this is less than o
+        final int versionComparison = compareVersionNumbers(o);
+        if (versionComparison != 0) {
+            return versionComparison;
+        }
+        return comparePrerelease(o);
+    }
+
+    private int compareVersionNumbers(SemanticVersion o) {
+        // semver only allows 3, we only use 4.
+        // gradle supports an arbitrary number, but it gets complicated if there is a pre-release or build info
+        if (versionNumbers.size() != o.versionNumbers.size()) {
+            throw new IllegalArgumentException("Versions only differ by part count" + this + " vs " + o);
+        }
+        int length = versionNumbers.size();
+        for (int i = 0; i < length; i++) {
+            if (versionNumbers.get(i) < o.versionNumbers.get(i)) {
+                return -1;
+            } else if (versionNumbers.get(i) > o.versionNumbers.get(i)) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    private int comparePrerelease(SemanticVersion o) {
+        if (!prerelease.isEmpty() && o.prerelease.isEmpty()) {
+            return -1;
+        } else if (prerelease.isEmpty() && !o.prerelease.isEmpty()) {
+            return 1;
+        }
+        int length = Math.min(prerelease.size(), o.prerelease.size());
+        for (int i = 0; i < length; i++) {
+            String thisPart = prerelease.get(i);
+            String otherPart = o.prerelease.get(i);
+            if (NUMERIC_PATTERN.matcher(thisPart).matches()) {
+                if (NUMERIC_PATTERN.matcher(otherPart).matches()) {
+                    int thisNumber = Integer.parseInt(thisPart);
+                    int otherNumber = Integer.parseInt(otherPart);
+                    if (thisNumber < otherNumber) {
+                        return -1;
+                    } else if (thisNumber > otherNumber) {
+                        return 1;
+                    }
+                } else {
+                    return -1;
+                }
+            } else {
+                if (NUMERIC_PATTERN.matcher(otherPart).matches()) {
+                    return 1;
+                } else {
+                    int comparison = thisPart.compareTo(otherPart);
+                    if (comparison < 0) {
+                        return -1;
+                    } else if (comparison > 0) {
+                        return 1;
+                    }
+                }
+            }
+        }
+        if (prerelease.size() < o.prerelease.size()) {
+            return -1;
+        } else if (prerelease.size() > o.prerelease.size()) {
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  *     a sequence of positive numbers ({@code 0|[1-9]\\d*} separated by {@code .}s, and an optional {@code -SNAPSHOT}
  *     at the end. Each version component is compared as integers, and versions with a different number of components
  *     are not comparable. A version with {@code -SNAPSHOT} version added to a version the less than the same set of
- *     numbers without {@code -SNAPSHOT} (e.g. {@code 3.4.5.1-SNAPSHOT < 3.4.5.1-SNAPSHOT}).
+ *     numbers without {@code -SNAPSHOT} (e.g. {@code 3.4.5.1-SNAPSHOT < 3.4.5.1).
  * @see <a href="https://github.com/FoundationDB/fdb-record-layer/blob/main/docs/Versioning.md#semantic-versioning">Versioning</a>
  */
 public class SemanticVersion implements Comparable<SemanticVersion> {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes to support running the yaml tests against an external server.
+ */
+package com.apple.foundationdb.relational.yamltests.server;

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.yamltests.server;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -44,7 +45,7 @@ class SemanticVersionTest {
         final SemanticVersion versionB = SemanticVersion.parse(rawVersionB);
         Assertions.assertAll(
                 () -> assertEquals(0, versionA.compareTo(versionB)),
-                () -> assertEquals(0, versionA.compareTo(versionB)));
+                () -> assertEquals(0, versionB.compareTo(versionA)));
     }
 
     @ParameterizedTest
@@ -77,9 +78,9 @@ class SemanticVersionTest {
     void alignsWithComparator(int versionA, int versionB) {
         // Ensure that the signage aligns with the standard `compare` methods
         // the value doesn't have to, but it does, and this is easier than asserting that they have the same sign
-        assertEquals(Integer.compare(versionA, versionB),
-                SemanticVersion.parse(versionA + ".0.0").compareTo(
-                        SemanticVersion.parse(versionB + ".0.0")));
+        assertEquals(Integer.signum(Integer.compare(versionA, versionB)),
+                Integer.signum(SemanticVersion.parse(versionA + ".0.0").compareTo(
+                        SemanticVersion.parse(versionB + ".0.0"))));
     }
 
     @ParameterizedTest
@@ -89,7 +90,7 @@ class SemanticVersionTest {
             "3, 3.0-SNAPSHOT",
             "3.3, 3.3.0",
             "3.2-SNAPSHOT, 3.2.0",
-            "3.2-SNAPSHOT, 3.2.1",
+            "3.2-SNAPSHOT, 3.2.1"
     })
     void incomparible(String rawVersionA, String rawVersionB) {
         final SemanticVersion versionA = SemanticVersion.parse(rawVersionA);
@@ -98,7 +99,15 @@ class SemanticVersionTest {
                 () -> assertThrows(IllegalArgumentException.class,
                         () -> versionA.compareTo(versionB)),
                 () -> assertThrows(IllegalArgumentException.class,
-                        () -> versionA.compareTo(versionB)));
+                        () -> versionB.compareTo(versionA)));
+    }
+
+
+    @Test
+    void compareToNull() throws Exception {
+        final SemanticVersion versionA = SemanticVersion.parse("4.0.559.0");
+        assertThrows(NullPointerException.class,
+                () -> versionA.compareTo(null));
     }
 
     // Comparing pre-releases is complicated, but we only ever use "SNAPSHOT", so forbid everything else.
@@ -115,9 +124,14 @@ class SemanticVersionTest {
             "3.2-RELEASE",
             "1.a",
             "3.4.a",
-            "4.2.3+boo",
+            "4.2.3+boo"
     })
     void badVersion(String rawVersion) throws Exception {
         assertThrows(IllegalArgumentException.class, () -> SemanticVersion.parse(rawVersion));
+    }
+
+    @Test
+    void parseNull() throws Exception {
+        assertThrows(NullPointerException.class, () -> SemanticVersion.parse(null));
     }
 }

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionTest.java
@@ -1,0 +1,123 @@
+/*
+ * SemanticVersionTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.server;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.apple.foundationdb.record.TestHelpers.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SemanticVersionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "3.5.555.0, 3.5.555.0",
+            "4, 4",
+            "4.2, 4.2",
+            "5.8.9, 5.8.9",
+            "9.7.4.3.0, 9.7.4.3.0",
+            "5.4.3-SNAPSHOT, 5.4.3-SNAPSHOT"
+    })
+    void equal(String rawVersionA, String rawVersionB) {
+        final SemanticVersion versionA = SemanticVersion.parse(rawVersionA);
+        final SemanticVersion versionB = SemanticVersion.parse(rawVersionB);
+        Assertions.assertAll(
+                () -> assertEquals(0, versionA.compareTo(versionB)),
+                () -> assertEquals(0, versionA.compareTo(versionB)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "3, 4",
+            "1.1, 1.2",
+            "3.4.2.0-SNAPSHOT, 3.4.2.0",
+            "3.4.2.1-SNAPSHOT, 3.4.2.1",
+            "3.4.2-SNAPSHOT, 3.4.2",
+            "3.1, 3.2-SNAPSHOT",
+            "3.5.5.0, 3.5.12.0",
+            "3.5.55.0, 3.5.55.1",
+            "3.5.55.1, 3.5.56.0",
+            "3.5.55.0, 3.55.5.0",
+    })
+    void notEqual(String rawLowerVersion, String rawHigherVersion) {
+        final SemanticVersion lowerVersion = SemanticVersion.parse(rawLowerVersion);
+        final SemanticVersion higherVersion = SemanticVersion.parse(rawHigherVersion);
+        Assertions.assertAll(
+                () -> assertEquals(-1, lowerVersion.compareTo(higherVersion)),
+                () -> assertEquals(1, higherVersion.compareTo(lowerVersion)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "3, 4",
+            "4, 3",
+            "4, 4",
+    })
+    void alignsWithComparator(int versionA, int versionB) {
+        // Ensure that the signage aligns with the standard `compare` methods
+        // the value doesn't have to, but it does, and this is easier than asserting that they have the same sign
+        assertEquals(Integer.compare(versionA, versionB),
+                SemanticVersion.parse(versionA + ".0.0").compareTo(
+                        SemanticVersion.parse(versionB + ".0.0")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "3, 3.0",
+            "3, 3.0.0",
+            "3, 3.0-SNAPSHOT",
+            "3.3, 3.3.0",
+            "3.2-SNAPSHOT, 3.2.0",
+            "3.2-SNAPSHOT, 3.2.1",
+    })
+    void incomparible(String rawVersionA, String rawVersionB) {
+        final SemanticVersion versionA = SemanticVersion.parse(rawVersionA);
+        final SemanticVersion versionB = SemanticVersion.parse(rawVersionB);
+        Assertions.assertAll(
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> versionA.compareTo(versionB)),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> versionA.compareTo(versionB)));
+    }
+
+    // Comparing pre-releases is complicated, but we only ever use "SNAPSHOT", so forbid everything else.
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "badVersion",
+            "00002",
+            "3-4-3-2",
+            "3.0-RC",
+            "3.2.3.4-RC",
+            "3.2.3.0-snapshot",
+            "3.2.3.0-4",
+            "3.2.3.0-SNAPSHOT.4",
+            "3.2-RELEASE",
+            "1.a",
+            "3.4.a",
+            "4.2.3+boo",
+    })
+    void badVersion(String rawVersion) throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> SemanticVersion.parse(rawVersion));
+    }
+}

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.asciitable)
     implementation(libs.jsr305)
     implementation(libs.junit.api)
+    implementation(libs.junit.params)
     implementation(libs.log4j.api)
     implementation(libs.protobuf)
     implementation(libs.protobuf.util)


### PR DESCRIPTION
This introduces a class for parsing and comparing versions of the Record Layer. 
This can be combined with the work in https://github.com/FoundationDB/fdb-record-layer/pull/3031 to control what versions a yaml test will run against.