### PR TITLE
set skip and limit for the recursive union cursor correctly.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRecursiveUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRecursiveUnionPlan.java
@@ -150,16 +150,18 @@ public class RecordQueryRecursiveUnionPlan implements RecordQueryPlanWithChildre
                                                                      @Nullable final byte[] continuation,
                                                                      @Nonnull final ExecuteProperties executeProperties) {
         final var type = getInnerTypeDescriptor(context);
+        final var childExecuteProperties = executeProperties.clearSkipAndLimit();
         final var recursiveStateManager = new RecursiveStateManagerImpl(
                 (initialContinuation, evaluationContext) -> getInitialStatePlan().executePlan(store, evaluationContext,
-                        initialContinuation == null ? null : initialContinuation.toByteArray(), executeProperties),
+                        initialContinuation == null ? null : initialContinuation.toByteArray(), childExecuteProperties),
                 (recursiveContinuation, evaluationContext) -> getRecursiveStatePlan().executePlan(store, evaluationContext,
-                        recursiveContinuation == null ? null : recursiveContinuation.toByteArray(), executeProperties),
+                        recursiveContinuation == null ? null : recursiveContinuation.toByteArray(), childExecuteProperties),
                 context,
                 tempTableScanAlias,
                 tempTableInsertAlias,
                 proto -> TempTable.from(proto, type), store.getContext().getTempTableFactory(), continuation);
-        return new RecursiveUnionCursor<>(recursiveStateManager, store.getExecutor());
+        return new RecursiveUnionCursor<>(recursiveStateManager, store.getExecutor())
+                .skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
     }
 
     @Nullable

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -30,7 +30,6 @@ import com.apple.foundationdb.relational.recordlayer.query.ParseHelpers;
 import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
 
 import com.google.common.collect.HashMultiset;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -64,7 +63,7 @@ public class Matchers {
         if (obj instanceof List) {
             return (List<?>) obj;
         }
-        fail(String.format("Expecting '%s' to be of type '%s'", desc, List.class.getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting '%s' to be of type '%s'", desc, List.class.getSimpleName()));
         return null;
     }
 
@@ -80,7 +79,7 @@ public class Matchers {
         if (obj instanceof Map<?, ?>) {
             return (Map<?, ?>) obj;
         }
-        fail(String.format("Expecting %s to be of type %s", desc, Map.class.getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s", desc, Map.class.getSimpleName()));
         return null;
     }
 
@@ -88,7 +87,7 @@ public class Matchers {
         if (obj instanceof Map.Entry<?, ?>) {
             return (Map.Entry<?, ?>) obj;
         }
-        fail(String.format("Expecting %s to be of type %s", desc, Map.Entry.class.getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s", desc, Map.Entry.class.getSimpleName()));
         return null;
     }
 
@@ -98,21 +97,21 @@ public class Matchers {
 
     public static Object first(@Nonnull final List<?> obj, @Nonnull final String desc) {
         if (obj.isEmpty()) {
-            fail(String.format("Expecting %s to contain at least one element, however it is empty", desc));
+            fail(String.format(Locale.ROOT, "Expecting %s to contain at least one element, however it is empty", desc));
         }
         return obj.get(0);
     }
 
     public static Object second(@Nonnull final List<?> obj) {
         if (obj.size() <= 1) {
-            fail(String.format("Expecting %s to contain at least two elements, however it contains %s element", obj, obj.size()));
+            fail(String.format(Locale.ROOT, "Expecting %s to contain at least two elements, however it contains %s element", obj, obj.size()));
         }
         return obj.get(1);
     }
 
     public static Object third(@Nonnull final List<?> obj) {
         if (obj.size() <= 2) {
-            fail(String.format("Expecting %s to contain at least three elements, however it contains %s element", obj, obj.size()));
+            fail(String.format(Locale.ROOT, "Expecting %s to contain at least three elements, however it contains %s element", obj, obj.size()));
         }
         return obj.get(2);
     }
@@ -122,7 +121,7 @@ public class Matchers {
             // <NULL> should return null maybe?
             return (String) obj;
         }
-        fail(String.format("Expecting %s to be of type %s, however it is of type %s", desc, String.class.getSimpleName(), obj.getClass().getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s", desc, String.class.getSimpleName(), obj.getClass().getSimpleName()));
         return null;
     }
 
@@ -147,7 +146,7 @@ public class Matchers {
             // <NULL> should return null maybe?
             return (Boolean) obj;
         }
-        fail(String.format("Expecting %s to be of type %s, however it is of type %s", obj, Boolean.class.getSimpleName(), obj.getClass().getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s", obj, Boolean.class.getSimpleName(), obj.getClass().getSimpleName()));
         return false; // never reached.
     }
 
@@ -162,7 +161,7 @@ public class Matchers {
         if (obj instanceof Integer) {
             return Long.valueOf((Integer) obj);
         }
-        fail(String.format("Expecting %s to be of type %s, however it is of type %s", obj, Long.class.getSimpleName(), obj.getClass().getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s", obj, Long.class.getSimpleName(), obj.getClass().getSimpleName()));
         return -1; // never reached.
     }
 
@@ -174,7 +173,7 @@ public class Matchers {
         if (obj instanceof Integer) {
             return (Integer) obj;
         }
-        fail(String.format("Expecting %s to be of type %s, however it is of type %s", obj, Integer.class.getSimpleName(), obj.getClass().getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s", obj, Integer.class.getSimpleName(), obj.getClass().getSimpleName()));
         return -1; // never reached.
     }
 
@@ -186,7 +185,7 @@ public class Matchers {
         if (obj instanceof Double) {
             return (Double) obj;
         }
-        fail(String.format("Expecting %s to be of type %s, however it is of type %s", obj, Double.class.getSimpleName(), obj.getClass().getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s", obj, Double.class.getSimpleName(), obj.getClass().getSimpleName()));
         return -1; // never reached.
     }
 
@@ -208,7 +207,7 @@ public class Matchers {
         if (obj instanceof Message) {
             return (Message) obj;
         }
-        fail(String.format("Expecting %s to be of type %s, however it is of type %s.", obj, Message.class.getSimpleName(), obj.getClass().getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s.", obj, Message.class.getSimpleName(), obj.getClass().getSimpleName()));
         return null;
     }
 
@@ -216,7 +215,7 @@ public class Matchers {
     @Nonnull
     public static <T> T notNull(@Nullable final T object, @Nonnull final String desc) {
         if (object == null) {
-            fail(String.format("unexpected %s to be null", desc));
+            fail(String.format(Locale.ROOT, "unexpected %s to be null", desc));
         }
         return object;
     }
@@ -227,14 +226,14 @@ public class Matchers {
         if (obj instanceof Map) {
             return ((Map<?, ?>) obj).entrySet().iterator().next();
         }
-        fail(String.format("Expecting %s to be of type %s, however it is of type %s.", desc, Map.class.getSimpleName(), obj.getClass().getSimpleName()));
+        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s.", desc, Map.class.getSimpleName(), obj.getClass().getSimpleName()));
         return null;
     }
 
     @Nonnull
     public static Object valueElseKey(@Nonnull final Map.Entry<?, ?> entry) {
         if (isNull(entry.getKey()) && isNull(entry.getValue())) {
-            fail(String.format("encountered YAML-style 'null' which is not supported, consider using '%s' instead", CustomTag.NullPlaceholder.INSTANCE));
+            fail(String.format(Locale.ROOT, "encountered YAML-style 'null' which is not supported, consider using '%s' instead", CustomTag.NullPlaceholder.INSTANCE));
         }
         return entry.getValue() == null ? entry.getKey() : entry.getValue();
     }
@@ -430,7 +429,7 @@ public class Matchers {
         for (final var expectedRow : expectedAsList) {
             if (!actual.next()) {
                 printCurrentAndRemaining(actual, resultSetPrettyPrinter);
-                return ImmutablePair.of(ResultSetMatchResult.fail(String.format("result does not contain all expected rows! expected %d rows, got %d", expectedAsList.size(), i - 1)), null);
+                return ImmutablePair.of(ResultSetMatchResult.fail(String.format(Locale.ROOT, "result does not contain all expected rows! expected %d rows, got %d", expectedAsList.size(), i - 1)), null);
             }
             if (!isMap(expectedRow)) { // I think it should be possible to expect a result set like: [[1,2,3], [4,5,6]]. But ok for now.
                 printCurrentAndRemaining(actual, resultSetPrettyPrinter);
@@ -444,7 +443,7 @@ public class Matchers {
         }
         if (printRemaining(actual, resultSetPrettyPrinter)) {
             final var leftActualRowCount = resultSetPrettyPrinter.getRowCount();
-            return ImmutablePair.of(ResultSetMatchResult.fail(String.format("too many rows in actual result set! expected %d rows, got %d.", expectedAsList.size(), expectedAsList.size() + leftActualRowCount)), resultSetPrettyPrinter);
+            return ImmutablePair.of(ResultSetMatchResult.fail(String.format(Locale.ROOT, "too many rows in actual result set! expected %d rows, got %d.", expectedAsList.size(), expectedAsList.size() + leftActualRowCount)), resultSetPrettyPrinter);
         }
         return ImmutablePair.of(ResultSetMatchResult.success(), null);
     }
@@ -461,7 +460,7 @@ public class Matchers {
                 while (actual.next()) {
                     actualRowsCounter++;
                 }
-                return ImmutablePair.of(ResultSetMatchResult.fail(String.format("too many rows in actual result set! expected %d row(s), got %d row(s) instead.", expectedRowCount, actualRowsCounter - 1)), resultSetPrettyPrinter);
+                return ImmutablePair.of(ResultSetMatchResult.fail(String.format(Locale.ROOT, "too many rows in actual result set! expected %d row(s), got %d row(s) instead.", expectedRowCount, actualRowsCounter - 1)), resultSetPrettyPrinter);
             }
             for (final var expectedRow : expectedAsMultiSet.elementSet()) {
                 if (!isMap(expectedRow)) { // I think it should be possible to expect a result set like: [[1,2,3], [4,5,6]]. But ok for now.
@@ -477,12 +476,12 @@ public class Matchers {
             }
             if (!found) {
                 printCurrentAndRemaining(actual, resultSetPrettyPrinter);
-                return ImmutablePair.of(ResultSetMatchResult.fail(String.format("actual row at %d does not match any expected records", actualRowsCounter)), resultSetPrettyPrinter);
+                return ImmutablePair.of(ResultSetMatchResult.fail(String.format(Locale.ROOT, "actual row at %d does not match any expected records", actualRowsCounter)), resultSetPrettyPrinter);
             }
             actualRowsCounter++;
         }
         if (!expectedAsMultiSet.isEmpty()) {
-            return ImmutablePair.of(ResultSetMatchResult.fail(String.format("result does not contain all expected rows, expected %d row(s), got %d row(s) instead.", expectedRowCount, actualRowsCounter - 1)), null);
+            return ImmutablePair.of(ResultSetMatchResult.fail(String.format(Locale.ROOT, "result does not contain all expected rows, expected %d row(s), got %d row(s) instead.", expectedRowCount, actualRowsCounter - 1)), null);
         }
         return ImmutablePair.of(ResultSetMatchResult.success(), null);
     }
@@ -517,7 +516,7 @@ public class Matchers {
                                                  int rowNumber) throws SQLException {
         final var expectedColCount = expected.entrySet().size();
         if (actualEntriesCount != expectedColCount) {
-            return ResultSetMatchResult.fail(String.format("row cardinality mismatch at %d! expected a row comprising %d column(s), received %d column(s) instead.", rowNumber, expectedColCount, actualEntriesCount));
+            return ResultSetMatchResult.fail(String.format(Locale.ROOT, "row cardinality mismatch at %d! expected a row comprising %d column(s), received %d column(s) instead.", rowNumber, expectedColCount, actualEntriesCount));
         }
         return matchMap(expected, actualEntriesCount, entryByNameAccessor, entryByNumberAccessor, rowNumber, "");
     }
@@ -532,7 +531,7 @@ public class Matchers {
         int counter = 1;
         final var expectedColCount = expected.entrySet().size();
         if (actualEntriesCount != expectedColCount) {
-            return ResultSetMatchResult.fail(String.format("! expected a row comprising %d column(s), received %d column(s) instead.", expectedColCount, actualEntriesCount));
+            return ResultSetMatchResult.fail(String.format(Locale.ROOT, "! expected a row comprising %d column(s), received %d column(s) instead.", expectedColCount, actualEntriesCount));
         }
         for (final var entry : expected.entrySet()) {
             final var expectedField = valueElseKey(entry);
@@ -578,7 +577,7 @@ public class Matchers {
         // (nested) message
         if (expected instanceof Map<?, ?>) {
             if (!(actual instanceof RelationalStruct)) {
-                return ResultSetMatchResult.fail(String.format("cell mismatch at row: %d cellRef: %s%n expected 🟢 to match a struct, got 🟡 instead.%n🟢 %s (Struct)%n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
+                return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 to match a struct, got 🟡 instead.%n🟢 %s (Struct)%n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
             }
             final var struct = (RelationalStruct) (actual);
             return matchMap(map(expected), struct.getAttributes().length, valueByName(struct), valueByIndex(struct), rowNumber, cellRef);
@@ -588,13 +587,13 @@ public class Matchers {
         if (expected instanceof List<?>) {
             final var expectedArray = (List<?>) (expected);
             if (!(actual instanceof RelationalArray)) {
-                return ResultSetMatchResult.fail(String.format("cell mismatch at row: %d cellRef: %s%n expected 🟢 to match an array, got 🟡 instead.%n🟢 %s (Array)%n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
+                return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 to match an array, got 🟡 instead.%n🟢 %s (Array)%n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
             }
             final var actualArray = (RelationalArray) (actual);
             final var actualArrayContent = actualArray.getResultSet();
             for (int i = 0; i < expectedArray.size(); i++) {
                 if (!actualArrayContent.next()) {
-                    return ResultSetMatchResult.fail(String.format("cell mismatch at row: %d cellRef: %s%n expected 🟢 (containing %d array items) does not match 🟡 (containing %d array items).%n🟢 %s%n🟡 %s",
+                    return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 (containing %d array items) does not match 🟡 (containing %d array items).%n🟢 %s%n🟡 %s",
                             rowNumber, cellRef, expectedArray.size(), i, expected, actual));
                 }
                 if (isMap(expectedArray.get(i))) {
@@ -649,7 +648,7 @@ public class Matchers {
         if (Objects.equals(expected, actual)) {
             return ResultSetMatchResult.success();
         } else {
-            return ResultSetMatchResult.fail(String.format("cell mismatch at row: %d cellRef: %s%n expected 🟢 does not match 🟡.%n🟢 %s (%s)%n🟡 %s (%s)", rowNumber, cellRef, expected, expected == null ? "NULL" : expected.getClass().getSimpleName(), actual, actual.getClass().getSimpleName()));
+            return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 does not match 🟡.%n🟢 %s (%s)%n🟡 %s (%s)", rowNumber, cellRef, expected, expected == null ? "NULL" : expected.getClass().getSimpleName(), actual, actual.getClass().getSimpleName()));
         }
     }
 
@@ -671,6 +670,6 @@ public class Matchers {
                 return ResultSetMatchResult.success();
             }
         }
-        return ResultSetMatchResult.fail(String.format("cell mismatch at row: %d cellRef: %s%n expected 🟢 does not match 🟡.%n🟢 %s (Integer) %n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
+        return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 does not match 🟡.%n🟢 %s (Integer) %n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
     }
 }

--- a/yaml-tests/src/test/resources/cte.yamsql
+++ b/yaml-tests/src/test/resources/cte.yamsql
@@ -119,4 +119,12 @@ test_block:
       # TODO (CTEs and subqueries are not fully optimized)
       - query: with c1(x, y) as (select col1, col2 from t1) select x from c1 where y < 3
       - explain: "SCAN(<,>) | MAP (_.COL1 AS COL1, _.COL2 AS COL2) | FILTER _.COL2 LESS_THAN promote(@c24 AS LONG) | MAP (_.COL1 AS X)"
+    -
+      - query: with c1 as (select col1, col2 from t1) select col1, col2 from c1
+      - maxRows: 1
+      - result: [{COL1: 10, COL2: 1}]
+      - result: [{COL1: 10, COL2: 2}]
+      - result: [{COL1: 20, COL2: 6}]
+      - result: [{COL1: 20, COL2: 7}]
+      - result: []
 ...

--- a/yaml-tests/src/test/resources/recursive-cte.yamsql
+++ b/yaml-tests/src/test/resources/recursive-cte.yamsql
@@ -68,6 +68,49 @@ test_block:
                  {210, 20},
                  {250, 50},
                  {250, 50}]
+    -
+      - query: with recursive c1 as (
+            select id, parent from t1 where parent = -1
+            union all
+            select b.id, b.parent from c1 as a, t1 as b where a.id = b.parent) select id from c1
+      - maxRows: 1
+      - result: [{ID: 1}]
+      - result: [{ID: 10}]
+      - result: [{ID: 20}]
+      - result: [{ID: 40}]
+      - result: [{ID: 50}]
+      - result: [{ID: 70}]
+      - result: [{ID: 100}]
+      - result: [{ID: 210}]
+      - result: [{ID: 250}]
+      - result: []
+    -
+      - query: with recursive allDescendants as (
+            with recursive ancestorsOf250 as (
+            select id, parent from t1 where id = 250
+            union all
+            select b.id, b.parent from ancestorsOf250 as a, t1 as b where a.parent = b.id) select id, parent from ancestorsOf250
+            union all
+            select b.id, b.parent from allDescendants as a, t1 as b where a.id = b.parent) select id, parent from allDescendants
+      - maxRows: 1
+      - result: [{250, 50}]
+      - result: [{50, 10}]
+      - result: [{10, 1}]
+      - result: [{1, -1}]
+      - result: [{10, 1}]
+      - result: [{20, 1}]
+      - result: [{40, 10}]
+      - result: [{50, 10}]
+      - result: [{70, 10}]
+      - result: [{250, 50}]
+      - result: [{40, 10}]
+      - result: [{50, 10}]
+      - result: [{70, 10}]
+      - result: [{100, 20}]
+      - result: [{210, 20}]
+      - result: [{250, 50}]
+      - result: [{250, 50}]
+      - result: []
 #    -
 # does not currently work due to bug in NLJ planning, see https://github.com/FoundationDB/fdb-record-layer/issues/2997
 #      - query: with recursive c1 as (

--- a/yaml-tests/src/test/resources/recursive-cte.yamsql
+++ b/yaml-tests/src/test/resources/recursive-cte.yamsql
@@ -73,6 +73,7 @@ test_block:
             select id, parent from t1 where parent = -1
             union all
             select b.id, b.parent from c1 as a, t1 as b where a.id = b.parent) select id from c1
+      - supported_version: !current_version
       - maxRows: 1
       - result: [{ID: 1}]
       - result: [{ID: 10}]
@@ -92,6 +93,7 @@ test_block:
             select b.id, b.parent from ancestorsOf250 as a, t1 as b where a.parent = b.id) select id, parent from ancestorsOf250
             union all
             select b.id, b.parent from allDescendants as a, t1 as b where a.id = b.parent) select id, parent from allDescendants
+      - supported_version: !current_version
       - maxRows: 1
       - result: [{250, 50}]
       - result: [{50, 10}]


### PR DESCRIPTION
This sets the `limit` and `skip` (if any) on the recursive union cursor correctly. It also includes a number of small fixes to the YAML test framework error reporting in case of result mismatches, and a small optimization of handling unordered result matching.

This fixes #3100.