### PR TITLE
Update relase workflow to accept artifact version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - 'main'
+  workflow_dispatch:
+    inputs:
+      artifact_version:
+        description: 'Target version for artifacts to build and publish'
+        required: true
 
 jobs:
   gradle:
@@ -19,4 +21,5 @@ jobs:
     - name: Run Gradle Test
       uses: ./actions/gradle-test
       with:
+        artifacts_version: "${{ inputs.artifact_version }}"
         gradle_args: "-PreleaseBuild=true"

--- a/actions/gradle-test/action.yml
+++ b/actions/gradle-test/action.yml
@@ -1,6 +1,10 @@
 name: Gradle Test
 
 inputs:
+  artifact_version:
+    description: 'Version of final artifacts to build'
+    required: false
+    default: ''
   fdb_version:
     description: 'Version of FDB to run'
     required: false
@@ -42,7 +46,7 @@ runs:
     run: sed -i -e "s/^org\.gradle\..*/#&/g" gradle.properties
   - name: Run build and test
     shell: bash
-    run: GRADLE_OPTS="-XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" ./gradlew --no-daemon --console=plain -b ./build.gradle build destructiveTest -PcoreNotStrict ${{ inputs.gradle_args }}
+    run: ARTIFACT_VERSION="${{ inputs.artifact_version }}" GRADLE_OPTS="-XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" ./gradlew --no-daemon --console=plain -b ./build.gradle build destructiveTest -PcoreNotStrict ${{ inputs.gradle_args }}
   - name: Copy Test Reports
     shell: bash
     if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -170,10 +170,12 @@ allprojects {
     }
 
     repositories {
-        if (System.getenv("ARTIFACT_VERSION") != null) {
-           version = "${System.getenv('ARTIFACT_VERSION')}"
-        } else if (System.getenv("RECORD_LAYER_BUILD_NUMBER") != null) {
-           version = "${version}.${System.getenv('RECORD_LAYER_BUILD_NUMBER')}"
+        var artifactVersion = System.getenv("ARTIFACT_VERSION")
+        var buildNumber = System.getenv("RECORD_LAYER_BUILD_NUMBER")
+        if (artifactVersion != null && !artifactVersion.isEmpty()) {
+           version = artifactVersion
+        } else if (buildNumber != null && !buildNumber.isEmpty()) {
+           version = "${version}.${buildNumber}"
         }
         if (Boolean.parseBoolean(mavenLocalEnabled)) {
             mavenLocal()


### PR DESCRIPTION
This updates the release workflow so that it runs when someone manually triggers it rather than on every commit. It also takes an argument for the version, which hopefully will fix some tests that are failing during the current build.

It still doesn't update the build to do any of the other things we associate with releases (e.g., updating any of the values storing the current version), but it may give us insight into the release build itself.