### PR TITLE
Introduce spotless and use it to fix copyright headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ plugins {
     alias(libs.plugins.artifactory)
     alias(libs.plugins.download)
     alias(libs.plugins.sonarqube)
+    alias(libs.plugins.spotless)
 }
 
 ext {
@@ -266,6 +267,23 @@ subprojects {
     }
 
     check.dependsOn quickCheck
+}
+
+// Spotless
+
+spotless {
+    ratchetFrom('HEAD')
+    java {
+        target "**/src/main/java/**/*.java", "**/src/test/java/**/*.java", "**/src/testFixtures/java/**/*.java"
+        // target "fdb-record-layer-core/src/main/java/", "fdb-record-layer-core/src/test/java/", "fdb-record-layer-core/src/testFixtures/java/"
+        targetExclude "**/.out/", "**/protogen/", "fdb-record-layer-lucene/src/main/java/org/apache/"
+        licenseHeaderFile("${rootDir}/gradle/codequality/java-copyright.txt")
+        removeUnusedImports()
+    }
+    protobuf {
+        target "**/src/main/proto/**/*.proto", "**/src/test/proto/**/*.proto", "**/src/testFixtures/proto/**/*.proto"
+        licenseHeaderFile("${rootDir}/gradle/codequality/java-copyright.txt")
+    }
 }
 
 // Script for upgrading gradle. To upgrade the gradle version, set the property to the version

--- a/examples/src/main/proto/sample.proto
+++ b/examples/src/main/proto/sample.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.sample;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/FDBError.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/FDBError.java
@@ -1,5 +1,5 @@
 /*
- * ErrorCodes.java
+ * FDBError.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/VersionFromTimestamp.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/VersionFromTimestamp.java
@@ -1,9 +1,9 @@
 /*
- * VersionstampFromDate.java
+ * VersionFromTimestamp.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleOrdering.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleOrdering.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/test/TestDatabaseExtension.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/test/TestDatabaseExtension.java
@@ -1,5 +1,5 @@
 /*
- * FDBExtension.java
+ * TestDatabaseExtension.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleOrderingTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleOrderingTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/DoubleState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/DoubleState.java
@@ -1,5 +1,5 @@
 /*
- * IntState.java
+ * DoubleState.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/FloatState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/FloatState.java
@@ -1,5 +1,5 @@
 /*
- * IntState.java
+ * FloatState.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/IntegerState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/IntegerState.java
@@ -1,5 +1,5 @@
 /*
- * IntState.java
+ * IntegerState.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/LongState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/LongState.java
@@ -1,5 +1,5 @@
 /*
- * IntState.java
+ * LongState.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
@@ -1,5 +1,5 @@
 /*
- * GroupAggregator.java
+ * StreamGrouping.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/DimensionsKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/DimensionsKeyExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LongArithmethicFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/LongArithmethicFunctionKeyExpression.java
@@ -1,5 +1,5 @@
 /*
- * ArithmethicFunctionKeyExpression.java
+ * LongArithmethicFunctionKeyExpression.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/OrderFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/OrderFunctionKeyExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/OrderFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/OrderFunctionKeyExpressionFactory.java
@@ -1,9 +1,9 @@
 /*
- * OrderFunctionKeyExpressionFactoryRE.java
+ * OrderFunctionKeyExpressionFactory.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/CipherPool.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/CipherPool.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/EventKeeperTranslator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/EventKeeperTranslator.java
@@ -1,5 +1,5 @@
 /*
- * EventKeeperDelegator.java
+ * EventKeeperTranslator.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * FDBDatabaseFactory.java
+ * FDBDatabaseFactoryImpl.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRawRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBIndexedRawRecord.java
@@ -1,5 +1,5 @@
 /*
- * FDBIndexedRecord.java
+ * FDBIndexedRawRecord.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBSystemOperations.java
@@ -1,5 +1,5 @@
 /*
- * FDBSystemDatabase.java
+ * FDBSystemOperations.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexDeferredMaintenanceControl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexDeferredMaintenanceControl.java
@@ -1,5 +1,5 @@
 /*
- * IndexDeferredMaintenancePolicy.java
+ * IndexDeferredMaintenanceControl.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexPrefetchRangeKeyValueCursor.java
@@ -1,5 +1,5 @@
 /*
- * IndexRangeKeyValueCursor.java
+ * IndexPrefetchRangeKeyValueCursor.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanBounds.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanBounds.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanRange.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -1,5 +1,5 @@
 /*
- * IndexingRepair.java
+ * IndexingScrubDangling.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -1,5 +1,5 @@
 /*
- * IndexingRepair.java
+ * IndexingScrubMissing.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -1,5 +1,5 @@
 /*
- * KeyValueCursor.java
+ * KeyValueCursorBase.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanBounds.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanBounds.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * OnlineIndexerBaseBuilder.java
+ * OnlineIndexOperationBaseBuilder.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -1,5 +1,5 @@
 /*
- * OnlineScrubber.java
+ * OnlineIndexScrubber.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SortedRecordSerializer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedMethodException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedMethodException.java
@@ -1,5 +1,5 @@
 /*
- * UnsupportedFormatVersionException.java
+ * UnsupportedMethodException.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedRemoteFetchIndexException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/UnsupportedRemoteFetchIndexException.java
@@ -1,5 +1,5 @@
 /*
- * UnsupportedFormatVersionException.java
+ * UnsupportedRemoteFetchIndexException.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/clientlog/KeySpaceCountTree.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
@@ -1,9 +1,9 @@
 /*
- * BitmapValueIndexMaintainer.java
+ * BitmapValueIndexMaintainerFactory.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultiDimensionalIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultiDimensionalIndexHelper.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
@@ -1,9 +1,9 @@
 /*
- * RankIndexMaintainerFactory.java
+ * MultidimensionalIndexMaintainerFactory.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexScrubbingToolsMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexScrubbingToolsMissing.java
@@ -1,5 +1,5 @@
 /*
- * ValueIndexScrubbingTools.java
+ * ValueIndexScrubbingToolsMissing.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceTreeResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceTreeResolver.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020-2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowScanComparisons.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowScanRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowScanRange.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/PassThroughRecordStoreStateCache.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/PassThroughRecordStoreStateCache.java
@@ -1,5 +1,5 @@
 /*
- * PassThroughRecordStoreInfoCache.java
+ * PassThroughRecordStoreStateCache.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/PassThroughRecordStoreStateCacheFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/PassThroughRecordStoreStateCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * PassThroughRecordStoreInfoCacheFactory.java
+ * PassThroughRecordStoreStateCacheFactory.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/ReadVersionRecordStoreStateCacheFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/storestate/ReadVersionRecordStoreStateCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * ReadVersionRecordStoreInfoCacheFactory.java
+ * ReadVersionRecordStoreStateCacheFactory.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OrderQueryKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/OrderQueryKeyExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithOneOfComparison.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/QueryKeyExpressionWithOneOfComparison.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanWithOrderingKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanWithOrderingKey.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanWithStoredFields.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PlanWithStoredFields.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexAggregate.java
@@ -1,9 +1,9 @@
 /*
- * ComposedBitmapIndex.java
+ * ComposedBitmapIndexAggregate.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpansionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * KeyExpressionVisitor.java
+ * ExpansionVisitor.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentityMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentityMap.java
@@ -1,5 +1,5 @@
 /*
- * LinkedIdentitySet.java
+ * LinkedIdentityMap.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchPartition.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchPartition.java
@@ -1,5 +1,5 @@
 /*
- * PartialMatch.java
+ * MatchPartition.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PreOrderPruningIterator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PreOrderPruningIterator.java
@@ -1,5 +1,5 @@
 /*
- * PreOrderIterator.java
+ * PreOrderPruningIterator.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryScanMatchCandidate.java
@@ -1,5 +1,5 @@
 /*
- * MatchCandidate.java
+ * PrimaryScanMatchCandidate.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexExpansionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * ScalagAggIndexExpansionVisitor.java
+ * WindowedIndexExpansionVisitor.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
@@ -1,5 +1,5 @@
 /*
- * MatchCandidate.java
+ * WindowedIndexScanMatchCandidate.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalDistinctExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalDistinctExpression.java
@@ -1,5 +1,5 @@
 /*
- * LogicalDistinctPlan.java
+ * LogicalDistinctExpression.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/DatabaseObjectDependenciesPredicate.java
@@ -1,5 +1,5 @@
 /*
- * DatabaseObjectsDependencies.java
+ * DatabaseObjectDependenciesPredicate.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementExplodeRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementExplodeRule.java
@@ -1,5 +1,5 @@
 /*
- * ImplementSimpleSelectRule.java
+ * ImplementExplodeRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInsertRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInsertRule.java
@@ -1,5 +1,5 @@
 /*
- * ImplementUpdateRule.java
+ * ImplementInsertRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
@@ -1,5 +1,5 @@
 /*
- * ImplementGroupByRule.java
+ * ImplementStreamingAggregationRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushInJoinThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushInJoinThroughFetchRule.java
@@ -1,5 +1,5 @@
 /*
- * PushFilterThroughFetchRule.java
+ * PushInJoinThroughFetchRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughDeleteRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughDeleteRule.java
@@ -1,5 +1,5 @@
 /*
- * PushRequestedOrderingThroughSortRule.java
+ * PushRequestedOrderingThroughDeleteRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInsertRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInsertRule.java
@@ -1,5 +1,5 @@
 /*
- * PushRequestedOrderingThroughSortRule.java
+ * PushRequestedOrderingThroughInsertRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUpdateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUpdateRule.java
@@ -1,5 +1,5 @@
 /*
- * PushRequestedOrderingThroughSortRule.java
+ * PushRequestedOrderingThroughUpdateRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexableAggregateValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/IndexableAggregateValue.java
@@ -1,5 +1,5 @@
 /*
- * IndexableAggregationValue.java
+ * IndexableAggregateValue.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractRule.java
@@ -1,5 +1,5 @@
 /*
- * AbstractValueRule.java
+ * AbstractRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractRuleCall.java
@@ -1,5 +1,5 @@
 /*
- * AbstractValueRuleCall.java
+ * AbstractRuleCall.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/AbstractRuleSet.java
@@ -1,5 +1,5 @@
 /*
- * AbstractValueRuleSet.java
+ * AbstractRuleSet.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFirstOrDefaultPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFirstOrDefaultPlan.java
@@ -1,5 +1,5 @@
 /*
- * RecordQueryMapPlan.java
+ * RecordQueryFirstOrDefaultPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionOnKeyExpressionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionOnKeyExpressionPlan.java
@@ -1,5 +1,5 @@
 /*
- * RecordQueryUnionOnKeyExpressionPlan.java
+ * RecordQueryInUnionOnKeyExpressionPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionOnValuesPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionOnValuesPlan.java
@@ -1,5 +1,5 @@
 /*
- * RecordQueryUnionOnValuesPlan.java
+ * RecordQueryInUnionOnValuesPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRecursiveUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRecursiveUnionPlan.java
@@ -1,5 +1,5 @@
 /*
- * RecursiveUnionQueryPlan.java
+ * RecordQueryRecursiveUnionPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQueryDamPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQueryDamPlan.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQueryPlannerSortConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQueryPlannerSortConfiguration.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortAdapter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortKey.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/sorting/RecordQuerySortPlan.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/UnorderedPrimaryKeyDistinctVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/visitor/UnorderedPrimaryKeyDistinctVisitor.java
@@ -1,5 +1,5 @@
 /*
- * IndexFetchToUnorderedPrimaryKeyDistinctVisitor.java
+ * UnorderedPrimaryKeyDistinctVisitor.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortAdapter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSortCursorContinuation.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSorter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/FileSorter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemoryDam.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemoryDam.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemoryScratchpad.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemoryScratchpad.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortAdapter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortAdapter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursorContinuation.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySortCursorContinuation.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/MemorySorter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortEvents.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortEvents.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortedFileReader.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/sorting/SortedFileReader.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/main/proto/index_build.proto
+++ b/fdb-record-layer-core/src/main/proto/index_build.proto
@@ -1,22 +1,22 @@
 /*
-  * index_metadata.proto
-  *
-  * This source file is part of the FoundationDB open source project
-  *
-  * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *     http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * index_build.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 syntax = "proto2";
 

--- a/fdb-record-layer-core/src/main/proto/planner_debugger.proto
+++ b/fdb-record-layer-core/src/main/proto/planner_debugger.proto
@@ -1,7 +1,7 @@
 /*
  * planner_debugger.proto
  *
- * This source file is part of the FoundationDB open source projectsour
+ * This source file is part of the FoundationDB open source project
  *
  * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
  *
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.query.plan.cascades.debug.eventprotos;

--- a/fdb-record-layer-core/src/main/proto/record_cursor.proto
+++ b/fdb-record-layer-core/src/main/proto/record_cursor.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/record_metadata.proto
+++ b/fdb-record-layer-core/src/main/proto/record_metadata.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/record_metadata_options.proto
+++ b/fdb-record-layer-core/src/main/proto/record_metadata_options.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/record_planner_config.proto
+++ b/fdb-record-layer-core/src/main/proto/record_planner_config.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.planprotos;

--- a/fdb-record-layer-core/src/main/proto/record_query_runtime.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_runtime.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.planprotos;

--- a/fdb-record-layer-core/src/main/proto/record_sorting.proto
+++ b/fdb-record-layer-core/src/main/proto/record_sorting.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/resolver_state.proto
+++ b/fdb-record-layer-core/src/main/proto/resolver_state.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/string_interning_data.proto
+++ b/fdb-record-layer-core/src/main/proto/string_interning_data.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/time_window_leaderboard.proto
+++ b/fdb-record-layer-core/src/main/proto/time_window_leaderboard.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/main/proto/tuple_fields.proto
+++ b/fdb-record-layer-core/src/main/proto/tuple_fields.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/FallbackCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/FallbackCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * ChainedCursorTest.java
+ * FallbackCursorTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * MetaDataEvolutionTest.java
+ * MetaDataEvolutionValidatorTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/MappedPoolTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/MappedPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * MappedPoolTests.java
+ * MappedPoolTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCrudTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCrudTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreCRUDTest.java
+ * FDBRecordStoreCrudTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreEstimateSizeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreEstimateSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreEstimatedSizeTest.java
+ * FDBRecordStoreEstimateSizeTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreUniquenessTest.java
+ * FDBRecordStoreUniqueIndexTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/IndexFunctionHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/IndexFunctionHelperTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -1,5 +1,5 @@
 /*
- * OnlineIndexerIndexFromIndexTest.java
+ * OnlineIndexScrubberTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * OnlineIndexerIndexFromIndexTest.java
+ * OnlineIndexerMultiTargetTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchIndexScanTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreIndexPrefetchTest.java
+ * RemoteFetchIndexScanTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchMultiColumnKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchMultiColumnKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreIndexPrefetchTest.java
+ * RemoteFetchMultiColumnKeyTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchOldVersionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchOldVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreIndexPrefetchOldVersionTest.java
+ * RemoteFetchOldVersionTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchSplitRecordsTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreIndexPrefetchSplitRecordsTest.java
+ * RemoteFetchSplitRecordsTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreIndexPrefetchTest.java
+ * RemoteFetchTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchTestBase.java
@@ -1,5 +1,5 @@
 /*
- * FDBRecordStoreIndexPrefetchOldVersionTest.java
+ * RemoteFetchTestBase.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RemoteFetchWithoutSplitRecordsTest.java
@@ -1,5 +1,5 @@
 /*
- * IndexPrefetchWithoutSplitRecordsTest.java
+ * RemoteFetchWithoutSplitRecordsTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/cursors/SortCursorTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexTestBase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBLongArithmeticFunctionQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBLongArithmeticFunctionQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBBitwiseFunctionQueryTest.java
+ * FDBLongArithmeticFunctionQueryTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrderingQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBOrderingQueryTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBQueryGraphTestHelpers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBQueryGraphTestHelpers.java
@@ -1,5 +1,5 @@
 /*
- * FDBSimpleQueryGraphTest.java
+ * FDBQueryGraphTestHelpers.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanMaxCardinalityTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanMaxCardinalityTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ChooseKTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ChooseKTest.java
@@ -1,5 +1,5 @@
 /*
- * AliasMapTest.java
+ * ChooseKTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/LikeOperatorValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/LikeOperatorValueTest.java
@@ -1,5 +1,5 @@
 /*
- * ArithmeticValueTest.java
+ * LikeOperatorValueTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/VariadicFunctionValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/VariadicFunctionValueTest.java
@@ -1,5 +1,5 @@
 /*
- * ArithmeticValueTest.java
+ * VariadicFunctionValueTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/DebuggerWithSymbolTables.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/DebuggerWithSymbolTables.java
@@ -1,5 +1,5 @@
 /*
- * PlannerRepl.java
+ * DebuggerWithSymbolTables.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/AnyFilterMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/AnyFilterMatcher.java
@@ -1,5 +1,5 @@
 /*
- * FilterMatcherWithComponent.java
+ * AnyFilterMatcher.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/ComposedBitmapIndexMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/ComposedBitmapIndexMatcher.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/SortMatcher.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/match/SortMatcher.java
@@ -1,9 +1,9 @@
 /*
- * FilterMatcher.java
+ * SortMatcher.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticPlanMatchers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticPlanMatchers.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/ExceptionLoggingDetailsExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/ExceptionLoggingDetailsExtension.java
@@ -1,5 +1,5 @@
 /*
- * ConflictExceptionExtension.java
+ * ExceptionLoggingDetailsExtension.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/ExceptionLoggingDetailsExtensionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/ExceptionLoggingDetailsExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * ExtensionLoggingDetailsExtensionTest.java
+ * ExceptionLoggingDetailsExtensionTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
@@ -1,5 +1,5 @@
 /*
- * FDBDatabaseFactoryExtension.java
+ * FDBDatabaseExtension.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/TestKeySpacePathManagerExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/TestKeySpacePathManagerExtension.java
@@ -1,5 +1,5 @@
 /*
- * TestKeySpacePathExtension.java
+ * TestKeySpacePathManagerExtension.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/proto/evolution/test_field_type_change.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_field_type_change.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.fieldtypechange;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_header_as_group.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_header_as_group.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.headergroup;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_merged_nested_types.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_merged_nested_types.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.mergednested;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_nested_proto2.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_nested_proto2.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.nestedproto2;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_nested_proto3.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_nested_proto3.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto3";
 
 package com.apple.foundationdb.record.evolution.nestedproto3;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_new_record_type.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_new_record_type.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.newtype;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_records_1_imported.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_records_1_imported.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto3";
 
 package com.apple.foundationdb.record.evolution.test1imported;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_records_3_proto3.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_records_3_proto3.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto3";
 
 package com.apple.foundationdb.record.evolution.test3proto3;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_records_enum_proto3.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_records_enum_proto3.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto3";
 
 package com.apple.foundationdb.record.evolution.testenum3;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_records_nested_proto2.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_records_nested_proto2.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto3";
 
 package com.apple.foundationdb.record.evolution.nestedproto2;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_records_nested_proto3.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_records_nested_proto3.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto3";
 
 package com.apple.foundationdb.record.evolution.nestedproto3;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_self_reference.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_self_reference.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.selfreference;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_self_reference_unspooled.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_self_reference_unspooled.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.selfreferenceunspooled;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_split_nested_types.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_split_nested_types.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.splitnested;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_swap_union_fields.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_swap_union_fields.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.swap;

--- a/fdb-record-layer-core/src/test/proto/evolution/test_unmerged_nested_types.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_unmerged_nested_types.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.evolution.unmergednested;

--- a/fdb-record-layer-core/src/test/proto/expression_tests.proto
+++ b/fdb-record-layer-core/src/test/proto/expression_tests.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.metadata;

--- a/fdb-record-layer-core/src/test/proto/test_hierarchies.proto
+++ b/fdb-record-layer-core/src/test/proto/test_hierarchies.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test_hierarchies;

--- a/fdb-record-layer-core/src/test/proto/test_no_indexes.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_indexes.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test.no.indexes;

--- a/fdb-record-layer-core/src/test/proto/test_no_union.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testnounion;

--- a/fdb-record-layer-core/src/test/proto/test_no_union_evolved.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union_evolved.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testnounionevolved;

--- a/fdb-record-layer-core/src/test/proto/test_no_union_evolved_illegal.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union_evolved_illegal.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testnounionevolvedillegal;

--- a/fdb-record-layer-core/src/test/proto/test_no_union_evolved_renamed_type.proto
+++ b/fdb-record-layer-core/src/test/proto/test_no_union_evolved_renamed_type.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testnounionrenamedrecordtype;

--- a/fdb-record-layer-core/src/test/proto/test_records_1.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_1.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test1;

--- a/fdb-record-layer-core/src/test/proto/test_records_1_evolved.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_1_evolved.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test1evolved;

--- a/fdb-record-layer-core/src/test/proto/test_records_1_evolved_again.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_1_evolved_again.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test1evolvedagain;

--- a/fdb-record-layer-core/src/test/proto/test_records_1_evolved_with_map.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_1_evolved_with_map.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test1withmap;

--- a/fdb-record-layer-core/src/test/proto/test_records_2.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_2.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test2;

--- a/fdb-record-layer-core/src/test/proto/test_records_3.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_3.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test3;

--- a/fdb-record-layer-core/src/test/proto/test_records_4.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_4.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test4;

--- a/fdb-record-layer-core/src/test/proto/test_records_4_wrapper.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_4_wrapper.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test4wrapper;

--- a/fdb-record-layer-core/src/test/proto/test_records_5.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_5.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test5;

--- a/fdb-record-layer-core/src/test/proto/test_records_6.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_6.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test6;

--- a/fdb-record-layer-core/src/test/proto/test_records_7.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_7.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test7;

--- a/fdb-record-layer-core/src/test/proto/test_records_8.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_8.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test8;

--- a/fdb-record-layer-core/src/test/proto/test_records_bad_union_1.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_bad_union_1.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testBadUnion1;

--- a/fdb-record-layer-core/src/test/proto/test_records_bad_union_2.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_bad_union_2.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testBadUnion2;

--- a/fdb-record-layer-core/src/test/proto/test_records_bitmap.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_bitmap.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2020 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.bitmap;

--- a/fdb-record-layer-core/src/test/proto/test_records_bytes.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_bytes.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testb;

--- a/fdb-record-layer-core/src/test/proto/test_records_chained_1.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_chained_1.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.chained1;

--- a/fdb-record-layer-core/src/test/proto/test_records_chained_2.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_chained_2.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.chained2;

--- a/fdb-record-layer-core/src/test/proto/test_records_datatypes.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_datatypes.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test.scalarTypes;

--- a/fdb-record-layer-core/src/test/proto/test_records_double_nested.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_double_nested.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test.doublenested;

--- a/fdb-record-layer-core/src/test/proto/test_records_duplicate_union_fields.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_duplicate_union_fields.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test.duplicateunionfields;

--- a/fdb-record-layer-core/src/test/proto/test_records_duplicate_union_fields_reordered.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_duplicate_union_fields_reordered.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test.duplicateunionfields.reordered;

--- a/fdb-record-layer-core/src/test/proto/test_records_enum.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_enum.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testenum;

--- a/fdb-record-layer-core/src/test/proto/test_records_grouped_parent_child.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_grouped_parent_child.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.groupedParentChildProto;

--- a/fdb-record-layer-core/src/test/proto/test_records_implicit_usage.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_implicit_usage.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testimplicitusage;

--- a/fdb-record-layer-core/src/test/proto/test_records_implicit_usage_no_union.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_implicit_usage_no_union.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testimplicitusagenounion;

--- a/fdb-record-layer-core/src/test/proto/test_records_import.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_import.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.import;

--- a/fdb-record-layer-core/src/test/proto/test_records_import_flat.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_import_flat.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.importflat;

--- a/fdb-record-layer-core/src/test/proto/test_records_imported_and_new.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_imported_and_new.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test.importedandnew;

--- a/fdb-record-layer-core/src/test/proto/test_records_index_compat.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_index_compat.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testcompat;

--- a/fdb-record-layer-core/src/test/proto/test_records_index_filtering.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_index_filtering.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testIndexFiltering;

--- a/fdb-record-layer-core/src/test/proto/test_records_join_index.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_join_index.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testjoinindex;

--- a/fdb-record-layer-core/src/test/proto/test_records_leaderboard.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_leaderboard.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testleaderboard;

--- a/fdb-record-layer-core/src/test/proto/test_records_map.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_map.proto
@@ -1,3 +1,23 @@
+/*
+ * test_records_map.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.nestedmaptest;

--- a/fdb-record-layer-core/src/test/proto/test_records_maps.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_maps.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testMaps;

--- a/fdb-record-layer-core/src/test/proto/test_records_marked_unmarked.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_marked_unmarked.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testmarkedunmarked;

--- a/fdb-record-layer-core/src/test/proto/test_records_multi.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_multi.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record;

--- a/fdb-record-layer-core/src/test/proto/test_records_multidimensional.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_multidimensional.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test;

--- a/fdb-record-layer-core/src/test/proto/test_records_name_clash.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_name_clash.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.nameclash;

--- a/fdb-record-layer-core/src/test/proto/test_records_nested_as_record.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_nested_as_record.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.nestedasrecord;

--- a/fdb-record-layer-core/src/test/proto/test_records_no_primary_key.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_no_primary_key.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testNoPrimaryKey;

--- a/fdb-record-layer-core/src/test/proto/test_records_nulls_2.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_nulls_2.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testnulls2;

--- a/fdb-record-layer-core/src/test/proto/test_records_nulls_3.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_nulls_3.proto
@@ -1,3 +1,23 @@
+/*
+ * test_records_nulls_3.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 syntax = "proto3";
 
 package com.apple.foundationdb.record.testnulls3;

--- a/fdb-record-layer-core/src/test/proto/test_records_oneof.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_oneof.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testOneOf;

--- a/fdb-record-layer-core/src/test/proto/test_records_parent_child.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_parent_child.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test7;

--- a/fdb-record-layer-core/src/test/proto/test_records_rank.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_rank.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testrank;

--- a/fdb-record-layer-core/src/test/proto/test_records_text.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_text.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testtext;

--- a/fdb-record-layer-core/src/test/proto/test_records_transform.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_transform.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.transform;

--- a/fdb-record-layer-core/src/test/proto/test_records_tuple_fields.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_tuple_fields.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testTupleFields;

--- a/fdb-record-layer-core/src/test/proto/test_records_two_unions.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_two_unions.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testtwounions;

--- a/fdb-record-layer-core/src/test/proto/test_records_union_default_name.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_union_default_name.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testuniondefaultname;

--- a/fdb-record-layer-core/src/test/proto/test_records_union_missing_record.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_union_missing_record.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testunionmissingrecord;

--- a/fdb-record-layer-core/src/test/proto/test_records_union_with_imported_nested.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_union_with_imported_nested.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testunionwithimportednested;

--- a/fdb-record-layer-core/src/test/proto/test_records_union_with_nested.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_union_with_nested.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testunionwithnested;

--- a/fdb-record-layer-core/src/test/proto/test_records_unsigned_1.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_unsigned_1.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.unsigned;

--- a/fdb-record-layer-core/src/test/proto/test_records_unsigned_2.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_unsigned_2.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.unsigned;

--- a/fdb-record-layer-core/src/test/proto/test_records_unsigned_3.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_unsigned_3.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.unsigned;

--- a/fdb-record-layer-core/src/test/proto/test_records_unsigned_4.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_unsigned_4.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.unsigned;

--- a/fdb-record-layer-core/src/test/proto/test_records_unsigned_5.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_unsigned_5.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.unsigned;

--- a/fdb-record-layer-core/src/test/proto/test_records_with_header.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_with_header.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testheader;

--- a/fdb-record-layer-core/src/test/proto/test_records_with_union.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_with_union.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.testunion;

--- a/fdb-record-layer-core/src/test/proto/test_required_nested_record.proto
+++ b/fdb-record-layer-core/src/test/proto/test_required_nested_record.proto
@@ -1,3 +1,23 @@
+/*
+ * test_required_nested_record.proto
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.test_required_nested_record;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteQueryClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteQueryClause.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneBooleanQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneBooleanQuery.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -1,9 +1,9 @@
 /*
- * FDBStoreTimer.java
+ * LuceneEvents.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionNames.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexValidator.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexValidator.java
@@ -1,9 +1,9 @@
 /*
- * LuceneIndexMaintainerValidator.java
+ * LuceneIndexValidator.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLogMessageKeys.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneNotQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneNotQuery.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryClause.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryMultiFieldSearchClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryMultiFieldSearchClause.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRepartitionPlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRepartitionPlanner.java
@@ -1,5 +1,5 @@
 /*
- * LucenePartitionPlanner.java
+ * LuceneRepartitionPlanner.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanBounds.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanBounds.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheck.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheck.java
@@ -1,9 +1,9 @@
 /*
- * LuceneScanSpellcheck.java
+ * LuceneScanSpellCheck.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanTypes.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanTypes.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
@@ -1,5 +1,5 @@
 /*
- * LuceneSpellcheckResultCursor.java
+ * LuceneSpellCheckRecordCursor.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedLiveDocsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedLiveDocsFormat.java
@@ -1,5 +1,5 @@
 /*
- * LuceneLiveDocsFormat.java
+ * LuceneOptimizedLiveDocsFormat.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCache.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCache.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCacheManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCacheManager.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreFormatException.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreFormatException.java
@@ -1,5 +1,5 @@
 /*
- * RecordCoreArgumentException.java
+ * RecordCoreFormatException.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreSizeException.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreSizeException.java
@@ -1,5 +1,5 @@
 /*
- * RecordCodeTooLongException.java
+ * RecordCoreSizeException.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
@@ -1,5 +1,5 @@
 /*
- * LuceneOptimizedParser.java
+ * ConfigAwareQueryParser.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldStopWordsQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldStopWordsQueryParser.java
@@ -1,5 +1,5 @@
 /*
- * LuceneOptimizedStopWordsQueryParser.java
+ * LuceneOptimizedMultiFieldStopWordsQueryParser.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactoryProvider.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * LuceneQueryParserFactory.java
+ * LuceneQueryParserFactoryProvider.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/EnglishSynonymMapConfig.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/EnglishSynonymMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * SynonymMapConfig.java
+ * EnglishSynonymMapConfig.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistry.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistry.java
@@ -1,5 +1,5 @@
 /*
- * SynonymAnalyzer.java
+ * SynonymMapRegistry.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * SynonymAnalyzer.java
+ * SynonymMapRegistryImpl.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/main/proto/lucene_continuation.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_continuation.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.lucene;

--- a/fdb-record-layer-lucene/src/main/proto/lucene_field_infos.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_field_infos.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020-2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.lucene;

--- a/fdb-record-layer-lucene/src/main/proto/lucene_file_system.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_file_system.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020-2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.lucene;

--- a/fdb-record-layer-lucene/src/main/proto/lucene_partitioning.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_partitioning.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.lucene;

--- a/fdb-record-layer-lucene/src/main/proto/lucene_record_query_plan.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_record_query_plan.proto
@@ -1,7 +1,7 @@
 /*
- * record_metadata.proto
+ * lucene_record_query_plan.proto
  *
- * This source file is part of the FoundationDB open source projectsour
+ * This source file is part of the FoundationDB open source project
  *
  * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
  *
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.planprotos;

--- a/fdb-record-layer-lucene/src/main/proto/lucene_stored_fields.proto
+++ b/fdb-record-layer-lucene/src/main/proto/lucene_stored_fields.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2020-2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.lucene;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecordTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecordTest.java
@@ -1,9 +1,9 @@
 /*
- * LuceneGroupingTest.java
+ * LuceneDocumentFromRecordTest.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -1,5 +1,5 @@
 /*
- * LuceneIndexValidationTest.java
+ * LuceneIndexMaintenanceTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -1,5 +1,5 @@
 /*
- * LuceneIndexModel.java
+ * LuceneIndexTestDataModel.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
@@ -1,5 +1,5 @@
 /*
- * LuceneIndexValidator.java
+ * LuceneIndexTestValidator.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneLockFailureTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneLockFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * LucenOnlineIndexingTest.java
+ * LuceneLockFailureTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
@@ -1,5 +1,5 @@
 /*
- * LucenOnlineIndexingTest.java
+ * LuceneOnlineIndexingTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlanMatchers.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlanMatchers.java
@@ -1,9 +1,9 @@
 /*
- * FDBLuceneQueryTest.java
+ * LucenePlanMatchers.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSharedCacheTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSharedCacheTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBIndexInputTest.java
+ * FDBIndexOutputTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFunctionalityTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBDirectoryTest.java
+ * FDBLuceneFunctionalityTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBLuceneHighlightingTest.java
+ * LuceneLocaleTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2023 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/idformat/IdFormatParserTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/idformat/IdFormatParserTest.java
@@ -1,5 +1,5 @@
 /*
- * TestIdFormatParser.java
+ * IdFormatParserTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/DoubleValueOrParameter.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/DoubleValueOrParameter.java
@@ -1,5 +1,5 @@
 /*
- * CoordinateValueOrParameter.java
+ * DoubleValueOrParameter.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileBoxLatLon.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileBoxLatLon.java
@@ -1,5 +1,5 @@
 /*
- * BoxLatLon.java
+ * GeophileBoxLatLon.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileBoxLatLonWithWraparound.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileBoxLatLonWithWraparound.java
@@ -1,5 +1,5 @@
 /*
- * BoxLatLonWithWraparound.java
+ * GeophileBoxLatLonWithWraparound.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCoveringPointRecord.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCoveringPointRecord.java
@@ -1,5 +1,5 @@
 /*
- * CoveringPointRecord.java
+ * GeophileCoveringPointRecord.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainer.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainer.java
@@ -1,5 +1,5 @@
 /*
- * SpatialIndexMaintainer.java
+ * GeophileIndexMaintainer.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * SpatialIndexMaintainerFactory.java
+ * GeophileIndexMaintainerFactory.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexTypes.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexTypes.java
@@ -1,5 +1,5 @@
 /*
- * SpatialIndexTypes.java
+ * GeophileIndexTypes.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexValidator.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexValidator.java
@@ -1,5 +1,5 @@
 /*
- * SpatialIndexValidator.java
+ * GeophileIndexValidator.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
@@ -1,5 +1,5 @@
 /*
- * GeoPointWithinDistanceQueryPlan.java
+ * GeophilePointWithinDistanceQueryPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileScanTypes.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileScanTypes.java
@@ -1,5 +1,5 @@
 /*
- * SpatialScanTypes.java
+ * GeophileScanTypes.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpression.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpression.java
@@ -1,5 +1,5 @@
 /*
- * SpatialFunctionKeyExpression.java
+ * GeophileSpatialFunctionKeyExpression.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpressionFactory.java
@@ -1,5 +1,5 @@
 /*
- * SpatialFunctionKeyExpressionFactory.java
+ * GeophileSpatialFunctionKeyExpressionFactory.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionNames.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionNames.java
@@ -1,5 +1,5 @@
 /*
- * SpatialFunctionNames.java
+ * GeophileSpatialFunctionNames.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialIndexJoinPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialIndexJoinPlan.java
@@ -1,5 +1,5 @@
 /*
- * SpatialIndexJoinPlan.java
+ * GeophileSpatialIndexJoinPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
@@ -1,5 +1,5 @@
 /*
- * SpatialObjectQueryPlan.java
+ * GeophileSpatialObjectQueryPlan.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/test/java/com/apple/foundationdb/record/spatial/geophile/GeophileQueryTest.java
+++ b/fdb-record-layer-spatial/src/test/java/com/apple/foundationdb/record/spatial/geophile/GeophileQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * FDBSpatialQueryTest.java
+ * GeophileQueryTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-spatial/src/test/proto/test_records_geo.proto
+++ b/fdb-record-layer-spatial/src/test/proto/test_records_geo.proto
@@ -17,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 syntax = "proto2";
 
 package com.apple.foundationdb.record.spatial.geophile;

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/ArrayMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/ArrayMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Continuation.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Continuation.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/DynamicMessageBuilder.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/DynamicMessageBuilder.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/FieldDescription.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/FieldDescription.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/KeySet.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/KeySet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/ParseTreeInfo.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/ParseTreeInfo.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalArray.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalArray.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalArrayBuilder.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalArrayBuilder.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalArrayMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalArrayMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalConnection.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalConnection.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDatabaseMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDatabaseMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDirectAccessStatement.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDirectAccessStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDriver.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDriver.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalPreparedStatement.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalPreparedStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSet.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSetMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSetMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStatement.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStruct.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStruct.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStructBuilder.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStructBuilder.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStructMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStructMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Row.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Row.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/SqlTypeNamesSupport.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/SqlTypeNamesSupport.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/StructMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/StructMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/StructResultSetMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/StructResultSetMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ContextualSQLException.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ContextualSQLException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ErrorCode.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ErrorCode.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/InternalErrorException.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/InternalErrorException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/InvalidColumnReferenceException.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/InvalidColumnReferenceException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/InvalidTypeException.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/InvalidTypeException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/RelationalException.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/RelationalException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/UncheckedRelationalException.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/UncheckedRelationalException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/FluentVisitor.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/FluentVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/SqlVisitor.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/SqlVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/BooleanExpressionTrait.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/BooleanExpressionTrait.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/BooleanFunction.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/BooleanFunction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/BooleanLiteral.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/BooleanLiteral.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ComparableExpressionTrait.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ComparableExpressionTrait.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ComparableFunction.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ComparableFunction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Expression.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Expression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ExpressionFactory.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ExpressionFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ExpressionFragment.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ExpressionFragment.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Field.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Field.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/FunctionLike.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/FunctionLike.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Literal.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Literal.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NestedBooleanExpression.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NestedBooleanExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NumericExpressionTrait.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NumericExpressionTrait.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NumericFunction.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NumericFunction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NumericLiteral.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/NumericLiteral.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Operation.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/Operation.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ParsingFragment.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ParsingFragment.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ScalarExpression.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/ScalarExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/StringLiteral.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/StringLiteral.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/UserDefinedField.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/UserDefinedField.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/details/Mixins.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/expression/details/Mixins.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/statement/StatementBuilderFactory.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/statement/StatementBuilderFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/statement/StructuredQuery.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/statement/StructuredQuery.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/statement/UpdateStatement.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/fluentsql/statement/UpdateStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Column.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Column.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/DataType.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/DataType.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Index.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Index.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Metadata.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Metadata.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Schema.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Schema.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/SchemaTemplate.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/SchemaTemplate.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Table.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Table.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Visitor.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/Visitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/OptionContract.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/OptionContract.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/RangeContract.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/RangeContract.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/TypeContract.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/TypeContract.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/BuildVersion.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/BuildVersion.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/ExcludeFromJacocoGeneratedReport.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/ExcludeFromJacocoGeneratedReport.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/PositionalIndex.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/PositionalIndex.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/SpotBugsSuppressWarnings.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/SpotBugsSuppressWarnings.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/api/OptionsTest.java
+++ b/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/api/OptionsTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/api/RelationalExceptionTest.java
+++ b/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/api/RelationalExceptionTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/util/BuildVersionTest.java
+++ b/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/util/BuildVersionTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/MessageAssert.java
+++ b/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/MessageAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/RelationalAssert.java
+++ b/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/RelationalAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/RelationalAssertions.java
+++ b/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/RelationalAssertions.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/Customize.java
+++ b/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/Customize.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/JsonOutputFormatPlus.java
+++ b/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/JsonOutputFormatPlus.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/RelationalSQLLine.java
+++ b/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/RelationalSQLLine.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/main/java/sqlline/PlannerDebuggerCommandHandler.java
+++ b/fdb-relational-cli/src/main/java/sqlline/PlannerDebuggerCommandHandler.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/main/java/sqlline/SetSchema.java
+++ b/fdb-relational-cli/src/main/java/sqlline/SetSchema.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/main/java/sqlline/Utils.java
+++ b/fdb-relational-cli/src/main/java/sqlline/Utils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/test/java/com/apple/foundationdb/relational/cli/LaunchSQLLine.java
+++ b/fdb-relational-cli/src/test/java/com/apple/foundationdb/relational/cli/LaunchSQLLine.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/test/java/com/apple/foundationdb/relational/cli/SQLLineTest.java
+++ b/fdb-relational-cli/src/test/java/com/apple/foundationdb/relational/cli/SQLLineTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-cli/src/test/java/sqlline/UtilsTest.java
+++ b/fdb-relational-cli/src/test/java/sqlline/UtilsTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ConnectionScoped.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ConnectionScoped.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalArray.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalArray.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalDriver.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalDriver.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalEngine.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalEngine.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalStruct.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/EmbeddedRelationalStruct.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ImmutableRowStruct.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ImmutableRowStruct.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/MutableRowStruct.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/MutableRowStruct.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/NonTransactional.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/NonTransactional.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/OperationSet.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/OperationSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ProtobufDataBuilder.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ProtobufDataBuilder.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/RowArray.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/RowArray.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/RowStruct.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/RowStruct.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/SqlTypeSupport.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/SqlTypeSupport.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/StorageCluster.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/StorageCluster.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/TransactionManager.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/TransactionManager.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/TransactionScoped.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/TransactionScoped.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/CatalogValidator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/CatalogValidator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/DatabaseSchema.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/DatabaseSchema.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/DatabaseTemplate.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/DatabaseTemplate.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/NoOpSchemaTemplateCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/NoOpSchemaTemplateCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/RelationalDatabase.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/RelationalDatabase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/SchemaTemplateCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/SchemaTemplateCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/StoreCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/catalog/StoreCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/AbstractMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/AbstractMetadataOperationsFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/AbstractQueryFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/AbstractQueryFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/CatalogQueryFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/CatalogQueryFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/ConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/ConstantAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/CreateSchemaTemplateConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/CreateSchemaTemplateConstantAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/DdlPreparedAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/DdlPreparedAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/DdlQuery.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/DdlQuery.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/DdlQueryFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/DdlQueryFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/MetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/MetadataOperationsFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/NoOpQueryFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/NoOpQueryFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/ProtobufDdlUtil.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/ProtobufDdlUtil.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/exceptions/InvalidCursorStateException.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/exceptions/InvalidCursorStateException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/exceptions/OperationUnsupportedException.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/exceptions/OperationUnsupportedException.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/MetricCollector.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/MetricCollector.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/NoOpMetricRegistry.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/NoOpMetricRegistry.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/RelationalMetric.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/RelationalMetric.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractDatabase.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractDatabase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractRecordLayerResultSet.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractRecordLayerResultSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractRow.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractRow.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ArrayRow.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ArrayRow.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/CatalogMetaData.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/CatalogMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ContinuationBuilder.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ContinuationBuilder.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ContinuationImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ContinuationImpl.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/DirectFdbConnection.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/DirectFdbConnection.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/DirectScannable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/DirectScannable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmptyTuple.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmptyTuple.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ErrorCapturingResultSet.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ErrorCapturingResultSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/FDBTuple.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/FDBTuple.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/FdbConnection.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/FdbConnection.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/HollowTransactionManager.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/HollowTransactionManager.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ImmutableKeyValue.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ImmutableKeyValue.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/Index.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/Index.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/IteratorResultSet.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/IteratorResultSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/KeyBuilder.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/KeyBuilder.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/KeySpaceUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/KeySpaceUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/MessageTuple.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/MessageTuple.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/QueryExecutor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/QueryExecutor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/QueryPropertiesUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/QueryPropertiesUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordContextTransaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordContextTransaction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerConfig.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerConfig.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerDatabase.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerDatabase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerEngine.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerEngine.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerIterator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerIterator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerResultSet.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerResultSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerSchema.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerSchema.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerStorageCluster.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerStorageCluster.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerTransactionManager.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerTransactionManager.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreAndRecordContextTransaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreAndRecordContextTransaction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreIndex.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreIndex.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordTypeScannable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordTypeScannable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordTypeTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordTypeTable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RelationalKeyspaceProvider.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RelationalKeyspaceProvider.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ResumableIterator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ResumableIterator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/SerializerRegistry.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/SerializerRegistry.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/Table.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/Table.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/TupleUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/TupleUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ValueTuple.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ValueTuple.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/CachedMetaDataStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/CachedMetaDataStore.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataProvider.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataProvider.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataStore.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreSchemaTemplateCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreSchemaTemplateCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordMetaDataStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordMetaDataStore.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/StoreCatalogProvider.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/StoreCatalogProvider.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/TransactionBoundDatabase.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/TransactionBoundDatabase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/DatabaseInfoSystemTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/DatabaseInfoSystemTable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SchemaSystemTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SchemaSystemTable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SchemaTemplateSystemTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SchemaTemplateSystemTable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SystemTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SystemTable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SystemTableRegistry.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SystemTableRegistry.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/CreateDatabaseConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/CreateDatabaseConstantAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/DropDatabaseConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/DropDatabaseConstantAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/DropSchemaConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/DropSchemaConstantAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerCatalogQueryFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerCatalogQueryFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerCreateSchemaConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerCreateSchemaConstantAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerSetStoreStateConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerSetStoreStateConstantAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/DataTypeUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/DataTypeUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/NoOpSchemaTemplate.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/NoOpSchemaTemplate.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerColumn.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerColumn.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerIndex.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerIndex.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerSchema.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerSchema.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerSchemaTemplate.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerSchemaTemplate.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerTable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/SkeletonVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/SkeletonVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/FileDescriptorSerializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/FileDescriptorSerializer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataSerializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataSerializer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metric/RecordLayerMetricCollector.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metric/RecordLayerMetricCollector.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * AstHasher.java
+ * AstNormalizer.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CaseInsensitiveCharStream.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CaseInsensitiveCharStream.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CatalogKey.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CatalogKey.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/EphemeralExpression.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/EphemeralExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/FieldValueTrieNode.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/FieldValueTrieNode.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Identifier.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Identifier.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/IndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/IndexGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LiteralsUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LiteralsUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperatorCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperatorCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperators.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperators.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalPlanFragment.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalPlanFragment.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalQuery.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalQuery.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
@@ -1,5 +1,5 @@
 /*
- * ParserContext.java
+ * MutablePlanGenerationContext.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/OrderByExpression.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/OrderByExpression.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseHelpers.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseHelpers.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseTreeInfoImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseTreeInfoImpl.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Plan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Plan.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanValidator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanValidator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlannerConfiguration.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlannerConfiguration.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PreparedParams.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PreparedParams.java
@@ -1,5 +1,5 @@
 /*
- * ParserContext.java
+ * PreparedParams.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ProceduralPlan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ProceduralPlan.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PseudoColumn.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PseudoColumn.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryExecutionContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryExecutionContext.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryHasherContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryHasherContext.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryParser.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryParser.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Star.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Star.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/StringTrieNode.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/StringTrieNode.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/TautologicalValue.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/TautologicalValue.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/AbstractCache.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/AbstractCache.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/MultiStageCache.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/MultiStageCache.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/PhysicalPlanEquivalence.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/PhysicalPlanEquivalence.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/QueryCacheKey.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/QueryCacheKey.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCache.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCache.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/AutoServiceFunctionCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/AutoServiceFunctionCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/FunctionCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/FunctionCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/IdentifierVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/IdentifierVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/MetadataPlanVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/MetadataPlanVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStore.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingRecordStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingRecordStore.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingStore.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/LocatableResolverMetaDataProvider.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/LocatableResolverMetaDataProvider.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/StoreConfig.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/StoreConfig.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/expression/ExpressionFactoryImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/expression/ExpressionFactoryImpl.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/expression/FieldImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/expression/FieldImpl.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/statement/StatementBuilderFactoryImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/statement/StatementBuilderFactoryImpl.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/statement/UpdateStatementImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/statement/UpdateStatementImpl.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/ExceptionUtil.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/ExceptionUtil.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/Hex.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/Hex.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/MetricRegistryStoreTimer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/MetricRegistryStoreTimer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/TransactionBoundEmbeddedRelationalEngine.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/TransactionBoundEmbeddedRelationalEngine.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/TransactionBoundStorageCluster.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/TransactionBoundStorageCluster.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowSchemaTemplateCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowSchemaTemplateCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowStoreCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowStoreCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Clock.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Clock.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Clocks.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Clocks.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/DistinctSampler.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/DistinctSampler.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Environment.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Environment.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/EventSampler.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/EventSampler.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/NullableArrayUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/NullableArrayUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/RelationalLoggingUtil.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/RelationalLoggingUtil.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Sampler.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Sampler.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Sampling.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Sampling.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Supplier.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/Supplier.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/TokenBucketSampler.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/TokenBucketSampler.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/proto/continuation.proto
+++ b/fdb-relational-core/src/main/proto/continuation.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/proto/relational_record_query_plan.proto
+++ b/fdb-relational-core/src/main/proto/relational_record_query_plan.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/SqlInsertTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/SqlInsertTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/DriverManagerTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/DriverManagerTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ProtobufDataBuilderTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ProtobufDataBuilderTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/RelationalConnectionTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/RelationalConnectionTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/catalog/CatalogValidatorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/catalog/CatalogValidatorTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/DdlStatementParsingTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/DdlStatementParsingTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/DdlTestUtil.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/DdlTestUtil.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/ProtobufDdlUtilTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/ProtobufDdlUtilTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/AutomatedTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/AutomatedTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Connection.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Connection.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Connector.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Connector.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Data.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Data.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/DataSet.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/DataSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/ParameterizedQuery.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/ParameterizedQuery.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Query.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Query.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Schema.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/Schema.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/SchemaDescription.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/SchemaDescription.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/TableDescription.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/TableDescription.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/WorkloadConfig.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/WorkloadConfig.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/WorkloadConfiguration.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/WorkloadConfiguration.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/cases/DirectPrimaryKeyScanTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/cases/DirectPrimaryKeyScanTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/cases/KnownPkGetTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/cases/KnownPkGetTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/ArrayFieldGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/ArrayFieldGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/DataSample.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/DataSample.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/FieldGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/FieldGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/PrimitiveFieldGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/PrimitiveFieldGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/RandomDataSet.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/RandomDataSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/RandomDataSource.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/RandomDataSource.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/SchemaGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/SchemaGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/StructFieldGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/StructFieldGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/TableDataGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/TableDataGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/UniformDataSource.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/datagen/UniformDataSource.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestDescriptor.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestDescriptor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestEngine.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestEngine.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestResolver.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestResolver.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoWorkload.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoWorkload.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/ConfigurationInvoker.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/ConfigurationInvoker.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/ConnectionMaker.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/ConnectionMaker.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/DataInvoker.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/DataInvoker.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/QueryInvoker.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/QueryInvoker.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/QuerySet.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/QuerySet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/SchemaInvoker.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/SchemaInvoker.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/SchemaParameterResolver.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/SchemaParameterResolver.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/WorkloadReporter.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/WorkloadReporter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/WorkloadTestDescriptor.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/WorkloadTestDescriptor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/Column.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/Column.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/DataGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/DataGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/JDBCDatabaseMetaData.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/JDBCDatabaseMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/JDBCRelationalResultSet.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/JDBCRelationalResultSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/MapRow.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/MapRow.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/RandomDataGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/RandomDataGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/RelationalStructure.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/RelationalStructure.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/ResultSetUtils.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/ResultSetUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/Row.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/Row.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/Table.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/Table.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/TabularToProtobufParser.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/TabularToProtobufParser.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/TestResult.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/TestResult.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/TransactionAction.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/TransactionAction.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/ValuesClause.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/compare/ValuesClause.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCEmbedDriverTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCEmbedDriverTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryCatalog.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalConnection.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalConnection.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalStatement.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemorySchemaTemplateCatalog.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemorySchemaTemplateCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryTable.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryTable.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AbstractRecordLayerResultSetTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AbstractRecordLayerResultSetTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AbstractRowTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AbstractRowTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AutoCommitTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AutoCommitTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/BasicMetadataTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/BasicMetadataTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/CaseSensitiveDbObjectsTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/CaseSensitiveDbObjectsTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/CaseSensitivityTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/CaseSensitivityTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ContinuationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ContinuationTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/CursorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/CursorTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeNoMetadataKeyTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeNoMetadataKeyTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalExtension.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalExtension.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/EmptyTupleTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/EmptyTupleTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/FDBTupleTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/FDBTupleTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ImmutableKeyValueTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ImmutableKeyValueTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/InsertTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/InsertTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/IntermingledTablesTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/IntermingledTablesTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/IteratorResultSetTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/IteratorResultSetTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/JoinWithLimitTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/JoinWithLimitTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/KeyBuilderTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/KeyBuilderTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/KeySpacePathParsingTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/KeySpacePathParsingTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/LogAppenderRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/LogAppenderRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/MessageTupleTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/MessageTupleTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/NullsInResultSetTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/NullsInResultSetTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/OptionScopeTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/OptionScopeTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlaceholderCatalog.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlaceholderCatalog.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlanGenerationStackTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlanGenerationStackTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/QueryLoggingTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/QueryLoggingTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/QueryPropertiesTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/QueryPropertiesTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RecordLayerResultSetTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RecordLayerResultSetTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RecordTypeKeyTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RecordTypeKeyTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalArrayTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalArrayTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalConnectionRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalConnectionRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalExtension.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalExtension.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalKeyspaceProviderTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalKeyspaceProviderTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalStatementRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalStatementRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ResultSetMetaDataTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ResultSetMetaDataTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/SimpleDirectAccessInsertionTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/SimpleDirectAccessInsertionTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/StructDataMetadataTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/StructDataMetadataTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/SystemCatalogQueryTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/SystemCatalogQueryTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableMetadataVersionTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableMetadataVersionTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableWithEnumTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableWithEnumTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableWithNoPkTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TableWithNoPkTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseWithEnumTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseWithEnumTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionConfigTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionConfigTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/UniqueIndexTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/UniqueIndexTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/Utils.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/Utils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ValueTupleTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ValueTupleTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataProviderTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataProviderTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogImplTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogImplTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogTestBase.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogTestBase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogWithNoTemplateOperationsTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogWithNoTemplateOperationsTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/DdlDatabaseTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/DdlDatabaseTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/DdlRecordLayerSchemaTemplateTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/DdlRecordLayerSchemaTemplateTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/DdlRecordLayerSchemaTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/DdlRecordLayerSchemaTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metric/MetricsCollectionTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metric/MetricsCollectionTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metric/RecordLayerMetricCollectorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metric/RecordLayerMetricCollectorTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -1,5 +1,5 @@
 /*
- * QueryHashingTests.java
+ * AstNormalizerTests.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/CountQueryTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/CountQueryTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExecutePropertyTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExecutePropertyTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LargeRecordLayerSchemaTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LargeRecordLayerSchemaTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/NullableArrayUtilsTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/NullableArrayUtilsTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ParserTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ParserTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/PreparedStatementTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/PreparedStatementTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryTestUtils.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryTestUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryTypeTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryTypeTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StandardQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StandardQueryTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/TransactionBoundQueryTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/TransactionBoundQueryTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/UpdateTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/UpdateTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/V2PlanGeneratorTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/V2PlanGeneratorTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConcurrentCacheTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConcurrentCacheTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConstraintValidityTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConstraintValidityTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/MultiStageCacheTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/MultiStageCacheTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/PhysicalPlanEquivalenceTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/PhysicalPlanEquivalenceTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCacheTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCacheTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/udf/ByteOperationsUdf.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/udf/ByteOperationsUdf.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/udf/SumUdf.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/udf/SumUdf.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStoreTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStoreTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/ExpressionEqualityTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/ExpressionEqualityTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/ExpressionTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/ExpressionTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/SqlVisitorTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/SqlVisitorTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/StatementBuilderTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/StatementBuilderTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/util/ExceptionUtilTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/util/ExceptionUtilTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/util/EventSamplerTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/util/EventSamplerTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/util/TokenBucketSamplerTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/util/TokenBucketSamplerTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/DatabaseRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/DatabaseRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/Ddl.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/Ddl.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/DdlPermutationGenerator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/DdlPermutationGenerator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/DescriptorAssert.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/DescriptorAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/ExpectedResultSet.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/ExpectedResultSet.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/FieldDescriptorAssert.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/FieldDescriptorAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/InMemoryTransactionManager.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/InMemoryTransactionManager.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/PermutationIterator.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/PermutationIterator.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/RelationalResultSetAssert.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/RelationalResultSetAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/ReservoirSample.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/ReservoirSample.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/RowAssert.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/RowAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/SchemaRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/SchemaRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/SchemaTemplateRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/SchemaTemplateRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/SimpleDatabaseRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/SimpleDatabaseRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/TableDefinition.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/TableDefinition.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/TypeDefinition.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/TypeDefinition.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/test/java/org/junit/jupiter/engine/descriptor/JunitUtils.java
+++ b/fdb-relational-core/src/test/java/org/junit/jupiter/engine/descriptor/JunitUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ArrayAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ArrayAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ArrayMetaDataAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ArrayMetaDataAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/RelationalStructAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/RelationalStructAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetMetaDataAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetMetaDataAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetTestUtils.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetTestUtils.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/StructMetaDataAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/StructMetaDataAssert.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/TestSchemas.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/TestSchemas.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacade.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetFacade.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetMetaDataFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetMetaDataFacade.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacade.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcConstants.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcConstants.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtil.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtil.java
@@ -1,9 +1,9 @@
 /*
- * GrpcSQLException.java
+ * GrpcSQLExceptionUtil.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/column.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/column.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/continuation.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/continuation.proto
@@ -18,10 +18,6 @@
  * limitations under the License.
  */
 
-// Continuation support for the GRPC client-server implementation.
-// This is modeled after the internal continuation.
-// The model has its own "reason" so that it can communicate that at the API level, as well as a wrapper around any
-// internal state it needs to communicate to the server in order to recreate the internal continuation instance.
 syntax = "proto3";
 package grpc.relational.jdbc.v1;
 option java_multiple_files = true;

--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/result_set.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/result_set.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@
  * limitations under the License.
  */
 
+syntax = "proto3";
+
 // Based on google/spanner/v1/result_set.proto but simplified for now
 // with richer -- and ordered -- metadata to support relational Stucts/Arrays.
 // Note that this protobuf ResultSet is used both as the return vehicle for
 // query responses but also to carry insert data from the client to the
 // server.
-syntax = "proto3";
+
 package grpc.relational.jdbc.v1;
 option java_multiple_files = true;
 // Put the generated classes into grpc subpackage so I can exclude

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/ProtobufConversionTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/ProtobufConversionTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacadeTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacadeTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacadeBuilderTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacadeBuilderTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacadeTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacadeTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtilTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtilTest.java
@@ -1,9 +1,9 @@
 /*
- * GrpcSQLExceptionTest.java
+ * GrpcSQLExceptionUtilTest.java
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalArray.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalArray.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaData.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaData.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDriver.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDriver.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalPreparedStatement.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalPreparedStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStatement.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStatement.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStruct.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStruct.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCURI.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCURI.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaDataTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaDataTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDriverTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDriverTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCSimpleStatementTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCSimpleStatementTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/ServerSideExceptionsOnClientSideTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/ServerSideExceptionsOnClientSideTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/SimpleDirectAccessInsertionTests.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/SimpleDirectAccessInsertionTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/InProcessRelationalServer.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/InProcessRelationalServer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/RelationalServer.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/RelationalServer.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/JDBCService.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/JDBCService.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/InProcessRelationalServerTest.java
+++ b/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/InProcessRelationalServerTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/RelationalServerTest.java
+++ b/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/RelationalServerTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/jdbc/v1/JDBCServiceTest.java
+++ b/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/jdbc/v1/JDBCServiceTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/ServerTestUtil.java
+++ b/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/ServerTestUtil.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/codequality/checkstyle.xml
+++ b/gradle/codequality/checkstyle.xml
@@ -12,7 +12,7 @@
 
     <module name="Header">
       <property name="headerFile" value="${projectDir}/gradle/codequality/java-copyright.txt"/>
-      <property name="ignoreLines" value="2,6"/> 
+      <property name="ignoreLines" value="2,6,20"/>
       <property name="fileExtensions" value="java,proto"/> 
     </module>
 

--- a/gradle/codequality/java-copyright.txt
+++ b/gradle/codequality/java-copyright.txt
@@ -1,9 +1,9 @@
 /*
- * Filename
+ * $FILE
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-ThisYear Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-$YEAR Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,3 +17,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -159,4 +159,5 @@ serviceloader = { id = "com.github.harbby.gradle.serviceloader", version = "1.1.
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 sonarqube = { id = "org.sonarqube", version = "3.3" }
 spotbugs = { id = "com.github.spotbugs", version = "4.6.1" }
+spotless = { id = "com.diffplug.spotless", version = "7.0.2" }
 versions = { id = "com.github.ben-manes.versions", version = "0.38.0" }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomTag.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/FileOptions.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CommandUtil.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CommandUtil.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/InListParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/InListParameter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/ListParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/ListParameter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/Parameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/Parameter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/PrimitiveParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/PrimitiveParameter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/TupleParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/TupleParameter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/UnboundParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/UnboundParameter.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/RunExternalServerExtension.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/proto/deprecated_fields_tests.proto
+++ b/yaml-tests/src/main/proto/deprecated_fields_tests.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/proto/disabled_index_tests.proto
+++ b/yaml-tests/src/main/proto/disabled_index_tests.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/proto/field_index_tests.proto
+++ b/yaml-tests/src/main/proto/field_index_tests.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/proto/schema_instance.proto
+++ b/yaml-tests/src/main/proto/schema_instance.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/proto/standard_tests.proto
+++ b/yaml-tests/src/main/proto/standard_tests.proto
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/java/EmbeddedYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/EmbeddedYamlIntegrationTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/java/JDBCExternalYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/JDBCExternalYamlIntegrationTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/java/JDBCInProcessYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/JDBCInProcessYamlIntegrationTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/java/JDBCYamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/JDBCYamlIntegrationTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/java/MultiServerJDBCYamlTests.java
+++ b/yaml-tests/src/test/java/MultiServerJDBCYamlTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/java/YamlTestBase.java
+++ b/yaml-tests/src/test/java/YamlTestBase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This uses the plugin `spotless` to try and do some code cleanup. As a preliminary step, I've done this to fix up the copyright headers, which have drifted in quite a few files. We could also probably replace, say, `checkstyle` with some spotless configuration, though I haven't gone that far down that path (yet).