### PR TITLE
preparing for up-level DEFAULTS_ON_EMPTY changes

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,7 +22,7 @@ Our API stability annotations have been updated to reflect greater API instabili
 * **Bug fix** Fix 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Bug fix** Fix 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
-* **Bug fix** Fix 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Bug fix** Streaming aggregations to communicate whether to create a default on empty value via continuations which prepares a later fix for infinite continuations [(Issue #3093)](https://github.com/FoundationDB/fdb-record-layer/issues/3093)
 * **Bug fix** Fix 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Performance** Improvement 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/AggregateCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/aggregate/AggregateCursor.java
@@ -50,6 +50,7 @@ public class AggregateCursor<M extends Message> implements RecordCursor<QueryRes
     // group aggregator to break incoming records into groups
     @Nonnull
     private final StreamGrouping<M> streamGrouping;
+    private final boolean isCreateDefaultOnEmpty;
     // Previous record processed by this cursor
     @Nullable
     private RecordCursorResult<QueryResult> previousResult;
@@ -57,9 +58,12 @@ public class AggregateCursor<M extends Message> implements RecordCursor<QueryRes
     @Nullable
     private RecordCursorResult<QueryResult> previousValidResult;
 
-    public AggregateCursor(@Nonnull RecordCursor<QueryResult> inner, @Nonnull final StreamGrouping<M> streamGrouping) {
+    public AggregateCursor(@Nonnull RecordCursor<QueryResult> inner,
+                           @Nonnull final StreamGrouping<M> streamGrouping,
+                           final boolean isCreateDefaultOnEmpty) {
         this.inner = inner;
         this.streamGrouping = streamGrouping;
+        this.isCreateDefaultOnEmpty = isCreateDefaultOnEmpty;
     }
 
     @Nonnull
@@ -73,7 +77,7 @@ public class AggregateCursor<M extends Message> implements RecordCursor<QueryRes
         return AsyncUtil.whileTrue(() -> inner.onNext().thenApply(innerResult -> {
             previousResult = innerResult;
             if (!innerResult.hasNext()) {
-                if (!isNoRecords() || streamGrouping.isResultOnEmpty()) {
+                if (!isNoRecords() || (isCreateDefaultOnEmpty && streamGrouping.isResultOnEmpty())) {
                     streamGrouping.finalizeGroup();
                 }
                 return false;
@@ -86,7 +90,7 @@ public class AggregateCursor<M extends Message> implements RecordCursor<QueryRes
         }), getExecutor()).thenApply(vignore -> {
             if (isNoRecords()) {
                 // Edge case where there are no records at all
-                if (streamGrouping.isResultOnEmpty()) {
+                if (isCreateDefaultOnEmpty && streamGrouping.isResultOnEmpty()) {
                     return RecordCursorResult.withNextValue(QueryResult.ofComputed(streamGrouping.getCompletedGroupResult()), RecordCursorStartContinuation.START);
                 } else {
                     return RecordCursorResult.exhausted();

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1659,6 +1659,7 @@ message PRecordQueryStreamingAggregationPlan {
     optional string grouping_key_alias = 4;
     optional string aggregate_alias = 5;
     optional PValue complete_result_value = 6;
+    optional bool is_create_default_on_empty = 7;
 }
 
 //


### PR DESCRIPTION
Cherry picks the cursor code from #3092 onto the 4.0.559 branch. That PR adapts the behavior of the `AggregateCursor` so that it no longer produces an incorrect "BEGIN" continuation in association with the final element of an empty aggregate. Such a continuation can produce an infinite loop if the continuation is then used to re-issue the query from the beginning (or throw an error if passed to `EXECUTE CONTINUATION`).

Because the fix changes the behavior of `AggregateCursor`, there would normally be some danger when continuing a plan from that version on older versions and vice versa To prevent this, the code in #3092 only goes to the new behavior if there is a flag set in the serialized continuation (so it will continue with the older semantics when deserializing an older continuation). We want to be able to reliably go to the new behavior in mixed-mode scenarios with 4.0.559 and the current `main` version, and so to make that work, we need to be able to parse this new flag on the 4.0.559 branch.

Note that the code in this PR _only_ goes to the new behavior when deserializing a new continuation with the flag set. So, behavior is preserved except in mixed-mode scenarios. Future upgrade testing will be done to validate that the continuation does get parsed correctly and produce the expected outcome, but the code is identical to the one taken in #3092 (except for defaulting to the old behavior instead of the new), so we are confident that this should be safe and correct.