### PR TITLE
Initial attempt at automatic GitHub release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  # TODO exclude commits from release process
+  categories:
+    - title: Breaking Changes
+      labels:
+        - "breaking change"
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Documentation improvements
+      labels:
+        - documentation
+    - title: Bug Fixes
+      labels:
+        - "bug fix"
+    - title: Performance Improvements
+      labels:
+        - performance
+    - title: Dependency Updates
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This introduces a spec for how to categorize PRs into release notes.

I'm fairly certain, this doesn't do anything without someone creating the release notes using the `--generate-notes` option.

I couldn't figure out how to test this without merging, or creating a new branch on FoundationDB or creating a whole new repo with a whole bunch of test PRs.