### PR TITLE
Fix publication of shaded jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,7 @@ subprojects {
     ext {
         coreProjectName = "fdb-record-layer-core"
         shadedProjectName = "fdb-record-layer-core-shaded"
+        publishLibrary = true
     }
 
     artifacts {

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -52,6 +52,8 @@ task shadedSourcesJar(type: Jar) {
     archiveClassifier = "sources"
     from project(coreProject).sourceSets.main.allSource
     from project(':fdb-extensions').sourceSets.main.allSource
+    dependsOn(project(coreProject).tasks.generateProto)
+    dependsOn(project(coreProject).tasks.compileJava)
 }
 
 task shadedJavadocJar(type: Jar) {
@@ -79,11 +81,11 @@ def addDependencies(projectObj, dependenciesNode) {
     }
 }
 
+ext.publishLibrary = false
+
 apply from: rootProject.file('gradle/publishing.gradle')
 
 publishing {
-    publications.remove(publishing.publications.library)
-
     publications {
         shadow(MavenPublication) { publication ->
             from project.shadow.component(publication)
@@ -111,6 +113,7 @@ publishing {
             artifact tasks.shadedSourcesJar
             artifact tasks.shadedJavadocJar
         }
+
     }
     artifactoryPublish {
         publications (publishing.publications.shadow)

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -47,36 +47,32 @@ def addPublishingInfo(publication) {
     }
 }
 
-ext {
-    // Make the "addPublishingInfo" method visible from outside this plugin
-    addPublishingInfo = this.&addPublishingInfo
-}
+if (ext.publishLibrary) {
+    publishing {
+        publications {
+            library(MavenPublication) { publication ->
+                from components.java
 
-publishing {
-    publications {
-        library(MavenPublication) { publication ->
-            from components.java
-
-            // Test fixtures appear to be placing their dependencies in the wrong scope
-            // for maven compilation, which means that their dependencies wind up in the
-            // final project's pom.xml.
-            // See: https://github.com/gradle/gradle/issues/14936
-            // Until this is fixed, skip these configurations to avoid polluting the list of dependencies
-            configurations.each { config ->
-                if (config.name == 'testFixturesApiElements' || config.name == 'testFixturesRuntimeElements') {
-                    components.java.withVariantsFromConfiguration(config) {
-                        skip()
+                // Test fixtures appear to be placing their dependencies in the wrong scope
+                // for maven compilation, which means that their dependencies wind up in the
+                // final project's pom.xml.
+                // See: https://github.com/gradle/gradle/issues/14936
+                // Until this is fixed, skip these configurations to avoid polluting the list of dependencies
+                configurations.each { config ->
+                    if (config.name == 'testFixturesApiElements' || config.name == 'testFixturesRuntimeElements') {
+                        components.java.withVariantsFromConfiguration(config) {
+                            skip()
+                        }
                     }
                 }
-            }
 
-            artifact tasks.sourcesJar
-            artifact tasks.javadocJar
-            artifact tasks.testJar
-            addPublishingInfo(publication)
+                artifact tasks.sourcesJar
+                artifact tasks.javadocJar
+                artifact tasks.testJar
+                addPublishingInfo(publication)
+            }
         }
     }
-
     artifactoryPublish {
         // As a safeguard, only actually publish to artifactory if -PpublishBuild=true is passed to gradle
         // Note: skip is documented, but onlyIf seems to also be required to make this work for some reason
@@ -88,7 +84,29 @@ publishing {
         }
         publications(publishing.publications.library)
     }
+    createDistribution.configure {
+        afterEvaluate {
+            dependsOn generatePomFileForLibraryPublication
+            from tasks.jar, tasks.sourcesJar, tasks.javadocJar, tasks.testJar, tasks.generatePomFileForLibraryPublication
+            rename { filename ->
+                GenerateMavenPom pomTask = tasks.generatePomFileForLibraryPublication
+                Jar jarTask = tasks.jar
+                if (filename == pomTask.destination.name) {
+                    jarTask.archiveName.replace "jar", "pom"
+                } else {
+                    filename
+                }
+            }
+        }
+    }
+}
 
+ext {
+    // Make the "addPublishingInfo" method visible from outside this plugin
+    addPublishingInfo = this.&addPublishingInfo
+}
+
+publishing {
     if (Boolean.parseBoolean(publishBuild)) {
         repositories {
             if (Boolean.parseBoolean(githubPublish)) {
@@ -133,22 +151,6 @@ if (System.getenv('ARTIFACTORY_USER') != null && System.getenv('ARTIFACTORY_KEY'
                 publishArtifacts = publishBuild
                 publishBuildInfo = publishBuild
                 publishIvy = false
-            }
-        }
-    }
-}
-
-createDistribution.configure {
-    afterEvaluate {
-        dependsOn generatePomFileForLibraryPublication
-        from tasks.jar, tasks.sourcesJar, tasks.javadocJar, tasks.testJar, tasks.generatePomFileForLibraryPublication
-        rename { filename ->
-            GenerateMavenPom pomTask = tasks.generatePomFileForLibraryPublication
-            Jar jarTask = tasks.jar
-            if (filename == pomTask.destination.name) {
-                jarTask.archiveName.replace "jar", "pom"
-            } else {
-                filename
             }
         }
     }


### PR DESCRIPTION
There was a problem in the last release job where the shaded jars weren't able to be published. That's because we were actually publishing both a "library" and a "shadow" publication for that build, and the second publication's artifacts were attemping to override the artifacts from the first. So, this removes the library publication for that subproject. It also fixes up some task dependency problems to remove those warnings.