### PR TITLE
Auto update supported_version in yamsql files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ defaultTasks 'build'
 apply from: 'gradle/root.gradle'
 apply from: 'gradle/sonar.gradle'
 
+def isReleaseBuild = Boolean.parseBoolean(getProperty('releaseBuild'))
+
 allprojects {
     apply plugin: 'base'
     apply plugin: 'java-library'
@@ -91,49 +93,10 @@ allprojects {
     }
 
     // Add -SNAPSHOT to version of non-release builds
-    def isReleaseBuild = Boolean.parseBoolean(getProperty('releaseBuild'))
     if (!isReleaseBuild) {
         def versionString = project.version.toString()
         if (!versionString.endsWith("-SNAPSHOT")) {
             project.version = versionString + "-SNAPSHOT"
-        }
-    }
-
-    // At the end of a release build, we want to update all the yamsql files to replace !current_version with the
-    // version being built
-    // Note: This is scheduled to happen at the end of each sub-projects `build` task, which should be fine, as long
-    // as we don't start having subprojects depending on other subprojects yamsql resources.
-    if (isReleaseBuild) {
-        build.doLast {
-            // don't replace !current_version in the supported-version resources, as those are there to test
-            // supported_version, we want the !current_version to stick around
-            println("Replacing !current_version...")
-            sourceSets["test"].resources.srcDirs.stream().flatMap( resourceDir ->
-                fileTree(dir: resourceDir).matching {
-                    include '**/*.yamsql'
-                    exclude '/supported-version/*'
-                }.stream()
-            ).forEach { yamsql ->
-                def original = yamsql.text
-                def updated = original.replaceAll("(?<!\")!current_version(?!\")", project.version)
-                if (!original.equals(updated)) {
-                    // TODO validate clean working tree? There could be other yamsql files already modified
-                    println("Replacing !current_version in " + yamsql)
-                    // Replace !current_version in all yamsql, unless it is surrounded by ", allowing it to be used in
-                    // comments, without issue, e.g. in showcasing-tests
-                    yamsql.write(updated)
-                    exec {
-                        workingDir '.'
-                        commandLine 'git', 'add', yamsql
-                    }
-                    // This won't be great if we have more than one subproject with yamsql files... but for now will
-                    // work.
-                    exec {
-                        workingDir '.'
-                        commandLine 'git', 'commit', '-m', 'Updating !current_version in yamsql files to ' + project.version
-                    }
-                }
-            }
         }
     }
 
@@ -304,6 +267,40 @@ subprojects {
     }
 
     check.dependsOn quickCheck
+
+    // At the end of a release build, we want to update all the yamsql files to replace !current_version with the
+    // version being built
+    task updateYamsql(type: Task) {
+        mustRunAfter 'test'
+        mustRunAfter 'build'
+        doLast {
+            if (isReleaseBuild) {
+                // don't replace !current_version in the supported-version resources, as those are there to test
+                // supported_version, we want the !current_version to stick around
+                println("Replacing !current_version...")
+                sourceSets["test"].resources.srcDirs.stream().flatMap( resourceDir ->
+                    fileTree(dir: resourceDir).matching {
+                        include '**/*.yamsql'
+                        exclude '/supported-version/*'
+                    }.stream()
+                ).forEach { yamsql ->
+                    def original = yamsql.text
+                    def updated = original.replaceAll("(?<!\")!current_version(?!\")", project.version)
+                    if (!original.equals(updated)) {
+                        // TODO validate clean working tree? There could be other yamsql files already modified
+                        println("Replacing !current_version in " + yamsql)
+                        // Replace !current_version in all yamsql, unless it is surrounded by ", allowing it to be used in
+                        // comments, without issue, e.g. in showcasing-tests
+                        yamsql.write(updated)
+                        exec {
+                            workingDir '.'
+                            commandLine 'git', 'add', yamsql
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Script for upgrading gradle. To upgrade the gradle version, set the property to the version

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,44 @@ allprojects {
         }
     }
 
+    // At the end of a release build, we want to update all the yamsql files to replace !current_version with the
+    // version being built
+    // Note: This is scheduled to happen at the end of each sub-projects `build` task, which should be fine, as long
+    // as we don't start having subprojects depending on other subprojects yamsql resources.
+    if (isReleaseBuild) {
+        build.doLast {
+            // don't replace !current_version in the supported-version resources, as those are there to test
+            // supported_version, we want the !current_version to stick around
+            println("Replacing !current_version...")
+            sourceSets["test"].resources.srcDirs.stream().flatMap( resourceDir ->
+                fileTree(dir: resourceDir).matching {
+                    include '**/*.yamsql'
+                    exclude '/supported-version/*'
+                }.stream()
+            ).forEach { yamsql ->
+                def original = yamsql.text
+                def updated = original.replaceAll("(?<!\")!current_version(?!\")", project.version)
+                if (!original.equals(updated)) {
+                    // TODO validate clean working tree? There could be other yamsql files already modified
+                    println("Replacing !current_version in " + yamsql)
+                    // Replace !current_version in all yamsql, unless it is surrounded by ", allowing it to be used in
+                    // comments, without issue, e.g. in showcasing-tests
+                    yamsql.write(updated)
+                    exec {
+                        workingDir '.'
+                        commandLine 'git', 'add', yamsql
+                    }
+                    // This won't be great if we have more than one subproject with yamsql files... but for now will
+                    // work.
+                    exec {
+                        workingDir '.'
+                        commandLine 'git', 'commit', '-m', 'Updating !current_version in yamsql files to ' + project.version
+                    }
+                }
+            }
+        }
+    }
+
     // Configure JUnit tests
     tasks.withType(Test) {
         reports.junitXml.destination = project.file("${->project.buildDir}/test-results")

--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,6 @@ subprojects {
                     def original = yamsql.text
                     def updated = original.replaceAll("(?<!\")!current_version(?!\")", project.version)
                     if (!original.equals(updated)) {
-                        // TODO validate clean working tree? There could be other yamsql files already modified
                         println("Replacing !current_version in " + yamsql)
                         // Replace !current_version in all yamsql, unless it is surrounded by ", allowing it to be used in
                         // comments, without issue, e.g. in showcasing-tests

--- a/build/commit_yamsql_updates.py
+++ b/build/commit_yamsql_updates.py
@@ -5,7 +5,7 @@
 #
 # This source file is part of the FoundationDB open source project
 #
-# Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+# Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/commit_yamsql_updates.py
+++ b/build/commit_yamsql_updates.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+#
+# commit_yamsql_updates.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Utility script for committing the updates to yamsql as part of release.
+#
+# As part of a release we should update the *.yamsql files, replacing !current_version
+# with the version being released. This is done via a gradle task: updateYamsql
+# This script will check that there are no extraneous changes staged, and commit
+# the updates to the yamsql files.
+#
+
+import argparse
+import subprocess
+import sys
+
+
+def main(argv):
+    '''Replace !current_version in yamsql files with the provided version'''
+    parser = argparse.ArgumentParser()
+    parser.add_argument('new_version', help='New version to use when updating the yamsql files')
+    args = parser.parse_args(argv)
+
+    process = subprocess.run(['git', 'status', '--porcelain=v1', '--untracked=no', '--no-renames'],
+                             check=True, capture_output=True, text=True)
+    should_commit = False
+    for line in process.stdout.splitlines():
+        indexState = line[0]
+        if indexState != ' ':
+            if line.endswith('.yamsql'):
+                should_commit = True
+            else:
+                print("Unexpected change: " + line)
+                exit(1)
+
+    if should_commit:
+        print("Updating !current_version in yamsql files to " + args.new_version)
+        subprocess.run(['git', 'commit', '-m', "Updating !current_version in yamsql files to " + args.new_version],
+                       check=True)
+    else:
+        print("Nothing to commit")
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/yaml-tests/src/test/resources/showcasing-tests.yamsql
+++ b/yaml-tests/src/test/resources/showcasing-tests.yamsql
@@ -39,7 +39,8 @@
 options:
     # supported_version specifies what versions this works with
     # Any version greater than the provided version is expected to work
-    # When developing a new feature use !current_version to specify that it only works with the current version
+    # When developing a new feature use "!current_version" (but without the quotes) to specify that it only works with
+    # the current version
     supported_version: 4.0.559.0
 ---
 schema_template:

--- a/yaml-tests/src/test/resources/showcasing-tests.yamsql
+++ b/yaml-tests/src/test/resources/showcasing-tests.yamsql
@@ -38,9 +38,11 @@
 ---
 options:
     # supported_version specifies what versions this works with
-    # Any version greater than the provided version is expected to work
+    # Any version greater than the provided version is expected to work. If running against an older version,
+    # this test will be skipped.
     # When developing a new feature use "!current_version" (but without the quotes) to specify that it only works with
-    # the current version
+    # the current version; the release process will replace it with the version being released. The current version is
+    # always considered to be supported.
     supported_version: 4.0.559.0
 ---
 schema_template:


### PR DESCRIPTION
This adds the necessary tooling to update the `.yamsql` files, replacing `!current_version` with the version being released. I validated that it does the replacement correctly, locally. In order to support having a comment about `!current_version` in `showcasing-tests.yamsql`, I have it leave it alone if it is immediately surrounded by quotes. This seemed like a good compromise that avoided me having to get too much into yaml parsing, although something about whether the whole line is a comment could also work.

To be extra safe, the commit script validates that it's not trying to update anything other than `.yamsql` files.

I thought about adding the commit code to the gradle build also, but I couldn't figure out a way to have the dependencies be enforced so that committing always ran after all the subprojects updated their `.yamsql` files, so I went with a separate  python script, similar to how we update the release notes. I don't think it would be hard to do the commit from gradle directly.