### PR TITLE
Improve LuceneIndexTestDataModel

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -65,10 +64,9 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                 .setPartitionHighWatermark(-1) // disable partitioning
                 .setIsGrouped(isGrouped)
                 .build();
-        final long start = Instant.now().toEpochMilli();
         for (int i = 0; i < 5; i++) {
             try (FDBRecordContext context = openContext()) {
-                dataModel.saveRecords(10, start, context, i);
+                dataModel.saveRecords(10, context, i);
                 commit(context);
             }
         }
@@ -99,10 +97,9 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                 .setPartitionHighWatermark(10)
                 .setIsGrouped(isGrouped)
                 .build();
-        final long start = Instant.now().toEpochMilli();
         for (int i = 0; i < 6; i++) {
             try (FDBRecordContext context = openContext()) {
-                dataModel.saveRecords(10, start, context, i / 3);
+                dataModel.saveRecords(10, context, i / 3);
                 commit(context);
             }
             explicitMergeIndex(dataModel);
@@ -144,10 +141,9 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                 .setPartitionHighWatermark(10)
                 .setIsGrouped(false)
                 .build();
-        final long start = Instant.now().toEpochMilli();
         for (int i = 0; i < 6; i++) {
             try (FDBRecordContext context = openContext()) {
-                dataModel.saveRecords(10, start, context, i / 3);
+                dataModel.saveRecords(10, context, i / 3);
                 commit(context);
             }
             explicitMergeIndex(dataModel);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
@@ -225,7 +225,7 @@ public class LuceneIndexTestValidator {
     }
 
     List<LucenePartitionInfoProto.LucenePartitionInfo> getPartitionMeta(Index index,
-                                                                                Tuple groupingKey) {
+                                                                        Tuple groupingKey) {
         try (FDBRecordContext context = contextProvider.get()) {
             final FDBRecordStore recordStore = schemaSetup.apply(context);
             LuceneIndexMaintainer indexMaintainer = (LuceneIndexMaintainer) recordStore.getIndexMaintainer(index);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
@@ -78,12 +78,11 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
         Tuple group2EmptyDoc = null;
         // Populate data: 1 doc for groups 1 and 2 and one empty doc (if needed)
         try (FDBRecordContext context = openContext()) {
-            final long start = Instant.now().toEpochMilli();
             final FDBRecordStore store = dataModel.createOrOpenRecordStore(context);
-            group1ContentDoc = dataModel.saveRecord(start, store, 1);
-            group2ContentDoc = dataModel.saveRecord(start, store, 2);
+            group1ContentDoc = dataModel.saveRecord(store, 1);
+            group2ContentDoc = dataModel.saveRecord(store, 2);
             if (includeEmptyDoc) {
-                group2EmptyDoc = dataModel.saveEmptyRecord(start, store, 2);
+                group2EmptyDoc = dataModel.saveEmptyRecord(store, 2);
             }
             commit(context);
         }
@@ -140,9 +139,8 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
                 .setPartitionHighWatermark(10)
                 .build();
 
-        final long start = Instant.now().toEpochMilli();
         try (FDBRecordContext context = openContext()) {
-            dataModel.saveRecords(500, start, context, 2);
+            dataModel.saveRecords(500, context, 2);
             commit(context);
         }
 
@@ -176,9 +174,8 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
                 .setPartitionHighWatermark(210)
                 .build();
 
-        final long start = Instant.now().toEpochMilli();
         try (FDBRecordContext context = openContext()) {
-            dataModel.saveRecords(500, start, context, 2);
+            dataModel.saveRecords(500, context, 2);
             commit(context);
         }
         // Scan properties with a limit of 36


### PR DESCRIPTION
This makes some improvements to the `LuceneIndexTestDataModel`:
1. Remove the confusing `start` parameter
2. Support for saving records older than existing records. This allows a new test that saving old records will create older partitions without re-partitioning
3. Add support for isSynthetic to recordsUnderTest. This allows expanding the concurrency tests to run against synthetic too
4. Add support for sampling recordsUnderTest. This allows a test that deletes every other record in each group. This behavior is pretty well covered already, but this adds a version using `LuceneIndexTestDataModel`, which seems valuable to me.

My primary reason for making these changes was to support the tests required for: https://github.com/FoundationDB/fdb-record-layer/pull/3009 but I also wanted to make sure they came with there own tests.
