### PR TITLE
Split out the PR coverage commenting workflow …

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -54,14 +54,6 @@ jobs:
         name: core-test-reports
         path: |
           test-reports/fdb-record-layer-core/
-    - name: Test Coverage Comment
-      uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
-      with:
-        paths: |
-          fdb-record-layer-core/.out/reports/jacoco/test/jacocoTestReport.xml,
-        token: ${{ secrets.GITHUB_TOKEN }}
-        min-coverage-overall: 75
-        min-coverage-changed-files: 80
 
   other-tests:
     runs-on: ubuntu-latest
@@ -101,21 +93,3 @@ jobs:
             test-reports/fdb-relational-jdbc/
             test-reports/fdb-relational-server/
             test-reports/yaml-tests/
-      - name: Test Coverage Comment
-        uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
-        with:
-          paths: |
-            fdb-extensions/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-record-layer-icu/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-record-layer-spatial/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-record-layer-lucene/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-relational-api/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-relational-core/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-relational-cli/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-relational-grpc/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-relational-jdbc/.out/reports/jacoco/test/jacocoTestReport.xml,
-            fdb-relational-server/.out/reports/jacoco/test/jacocoTestReport.xml,
-            yaml-tests/.out/reports/jacoco/test/jacocoTestReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 75
-          min-coverage-changed-files: 80

--- a/.github/workflows/pull_request_comments.yml
+++ b/.github/workflows/pull_request_comments.yml
@@ -26,19 +26,22 @@ jobs:
                repo: context.repo.repo,
                run_id: context.payload.workflow_run.id,
             });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == 'test-reports';
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+            let matchingArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.endsWith('-test-reports');
             });
             const fs = require('fs');
-            fs.writeFileSync('${{ github.workspace }}/test-reports.zip', Buffer.from(download.data));
-      - name: 'Unzip artifact'
-        run: unzip test-reports.zip
+            for (matchingArtifact of matchingArtifacts) {
+              core.info(`Downloading ${matchingArtifact.name}.`);
+              let download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: matchingArtifact.id,
+                 archive_format: 'zip',
+              });
+              fs.writeFileSync(`${{ github.workspace }}/${ matchingArtifact.name }.zip`, Buffer.from(download.data));
+            }
+      - name: 'Unzip artifacts'
+        run: for file in *-test-reports.zip; do unzip -q $file; done
       - name: Test Coverage Comment
         uses: madrapps/jacoco-report@e4bbaf00a0b8920cb86a448ae3ec0fc6f6bfeacc
         with:

--- a/.github/workflows/pull_request_comments.yml
+++ b/.github/workflows/pull_request_comments.yml
@@ -1,0 +1,49 @@
+name: Pull Request Comments
+
+on:
+  workflow_run:
+    workflows: [Pull Request]
+    types:
+      - completed
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == 'test-reports';
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{ github.workspace }}/test-reports.zip', Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip test-reports.zip
+      - name: Test Coverage Comment
+        uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
+        with:
+          paths: |
+            ${{ github.workspace }}/**/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 75
+          min-coverage-changed-files: 80

--- a/.github/workflows/pull_request_comments.yml
+++ b/.github/workflows/pull_request_comments.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 'Unzip artifact'
         run: unzip test-reports.zip
       - name: Test Coverage Comment
-        uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
+        uses: madrapps/jacoco-report@e4bbaf00a0b8920cb86a448ae3ec0fc6f6bfeacc
         with:
           paths: |
             ${{ github.workspace }}/**/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
… so that it can run in the target (default) branch context.

Pull request tests run in the potentially unsafe context of the base, but can only produce artifacts.
A second workflow is triggered after that and runs in default branch context, so it can be given permission to add a comment to the PR.