### PR TITLE
Split PRB into three jobs that can run in parallel

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,31 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  gradle:
+  # Three parallel jobs:
+  #  1. style: Runs all checks on the build (including compilation static analysis) except the tests
+  #     This allows us to catch anything related to build and style faster, as we don't have to wait
+  #     on tests to complete. It also allows the test jobs to continue even if there's a style failure.
+  #  2. core-tests: Runs the fdb-record-layer-core tests. This is the longest one of the tests, so
+  #     separating it out allows us to speed up the PRB time.
+  #  3. other-tests: Runs the rest of the tests. This completes the build steps.
+
+  style:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Run Gradle Build
+        uses: ./actions/run-gradle
+        with:
+          gradle_command: build -x test -PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport
+
+  core-tests:
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -21,64 +45,102 @@ jobs:
     - name: Run Gradle Test
       uses: ./actions/gradle-test
       with:
-        gradle_args: "-PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport"
+        gradle_command: :fdb-record-layer-core:test :fdb-record-layer-core:destructiveTest
+        gradle_args: -PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport
     - name: Publish Test Reports
       if: always()
       uses: actions/upload-artifact@v4.6.0
       with:
-        name: test-reports
+        name: core-test-reports
         path: |
-          test-reports/fdb-java-annotations/
-          test-reports/fdb-extensions/
           test-reports/fdb-record-layer-core/
-          test-reports/fdb-record-layer-icu/
-          test-reports/fdb-record-layer-spatial/
-          test-reports/fdb-record-layer-lucene/
-          test-reports/fdb-record-layer-jmh/
-          test-reports/examples/
-          test-reports/fdb-relational-api/
-          test-reports/fdb-relational-core/
-          test-reports/fdb-relational-cli/
-          test-reports/fdb-relational-grpc/
-          test-reports/fdb-relational-jdbc/
-          test-reports/fdb-relational-server/
-          test-reports/yaml-tests/
     - name: Test Summary
       if: always()
       uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
       with:
         paths: |
-          fdb-java-annotations/.out/test-results/**/TEST-*.xml
-          fdb-extensions/.out/test-results/**/TEST-*.xml
           fdb-record-layer-core/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-icu/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-spatial/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-lucene/.out/test-results/**/TEST-*.xml
-          fdb-record-layer-jmh/.out/test-results/**/TEST-*.xml
-          examples/.out/test-results/**/TEST-*.xml
-          fdb-relational-api/.out/test-results/**/TEST-*.xml
-          fdb-relational-core/.out/test-results/**/TEST-*.xml
-          fdb-relational-cli/.out/test-results/**/TEST-*.xml
-          fdb-relational-grpc/.out/test-results/**/TEST-*.xml
-          fdb-relational-jdbc/.out/test-results/**/TEST-*.xml
-          fdb-relational-server/.out/test-results/**/TEST-*.xml
-          yaml-tests/.out/test-results/**/TEST-*.xml
     - name: Test Coverage Comment
       uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
       with:
         paths: |
-          fdb-extensions/.out/reports/jacoco/test/jacocoTestReport.xml,
           fdb-record-layer-core/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-record-layer-icu/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-record-layer-spatial/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-record-layer-lucene/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-relational-api/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-relational-core/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-relational-cli/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-relational-grpc/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-relational-jdbc/.out/reports/jacoco/test/jacocoTestReport.xml,
-          fdb-relational-server/.out/reports/jacoco/test/jacocoTestReport.xml,
-          yaml-tests/.out/reports/jacoco/test/jacocoTestReport.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         min-coverage-overall: 75
         min-coverage-changed-files: 80
+
+  other-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Setup FDB
+        uses: ./actions/setup-fdb
+      - name: Run Gradle Test
+        uses: ./actions/gradle-test
+        with:
+          gradle_command: test -x :fdb-record-layer-core:test destructiveTest -x :fdb-record-layer-core:destructiveTest
+          gradle_args: -PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport
+      - name: Publish Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: other-test-reports
+          path: |
+            test-reports/fdb-java-annotations/
+            test-reports/fdb-extensions/
+            test-reports/fdb-record-layer-icu/
+            test-reports/fdb-record-layer-spatial/
+            test-reports/fdb-record-layer-lucene/
+            test-reports/fdb-record-layer-jmh/
+            test-reports/examples/
+            test-reports/fdb-relational-api/
+            test-reports/fdb-relational-core/
+            test-reports/fdb-relational-cli/
+            test-reports/fdb-relational-grpc/
+            test-reports/fdb-relational-jdbc/
+            test-reports/fdb-relational-server/
+            test-reports/yaml-tests/
+      - name: Test Summary
+        if: always()
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
+        with:
+          paths: |
+            fdb-java-annotations/.out/test-results/**/TEST-*.xml
+            fdb-extensions/.out/test-results/**/TEST-*.xml
+            fdb-record-layer-icu/.out/test-results/**/TEST-*.xml
+            fdb-record-layer-spatial/.out/test-results/**/TEST-*.xml
+            fdb-record-layer-lucene/.out/test-results/**/TEST-*.xml
+            fdb-record-layer-jmh/.out/test-results/**/TEST-*.xml
+            examples/.out/test-results/**/TEST-*.xml
+            fdb-relational-api/.out/test-results/**/TEST-*.xml
+            fdb-relational-core/.out/test-results/**/TEST-*.xml
+            fdb-relational-cli/.out/test-results/**/TEST-*.xml
+            fdb-relational-grpc/.out/test-results/**/TEST-*.xml
+            fdb-relational-jdbc/.out/test-results/**/TEST-*.xml
+            fdb-relational-server/.out/test-results/**/TEST-*.xml
+            yaml-tests/.out/test-results/**/TEST-*.xml
+      - name: Test Coverage Comment
+        uses: madrapps/jacoco-report@7c362aca34caf958e7b1c03464bd8781db9f8da7
+        with:
+          paths: |
+            fdb-extensions/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-record-layer-icu/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-record-layer-spatial/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-record-layer-lucene/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-relational-api/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-relational-core/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-relational-cli/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-relational-grpc/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-relational-jdbc/.out/reports/jacoco/test/jacocoTestReport.xml,
+            fdb-relational-server/.out/reports/jacoco/test/jacocoTestReport.xml,
+            yaml-tests/.out/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 75
+          min-coverage-changed-files: 80

--- a/actions/gradle-test/action.yml
+++ b/actions/gradle-test/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Version of FDB to run'
     required: false
     default: "7.3.42"
+  gradle_command:
+    description: 'Gradle command to run'
+    default: build destructiveTest
+    required: false
   gradle_args:
     description: 'Gradle arguments for running'
     required: true
@@ -15,7 +19,7 @@ runs:
   - name: Run build and test
     uses: ./actions/run-gradle
     with:
-      gradle_command: build destructiveTest -PcoreNotStrict ${{ inputs.gradle_args }}
+      gradle_command: ${{ inputs.gradle_command }} -PcoreNotStrict ${{ inputs.gradle_args }}
   - name: Copy Test Reports
     shell: bash
     if: always()


### PR DESCRIPTION
This updates the PRB configuration to allow for faster PRB feedback. The three jobs are:

1. A job that runs the build except for tests. This allows us to get any non-test related feedback first without having to wait for the tests to run, and it allows the tests to run even if there's some style issue.
2. A job that runs the `fdb-record-layer-core` tests. These took the longest to run (approximately half the build time), so allowing these to run separately roughly halves our build time. Without splitting that up more or adding additional parallelism (which has been hard to introduce without introducing flakiness), I think this is the best we can do.
3. A job that runs the rest of the tests.