### PR TITLE
restore showPlannerExpression

### DIFF
--- a/fdb-record-layer-core/src/main/resources/showPlannerExpression.html
+++ b/fdb-record-layer-core/src/main/resources/showPlannerExpression.html
@@ -33,6 +33,7 @@
   </style>
 </head>
 <body>
+<div id="output" style="width: 100%; height: 100%;"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/viz.js" integrity="sha256-8RHyK+AFzq9iXwbFo2unqidwPbwHU5FFWe3RwkcVtuU=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/full.render.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js"></script>


### PR DESCRIPTION
#3085 for some reason modified this file and rendered it useless, i.e. plan show is only showing a white page in the browser. This commit restores the correct html.