### PR TITLE
make explain return planner metrics as separate column

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -32,7 +32,7 @@ Our API stability annotations have been updated to reflect greater API instabili
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** make EXPLAIN return a column for planner metrics [(Issue #3063)](https://github.com/FoundationDB/fdb-record-layer/issues/3063)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanInfo.java
@@ -66,7 +66,7 @@ public class QueryPlanInfo {
      * @param <T> The type of the value (not used in this method)
      * @return TRUE if the key exists in the table, FALSE otherwise
      */
-    public <T> boolean containsKey(@Nonnull QueryPlanInfoKey<T> key) {
+    public <T> boolean containsKey(@Nonnull final QueryPlanInfoKey<T> key) {
         return info.containsKey(key);
     }
 
@@ -111,22 +111,23 @@ public class QueryPlanInfo {
         @Nonnull
         private final String name;
 
-        public QueryPlanInfoKey(@Nonnull String name) {
+        public QueryPlanInfoKey(@Nonnull final String name) {
             this.name = name;
         }
 
+        @Nonnull
         public String getName() {
             return name;
         }
 
         // Suppress Unchecked Cast exception since all put() into the map use the right type for the value from the key.
         @SuppressWarnings("unchecked")
-        public T narrow(@Nonnull Object o) {
+        public T narrow(@Nonnull final Object o) {
             return (T) o;
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (this == o) {
                 return true;
             }
@@ -159,7 +160,7 @@ public class QueryPlanInfo {
             infoMap = new HashMap<>();
         }
 
-        private Builder(QueryPlanInfo source) {
+        private Builder(@Nonnull final QueryPlanInfo source) {
             infoMap = new HashMap<>(source.info);
         }
 
@@ -172,13 +173,13 @@ public class QueryPlanInfo {
          * @return this
          */
         @Nonnull
-        public <T> Builder put(@Nonnull QueryPlanInfoKey<T> key, @Nonnull T value) {
+        public <T> Builder put(@Nonnull final QueryPlanInfoKey<T> key, @Nullable final T value) {
             infoMap.put(key, value);
             return this;
         }
 
         @Nullable
-        public <T> T get(@Nonnull QueryPlanInfoKey<T> key) {
+        public <T> T get(@Nonnull final QueryPlanInfoKey<T> key) {
             return key.narrow(infoMap.get(key));
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanInfoKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/QueryPlanInfoKeys.java
@@ -20,13 +20,20 @@
 
 package com.apple.foundationdb.record.query.plan;
 
+import com.apple.foundationdb.record.query.plan.cascades.debug.StatsMaps;
+
 /**
  * Container for {@link QueryPlanInfo.QueryPlanInfoKey} static instances used in the planner.
  */
 public class QueryPlanInfoKeys {
-    public static final QueryPlanInfo.QueryPlanInfoKey<Integer> TOTAL_TASK_COUNT = new QueryPlanInfo.QueryPlanInfoKey<>("totalTaskCount");
-    public static final QueryPlanInfo.QueryPlanInfoKey<Integer> MAX_TASK_QUEUE_SIZE = new QueryPlanInfo.QueryPlanInfoKey<>("maxTaskQueueSize");
-    public static final QueryPlanInfo.QueryPlanInfoKey<QueryPlanConstraint> CONSTRAINTS = new QueryPlanInfo.QueryPlanInfoKey<>("constraints");
+    public static final QueryPlanInfo.QueryPlanInfoKey<Integer> TOTAL_TASK_COUNT =
+            new QueryPlanInfo.QueryPlanInfoKey<>("totalTaskCount");
+    public static final QueryPlanInfo.QueryPlanInfoKey<Integer> MAX_TASK_QUEUE_SIZE =
+            new QueryPlanInfo.QueryPlanInfoKey<>("maxTaskQueueSize");
+    public static final QueryPlanInfo.QueryPlanInfoKey<QueryPlanConstraint> CONSTRAINTS =
+            new QueryPlanInfo.QueryPlanInfoKey<>("constraints");
+    public static final QueryPlanInfo.QueryPlanInfoKey<StatsMaps> STATS_MAPS =
+            new QueryPlanInfo.QueryPlanInfoKey<>("statsMaps");
 
     private QueryPlanInfoKeys() {
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/Debugger.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/Debugger.java
@@ -97,6 +97,12 @@ public interface Debugger {
         return THREAD_LOCAL.get();
     }
 
+    @Nonnull
+    static Optional<Debugger> getDebuggerMaybe() {
+        final var debugger = getDebugger();
+        return Optional.ofNullable(debugger);
+    }
+
     /**
      * Invoke the {@link Consumer} on the currently set debugger. Do not do anything if there is no debugger set.
      * @param action consumer to invoke
@@ -206,6 +212,9 @@ public interface Debugger {
 
     @SuppressWarnings("unused") // only used by debugger
     String showStats();
+
+    @Nonnull
+    Optional<StatsMaps> getStatsMaps();
 
     /**
      * Shorthands to identify a kind of event.
@@ -435,8 +444,9 @@ public interface Debugger {
 
         public ExecutingTaskEvent(@Nonnull final Reference rootReference,
                                   @Nonnull final Deque<Task> taskStack,
+                                  @Nonnull final Location location,
                                   @Nonnull final Task task) {
-            super(rootReference, taskStack, Location.COUNT);
+            super(rootReference, taskStack, location);
             this.task = task;
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/Stats.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/Stats.java
@@ -1,0 +1,64 @@
+/*
+ * Stats.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.debug;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+public class Stats {
+    @Nonnull
+    protected final Map<Debugger.Location, Long> locationCountMap;
+
+    protected long totalTimeInNs;
+    protected long ownTimeInNs;
+
+    protected Stats(@Nonnull final Map<Debugger.Location, Long> locationCountMap,
+                    final long totalTimeInNs,
+                    final long ownTimeInNs) {
+        this.locationCountMap = locationCountMap;
+        this.totalTimeInNs = totalTimeInNs;
+        this.ownTimeInNs = ownTimeInNs;
+    }
+
+    @Nonnull
+    public Map<Debugger.Location, Long> getLocationCountMap() {
+        return locationCountMap;
+    }
+
+    public long getCount(@Nonnull final Debugger.Location location) {
+        return locationCountMap.getOrDefault(location, 0L);
+    }
+
+    public long getTotalTimeInNs() {
+        return totalTimeInNs;
+    }
+
+    public long getOwnTimeInNs() {
+        return ownTimeInNs;
+    }
+
+    @Nonnull
+    public Stats toImmutable() {
+        return new Stats(ImmutableMap.copyOf(locationCountMap), totalTimeInNs, ownTimeInNs);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/StatsMaps.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/StatsMaps.java
@@ -1,0 +1,79 @@
+/*
+ * StatsMaps.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.debug;
+
+import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class StatsMaps {
+    @Nonnull
+    private final Map<Class<? extends Debugger.Event>, ? extends Stats> eventClassStatsMap;
+    @Nonnull
+    private final Map<Class<? extends CascadesRule<?>>, ? extends Stats> plannerRuleClassStatsMap;
+
+    @Nonnull
+    private final Supplier<Map<Class<? extends Debugger.Event>, Stats>> immutableEventClassStatsMapSupplier;
+    @Nonnull
+    private final Supplier<Map<Class<? extends CascadesRule<?>>, Stats>> immutablePlannerRuleClassStatsMapSupplier;
+
+    public StatsMaps(@Nonnull final Map<Class<? extends Debugger.Event>, ? extends Stats> eventClassStatsMap,
+                     @Nonnull final Map<Class<? extends CascadesRule<?>>, ? extends Stats> plannerRuleClassStatsMap) {
+        this.eventClassStatsMap = eventClassStatsMap;
+        this.plannerRuleClassStatsMap = plannerRuleClassStatsMap;
+        this.immutableEventClassStatsMapSupplier = Suppliers.memoize(this::computeImmutableEventClassStatsMap);
+        this.immutablePlannerRuleClassStatsMapSupplier = Suppliers.memoize(this::computeImmutablePlannerRuleClassStatsMap);
+    }
+
+    @Nonnull
+    public Map<Class<? extends Debugger.Event>, Stats> getEventClassStatsMap() {
+        return immutableEventClassStatsMapSupplier.get();
+    }
+
+    @Nonnull
+    public Map<Class<? extends CascadesRule<?>>, Stats> getPlannerRuleClassStatsMap() {
+        return immutablePlannerRuleClassStatsMapSupplier.get();
+    }
+
+    @Nonnull
+    private Map<Class<? extends Debugger.Event>, Stats> computeImmutableEventClassStatsMap() {
+        final var eventClassStatsMapBuilder =
+                ImmutableMap.<Class<? extends Debugger.Event>, Stats>builder();
+        for (final var entry : eventClassStatsMap.entrySet()) {
+            eventClassStatsMapBuilder.put(entry.getKey(), entry.getValue().toImmutable());
+        }
+        return eventClassStatsMapBuilder.build();
+    }
+
+    @Nonnull
+    private Map<Class<? extends CascadesRule<?>>, Stats> computeImmutablePlannerRuleClassStatsMap() {
+        final var plannerRuleClassStatsMapBuilder =
+                ImmutableMap.<Class<? extends CascadesRule<?>>, Stats>builder();
+        for (final var entry : plannerRuleClassStatsMap.entrySet()) {
+            plannerRuleClassStatsMapBuilder.put(entry.getKey(), entry.getValue().toImmutable());
+        }
+        return plannerRuleClassStatsMapBuilder.build();
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/QueryPlanInfoTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/QueryPlanInfoTest.java
@@ -32,11 +32,11 @@ public class QueryPlanInfoTest {
     private static final QueryPlanInfo.QueryPlanInfoKey<Integer> KEY_INT = new QueryPlanInfo.QueryPlanInfoKey<>("I");
 
     @BeforeEach
-    void setup() throws Exception {
+    void setup() {
     }
 
     @Test
-    void testAddKey() throws Exception {
+    void testAddKey() {
         QueryPlanInfo classUnderTest = QueryPlanInfo.newBuilder()
                 .put(KEY_STR, "Value")
                 .build();
@@ -45,7 +45,7 @@ public class QueryPlanInfoTest {
     }
 
     @Test
-    void testAddTwoKeys() throws Exception {
+    void testAddTwoKeys() {
         QueryPlanInfo classUnderTest = QueryPlanInfo.newBuilder()
                 .put(KEY_STR, "Value")
                 .put(KEY_INT, 2)
@@ -57,19 +57,19 @@ public class QueryPlanInfoTest {
     }
 
     @Test
-    void testNullValue() throws Exception {
-        QueryPlanInfo classUnderTest = QueryPlanInfo.newBuilder()
+    void testNullValue() {
+        QueryPlanInfo queryPlanInfo = QueryPlanInfo.newBuilder()
                 .put(KEY_STR, null)
                 .put(KEY_INT, null)
                 .build();
-        Assertions.assertTrue(classUnderTest.containsKey(KEY_STR));
-        Assertions.assertTrue(classUnderTest.containsKey(KEY_INT));
-        Assertions.assertNull(classUnderTest.get(KEY_STR));
-        Assertions.assertNull(classUnderTest.get(KEY_INT));
+        Assertions.assertTrue(queryPlanInfo.containsKey(KEY_STR));
+        Assertions.assertTrue(queryPlanInfo.containsKey(KEY_INT));
+        Assertions.assertNull(queryPlanInfo.get(KEY_STR));
+        Assertions.assertNull(queryPlanInfo.get(KEY_INT));
     }
 
     @Test
-    void testBuildFrom() throws Exception {
+    void testBuildFrom() {
         QueryPlanInfo classUnderTest = QueryPlanInfo.newBuilder()
                 .put(KEY_STR, "Value")
                 .build();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/DebuggerWithSymbolTables.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/DebuggerWithSymbolTables.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
 import com.apple.foundationdb.record.query.plan.cascades.debug.RestartException;
+import com.apple.foundationdb.record.query.plan.cascades.debug.StatsMaps;
 import com.apple.foundationdb.record.query.plan.cascades.debug.eventprotos.PEvent;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.properties.ReferencesAndDependenciesProperty;
@@ -320,6 +321,16 @@ public class DebuggerWithSymbolTables implements Debugger {
             return currentState.showStats();
         }
         return "no stats";
+    }
+
+    @Nonnull
+    @Override
+    public Optional<StatsMaps> getStatsMaps() {
+        State currentState = stateStack.peek();
+        if (currentState != null) {
+            return Optional.of(currentState.getStatsMaps());
+        }
+        return Optional.empty();
     }
 
     private void reset() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/debug/PlannerRepl.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.query.plan.cascades.PlanContext;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
 import com.apple.foundationdb.record.query.plan.cascades.debug.RestartException;
+import com.apple.foundationdb.record.query.plan.cascades.debug.StatsMaps;
 import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraphProperty;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.util.ServiceLoaderProvider;
@@ -457,6 +458,16 @@ public class PlannerRepl implements Debugger {
             return currentState.showStats();
         }
         return "no stats";
+    }
+
+    @Nonnull
+    @Override
+    public Optional<StatsMaps> getStatsMaps() {
+        State currentState = stateStack.peek();
+        if (currentState != null) {
+            return Optional.of(currentState.getStatsMaps());
+        }
+        return Optional.empty();
     }
 
     private void reset() {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
@@ -67,8 +67,8 @@ public class ExplainTests {
 
     @Test
     void explainResultSetMetadataTest() throws Exception {
-        final var expectedLabels = List.of("PLAN", "PLAN_HASH", "PLAN_DOT", "PLAN_GML", "PLAN_CONTINUATION");
-        final var expectedTypes = List.of(Types.VARCHAR, Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.STRUCT);
+        final var expectedLabels = List.of("PLAN", "PLAN_HASH", "PLAN_DOT", "PLAN_GML", "PLAN_CONTINUATION", "PLANNER_METRICS");
+        final var expectedTypes = List.of(Types.VARCHAR, Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.STRUCT, Types.STRUCT);
         final var expectedContLabels = List.of("EXECUTION_STATE", "VERSION", "PLAN_HASH_MODE");
         final var expectedContTypes = List.of(Types.BINARY, Types.INTEGER, Types.VARCHAR);
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.relational.yamltests.server.SupportedVersionCheck;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.github.difflib.text.DiffRow;
 import com.github.difflib.text.DiffRowGenerator;
+import com.google.common.base.Verify;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -233,6 +234,14 @@ public abstract class QueryConfig {
                                 getLineNumber(), planDiffs, (!isExact ? "fragment" : ""), getValueString(), actualPlan);
                         reportTestFailure(diffMessage);
                     }
+                }
+
+                final var plannerMetrics = resultSet.getStruct(6);
+                if (plannerMetrics != null) {
+                    final var taskCount = plannerMetrics.getLong(1);
+                    Verify.verify(taskCount > 0);
+                    final var taskTotalTimeInNs = plannerMetrics.getLong(2);
+                    Verify.verify(taskTotalTimeInNs > 0);
                 }
             }
         };


### PR DESCRIPTION
```
 RelationalStructMetaData(
  FieldDescription.primitive("TASK_COUNT", Types.BIGINT, DatabaseMetaData.columnNoNulls),
  FieldDescription.primitive("TASK_TOTAL_TIME_NS", Types.BIGINT, DatabaseMetaData.columnNoNulls),
  FieldDescription.primitive("TRANSFORM_COUNT", Types.BIGINT, DatabaseMetaData.columnNoNulls),
  FieldDescription.primitive("TRANSFORM_TIME_NS", Types.BIGINT, DatabaseMetaData.columnNoNulls),
  FieldDescription.primitive("TRANSFORM_YIELD_COUNT", Types.BIGINT, DatabaseMetaData.columnNoNulls),
  FieldDescription.primitive("INSERT_TIME_NS", Types.BIGINT, DatabaseMetaData.columnNoNulls),
  FieldDescription.primitive("INSERT_NEW_COUNT", Types.BIGINT, DatabaseMetaData.columnNoNulls),
  FieldDescription.primitive("INSERT_REUSED_COUNT", Types.BIGINT, DatabaseMetaData.columnNoNulls), ...)
```

Most of the PR is just making sure that the `Debugger` stats structures become accessible to the code that prepares and packages the result that is sent to the client. For that purpose I extracted `Stats` from the respective `Debugger` implementations and make it is own first-class citizen. Similar goes for `StatsMaps`. One thing I wanted to make sure is that once the `StatsMaps` are accessed outside of the installed `Debugger`, the `StatsMaps` become immutable. For that purpose we make a copy, as usual, however, we only want to make that copy when the client of the planner (i.e. QueryPlan) needs the stats (when responding to an `EXPLAIN`).