### PR TITLE
Exclude transitive maven information in shaded jar

### DIFF
--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -32,6 +32,10 @@ shadowJar {
     setArchiveClassifier(null)
     relocate 'com.google', 'com.apple.foundationdb.record.shaded.com.google'
     dependencies {
+        // Exclude transitive information from the guava dependency to avoid
+        // confusing tooling inspecting the jar
+        exclude "META-INF/maven/**"
+
         include(dependency(coreProject))
         include(dependency(':fdb-extensions'))
         include(dependency('com.google.guava:guava'))


### PR DESCRIPTION
The shadow jar currently includes some information from transitive dependencies (particularly Guava) that it shouldn't. This was confusing tooling like the GitHub package and suggesting that the description coming from Guava was actually a description of our own package. Fix that up by removing the transitive maven information from the build.