### PR TITLE
Resolve #3135: Allow scrubbing of indexes in READABLE_UNIQUE_PENDING state

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -31,7 +31,7 @@ Users performing online updates are encouraged to update from [4.0.559.4](#40559
 * **Performance** Improvement 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add enum column support to relational server [(Issue #3073)](https://github.com/FoundationDB/fdb-record-layer/issues/3073)
-* **Feature** Feature 3 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** Allow scrubbing of indexes in READABLE_UNIQUE_PENDING state [(Issue #3135)](https://github.com/FoundationDB/fdb-record-layer/issues/3135)
 * **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Feature 5 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexState.java
@@ -95,6 +95,10 @@ public enum IndexState {
         return this.equals(READABLE) || this.equals(READABLE_UNIQUE_PENDING);
     }
 
+    public boolean isWriteOnly() {
+        return this.equals(WRITE_ONLY);
+    }
+
     public static IndexState fromCode(@Nonnull Object code) {
         for (IndexState state : IndexState.values()) {
             if (state.code().equals(code)) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.IndexBuildProto;
-import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -147,8 +146,8 @@ public class IndexScrubbing extends IndexingBase {
     }
 
     private <T> CompletableFuture<Boolean> indexScrubRangeOnly(final @Nonnull FDBRecordStore store, final @Nonnull AtomicLong recordsScanned, final Index index, final IndexScrubbingTools<T> tools, boolean isIdempotent) {
-        // scrubbing only readable
-        validateOrThrowEx(store.getIndexState(index) == IndexState.READABLE, "scrubbed index is not readable");
+        // scrubbing only scannable index (in readable or readable-unique-pending state)
+        validateOrThrowEx(store.getIndexState(index).isScannable(), "scrubbed index is not readable");
         // scrubbing only idempotent indexes (at least for now)
         validateOrThrowEx(isIdempotent, "scrubbed index is not idempotent");
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -126,8 +126,7 @@ public abstract class IndexingBase {
         this.common = common;
         this.policy = policy;
         this.isScrubber = isScrubber;
-        IndexState expectedIndexState = isScrubber ? IndexState.READABLE : IndexState.WRITE_ONLY;
-        this.throttle = new IndexingThrottle(common, expectedIndexState);
+        this.throttle = new IndexingThrottle(common, isScrubber);
         this.startingTimeMillis = System.currentTimeMillis();
         this.lastTypeStampCheckMillis = startingTimeMillis;
     }
@@ -280,7 +279,7 @@ public abstract class IndexingBase {
         return getRunner().runAsync(context -> openRecordStore(context).thenCompose(store -> {
             IndexState indexState = store.getIndexState(primaryIndex);
             if (isScrubber) {
-                validateOrThrowEx(indexState == IndexState.READABLE, "Scrubber was called for a non-readable index. Index:" + primaryIndex.getName() + " State: " + indexState);
+                validateOrThrowEx(indexState.isScannable(), "Scrubber was called for a non-readable index. Index:" + primaryIndex.getName() + " State: " + indexState);
                 return setScrubberTypeOrThrow(store).thenApply(ignore -> true);
             }
             OnlineIndexer.IndexingPolicy.DesiredAction desiredAction = policy.getStateDesiredAction(indexState);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
-import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordMetaData;
@@ -145,7 +144,7 @@ public class IndexingScrubDangling extends IndexingBase {
         // scrubbing only readable, VALUE, idempotence indexes (at least for now)
         validateOrThrowEx(maintainer.isIdempotent(), "scrubbed index is not idempotent");
         validateOrThrowEx(IndexTypes.VALUE.equals(index.getType()) || scrubbingPolicy.ignoreIndexTypeCheck(), "scrubbed index is not a VALUE index");
-        validateOrThrowEx(store.getIndexState(index) == IndexState.READABLE, "scrubbed index is not readable");
+        validateOrThrowEx(store.getIndexState(index).isScannable(), "scrubbed index is not readable");
 
         final ScanProperties scanProperties = scanPropertiesWithLimits(true);
         final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingIndex(store, index);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IndexEntry;
-import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.PipelineOperation;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
@@ -143,7 +142,7 @@ public class IndexingScrubMissing extends IndexingBase {
         // scrubbing only readable, VALUE, idempotence indexes (at least for now)
         validateOrThrowEx(maintainer.isIdempotent(), "scrubbed index is not idempotent");
         validateOrThrowEx(IndexTypes.VALUE.equals(index.getType()) || scrubbingPolicy.ignoreIndexTypeCheck(), "scrubbed index is not a VALUE index");
-        validateOrThrowEx(store.getIndexState(index) == IndexState.READABLE, "scrubbed index is not readable");
+        validateOrThrowEx(store.getIndexState(index).isScannable(), "scrubbed index is not readable");
 
         final ScanProperties scanProperties = scanPropertiesWithLimits(true);
         final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingRecords(store, index);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingThrottle.java
@@ -391,6 +391,7 @@ public class IndexingThrottle {
                 return;
             }
             throw new IndexingBase.UnexpectedReadableException(false, "Attempt to scrub a non readable index",
+                    LogMessageKeys.INDEX_NAME, common.getTargetIndexesNames(),
                     LogMessageKeys.INDEX_STATE, indexStates);
         }
         // Here: index building

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -157,7 +157,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @ParameterizedTest
@@ -189,7 +189,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -222,7 +222,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @ParameterizedTest
@@ -255,7 +255,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         }
         assertEquals(numRecords + otherRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -450,7 +450,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -508,7 +508,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -558,7 +558,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // counters should demonstrate a continuation to completion
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -610,7 +610,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // counters should demonstrate a continuation to completion
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -664,7 +664,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         // counters should demonstrate a continuation to completion
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -702,7 +702,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
 
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -864,7 +864,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -930,7 +930,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -995,7 +995,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -1030,7 +1030,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertReadable(tgtIndex);
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 
     @Test
@@ -1148,6 +1148,6 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
         assertReadable(tgtIndex);
-        assertAllValidated(List.of(tgtIndex));
+        scrubAndValidate(List.of(tgtIndex));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -154,7 +154,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @ParameterizedTest
@@ -190,7 +190,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @ParameterizedTest
@@ -224,7 +224,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertTrue(0 < timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_DEPLETION));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -272,7 +272,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @ParameterizedTest
@@ -419,7 +419,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @ParameterizedTest
@@ -470,7 +470,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         // 3. Verify all readable and valid
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -569,7 +569,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -611,7 +611,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords + numRecordsOther, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords + numRecordsOther, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
-        assertAllValidated(Arrays.asList(indexMyA, indexMyB, indexOtherA, indexOtherB));
+        scrubAndValidate(Arrays.asList(indexMyA, indexMyB, indexOtherA, indexOtherB));
     }
 
     @Test
@@ -827,7 +827,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
         // validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -879,7 +879,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         }
 
         // validate
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     void snooze(int millis) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -121,7 +121,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -162,7 +162,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
             }
         });
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
         assertTrue(count.get() > 1);
     }
 
@@ -220,7 +220,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
             assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         }
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     int oneThreadIndexing(List<Index> indexes, FDBStoreTimer callerTimer, List<Tuple> boundaries) {
@@ -326,7 +326,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -363,7 +363,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -404,7 +404,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     OnlineIndexer.IndexingPolicy.Builder mutualTakeOverIndexingPolicy(boolean explicit, boolean toMutual) {
@@ -456,7 +456,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @ParameterizedTest
@@ -525,7 +525,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -640,7 +640,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -774,7 +774,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
 
         // happy indexes assertion
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
         assertReadable(indexes);
     }
 
@@ -833,7 +833,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // happy indexes assertion
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -860,7 +860,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         IntStream.rangeClosed(0, 8).parallel().forEach(ignore ->
                 oneThreadIndexing(indexes, timer, boundariesList));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
 
         disableAll(indexes);
         // Duplicate entry, causing empty fragments
@@ -872,7 +872,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         IntStream.rangeClosed(0, 3).parallel().forEach(ignore ->
                 oneThreadIndexing(indexes, timer, boundariesList));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
 
         // pad with nulls, causing more empty fragments
         disableAll(indexes);
@@ -883,7 +883,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         IntStream.rangeClosed(0, 18).parallel().forEach(ignore ->
                 oneThreadIndexing(indexes, timer, boundariesList));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -933,7 +933,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         IntStream.rangeClosed(0, 8).parallel().forEach(ignore ->
                 oneThreadIndexing(indexes, timer, boundariesList));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
 
         disableAll(indexes);
         // Duplicate entry, causing empty fragments
@@ -945,7 +945,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         IntStream.rangeClosed(0, 3).parallel().forEach(ignore ->
                 oneThreadIndexing(indexes, timer, boundariesList));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
 
         // pad with nulls, causing more empty fragments
         disableAll(indexes);
@@ -956,7 +956,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         IntStream.rangeClosed(0, 18).parallel().forEach(ignore ->
                 oneThreadIndexing(indexes, timer, boundariesList));
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -1363,7 +1363,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 indexBuilder.buildIndex(true);
             }
         });
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -1456,7 +1456,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // Validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     private boolean allStampsAreEmpty(FDBRecordStoreTestBase.RecordMetaDataHook hook, List<Index> indexes) {
@@ -1569,7 +1569,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // Validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -1653,7 +1653,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // Validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test
@@ -1769,7 +1769,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
         // Validate
         assertReadable(indexes);
-        assertAllValidated(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -202,8 +202,9 @@ public abstract class OnlineIndexerTest {
         }
     }
 
-    protected void assertAllValidated(List<Index> indexes) {
+    protected void scrubAndValidate(List<Index> indexes) {
         final FDBStoreTimer timer = new FDBStoreTimer();
+        long numIssues = 0;
         for (Index index: indexes) {
             if (index.getType().equals(IndexTypes.VALUE)) {
                 try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(index, timer)
@@ -212,11 +213,12 @@ public abstract class OnlineIndexerTest {
                                 .setAllowRepair(false)
                                 .build())
                         .build()) {
-                    indexScrubber.scrubDanglingIndexEntries();
-                    indexScrubber.scrubMissingIndexEntries();
+                    numIssues += indexScrubber.scrubDanglingIndexEntries();
+                    numIssues += indexScrubber.scrubMissingIndexEntries();
                 }
                 assertEquals(0, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_DANGLING_ENTRIES));
                 assertEquals(0, timer.getCount(FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES));
+                assertEquals(0, numIssues);
             }
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
@@ -355,6 +355,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             assertTrue(recordStore.isIndexReadableUniquePending(indexName));
             context.commit();
         }
+        scrubAndValidate(List.of(index));
         // now try resolving it, and marking readable with another build
         try (FDBRecordContext context = openContext()) {
             Set<Tuple> indexEntries = new HashSet<>(recordStore.scanUniquenessViolations(index)
@@ -384,6 +385,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
                 .build()) {
             indexBuilder.buildIndex(true);
         }
+        scrubAndValidate(List.of(index));
         assertReadable(index);
     }
 
@@ -439,6 +441,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
                 .build()) {
             if (allowUniquePending) {
                 indexBuilder.buildIndex();
+                scrubAndValidate(indexes);
             } else {
                 buildIndexAssertThrowUniquenessViolation(indexBuilder);
             }
@@ -500,6 +503,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
                 .build()) {
             indexBuilder.buildIndex(true);
         }
+        scrubAndValidate(List.of(index));
         try (FDBRecordContext context = openContext()) {
             assertTrue(recordStore.isIndexReadable(index.getName()));
             assertEquals(0, (int)recordStore.scanUniquenessViolations(indexes.get(0)).getCount().join());
@@ -530,6 +534,9 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
                 .build()) {
             indexBuilder.buildIndex();
         }
+
+        // scrub index, assert valid
+        scrubAndValidate(indexes);
 
         // verify that unique pending state is unchanged
         try (FDBRecordContext context = openContext()) {
@@ -573,7 +580,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             context.commit();
         }
 
-        // assert readable state
+        // assert validity and readable state
+        scrubAndValidate(indexes);
         assertReadable(indexes);
     }
 
@@ -600,6 +608,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
                 .build()) {
             indexBuilder.buildIndex();
         }
+        scrubAndValidate(indexes);
 
         // verify that unique pending state is unchanged
         try (FDBRecordContext context = openContext()) {
@@ -651,6 +660,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         }
 
         // assert readable state
+        scrubAndValidate(indexes);
         try (FDBRecordContext context = openContext()) {
             for (Index index: indexes) {
                 assertTrue(recordStore.isIndexReadable(index));
@@ -753,6 +763,8 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             indexBuilder.buildIndex(true);
         }
 
+        // assert both source and target indexes are valid and scrub-able
+        scrubAndValidate(indexes);
         // assert target index state is readable
         assertReadable(tgtIndex);
     }


### PR DESCRIPTION
  Indexes in `READABLE_UNIQUE_PENDING` state are fully built, and hence can be scrubbed.

   If uniqueness violation will ever become a scrubbing feature (not likely), distinguishing the two states should be handled by the relevant `IndexScrubbingTool` implementation.