### PR TITLE
Replace test-summary action with custom action code

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,26 +43,6 @@ jobs:
           test-reports/fdb-relational-jdbc/
           test-reports/fdb-relational-server/
           test-reports/yaml-tests/
-    - name: Test Summary
-      if: always()
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
-      with:
-        paths: |
-          fdb-java-annotations/.out/test-results/**/TEST-*.xml
-          fdb-extensions/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-core/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-icu/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-spatial/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-lucene/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-jmh/.out/test-results/**/TEST-*.xml
-          examples/.out/test-results/**/TEST-*.xml
-          fdb-relational-api/.out/test-results/**/TEST-*.xml
-          fdb-relational-core/.out/test-results/**/TEST-*.xml
-          fdb-relational-cli/.out/test-results/**/TEST-*.xml
-          fdb-relational-grpc/.out/test-results/**/TEST-*.xml
-          fdb-relational-jdbc/.out/test-results/**/TEST-*.xml
-          fdb-relational-server/.out/test-results/**/TEST-*.xml
-          yaml-tests/.out/test-results/**/TEST-*.xml
     - name: Test Coverage Comment
       uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
       with:

--- a/actions/gradle-test/action.yml
+++ b/actions/gradle-test/action.yml
@@ -18,11 +18,11 @@ runs:
       gradle_command: build destructiveTest -PcoreNotStrict ${{ inputs.gradle_args }}
   - name: Test Summary
     shell: bash
-    if: ${{ hashFiles('.out/reports/test-summary.md') != '' }}
+    if: ${{ !cancelled() && hashFiles('.out/reports/test-summary.md') != '' }}
     run: cat .out/reports/test-summary.md > $GITHUB_STEP_SUMMARY
   - name: Test Failures
     shell: bash
-    if: ${{ hashFiles('.out/reports/test-failures.md') != '' }}
+    if: ${{ !cancelled() && hashFiles('.out/reports/test-failures.md') != '' }}
     run: cat .out/reports/test-failures.md > $GITHUB_STEP_SUMMARY
   - name: Copy Test Reports
     shell: bash

--- a/actions/gradle-test/action.yml
+++ b/actions/gradle-test/action.yml
@@ -16,6 +16,14 @@ runs:
     uses: ./actions/run-gradle
     with:
       gradle_command: build destructiveTest -PcoreNotStrict ${{ inputs.gradle_args }}
+  - name: Test Summary
+    shell: bash
+    if: ${{ hashFiles('.out/reports/test-summary.md') != '' }}
+    run: cat .out/reports/test-summary.md > $GITHUB_STEP_SUMMARY
+  - name: Test Failures
+    shell: bash
+    if: ${{ hashFiles('.out/reports/test-failures.md') != '' }}
+    run: cat .out/reports/test-failures.md > $GITHUB_STEP_SUMMARY
   - name: Copy Test Reports
     shell: bash
     if: always()

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -164,7 +164,7 @@ tasks.withType(Test) { theTask ->
         }
         if (!summary.exists()) {
             summary.append("|Test run|❌|⚠️|✅|time|\n")
-            summary.append("|--|--|--️|--|--|\n")
+            summary.append("|-|-|-|-|-|\n")
         }
     }
 

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -161,6 +161,11 @@ tasks.withType(Test) { theTask ->
         def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
         println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
         println()
+        if (System.getenv("GITHUB_STEP_SUMMARY") != null && result.resultType == TestResult.ResultType.FAILURE) {
+            new File(System.getenv("GITHUB_STEP_SUMMARY")).append(
+                "\n## ${getFullDisplayName(descriptor)} [FAILED] (${duration}ms)\n" +
+                "```\n${result.getException().asString()}\n```\n")
+        }
     }
     reports {
         junitXml.outputPerTestCase = true

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -164,6 +164,7 @@ tasks.withType(Test) { theTask ->
         }
         if (!summary.exists()) {
             summary.append("|Test run|❌|⚠️|✅|time|\n")
+            summary.append("|--------|--|--️|--|----|\n")
         }
     }
 

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -154,6 +154,10 @@ tasks.withType(Test) { theTask ->
         events 'failed'
         exceptionFormat = 'full'
     }
+    // This creates two reports to be picked up by the gradle actions (see actions/gradle-test/action.yml)
+    // We initialize the files here, to be filled out by test listeners below
+    // summary has a summary of all the test tasks we ran, and the success/skipped/failure counts & duration
+    // failures includes any failures that happened, with the stack trace
     def markdownReports = new File("$rootDir/.out/reports/")
     def summary = new File(markdownReports, "test-summary.md")
     def failures = new File(markdownReports, "test-failures.md")

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -164,7 +164,7 @@ tasks.withType(Test) { theTask ->
         }
         if (!summary.exists()) {
             summary.append("|Test run|❌|⚠️|✅|time|\n")
-            summary.append("|-|-|-️|-|-|\n")
+            summary.append("|--|--|--️|--|--|\n")
         }
     }
 

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -163,8 +163,11 @@ tasks.withType(Test) { theTask ->
         println()
         if (System.getenv("GITHUB_STEP_SUMMARY") != null && result.resultType == TestResult.ResultType.FAILURE) {
             new File(System.getenv("GITHUB_STEP_SUMMARY")).append(
-                "\n## ${getFullDisplayName(descriptor)} [FAILED] (${duration}ms)\n" +
-                "```\n${result.getException().asString()}\n```\n")
+                "<details>\n" +
+                    "<summary> ❌ ${getFullDisplayName(descriptor)}</summary>\n" +
+                    "(${duration}ms)\n" +
+                    "```\n${result.getException().asString()}\n```\n" +
+                "</details>\n")
         }
     }
     reports {

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -187,8 +187,9 @@ tasks.withType(Test) { theTask ->
     afterSuite { descriptor, result ->
         if (descriptor.parent == null) {
             def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
+            def description = descriptor.toString().replaceFirst("Gradle Test Run ", "")
             summary.append(
-                "|${descriptor}|${result.getFailedTestCount()}|${result.getSkippedTestCount()}|${result.getSuccessfulTestCount()}|${duration}ms|\n")
+                "|${description}|${result.getFailedTestCount()}|${result.getSkippedTestCount()}|${result.getSuccessfulTestCount()}|${duration}ms|\n")
         }
     }
     reports {

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -164,7 +164,7 @@ tasks.withType(Test) { theTask ->
         }
         if (!summary.exists()) {
             summary.append("|Test run|❌|⚠️|✅|time|\n")
-            summary.append("|--------|--|--️|--|----|\n")
+            summary.append("|-|-|-️|-|-|\n")
         }
     }
 

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -179,7 +179,7 @@ tasks.withType(Test) { theTask ->
             failures.append(
                 "<details>\n" +
                     "<summary> ❌ ${getFullDisplayName(descriptor)}</summary>\n" +
-                    "(${duration}ms)\n" +
+                    "(${duration}ms)\n\n" + // blank line is required for ``` to work
                     "```\n${result.getException().asString()}\n```\n" +
                 "</details>\n")
         }

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -154,6 +154,19 @@ tasks.withType(Test) { theTask ->
         events 'failed'
         exceptionFormat = 'full'
     }
+    def markdownReports = new File("$rootDir/.out/reports/")
+    def summary = new File(markdownReports, "test-summary.md")
+    def failures = new File(markdownReports, "test-failures.md")
+    doFirst {
+        // This may have issues with running tasks concurrently
+        if (!markdownReports.exists()) {
+            markdownReports.mkdirs()
+        }
+        if (!summary.exists()) {
+            summary.append("|Test run|❌|⚠️|✅|time|\n")
+        }
+    }
+
     beforeTest { descriptor -> 
         println "${Instant.now()} ${getFullDisplayName(descriptor)} STARTED"
     } 
@@ -161,8 +174,8 @@ tasks.withType(Test) { theTask ->
         def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
         println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
         println()
-        if (System.getenv("GITHUB_STEP_SUMMARY") != null && result.resultType == TestResult.ResultType.FAILURE) {
-            new File(System.getenv("GITHUB_STEP_SUMMARY")).append(
+        if (result.resultType == TestResult.ResultType.FAILURE) {
+            failures.append(
                 "<details>\n" +
                     "<summary> ❌ ${getFullDisplayName(descriptor)}</summary>\n" +
                     "(${duration}ms)\n" +
@@ -172,9 +185,9 @@ tasks.withType(Test) { theTask ->
     }
     afterSuite { descriptor, result ->
         if (descriptor.parent == null) {
-            println("Summary: ")
             def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
-            println("${descriptor}|${result.getFailedTestCount()}|${result.getSkippedTestCount()}|${result.getSuccessfulTestCount()}|${duration}ms")
+            summary.append(
+                "|${descriptor}|${result.getFailedTestCount()}|${result.getSkippedTestCount()}|${result.getSuccessfulTestCount()}|${duration}ms|\n")
         }
     }
     reports {

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -170,6 +170,13 @@ tasks.withType(Test) { theTask ->
                 "</details>\n")
         }
     }
+    afterSuite { descriptor, result ->
+        if (descriptor.parent == null) {
+            println("Summary: ")
+            def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
+            println("${descriptor}|${result.getFailedTestCount()}|${result.getSkippedTestCount()}|${result.getSuccessfulTestCount()}|${duration}ms")
+        }
+    }
     reports {
         junitXml.outputPerTestCase = true
     }


### PR DESCRIPTION
The test-summary action takes the xml files produced by the tests, but our xml files in the nightly action get too large for the action to load them as a string (~540mb), due to all the logging.
This replaces the test-summary action with built-in steps that print to `GITHUB_STEP_SUMMARY`. They use the listener to gather the test results and exceptions.

You can see two examples of PRBs with the resulting output. Both of these disable many of the tests so that I could iterate more quickly:
- A successful run: https://github.com/ScottDugas/fdb-record-layer/actions/runs/13246744981
- A run with some failures: https://github.com/ScottDugas/fdb-record-layer/actions/runs/13246749305

I think there's two followups that could be nice, but decided not to do them right now:
1. It would probably make sense to remove all the `destructiveTest` runs from the summary that have 0 tests in them, which would make that table much smaller.
2. It would probably make sense to trim the stack traces to remove a whole slew of junit code.