### PR TITLE
yamsql: Add supported_version to blocks and queries, and support for actual versions

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.relational.yamltests.block.SetupBlock;
 import com.apple.foundationdb.relational.yamltests.block.TestBlock;
 import com.apple.foundationdb.relational.yamltests.command.Command;
 import com.apple.foundationdb.relational.yamltests.command.QueryConfig;
-
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -35,13 +34,12 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
 
 public class CustomYamlConstructor extends SafeConstructor {
 
@@ -75,6 +73,7 @@ public class CustomYamlConstructor extends SafeConstructor {
         requireLineNumber.add(QueryConfig.QUERY_CONFIG_COUNT);
         requireLineNumber.add(QueryConfig.QUERY_CONFIG_PLAN_HASH);
         requireLineNumber.add(QueryConfig.QUERY_CONFIG_MAX_ROWS);
+        requireLineNumber.add(QueryConfig.QUERY_CONFIG_SUPPORTED_VERSION);
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
@@ -50,12 +50,12 @@ import java.util.Map;
  */
 public class FileOptions {
     public static final String OPTIONS = "options";
-    private static final String SUPPORTED_VERSION = "supported_version";
+    public static final String SUPPORTED_VERSION_OPTION = "supported_version";
     private static final Logger logger = LogManager.getLogger(FileOptions.class);
 
     public static Block parse(int lineNumber, Object document, YamlExecutionContext executionContext) {
         final Map<?, ?> options = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, OPTIONS));
-        Object rawVersion = options.get(SUPPORTED_VERSION);
+        Object rawVersion = options.get(SUPPORTED_VERSION_OPTION);
         final SupportedVersionCheck check = SupportedVersionCheck.parse(rawVersion, executionContext);
         if (!check.isSupported()) {
             // IntelliJ, at least, doesn't display the reason, so log it
@@ -76,24 +76,6 @@ public class FileOptions {
         @Override
         public String toString() {
             return "!current_version";
-        }
-    }
-
-    private static class NoOpBlock implements Block {
-        private final int lineNumber;
-
-        NoOpBlock(int lineNumber) {
-            this.lineNumber = lineNumber;
-        }
-
-        @Override
-        public int getLineNumber() {
-            return this.lineNumber;
-        }
-
-        @Override
-        public void execute() {
-
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
@@ -20,16 +20,15 @@
 
 package com.apple.foundationdb.relational.yamltests.block;
 
+import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
 import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
-import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
+import com.apple.foundationdb.relational.yamltests.server.SupportedVersionCheck;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assumptions;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Block that configures aspects of the test that do not require a connection yet.
@@ -55,34 +54,15 @@ public class FileOptions {
     private static final Logger logger = LogManager.getLogger(FileOptions.class);
 
     public static Block parse(int lineNumber, Object document, YamlExecutionContext executionContext) {
-        final Map<?, ?> options = Matchers.map(document, OPTIONS);
+        final Map<?, ?> options = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, OPTIONS));
         Object rawVersion = options.get(SUPPORTED_VERSION);
-        if (rawVersion instanceof CurrentVersion) {
-            final Set<String> versionsUnderTest = executionContext.getConnectionFactory().getVersionsUnderTest();
+        final SupportedVersionCheck check = SupportedVersionCheck.parse(rawVersion, executionContext);
+        if (!check.isSupported()) {
             // IntelliJ, at least, doesn't display the reason, so log it
-            if (!versionsUnderTest.isEmpty()) {
-                logger.info(
-                        "Skipping test that only works against the current version, when we're running with these versions: {}",
-                        versionsUnderTest);
+            if (logger.isInfoEnabled()) {
+                logger.info(check.getMessage());
             }
-            Assumptions.assumeTrue(versionsUnderTest.isEmpty(),
-                    () -> "Test only works against the current version, but we are running with these versions: " +
-                    versionsUnderTest);
-        } else if (rawVersion instanceof String) {
-            final SemanticVersion supported = SemanticVersion.parse((String)rawVersion);
-            final List<SemanticVersion> unsupportedVersions = supported.lesserVersions(
-                    executionContext.getConnectionFactory().getVersionsUnderTest());
-            if (!unsupportedVersions.isEmpty()) {
-                logger.info(
-                        "Skipping test that only works against {} and later, but we are running with these older versions: {}",
-                        supported, unsupportedVersions);
-            }
-            Assumptions.assumeTrue(unsupportedVersions.isEmpty(),
-                    () -> "Test only works against " + supported +
-                            " and later, but we are running with these older versions: " +
-                            unsupportedVersions);
-        } else {
-            throw new RuntimeException("Unsupported supported_version: " + rawVersion);
+            Assumptions.assumeTrue(check.isSupported(), check.getMessage());
         }
         return new NoOpBlock(lineNumber);
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/NoOpBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/NoOpBlock.java
@@ -1,0 +1,42 @@
+/*
+ * NoOpBlock.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.block;
+
+/**
+ * A block that does nothing.
+ */
+class NoOpBlock implements Block {
+    private final int lineNumber;
+
+    NoOpBlock(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
+    }
+
+    @Override
+    public void execute() {
+
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SkipBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SkipBlock.java
@@ -1,0 +1,51 @@
+/*
+ * NoOpBlock.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.block;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A block that does nothing.
+ */
+class SkipBlock implements Block {
+    private static final Logger logger = LogManager.getLogger(SkipBlock.class);
+    private final int lineNumber;
+    @Nonnull
+    private final String message;
+
+    SkipBlock(int lineNumber, @Nonnull String message) {
+        this.lineNumber = lineNumber;
+        this.message = message;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return this.lineNumber;
+    }
+
+    @Override
+    public void execute() {
+        logger.info(message);
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SkipBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SkipBlock.java
@@ -1,5 +1,5 @@
 /*
- * NoOpBlock.java
+ * SkipBlock.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
@@ -28,11 +28,13 @@ import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.command.Command;
 import com.apple.foundationdb.relational.yamltests.command.QueryCommand;
 import com.apple.foundationdb.relational.yamltests.command.QueryConfig;
-
+import com.apple.foundationdb.relational.yamltests.server.SupportedVersionCheck;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,9 +50,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Implementation of block that serves the purpose of running tests. The block consists of:
@@ -101,6 +100,7 @@ public final class TestBlock extends ConnectedBlock {
     static final String OPTION_STATEMENT_TYPE = "statement_type";
     static final String OPTION_STATEMENT_TYPE_SIMPLE = "simple";
     static final String OPTION_STATEMENT_TYPE_PREPARED = "prepared";
+    static final String OPTION_SUPPORTED_VERSION = FileOptions.SUPPORTED_VERSION_OPTION;
 
     /**
      * Defines the way in which the tests are run.
@@ -184,6 +184,7 @@ public final class TestBlock extends ConnectedBlock {
         private boolean checkCache = true;
         private ConnectionLifecycle connectionLifecycle = ConnectionLifecycle.TEST;
         private StatementType statementType = StatementType.BOTH;
+        private Object rawSupportedVersion;
 
         private void verifyPreset(@Nonnull String preset) {
             switch (preset) {
@@ -238,7 +239,9 @@ public final class TestBlock extends ConnectedBlock {
                         Assert.failUnchecked("Illegal Format: Unknown value for option `statement_type`: " + value);
                         break;
                 }
-
+            }
+            if (optionsMap.containsKey(OPTION_SUPPORTED_VERSION)) {
+                this.rawSupportedVersion = optionsMap.get(OPTION_SUPPORTED_VERSION);
             }
             setOptionConnectionLifecycle(optionsMap);
         }
@@ -303,7 +306,7 @@ public final class TestBlock extends ConnectedBlock {
         }
     }
 
-    public static TestBlock parse(int lineNumber, @Nonnull Object document, @Nonnull YamlExecutionContext executionContext) {
+    public static Block parse(int lineNumber, @Nonnull Object document, @Nonnull YamlExecutionContext executionContext) {
         try {
             // Since `options` is also a top-level block, the `CustomYamlConstructor` will add the line numbers,
             // changing it from a `String` to a `LinedObject` so that we know the line numbers when logging an error,
@@ -320,11 +323,17 @@ public final class TestBlock extends ConnectedBlock {
             }
             // higher priority than the preset is that of options map, set the options according to that, if any is present.
             if (testsMap.get(TEST_BLOCK_OPTIONS) != null) {
-                options.setWithOptionsMap(Matchers.map(testsMap.get(TEST_BLOCK_OPTIONS)));
+                options.setWithOptionsMap(CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(testsMap.get(TEST_BLOCK_OPTIONS))));
             }
             // execution context carries the highest priority, try setting options per that if it has some options to override.
             options.setWithExecutionContext(executionContext);
             final var testsObject = Matchers.notNull(testsMap.get(TEST_BLOCK_TESTS), "‼️ tests not found at line " + lineNumber);
+            if (options.rawSupportedVersion != null) {
+                final SupportedVersionCheck check = SupportedVersionCheck.parse(options.rawSupportedVersion, executionContext);
+                if (!check.isSupported()) {
+                    return new SkipBlock(lineNumber, check.getMessage());
+                }
+            }
             var randomGenerator = new Random(options.seed);
             final var executables = new ArrayList<Consumer<RelationalConnection>>();
             final var executableTestsWithCacheCheck = new ArrayList<Consumer<RelationalConnection>>();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -91,6 +91,11 @@ public final class QueryCommand extends Command {
             final var configs = queryConfigsWithValueList.isEmpty() ?
                     List.of(QueryConfig.getNoCheckConfig(lineNumber, executionContext)) :
                     queryConfigsWithValueList.stream().map(l -> QueryConfig.parse(l, executionContext)).collect(Collectors.toList());
+
+            Assert.thatUnchecked(configs.stream().skip(1)
+                    .noneMatch(config -> QueryConfig.QUERY_CONFIG_SUPPORTED_VERSION.equals(config.getConfigName())),
+                    "supported_version must be the first config in a query (after the query itself)");
+
             final List<QueryConfig> skipConfigs = configs.stream().filter(config -> config instanceof QueryConfig.SkipConfig)
                     .collect(Collectors.toList());
             Assert.thatUnchecked(skipConfigs.size() < 2, "Query should not have more than one skip");

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests.command;
 
+import com.apple.foundationdb.relational.yamltests.block.FileOptions;
 import com.apple.foundationdb.relational.yamltests.server.SupportedVersionCheck;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.relational.api.Continuation;
@@ -66,7 +67,7 @@ public abstract class QueryConfig {
     public static final String QUERY_CONFIG_PLAN_HASH = "planHash";
     public static final String QUERY_CONFIG_NO_CHECKS = "noChecks";
     public static final String QUERY_CONFIG_MAX_ROWS = "maxRows";
-    public static final String QUERY_CONFIG_SUPPORTED_VERSION = "supported_version";
+    public static final String QUERY_CONFIG_SUPPORTED_VERSION = FileOptions.SUPPORTED_VERSION_OPTION;
 
     @Nullable private final Object value;
     private final int lineNumber;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -33,6 +33,7 @@ import com.github.difflib.text.DiffRow;
 import com.github.difflib.text.DiffRowGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
 import org.opentest4j.AssertionFailedError;
 
 import javax.annotation.Nonnull;
@@ -354,6 +355,8 @@ public abstract class QueryConfig {
             @Override
             void checkResultInternal(@Nonnull final Object actual, @Nonnull final String queryDescription) throws SQLException {
                 // Nothing to do, this query is supported
+                // SupportedVersion configs are not executed
+                Assertions.fail("Supported version configs are not meant to be executed.");
             }
         };
     }
@@ -403,7 +406,7 @@ public abstract class QueryConfig {
 
         @Override
         void checkResultInternal(@Nonnull final Object actual, @Nonnull final String queryDescription) throws SQLException {
-            logger.info("Line: " + getLineNumber() + " " + message);
+            Assertions.fail("Skipped config should not be executed: Line: " + getLineNumber() + " " + message);
         }
 
         public String getMessage() {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -74,9 +74,6 @@ import java.util.stream.Collectors;
  * Here, the parameter can randomly take different values between 2 and 9 in each binding.
  */
 public final class QueryInterpreter {
-    /**
-     * The original query string with embedded parameter injections.
-     */
     @Nonnull
     private final String query;
     private final int lineNumber;
@@ -201,6 +198,14 @@ public final class QueryInterpreter {
         this.lineNumber = lineNumber;
         this.injections = getInjections(query);
         this.executionContext = executionContext;
+    }
+
+    /**
+     * The original query string with embedded parameter injections.
+     */
+    @Nonnull
+    String getQuery() {
+        return query;
     }
 
     private List<Pair<String, Parameter>> getInjections(@Nonnull String query) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
@@ -32,6 +32,8 @@ import java.sql.SQLException;
 
 /**
  * A command that should be skipped by the block.
+ * A SkippedCommand gets created when a command is deemed to be inappropriate for execution (because of a condition
+ * that makes it so). The SkippedCommand then is a placeholder for a command that is not executed.
  */
 public class SkippedCommand extends Command {
     private static final Logger logger = LogManager.getLogger(SkippedCommand.class);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
@@ -1,0 +1,60 @@
+/*
+ * SkippedCommand.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.command;
+
+import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+import com.apple.foundationdb.relational.util.Assert;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.sql.SQLException;
+
+/**
+ * A command that should be skipped by the block.
+ */
+public class SkippedCommand extends Command {
+    private static final Logger logger = LogManager.getLogger(SkippedCommand.class);
+    @Nonnull
+    private final String message;
+    @Nonnull
+    private final String query;
+
+    SkippedCommand(final int lineNumber, @Nonnull final YamlExecutionContext executionContext,
+                   @Nonnull String message, @Nonnull final String query) {
+        super(lineNumber, executionContext);
+        this.message = message;
+        this.query = query;
+    }
+
+    @Override
+    void executeInternal(@Nonnull final RelationalConnection connection) throws SQLException, RelationalException {
+        Assert.fail("Skipped commands should not be called");
+    }
+
+    public void log() {
+        if (logger.isInfoEnabled()) {
+            logger.info("Line " + getLineNumber() + ": '" + query + "' --  " + message);
+        }
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.relational.yamltests.server;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -139,6 +140,14 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
             return versionComparison;
         }
         return comparePrerelease(o);
+    }
+
+    @Nonnull
+    public List<SemanticVersion> lesserVersions(@Nonnull Collection<String> rawVersions) {
+        return rawVersions.stream()
+                .map(SemanticVersion::parse)
+                .filter(other -> other.compareTo(this) < 0)
+                .collect(Collectors.toList());
     }
 
     private int compareVersionNumbers(@Nonnull SemanticVersion o) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SupportedVersionCheck.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SupportedVersionCheck.java
@@ -1,5 +1,5 @@
 /*
- * SupportedVersion.java
+ * SupportedVersionCheck.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SupportedVersionCheck.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SupportedVersionCheck.java
@@ -1,0 +1,78 @@
+/*
+ * SupportedVersion.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.server;
+
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import com.apple.foundationdb.relational.yamltests.block.FileOptions;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Class to support the various places in a yaml file where you can have supported_version.
+ */
+public class SupportedVersionCheck {
+
+    private final boolean isSupported;
+    private final String message;
+
+    private SupportedVersionCheck() {
+        isSupported = true;
+        message = "";
+    }
+
+    private SupportedVersionCheck(final String message) {
+        isSupported = false;
+        this.message = message;
+    }
+
+    public static SupportedVersionCheck parse(Object rawVersion, YamlExecutionContext executionContext) {
+        if (rawVersion instanceof FileOptions.CurrentVersion) {
+            final Set<String> versionsUnderTest = executionContext.getConnectionFactory().getVersionsUnderTest();
+            // IntelliJ, at least, doesn't display the reason, so log it
+            if (!versionsUnderTest.isEmpty()) {
+                return new SupportedVersionCheck(
+                        "Skipping test that only works against the current version, when we're running with these versions: " +
+                                versionsUnderTest);
+            }
+            return new SupportedVersionCheck();
+        } else if (rawVersion instanceof String) {
+            final SemanticVersion supported = SemanticVersion.parse((String)rawVersion);
+            final List<SemanticVersion> unsupportedVersions = supported.lesserVersions(
+                    executionContext.getConnectionFactory().getVersionsUnderTest());
+            if (!unsupportedVersions.isEmpty()) {
+                return new SupportedVersionCheck("Skipping test that only works against " + supported +
+                        " and later, but we are running with these older versions: " + unsupportedVersions);
+            }
+            return new SupportedVersionCheck();
+        } else {
+            throw new RuntimeException("Unsupported supported_version: " + rawVersion);
+        }
+    }
+
+    public boolean isSupported() {
+        return isSupported;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -60,7 +60,8 @@ public class SupportedVersionTest extends YamlTestBase {
                 "supported-at-query",
                 "unspecified",
                 "lower-at-block",
-                "lower-at-query"
+                "lower-at-query",
+                "late-query-supported-version"
         );
     }
 
@@ -82,7 +83,8 @@ public class SupportedVersionTest extends YamlTestBase {
                 "current-version-at-query",
                 "higher-at-block",
                 "higher-at-query",
-                "fully-supported"
+                "fully-supported",
+                "query-with-multiple-configs"
         );
     }
 

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -81,7 +81,8 @@ public class SupportedVersionTest extends YamlTestBase {
                 "current-version-at-block",
                 "current-version-at-query",
                 "higher-at-block",
-                "higher-at-query"
+                "higher-at-query",
+                "fully-supported"
         );
     }
 

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -1,0 +1,93 @@
+/*
+ * SupportedVersionTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import com.apple.foundationdb.relational.yamltests.YamlRunner;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.net.URI;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests that {@code supported_version} skip what they should and nothing else.
+ */
+public class SupportedVersionTest extends YamlTestBase {
+
+    YamlRunner.YamlConnectionFactory createConnectionFactory() {
+        return new YamlRunner.YamlConnectionFactory() {
+            @Override
+            public RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+                return DriverManager.getConnection(connectPath.toString()).unwrap(RelationalConnection.class);
+            }
+
+            @Override
+            public Set<String> getVersionsUnderTest() {
+                return Set.of("3.0.18.0");
+            }
+        };
+    }
+
+    static Stream<String> shouldFail() {
+        return Stream.of(
+                "supported-at-file",
+                "supported-at-block",
+                "unsupported-at-block-only",
+                "supported-at-query",
+                "unspecified",
+                "lower-at-block",
+                "lower-at-query"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldFail")
+    void shouldFail(String filename) {
+        assertThrows(YamlExecutionContext.YamlExecutionError.class, () ->
+                doRun("supported-version/" + filename + ".yamsql"));
+    }
+
+
+    static Stream<String> shouldPass() {
+        return Stream.of(
+                "unsupported-at-file", // technically for this one the whole test is ignored
+                "unsupported-at-block",
+                "unsupported-at-query",
+                "current-version-at-file",
+                "current-version-at-block",
+                "current-version-at-query",
+                "higher-at-block",
+                "higher-at-query"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldPass")
+    void shouldPass(String filename) throws Exception {
+        doRun("supported-version/" + filename + ".yamsql");
+    }
+}

--- a/yaml-tests/src/test/resources/showcasing-tests.yamsql
+++ b/yaml-tests/src/test/resources/showcasing-tests.yamsql
@@ -40,7 +40,7 @@ options:
     # supported_version specifies what versions this works with
     # Any version greater than the provided version is expected to work
     # When developing a new feature use !current_version to specify that it only works with the current version
-    supported_version: 4.0.561.0
+    supported_version: 4.0.559.0
 ---
 schema_template:
     create table t1(id bigint, col1 bigint, primary key(id))
@@ -103,6 +103,9 @@ test_block:
       # Having multiple `result` configs for the `query` command checks the result sets
       # (in order of appearance) with consecutive continuations of the query.
       - query: select * from t1;
+      # Like the options at the top of the file, a supported_version can be specified for
+      # an individual query. This overrides the version specified in the file, or test block
+      - supported_version: 4.0.561.0
       - maxRows: 1
       - result: [{10, 20}]
       - result: [{30, 40}]

--- a/yaml-tests/src/test/resources/showcasing-tests.yamsql
+++ b/yaml-tests/src/test/resources/showcasing-tests.yamsql
@@ -157,6 +157,9 @@ test_block:
     # For `block` the connection is created just once and all the tests are executed in that connection.
     # optional. default: test
     connection_lifecycle: block
+    # Like the options at the top of the file, a supported_version can be specified for
+    # an individual test_block. This overrides the version specified in the file
+    supported_version: 4.0.560.0
   tests:
     -
       # We can selectively ignore part of the result set, by using the `!ignore dc` tag, which will cause

--- a/yaml-tests/src/test/resources/showcasing-tests.yamsql
+++ b/yaml-tests/src/test/resources/showcasing-tests.yamsql
@@ -36,6 +36,12 @@
 #       opaque as to how and where schemas are created, `setup` setup block gives the tester the option to execute
 #       whatever statements they want in whichever location.
 ---
+options:
+    # supported_version specifies what versions this works with
+    # Any version greater than the provided version is expected to work
+    # When developing a new feature use !current_version to specify that it only works with the current version
+    supported_version: 4.0.561.0
+---
 schema_template:
     create table t1(id bigint, col1 bigint, primary key(id))
     create table t2(col1 bigint, primary key(col1))

--- a/yaml-tests/src/test/resources/supported-version/current-version-at-block.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/current-version-at-block.yamsql
@@ -1,0 +1,31 @@
+#
+# current-version-at-block.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: !current_version
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/current-version-at-file.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/current-version-at-file.yamsql
@@ -1,0 +1,32 @@
+#
+# current-version-at-file.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should be ignored
+---
+options:
+    supported_version: !current_version
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/current-version-at-query.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/current-version-at-query.yamsql
@@ -1,0 +1,33 @@
+#
+# current-version-at-query.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - supported_version: !current_version
+      - result: []
+    - # You need at least one query
+      - query: SELECT * FROM t1;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/fully-supported.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/fully-supported.yamsql
@@ -1,0 +1,36 @@
+#
+# fully-supported.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass, we're trying to confirm that having supported_version that is supported
+# doesn't break things
+---
+options:
+    supported_version: 1.0.0.0
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 1.0.2.0
+  tests:
+    - # You need at least one query
+      - query: SELECT * FROM t1;
+      - supported_version: 1.0.3.0
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/higher-at-block.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/higher-at-block.yamsql
@@ -1,0 +1,34 @@
+#
+# higher-at-block.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+options:
+    supported_version: 3.0.18.0
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 3.0.18.1
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/higher-at-query.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/higher-at-query.yamsql
@@ -1,0 +1,35 @@
+#
+# higher-at-query.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 3.0.18.0
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - supported_version: 3.0.18.1
+      - result: []
+    - # You need at least one query
+      - query: SELECT * FROM t1;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/late-query-supported-version.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/late-query-supported-version.yamsql
@@ -1,0 +1,31 @@
+#
+# late-query-supported-version.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail because the supported_version is too late
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SELECT * FROM t1;
+      - explainContains: "("
+      - supported_version: 3.0.17.0
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/lower-at-block.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/lower-at-block.yamsql
@@ -1,0 +1,34 @@
+#
+# lower-at-block.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail
+---
+options:
+    supported_version: 3.0.18.0
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 3.0.17.9
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/lower-at-query.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/lower-at-query.yamsql
@@ -1,0 +1,32 @@
+#
+# lower-at-query.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 3.0.18.0
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - supported_version: 3.0.17.9
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/query-with-multiple-configs.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/query-with-multiple-configs.yamsql
@@ -1,0 +1,31 @@
+#
+# query-with-multiple-configs.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this is intended to be a copy of late-query-supported-version but without the supported_version
+# and thus should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SELECT * FROM t1;
+      - explainContains: "("
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/supported-at-block.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/supported-at-block.yamsql
@@ -1,0 +1,31 @@
+#
+# supported-at-block.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 3.0.18.0
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/supported-at-file.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/supported-at-file.yamsql
@@ -1,0 +1,32 @@
+#
+# supported-at-file.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail
+---
+options:
+    supported_version: 3.0.17.0
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/supported-at-query.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/supported-at-query.yamsql
@@ -1,0 +1,30 @@
+#
+# supported-at-query.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - supported_version: 3.0.18.0
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/unspecified.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/unspecified.yamsql
@@ -1,0 +1,29 @@
+#
+# unspecified.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/unsupported-at-block-only.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/unsupported-at-block-only.yamsql
@@ -1,0 +1,41 @@
+#
+# unsupported-at-block-only.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should fail
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 3.0.18.1
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []
+---
+test_block:
+  options:
+    supported_version: 3.0.18.0
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []
+
+

--- a/yaml-tests/src/test/resources/supported-version/unsupported-at-block.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/unsupported-at-block.yamsql
@@ -1,0 +1,31 @@
+#
+# unuspported-at-block.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: 3.0.18.1
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/unsupported-at-file.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/unsupported-at-file.yamsql
@@ -1,0 +1,32 @@
+#
+# unsupported-at-file.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should be ignored
+---
+options:
+    supported_version: 3.0.18.1
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/unsupported-at-query.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/unsupported-at-query.yamsql
@@ -1,0 +1,33 @@
+#
+# unsupported-at-query.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - supported_version: 3.0.18.1
+      - result: []
+    - # You need at least one query
+      - query: SELECT * FROM t1;
+      - result: []


### PR DESCRIPTION
This combines a few items that build on each other:
1. the supported_version option now supports old versions, not just `!current_version`
2. you can add `supported_version` to a single query
3. you can add `supported_version` to a test_block