### PR TITLE
Backport PRB to 4.0.559 branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,80 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4.2.2
+    - name: Run Gradle Test
+      uses: ./actions/gradle-test
+      with:
+        gradle_args: "-PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport"
+    - name: Publish Test Reports
+      if: always()
+      uses: actions/upload-artifact@v4.6.0
+      with:
+        name: test-reports
+        path: |
+          test-reports/fdb-java-annotations/
+          test-reports/fdb-extensions/
+          test-reports/fdb-record-layer-core/
+          test-reports/fdb-record-layer-icu/
+          test-reports/fdb-record-layer-spatial/
+          test-reports/fdb-record-layer-lucene/
+          test-reports/fdb-record-layer-jmh/
+          test-reports/examples/
+          test-reports/fdb-relational-api/
+          test-reports/fdb-relational-core/
+          test-reports/fdb-relational-cli/
+          test-reports/fdb-relational-grpc/
+          test-reports/fdb-relational-jdbc/
+          test-reports/fdb-relational-server/
+          test-reports/yaml-tests/
+    - name: Test Summary
+      if: always()
+      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
+      with:
+        paths: |
+          fdb-java-annotations/.out/test-results/**/TEST-*.xml
+          fdb-extensions/.out/test-results/**/TEST-*.xml
+          fdb-record-layer-core/.out/test-results/**/TEST-*.xml
+          fdb-record-layer-icu/.out/test-results/**/TEST-*.xml
+          fdb-record-layer-spatial/.out/test-results/**/TEST-*.xml
+          fdb-record-layer-lucene/.out/test-results/**/TEST-*.xml
+          fdb-record-layer-jmh/.out/test-results/**/TEST-*.xml
+          examples/.out/test-results/**/TEST-*.xml
+          fdb-relational-api/.out/test-results/**/TEST-*.xml
+          fdb-relational-core/.out/test-results/**/TEST-*.xml
+          fdb-relational-cli/.out/test-results/**/TEST-*.xml
+          fdb-relational-grpc/.out/test-results/**/TEST-*.xml
+          fdb-relational-jdbc/.out/test-results/**/TEST-*.xml
+          fdb-relational-server/.out/test-results/**/TEST-*.xml
+          yaml-tests/.out/test-results/**/TEST-*.xml
+    - name: Test Coverage Comment
+      uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
+      with:
+        paths: |
+          fdb-extensions/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-record-layer-core/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-record-layer-icu/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-record-layer-spatial/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-record-layer-lucene/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-relational-api/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-relational-core/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-relational-cli/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-relational-grpc/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-relational-jdbc/.out/reports/jacoco/test/jacocoTestReport.xml,
+          fdb-relational-server/.out/reports/jacoco/test/jacocoTestReport.xml,
+          yaml-tests/.out/reports/jacoco/test/jacocoTestReport.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
+        min-coverage-overall: 75
+        min-coverage-changed-files: 80

--- a/actions/gradle-test/action.yml
+++ b/actions/gradle-test/action.yml
@@ -1,0 +1,49 @@
+name: Gradle Test
+
+inputs:
+  fdb_version:
+    description: 'Version of FDB to run'
+    required: false
+    default: "7.3.42"
+  gradle_args:
+    description: 'Gradle arguments for running'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+  - name: Download FDB Client
+    shell: bash
+    run: wget -nv https://github.com/apple/foundationdb/releases/download/${{ inputs.fdb_version }}/foundationdb-clients_${{ inputs.fdb_version }}-1_amd64.deb
+  - name: Download FDB Server
+    shell: bash
+    run: wget -nv https://github.com/apple/foundationdb/releases/download/${{ inputs.fdb_version }}/foundationdb-server_${{ inputs.fdb_version }}-1_amd64.deb
+  - name: Install FDB Server
+    shell: bash
+    run: sudo dpkg -i foundationdb-clients_${{ inputs.fdb_version }}-1_amd64.deb foundationdb-server_${{ inputs.fdb_version }}-1_amd64.deb
+  - name: Fix FDB Network Addresses
+    shell: bash
+    run: sudo sed -i -e "s/public_address = auto:\$ID/public_address = 127.0.0.1:\$ID/g" -e "s/listen_address = public/listen_address = 0.0.0.0:\$ID/g" /etc/foundationdb/foundationdb.conf
+  - name: Start FDB Server
+    shell: bash
+    run: sudo /usr/lib/foundationdb/fdbmonitor /etc/foundationdb/foundationdb.conf --daemonize
+  - name: Switch FDB to SSD
+    shell: bash
+    run: fdbcli --exec "configure single ssd storage_migration_type=aggressive; status"
+  - name: Set up JDK 17
+    uses: actions/setup-java@v4.7.0
+    with:
+      java-version: '17'
+      distribution: 'temurin'
+  - name: Setup Gradle
+    uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6
+  - name: Remove JVM args
+    shell: bash
+    run: sed -i -e "s/^org\.gradle\..*/#&/g" gradle.properties
+  - name: Run build and test
+    shell: bash
+    run: GRADLE_OPTS="-XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" ./gradlew --no-daemon --console=plain -b ./build.gradle build destructiveTest -PcoreNotStrict ${{ inputs.gradle_args }}
+  - name: Copy Test Reports
+    shell: bash
+    if: always()
+    run: mkdir -p test-reports && for d in fdb-java-annotations fdb-extensions fdb-record-layer-core fdb-record-layer-icu fdb-record-layer-spatial fdb-record-layer-lucene fdb-record-layer-jmh examples fdb-relational-api fdb-relational-core fdb-relational-cli fdb-relational-grpc fdb-relational-jdbc fdb-relational-server yaml-tests; do ln -s ../$d/.out/reports test-reports/$d; done


### PR DESCRIPTION
A recent 4.0.559 build (#3108) didn't run in PRB. This should allow us to get PRB on that branch.