### PR TITLE
infinite continuations when NULL_ON_EMPTY is in the plan

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ Our API stability annotations have been updated to reflect greater API instabili
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** ungrouped GROUP BY queries result in infinite continuations when maxRows is 1 [(Issue #3093)](https://github.com/FoundationDB/fdb-record-layer/issues/3093)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
@@ -193,4 +193,8 @@ public class StreamGrouping<M extends Message> {
         final EvaluationContext nestedContext = context.withBinding(Bindings.Internal.CORRELATION, alias, currentObject);
         return Objects.requireNonNull(groupingKeyValue).eval(store, nestedContext);
     }
+
+    public boolean isResultOnEmpty() {
+        return groupingKeyValue == null;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/StreamGrouping.java
@@ -193,8 +193,4 @@ public class StreamGrouping<M extends Message> {
         final EvaluationContext nestedContext = context.withBinding(Bindings.Internal.CORRELATION, alias, currentObject);
         return Objects.requireNonNull(groupingKeyValue).eval(store, nestedContext);
     }
-
-    public boolean isResultOnEmpty() {
-        return groupingKeyValue == null;
-    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
@@ -93,9 +93,10 @@ public class RecordQueryDefaultOnEmptyPlan implements RecordQueryPlanWithChild, 
                                                                      @Nonnull final EvaluationContext context,
                                                                      @Nullable final byte[] continuation,
                                                                      @Nonnull final ExecuteProperties executeProperties) {
-        return RecordCursor.orElse(cont -> getChild().executePlan(store, context, cont, executeProperties),
-                (executor, cont) -> RecordCursor.fromList(ImmutableList.of(QueryResult.ofComputed(onEmptyResultValue.eval(store, context)))),
-                continuation);
+        return RecordCursor.orElse(cont -> getChild().executePlan(store, context, cont, executeProperties.clearSkipAndLimit()),
+                        (executor, cont) ->
+                                RecordCursor.fromList(ImmutableList.of(QueryResult.ofComputed(onEmptyResultValue.eval(store, context))), cont), continuation)
+                .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDefaultOnEmptyPlan.java
@@ -95,7 +95,7 @@ public class RecordQueryDefaultOnEmptyPlan implements RecordQueryPlanWithChild, 
                                                                      @Nonnull final ExecuteProperties executeProperties) {
         return RecordCursor.orElse(cont -> getChild().executePlan(store, context, cont, executeProperties.clearSkipAndLimit()),
                         (executor, cont) ->
-                                RecordCursor.fromList(ImmutableList.of(QueryResult.ofComputed(onEmptyResultValue.eval(store, context))), cont), continuation)
+                                RecordCursor.fromList(executor, ImmutableList.of(QueryResult.ofComputed(onEmptyResultValue.eval(store, context))), cont), continuation)
                 .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
     }
 

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1701,6 +1701,7 @@ message PRecordQueryStreamingAggregationPlan {
     optional string grouping_key_alias = 4;
     optional string aggregate_alias = 5;
     optional PValue complete_result_value = 6;
+    optional bool is_create_default_on_empty = 7;
 }
 
 //

--- a/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
@@ -188,8 +188,11 @@ test_block:
       - result: []
     -
       - query: select sum(col1) from T1;
+      - supported_version: !current_version
       - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"
+      - maxRows: 1
       - result: [{!null _}]
+      - result: []
     -
       - query: select sum(col1) from T1 where col1 = 0;
       - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0) | ON EMPTY NULL | MAP (_._0._0 AS _0)"

--- a/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
@@ -35,8 +35,11 @@ test_block:
   tests:
     -
       - query: select count(*) from T1;
+      - supported_version: !current_version
       - explain: "SCAN(<,>) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - maxRows: 1
       - result: [{0}]
+      - result: []
     -
       - query: select count(*) from T1 where col1 = 0;
       - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.COL1 EQUALS promote(@c11 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"


### PR DESCRIPTION
- remove default `...ON_EMPTY` behavior that previously was part of `RecordQueryStreamingAggregationPlan`
- have `RecordQueryDefaultOnEmptyPlan` enforce and adjust skips and limits correctly