### PR TITLE
Upgrade the versions gradle plugin from 0.38.0 to 0.52.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -159,4 +159,4 @@ serviceloader = { id = "com.github.harbby.gradle.serviceloader", version = "1.1.
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 sonarqube = { id = "org.sonarqube", version = "3.3" }
 spotbugs = { id = "com.github.spotbugs", version = "4.6.1" }
-versions = { id = "com.github.ben-manes.versions", version = "0.38.0" }
+versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }


### PR DESCRIPTION
Seems to still work, I ran `./gradlew dependencyUpdates` and it printed out a whole bunch of up-to-date dependencies and dependencies that need updating.