### PR TITLE
Fixes for Gradle tasks for Antlr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ fdb-environment.properties
 
 # Docker local support
 run/
+
+# Token files required for parsing Antlr files correctly in the IDE
+fdb-relational-core/src/main/antlr/*.tokens

--- a/gradle/antlr.gradle
+++ b/gradle/antlr.gradle
@@ -21,6 +21,7 @@
 apply plugin: 'antlr'
 
 generateGrammarSource {
+    outputDirectory = layout.buildDirectory.dir('generated-src/antlr/main/com/apple/foundationdb/relational/generated').get().asFile
     maxHeapSize = "128m"
     arguments += ['-package','com.apple.foundationdb.relational.generated', '-listener','-visitor', '-long-messages']
 }
@@ -28,4 +29,15 @@ generateGrammarSource {
 sourceSets.configureEach {
     var generateGrammarSource = tasks.named(getTaskName("generate", "GrammarSource"))
     java.srcDir(generateGrammarSource.map { files() })
+}
+
+generateGrammarSource.doLast {
+    final source = layout.buildDirectory.dir('generated-src/antlr/main/com/apple/foundationdb/relational/generated/')
+    final tokensFile = "*.tokens"
+    final dest = layout.projectDirectory.dir('src/main/antlr')
+    copy {
+        from source
+        include tokensFile
+        into dest
+    }
 }

--- a/gradle/antlr.gradle
+++ b/gradle/antlr.gradle
@@ -41,3 +41,12 @@ generateGrammarSource.doLast {
         into dest
     }
 }
+
+task cleanUpTokenFiles(type: Delete) {
+    final tokenFilesDir = layout.projectDirectory.dir('src/main/antlr')
+    delete fileTree(tokenFilesDir) { include '*.tokens' }
+}
+
+clean {
+    dependsOn "cleanUpTokenFiles"
+}


### PR DESCRIPTION
This adds two fixes:

- Puts the generated files in a directory that corresponds to their set package.
- Creates a post-`generateGrammarSource` task which copies all `*.token` files next to the grammar and lexer files in `src/main/antlr`. These files are added to `.gitignore` to avoid checking them in by mistake.

These effectively enable the IDE to correctly parse and present the grammar files as well as the generated files, before it was showing hundreds of errors due to file location mismatch and the inability to link the grammar file with the respective tokens array.