### PR TITLE
Switch from using capture_output to stdout=subprocess.PIPE

### DIFF
--- a/build/commit_yamsql_updates.py
+++ b/build/commit_yamsql_updates.py
@@ -41,7 +41,7 @@ def main(argv):
     args = parser.parse_args(argv)
 
     process = subprocess.run(['git', 'status', '--porcelain=v1', '--untracked=no', '--no-renames'],
-                             check=True, capture_output=True, text=True)
+                             check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     should_commit = False
     for line in process.stdout.splitlines():
         indexState = line[0]


### PR DESCRIPTION
This changes commit_yamsql_updates.py from using `capture_output=True` to the equivalent: `stdout=subprocess.PIPE, stderr=subprocess.PIPE`