### PR TITLE
Use deploy key to allow release build to write back to repo

### DIFF
--- a/.github/workflows/patch_release.yml
+++ b/.github/workflows/patch_release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Setup Base Environment
         uses: ./actions/setup-base-env
       - name: Setup FDB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.2.2
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Setup Base Environment
         uses: ./actions/setup-base-env
       - name: Setup FDB


### PR DESCRIPTION
This updates our release and patch release workflows to use a deploy key to get around branch protections when pushing back updates to the repository. This is used for things like updating the artifact version, the release notes, and the yamsql version.