### PR TITLE
Upgrade de.undercouch.download gradle plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -151,7 +151,7 @@ test-compileOnly = [ "autoService", "jsr305" ]
 [plugins]
 
 artifactory = { id = "com.jfrog.artifactory", version = "4.29.2" }
-download = { id = "de.undercouch.download", version = "4.1.1" }
+download = { id = "de.undercouch.download", version = "5.6.0" }
 gitversion = { id = "com.palantir.git-version", version = "3.1.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.2" }
 protobuf = { id = "com.google.protobuf", version = "0.8.19" }


### PR DESCRIPTION
This updates the download plugin to the latest version. It looks like this is used to download the geonames.