### PR TITLE
Change context options to a type-safe option with generics.

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
@@ -47,7 +47,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -99,7 +98,7 @@ public final class YamlRunner {
         }
     }
 
-    public YamlRunner(@Nonnull String resourcePath, @Nonnull YamlConnectionFactory factory, boolean correctExplain, @Nonnull final Map<String, Object> additionalOptions) throws RelationalException {
+    public YamlRunner(@Nonnull String resourcePath, @Nonnull YamlConnectionFactory factory, boolean correctExplain, @Nonnull final YamlExecutionContext.ContextOptions additionalOptions) throws RelationalException {
         this.resourcePath = resourcePath;
         this.executionContext = new YamlExecutionContext(resourcePath, factory, correctExplain, additionalOptions);
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestConfigExclusions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestConfigExclusions.java
@@ -48,7 +48,7 @@ public enum YamlTestConfigExclusions {
     FORCES_CONTINUATIONS {
         @Override
         boolean check(final YamlTestConfig config) {
-            return (Boolean) config.getRunnerOptions().getOrDefault(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, false);
+            return config.getRunnerOptions().getOrDefault(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, false);
         }
     };
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -243,7 +243,7 @@ public final class QueryInterpreter {
     @Nonnull
     public QueryExecutor getExecutor(@Nullable Random random, boolean runAsPreparedStatement) {
         try {
-            final boolean forceContinuations = (boolean)executionContext.getOption(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, false);
+            final boolean forceContinuations = executionContext.getOption(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, false);
             if (random == null) {
                 // we do not allow prepared statements if the Random generator is not there
                 Assert.thatUnchecked(injections.isEmpty(), "Parameter injection is not allowed in query without a Random(generator)");

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ConfigWithOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ConfigWithOptions.java
@@ -20,11 +20,10 @@
 
 package com.apple.foundationdb.relational.yamltests.configs;
 
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * An implementation of {@link YamlTestConfig} that sets additional options on top of a base config.
@@ -33,13 +32,11 @@ public class ConfigWithOptions implements YamlTestConfig {
     @Nonnull
     private final YamlTestConfig underlying;
     @Nonnull
-    private final Map<String, Object> runnerOptions;
+    private final YamlExecutionContext.ContextOptions runnerOptions;
 
-    public ConfigWithOptions(@Nonnull final YamlTestConfig underlying, @Nonnull Map<String, Object> newOptions) {
+    public ConfigWithOptions(@Nonnull final YamlTestConfig underlying, @Nonnull YamlExecutionContext.ContextOptions newOptions) {
         this.underlying = underlying;
-        final HashMap<String, Object> options = new HashMap<>(underlying.getRunnerOptions());
-        options.putAll(newOptions);
-        this.runnerOptions = Map.copyOf(options);
+        this.runnerOptions = underlying.getRunnerOptions().mergeFrom(newOptions);
     }
 
 
@@ -49,7 +46,7 @@ public class ConfigWithOptions implements YamlTestConfig {
     }
 
     @Override
-    public @Nonnull Map<String, Object> getRunnerOptions() {
+    public @Nonnull YamlExecutionContext.ContextOptions getRunnerOptions() {
         return runnerOptions;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.server.FRL;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
 import javax.annotation.Nonnull;
@@ -72,8 +73,8 @@ public class EmbeddedConfig implements YamlTestConfig {
     }
 
     @Override
-    public @Nonnull Map<String, Object> getRunnerOptions() {
-        return Map.of();
+    public @Nonnull YamlExecutionContext.ContextOptions getRunnerOptions() {
+        return YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ForceContinuations.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ForceContinuations.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
 import javax.annotation.Nonnull;
-import java.util.Map;
 
 /**
  * A configuration that runs an underlying configuration, but forces every query to be executed with {@code maxRows: 1}.
@@ -33,6 +32,6 @@ import java.util.Map;
  */
 public class ForceContinuations extends ConfigWithOptions {
     public ForceContinuations(@Nonnull final YamlTestConfig underlying) {
-        super(underlying, Map.of(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, true));
+        super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.jdbc.JDBCURI;
 import com.apple.foundationdb.relational.server.InProcessRelationalServer;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -81,8 +82,8 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     }
 
     @Override
-    public @Nonnull Map<String, Object> getRunnerOptions() {
-        return Map.of();
+    public @Nonnull YamlExecutionContext.ContextOptions getRunnerOptions() {
+        return YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/YamlTestConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/YamlTestConfig.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests.configs;
 
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
 import javax.annotation.Nonnull;
@@ -45,7 +46,7 @@ public interface YamlTestConfig {
      * @return the options for this config
      */
     @Nonnull
-    Map<String, Object> getRunnerOptions();
+    YamlExecutionContext.ContextOptions getRunnerOptions();
 
     void beforeAll() throws Exception;
 

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -31,7 +31,6 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -55,7 +54,7 @@ public class SupportedVersionTest {
     }
 
     private void doRun(String fileName) throws Exception {
-        new YamlRunner(fileName, createConnectionFactory(), false, Map.of()).run();
+        new YamlRunner(fileName, createConnectionFactory(), false, YamlExecutionContext.ContextOptions.EMPTY_OPTIONS).run();
     }
 
     YamlRunner.YamlConnectionFactory createConnectionFactory() {

--- a/yaml-tests/src/test/java/YamlTestBase.java
+++ b/yaml-tests/src/test/java/YamlTestBase.java
@@ -21,8 +21,8 @@
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.server.FRL;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 
 import javax.annotation.Nonnull;
 import java.sql.SQLException;
-import java.util.Collections;
-import java.util.Map;
 
 @Deprecated
 public abstract class YamlTestBase {
@@ -60,8 +58,8 @@ public abstract class YamlTestBase {
 
     abstract YamlRunner.YamlConnectionFactory createConnectionFactory();
 
-    protected Map<String, Object> getAdditionalOptions() {
-        return Collections.emptyMap();
+    protected YamlExecutionContext.ContextOptions getAdditionalOptions() {
+        return YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
     }
 
     protected final void doRun(@Nonnull final String fileName) throws Exception {


### PR DESCRIPTION
Pay technical debt from https://github.com/FoundationDB/fdb-record-layer/pull/3075: make context options type safe.
The options are now a simplified version of similar option implementations: An Option class and a wrapper around a map of the options allows us to remove the type cast when getting options. This was done this way (as opposed to a specific class with getters) in order to support the merging of options in `ConfigWithOptions`.
